### PR TITLE
design: editorial clean — warm off-white, serif, earthy accent

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,94 +1,147 @@
 @import "tailwindcss";
 
+/* Editorial Clean — warm off-white, serif-first, quiet accent */
+
 :root {
-  --font-serif: "EB Garamond", serif;
+  --font-serif: "EB Garamond", Georgia, serif;
   --font-mono: "JetBrains Mono", monospace;
-  --color-bg-primary: #000000;
-  --color-text-primary: #ffffff;
-  --color-accent: #ff0000;
-  --color-bg-secondary: #0a0a0a;
+
+  --color-bg:       #faf8f4;   /* warm paper */
+  --color-surface:  #f2efe9;   /* subtle card/sidebar */
+  --color-border:   #d6d0c4;   /* muted warm gray */
+  --color-text:     #1c1917;   /* near-black, warm */
+  --color-muted:    #78716c;   /* stone-500 */
+  --color-accent:   #92400e;   /* amber-800, earthy */
+
   --spacing-container: 44rem;
 }
 
+/* ── Base ──────────────────────────────────────────── */
+
 body {
-  background-color: var(--color-bg-primary);
-  color: var(--color-text-primary);
+  background-color: var(--color-bg);
+  color: var(--color-text);
   font-family: var(--font-serif);
-  line-height: 1.65;
+  font-size: 1.125rem;
+  line-height: 1.75;
   min-height: 100vh;
-  font-feature-settings: "kern", "liga", "clig", "calt";
+  font-feature-settings: "kern", "liga", "clig", "calt", "onum";
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
-p,
-li,
-blockquote {
+/* ── Typography ─────────────────────────────────────── */
+
+p, li, blockquote {
   max-width: 68ch;
 }
 
-p,
-ul,
-ol,
-blockquote,
-pre {
-  margin-bottom: 1.25rem;
+p, ul, ol, blockquote, pre {
+  margin-bottom: 1.4rem;
 }
 
 h1, h2, h3, h4, h5, h6 {
-  font-family: var(--font-mono);
-  font-weight: 700;
-  color: var(--color-text-primary);
-  text-transform: uppercase;
-  letter-spacing: -0.05em;
+  font-family: var(--font-serif);
+  font-weight: 600;
+  color: var(--color-text);
+  letter-spacing: -0.02em;
+  line-height: 1.2;
+  margin-bottom: 0.5em;
+  margin-top: 2em;
 }
 
-code, pre {
-  font-family: var(--font-mono);
-  background-color: var(--color-bg-secondary);
-  border: 1px solid var(--color-text-primary);
-  padding: 0.1em 0.3em;
-}
+h1 { font-size: 2.25rem; }
+h2 { font-size: 1.6rem; border-bottom: 1px solid var(--color-border); padding-bottom: 0.2em; }
+h3 { font-size: 1.25rem; }
 
-pre {
-  padding: 1rem;
-  overflow-x: auto;
-  line-height: 1.5;
-}
+/* ── Links ──────────────────────────────────────────── */
 
 a {
-  color: var(--color-text-primary);
+  color: var(--color-accent);
   text-decoration: none;
-  border-bottom: 1px solid var(--color-text-primary);
-  transition: none;
+  border-bottom: 1px solid transparent;
+  transition: border-color 0.15s ease;
 }
 
 a:hover {
-  color: var(--color-bg-primary);
-  background-color: var(--color-text-primary);
-  border-bottom-color: var(--color-bg-primary);
+  border-bottom-color: var(--color-accent);
 }
+
+/* ── Code ───────────────────────────────────────────── */
+
+code, pre {
+  font-family: var(--font-mono);
+  font-size: 0.875em;
+  background-color: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 3px;
+  padding: 0.1em 0.35em;
+}
+
+pre {
+  padding: 1.25rem;
+  overflow-x: auto;
+  line-height: 1.5;
+  border-radius: 4px;
+}
+
+pre code {
+  background: none;
+  border: none;
+  padding: 0;
+}
+
+/* ── Blockquote ─────────────────────────────────────── */
+
+blockquote {
+  border-left: 3px solid var(--color-accent);
+  padding-left: 1.25rem;
+  color: var(--color-muted);
+  font-style: italic;
+  margin-left: 0;
+}
+
+/* ── Sidenote ───────────────────────────────────────── */
 
 .sidenote {
   clear: right;
   margin-right: -25%;
   width: 20%;
   font-family: var(--font-mono);
-  font-size: 0.8em;
-  line-height: 1.3;
-  color: var(--color-text-primary);
-  border-left: 1px solid var(--color-text-primary);
-  padding-left: 0.5rem;
+  font-size: 0.78em;
+  line-height: 1.4;
+  color: var(--color-muted);
+  border-left: 2px solid var(--color-border);
+  padding-left: 0.75rem;
 }
+
+/* ── Utility classes used by Astro templates ────────── */
+
+/* Override Tailwind "text-white" / "bg-black" patterns from brutalist era */
+.text-white { color: var(--color-text) !important; }
+.bg-black, .bg-\[\#000\] { background-color: var(--color-bg) !important; }
+.border-white { border-color: var(--color-border) !important; }
+.hover\:bg-white:hover { background-color: var(--color-surface) !important; color: var(--color-text) !important; }
+.hover\:text-black:hover { color: var(--color-text) !important; }
+.text-white\/60, .text-white\/70 { color: var(--color-muted) !important; }
+.group-hover\:text-black { color: var(--color-text) !important; }
+
+/* Index heading — remove monospace uppercase */
+h1.font-mono, h2.font-mono {
+  font-family: var(--font-serif);
+  text-transform: none;
+  letter-spacing: -0.02em;
+}
+
+/* ── Mobile ─────────────────────────────────────────── */
 
 @media (max-width: 768px) {
   body {
-    line-height: 1.6;
+    font-size: 1rem;
+    line-height: 1.7;
   }
 
-  p,
-  li,
-  blockquote {
+  p, li, blockquote {
     max-width: none;
   }
 
@@ -97,7 +150,7 @@ a:hover {
     width: 100%;
     margin-right: 0;
     border-left: none;
-    border-top: 1px solid var(--color-text-primary);
+    border-top: 1px solid var(--color-border);
     padding: 0.5rem 0;
   }
 }


### PR DESCRIPTION
Troca o design brutalista (preto/branco/vermelho) por editorial clean:

**O que muda:**
- Fundo: `#faf8f4` (papel quente) ao invés de preto puro
- Texto: `#1c1917` (quase-preto quente) — mais legível
- Accent: `#92400e` (âmbar/marrom) — discreto, literário
- Tipografia: headings passam a ser serif (EB Garamond) ao invés de monospace uppercase
- Links: cor accent com underline sutil no hover, sem inversão agressiva
- Blockquote: borda esquerda amber, itálico, tom muted
- Code: fundo creme com borda suave

**Mantém:**
- Fonts carregadas (EB Garamond + JetBrains Mono)
- Sidenotes
- Layout/estrutura das páginas (só CSS mudou)

Fecha o design brutalista forçado pelo craig.