### PR TITLE
feat(seo): add robots.txt and structured data for blog posts

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://franklinbaldo.github.io/sitemap-index.xml

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -6,9 +6,11 @@ interface Props {
   title: string;
   description?: string;
   image?: string;
+  type?: "website" | "article";
 }
 
-const { title, description = "A digital memory palace.", image } = Astro.props;
+const { title, description = "A digital memory palace.", image, type = "website" } = Astro.props;
+const canonicalURL = new URL(Astro.url.pathname, Astro.site);
 ---
 
 <!doctype html>
@@ -20,13 +22,16 @@ const { title, description = "A digital memory palace.", image } = Astro.props;
     <meta name="generator" content={Astro.generator} />
     <title>{title}</title>
     <meta name="description" content={description} />
+    <link rel="canonical" href={canonicalURL} />
     <ClientRouter />
     
     <!-- Open Graph / Facebook -->
-    <meta property="og:type" content="website" />
+    <meta property="og:type" content={type} />
     <meta property="og:url" content={Astro.url} />
     <meta property="og:title" content={title} />
     <meta property="og:description" content={description} />
+    <meta property="og:site_name" content="The Chronicle" />
+    <meta property="og:locale" content="en_US" />
     {image && <meta property="og:image" content={new URL(image, Astro.url)} />}
 
     <!-- Twitter -->

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -20,9 +20,25 @@ const formatDate = (date: Date) => {
     day: 'numeric',
   }).format(date);
 };
+
+const schema = {
+  "@context": "https://schema.org",
+  "@type": "BlogPosting",
+  "headline": post.data.title,
+  "description": post.data.description,
+  "image": post.data.heroImage ? new URL(post.data.heroImage, Astro.site) : undefined,
+  "author": {
+    "@type": "Person",
+    "name": post.data.author || "Franklin Baldo"
+  },
+  "datePublished": post.data.date.toISOString(),
+  "dateModified": post.data.updatedDate ? post.data.updatedDate.toISOString() : post.data.date.toISOString(),
+  "url": new URL(Astro.url.pathname, Astro.site)
+};
 ---
 
-<Layout title={post.data.title} description={post.data.description} image={post.data.heroImage}>
+<Layout title={post.data.title} description={post.data.description} image={post.data.heroImage} type="article">
+  <script type="application/ld+json" set:html={JSON.stringify(schema)} />
   <article class="max-w-2xl mx-auto py-8 font-serif leading-relaxed animate-fade-in">
     <header class="mb-12 text-center md:text-left border-b border-[#2a2b36] pb-8 relative">
       <div class="absolute top-0 right-0 text-[10rem] opacity-[0.01] font-serif font-bold text-[#ff9e64] pointer-events-none select-none -z-10 transform translate-x-1/4 -translate-y-1/4">


### PR DESCRIPTION
Generated by neil-patel Jules session (13545797381644019491).

**Changes:**
- `public/robots.txt`: allow all crawlers, link sitemap
- `src/layouts/Layout.astro`: add canonical URL, og:site_name, og:locale, og:type meta tags
- `src/pages/blog/[...slug].astro`: add BlogPosting structured data (JSON-LD), type=article