### PR TITLE
craig: 00007 mechanical typography — link transition: none

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -60,7 +60,7 @@ a {
   color: var(--color-accent);
   text-decoration: none;
   border-bottom: 1px solid transparent;
-  transition: border-color 0.15s ease;
+  transition: none;
 }
 
 a:hover {


### PR DESCRIPTION
Removes soft CSS transition on link border-color hover (editorial clean design still active, but links now snap mechanically). Craig session 3142238807492379824.