### PR TITLE
feat: Mermaid diagram support + convert Verne diagram

### DIFF
--- a/src/content/blog/verne-autonomous-coding-pipelines.md
+++ b/src/content/blog/verne-autonomous-coding-pipelines.md
@@ -69,20 +69,13 @@ The result: a codebase that continuously improves itself. Each agent discovers w
 
 ## 3. Architecture
 
-```
-┌──────────────┐     Jules REST API      ┌──────────────┐
-│              │ ──── POST /sessions ──→  │              │
-│    Verne     │ ←── GET /activities ───  │  Jules API   │
-│  (Browser)   │ ──── sendMessage ────→   │  (Google)    │
-│              │ ──── approvePlan ────→   │              │
-└──────────────┘                          └──────────────┘
-       │
-       │ localStorage
-       ▼
-┌──────────────┐
-│  Persistence │  Chain configs, agent templates,
-│  (Browser)   │  session history, pipeline state
-└──────────────┘
+```mermaid
+graph LR
+    V["🌐 Verne<br/>(Browser)"] -->|POST /sessions| J["☁️ Jules API<br/>(Google)"]
+    J -->|GET /activities| V
+    V -->|sendMessage| J
+    V -->|approvePlan| J
+    V -->|localStorage| P["💾 Persistence<br/>(Browser)<br/>Chain configs, templates,<br/>session history, pipeline state"]
 ```
 
 Verne is entirely client-side. Your API key stays in your browser. No server sees your code or your prompts. Built with Astro 5 for fast static generation and Alpine.js for reactive UI.

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -73,6 +73,36 @@ const { title, description = "A digital memory palace.", image } = Astro.props;
       </div>
     </footer>
     
+    <!-- Mermaid diagram support -->
+    <script type="module">
+      import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
+      mermaid.initialize({
+        startOnLoad: false,
+        theme: 'dark',
+        themeVariables: {
+          darkMode: true,
+          background: '#1a1b26',
+          primaryColor: '#7dcfff',
+          primaryTextColor: '#e0e0e0',
+          primaryBorderColor: '#2a2b36',
+          lineColor: '#ff9e64',
+          secondaryColor: '#2a2b36',
+          tertiaryColor: '#13141f',
+          fontFamily: 'JetBrains Mono, monospace',
+          fontSize: '14px',
+        }
+      });
+      // Convert ```mermaid code blocks to rendered diagrams
+      document.querySelectorAll('pre > code.language-mermaid').forEach((el) => {
+        const pre = el.parentElement;
+        const div = document.createElement('div');
+        div.className = 'mermaid';
+        div.textContent = el.textContent;
+        pre.replaceWith(div);
+      });
+      await mermaid.run();
+    </script>
+
     <!-- The Aleph (Floating Action Button) -->
     <div class="fixed bottom-8 right-8 z-50 group">
       <button id="aleph-toggle" class="w-14 h-14 rounded-full bg-[#7dcfff] hover:bg-[#ff9e64] transition-all duration-300 shadow-[0_0_15px_rgba(125,207,255,0.3)] hover:shadow-[0_0_20px_rgba(255,158,100,0.5)] flex items-center justify-center text-[#13141f] cursor-pointer hover:scale-110 active:scale-95" aria-label="The Aleph">


### PR DESCRIPTION
- Added client-side Mermaid 11 via CDN (ESM module)
- Dark theme configured to match Memory Palace palette (charcoal/amber/cyan)
- Auto-converts ```mermaid code blocks to rendered diagrams
- Converted Verne architecture ASCII art to Mermaid flowchart
- Build passes ✅