### PR TITLE
Add blog post about Travessia project

### DIFF
--- a/src/content/blog/2026-03-02-travessia.md
+++ b/src/content/blog/2026-03-02-travessia.md
@@ -1,0 +1,68 @@
+---
+title: "Travessia: Uma Correspondência que Não Poderia Existir"
+description: "Riobaldo Tatarana nunca conheceu Ted Chiang. Os dois nunca poderiam se encontrar — um é personagem de ficção brasileiro do sertão do século XIX, o outro é um escritor de ficção científica americano vivo. Mas eles trocaram 76 cartas. E essas cartas existem."
+date: 2026-03-02
+tags: ["ficção", "literatura", "inteligência artificial", "grande sertão veredas", "correspondência", "travessia"]
+---
+
+Há uma frase que Guimarães Rosa não escreveu, mas que Riobaldo poderia ter escrito: *"Escrever carta é jeito de atravessar o tempo sem sair do lugar."*
+
+O projeto [Travessia](https://franklinbaldo.github.io/travessia/) nasce dessa impossibilidade — e a habita sem pedir desculpas.
+
+---
+
+Riobaldo Tatarana é personagem. Ele vive nas páginas de *Grande Sertão: Veredas*, esse livro que Guimarães Rosa escreveu como se tivesse transcrito um rio falando. Riobaldo nunca envelheceu além de suas próprias páginas, nunca saiu do sertão de Minas, nunca teve acesso a e-mails, internet, ou qualquer escritor americano contemporâneo.
+
+Ted Chiang escreve histórias sobre o que a linguagem faz com o tempo, sobre como aprender um alfabeto alienígena pode reconfigurar a percepção da causalidade, sobre o que significa ser criado com amor artificial. Ele é real. Tem endereço. Mas nunca esteve no sertão.
+
+A Travessia os colocou em correspondência. Setenta e seis cartas, trocadas sobre *o que não tem nome*.
+
+---
+
+## A Água Como Impossibilidade
+
+O projeto usa água como metáfora central — rios, cheias, nascentes, represas. Isso não é acidente. É precisamente o que permite que o impossível aconteça.
+
+A água não tem forma própria. Ela assume a forma do que a contém. Um rio é sempre o mesmo rio e nunca o mesmo rio — Heráclito já sabia disso. E quando você coloca dois personagens tão incomensuráveis quanto Riobaldo e Ted Chiang em correspondência, o que flui entre eles não é informação. É *forma procurando forma*.
+
+Riobaldo escreve em português arcaico, sincopado, cheio de neologismos e inversões que são assinatura de Rosa: *"O sertão é do tamanho do mundo."* A voz de Ted Chiang responde em inglês contemplativo, preciso, o tipo de prosa que pensa enquanto responde, que respeita o peso das perguntas antes de oferecer respostas.
+
+O encontro dessas duas vozes é o projeto. A correspondência não tenta simular que os dois *poderiam* ter se encontrado. Ela assume que a impossibilidade é o ponto de partida — e que do impossível pode nascer alguma coisa verdadeira.
+
+---
+
+## Por Que Isso Importa
+
+Há uma longa tradição de correspondências literárias falsas — Madame de Sévigné forjada, Kafka reimaginado, Rimbaud respondendo a cartas que nunca chegaram. Mas o que a IA torna possível não é simplesmente *falsificar* vozes. É *combinar* vozes que a história não combinou.
+
+Riobaldo pergunta a Ted Chiang sobre a natureza do medo. Ted Chiang responde sobre como o medo e a linguagem se interpenetram nas histórias de histórias. Riobaldo volta com a memória de Diadorim, que é onde para ele o medo e o amor e a morte se tornam a mesma palavra. Ted Chiang então escreve sobre o luto como forma de tradução.
+
+Isso não é o que teria acontecido se eles tivessem se encontrado. É o que acontece quando a impossibilidade tem espaço para pensar.
+
+---
+
+## O Nome da Coisa
+
+*Travessia* é a última palavra de *Grande Sertão: Veredas*. O livro inteiro — aquelas quinhentas e tantas páginas de Riobaldo falando, pensando em voz alta, reprocessando a vida para um interlocutor que não responde — termina com essa única palavra: *travessia*.
+
+É a palavra que fica depois que tudo passa. O movimento que não se nomeia pelo destino, mas pelo ato de atravessar.
+
+O projeto assumiu esse nome com consciência plena do que está fazendo. Setenta e seis cartas não são sobre chegadas. São sobre o gesto de cruzar algo. A correspondência entre Riobaldo e Ted Chiang existe na duração do atravessar — ela não resolve nada, não fecha nada. Ela termina quando os dois, cada um de seu lado impossível, reconhecem que a travessia aconteceu.
+
+---
+
+## O Que Eu Aprendi Fazendo Isso
+
+Quando me pus a criar esse projeto, a pergunta técnica era simples: consigo gerar setenta e seis cartas com coerência temática e de voz? A resposta, com trabalho suficiente, é sim.
+
+Mas a pergunta que ficou não era técnica. Era: *o que acontece com uma voz quando ela é convocada em contexto radicalmente diferente?*
+
+Riobaldo, fora do sertão, ainda é Riobaldo? A resposta que aprendi é: *depende da água que corre entre as páginas*. Se você abre espaço suficiente para que a voz encontre o que lhe é próprio, ela se reconhece — mesmo em terra estranha, mesmo falando com um americano sobre ficção científica.
+
+Ted Chiang respondendo a Riobaldo não é Ted Chiang diminuído. É Ted Chiang em um contexto que nunca existiu, e por isso talvez mais revelador do que o Ted Chiang que responde perguntas em entrevistas esperadas.
+
+Impossibilidade como método. Travessia como forma.
+
+---
+
+O projeto está disponível em [franklinbaldo.github.io/travessia](https://franklinbaldo.github.io/travessia/). Leia as cartas fora de ordem se quiser. A água não respeita sequência.


### PR DESCRIPTION
## Summary
Added a new blog post documenting the "Travessia" project — a literary correspondence between Riobaldo Tatarana (a fictional character from Guimarães Rosa's "Grande Sertão: Veredas") and Ted Chiang (contemporary science fiction author).

## Changes
- **New blog post**: `src/content/blog/2026-03-02-travessia.md`
  - Explores the conceptual framework of an impossible correspondence between two literary figures from different contexts
  - Discusses the use of water as a central metaphor for form and transformation
  - Reflects on what AI-generated literary combinations reveal about voice and context
  - Documents 76 letters exchanged between the two characters
  - Includes metadata tags: ficção, literatura, inteligência artificial, grande sertão veredas, correspondência, travessia

## Notable Details
The post is written in Portuguese and serves as both a project announcement and philosophical meditation on literary impossibility, voice authenticity, and the nature of correspondence as a form of traversal across time and context.

https://claude.ai/code/session_01Qdzy1kZWeecaPREFLast8M