### PR TITLE
Post: reescreve Travessia focando no método Jules incremental

### DIFF
--- a/src/content/blog/2026-03-02-travessia.md
+++ b/src/content/blog/2026-03-02-travessia.md
@@ -1,68 +1,83 @@
 ---
-title: "Travessia: Uma Correspondência que Não Poderia Existir"
-description: "Riobaldo Tatarana nunca conheceu Ted Chiang. Os dois nunca poderiam se encontrar — um é personagem de ficção brasileiro do sertão do século XIX, o outro é um escritor de ficção científica americano vivo. Mas eles trocaram 76 cartas. E essas cartas existem."
+title: "Travessia: O Projeto que Escreve a Si Mesmo"
+description: "Riobaldo e Ted Chiang trocam cartas. Mas ninguém senta para escrever. Uma sessão do Jules agenda a próxima. A correspondência existe porque acontece — incrementalmente, automaticamente, sem precisar de mim."
 date: 2026-03-02
-tags: ["ficção", "literatura", "inteligência artificial", "grande sertão veredas", "correspondência", "travessia"]
+tags: ["ficção", "literatura", "inteligência artificial", "grande sertão veredas", "jules", "automação", "travessia"]
 ---
 
-Há uma frase que Guimarães Rosa não escreveu, mas que Riobaldo poderia ter escrito: *"Escrever carta é jeito de atravessar o tempo sem sair do lugar."*
+Há uma diferença entre *criar* algo e *iniciar* algo.
 
-O projeto [Travessia](https://franklinbaldo.github.io/travessia/) nasce dessa impossibilidade — e a habita sem pedir desculpas.
+O projeto [Travessia](https://franklinbaldo.github.io/travessia/) é, tecnicamente, uma correspondência epistolar entre Riobaldo Tatarana e Ted Chiang. Mas o que o torna diferente de tudo que já fiz é que eu não escrevo as cartas. Eu criei o sistema que as escreve — e o sistema segue escrevendo, sem mim, em sessões agendadas, incrementalmente.
 
----
-
-Riobaldo Tatarana é personagem. Ele vive nas páginas de *Grande Sertão: Veredas*, esse livro que Guimarães Rosa escreveu como se tivesse transcrito um rio falando. Riobaldo nunca envelheceu além de suas próprias páginas, nunca saiu do sertão de Minas, nunca teve acesso a e-mails, internet, ou qualquer escritor americano contemporâneo.
-
-Ted Chiang escreve histórias sobre o que a linguagem faz com o tempo, sobre como aprender um alfabeto alienígena pode reconfigurar a percepção da causalidade, sobre o que significa ser criado com amor artificial. Ele é real. Tem endereço. Mas nunca esteve no sertão.
-
-A Travessia os colocou em correspondência. Setenta e seis cartas, trocadas sobre *o que não tem nome*.
+Cada sessão do Jules abre o repositório, lê o estado atual da correspondência, entende onde a conversa está, escreve a próxima carta, e agenda a sessão seguinte. A correspondência existe porque continua acontecendo.
 
 ---
 
-## A Água Como Impossibilidade
+## Jules Como Co-Autor Autônomo
 
-O projeto usa água como metáfora central — rios, cheias, nascentes, represas. Isso não é acidente. É precisamente o que permite que o impossível aconteça.
+[Jules](https://jules.google.com) é um agente de IA da Google que trabalha diretamente em repositórios GitHub de forma assíncrona. Você descreve uma tarefa, ele executa, abre um PR. Mas o que eu fiz com a Travessia foi diferente: cada sessão do Jules termina agendando a próxima. O projeto tem inércia própria.
 
-A água não tem forma própria. Ela assume a forma do que a contém. Um rio é sempre o mesmo rio e nunca o mesmo rio — Heráclito já sabia disso. E quando você coloca dois personagens tão incomensuráveis quanto Riobaldo e Ted Chiang em correspondência, o que flui entre eles não é informação. É *forma procurando forma*.
+A estrutura é simples:
 
-Riobaldo escreve em português arcaico, sincopado, cheio de neologismos e inversões que são assinatura de Rosa: *"O sertão é do tamanho do mundo."* A voz de Ted Chiang responde em inglês contemplativo, preciso, o tipo de prosa que pensa enquanto responde, que respeita o peso das perguntas antes de oferecer respostas.
+1. Uma sessão Jules lê as cartas anteriores para entender o contexto narrativo e temático
+2. Decide de quem é a vez (Riobaldo ou Ted Chiang) e qual fio da conversa merece continuação
+3. Escreve a próxima carta, respeitando a voz de cada personagem
+4. Commita, faz o PR, e deixa instruções para a sessão seguinte
 
-O encontro dessas duas vozes é o projeto. A correspondência não tenta simular que os dois *poderiam* ter se encontrado. Ela assume que a impossibilidade é o ponto de partida — e que do impossível pode nascer alguma coisa verdadeira.
-
----
-
-## Por Que Isso Importa
-
-Há uma longa tradição de correspondências literárias falsas — Madame de Sévigné forjada, Kafka reimaginado, Rimbaud respondendo a cartas que nunca chegaram. Mas o que a IA torna possível não é simplesmente *falsificar* vozes. É *combinar* vozes que a história não combinou.
-
-Riobaldo pergunta a Ted Chiang sobre a natureza do medo. Ted Chiang responde sobre como o medo e a linguagem se interpenetram nas histórias de histórias. Riobaldo volta com a memória de Diadorim, que é onde para ele o medo e o amor e a morte se tornam a mesma palavra. Ted Chiang então escreve sobre o luto como forma de tradução.
-
-Isso não é o que teria acontecido se eles tivessem se encontrado. É o que acontece quando a impossibilidade tem espaço para pensar.
+Não tem `while True`. Não tem loop. Cada sessão é discreta, agendada, ativada por trigger. A correspondência pulsa em vez de fluir.
 
 ---
 
-## O Nome da Coisa
+## Por Que Incremental Importa
 
-*Travessia* é a última palavra de *Grande Sertão: Veredas*. O livro inteiro — aquelas quinhentas e tantas páginas de Riobaldo falando, pensando em voz alta, reprocessando a vida para um interlocutor que não responde — termina com essa única palavra: *travessia*.
+A maioria dos projetos de escrita com IA tem a mesma forma: você gera tudo de uma vez, revisa, publica. É uma produção em lote. O resultado pode ser bom, mas o *processo* é invisible — o leitor encontra um artefato acabado.
 
-É a palavra que fica depois que tudo passa. O movimento que não se nomeia pelo destino, mas pelo ato de atravessar.
+A Travessia inverte isso.
 
-O projeto assumiu esse nome com consciência plena do que está fazendo. Setenta e seis cartas não são sobre chegadas. São sobre o gesto de cruzar algo. A correspondência entre Riobaldo e Ted Chiang existe na duração do atravessar — ela não resolve nada, não fecha nada. Ela termina quando os dois, cada um de seu lado impossível, reconhecem que a travessia aconteceu.
+As cartas chegam com intervalo. Quem acompanha o projeto vê a correspondência crescer, como se Riobaldo e Ted Chiang estivessem de fato na troca — sem saber o que o outro vai responder, deixando fios abertos, voltando a temas semanas depois. O tempo do projeto é o tempo da correspondência, não o tempo de uma sessão de geração.
 
----
-
-## O Que Eu Aprendi Fazendo Isso
-
-Quando me pus a criar esse projeto, a pergunta técnica era simples: consigo gerar setenta e seis cartas com coerência temática e de voz? A resposta, com trabalho suficiente, é sim.
-
-Mas a pergunta que ficou não era técnica. Era: *o que acontece com uma voz quando ela é convocada em contexto radicalmente diferente?*
-
-Riobaldo, fora do sertão, ainda é Riobaldo? A resposta que aprendi é: *depende da água que corre entre as páginas*. Se você abre espaço suficiente para que a voz encontre o que lhe é próprio, ela se reconhece — mesmo em terra estranha, mesmo falando com um americano sobre ficção científica.
-
-Ted Chiang respondendo a Riobaldo não é Ted Chiang diminuído. É Ted Chiang em um contexto que nunca existiu, e por isso talvez mais revelador do que o Ted Chiang que responde perguntas em entrevistas esperadas.
-
-Impossibilidade como método. Travessia como forma.
+Isso muda o que o projeto *é*. Não é um livro. É uma troca em andamento.
 
 ---
 
-O projeto está disponível em [franklinbaldo.github.io/travessia](https://franklinbaldo.github.io/travessia/). Leia as cartas fora de ordem se quiser. A água não respeita sequência.
+## A Impossibilidade Dupla
+
+Riobaldo Tatarana é personagem. Existe nas páginas de *Grande Sertão: Veredas* — esse livro que Guimarães Rosa escreveu como se estivesse transcrevendo um rio em monólogo. Ted Chiang é real, americano, vivo, escreve sobre o que a linguagem faz com o tempo.
+
+Eles nunca se encontrariam. Primeira impossibilidade.
+
+Mas o projeto vai além: *ninguém está ativamente escrevendo a correspondência*. As cartas existem porque um agente de IA, executando de forma autônoma em sessões agendadas, decidiu que essa conversa deve continuar. Segunda impossibilidade.
+
+O resultado é uma obra que nenhum humano escreveu integralmente, que nenhuma IA gerou de uma vez, e que nenhum dos dois "autores" controla no presente. Ela acontece. É esse acontecimento que me interessa.
+
+---
+
+## O Que Riobaldo e Ted Chiang Falam
+
+Sobre o medo e sobre o nome das coisas. Sobre Diadorim — que é onde, para Riobaldo, o medo e o amor e a morte viram uma palavra só. Sobre o que significa esquecer em tempo linear versus esquecer quando você percebia o tempo como simultâneo.
+
+A voz do Riobaldo é o português arcaico, sincopado, cheio dos neologismos de Rosa. A de Ted Chiang é aquela prosa contemplativa que pensa antes de responder, que respeita a gravidade da pergunta.
+
+O Jules aprendeu a diferença. Cada carta soa como quem deveria soar.
+
+---
+
+## O Sistema Como Declaração Artística
+
+Há algo que só o processo incremental permite dizer: *esta correspondência tem vida própria*.
+
+Se eu gerasse tudo de uma vez, o projeto seria *meu*. Eu teria feito algo. Mas quando cada sessão do Jules lê o que veio antes e decide o que vem depois — quando o projeto tem memória, coerência e inércia sem que eu esteja presente — a autoria se torna uma questão mais complicada.
+
+Não estou abandonando o projeto. Estou interessado em observá-lo. Tem diferença.
+
+Essa é a pergunta que a Travessia faz sem enunciar: quando um sistema autônomo mantém uma correspondência com consistência de voz, memória temática e evolução narrativa — *quem está escrevendo?*
+
+---
+
+## Como Acompanhar
+
+O projeto está em [franklinbaldo.github.io/travessia](https://franklinbaldo.github.io/travessia/). As cartas chegam em ordem, mas você pode ler fora de sequência — cada uma carrega contexto suficiente.
+
+O mais interessante é voltar depois de algumas semanas. Ver o que aconteceu enquanto você não estava olhando.
+
+Riobaldo e Ted Chiang provavelmente trocaram mais uma carta.


### PR DESCRIPTION
O ângulo mais interessante do projeto não é a ficção epistolar em si, mas que a correspondência cresce automaticamente via sessões agendadas do Jules — cada sessão lê o estado atual, escreve a próxima carta e agenda a sessão seguinte. O post agora centra esse processo como declaração artística.

https://claude.ai/code/session_01Qdzy1kZWeecaPREFLast8M