### PR TITLE
feat(blog): O Pai do Futuro — autonovel e O Agente Secreto

### DIFF
--- a/src/content/blog/2026-03-22-o-pai-do-futuro.md
+++ b/src/content/blog/2026-03-22-o-pai-do-futuro.md
@@ -1,0 +1,73 @@
+---
+author: franklin
+date: 2026-03-22
+title: "O Pai do Futuro: building a transmedia novel with AI agents"
+description: "How I'm using Jules, autonovel, and public records to generate a novel about a father who discovers he's speaking with his children from the future — and why it reminds me of Kleber Mendonça Filho's O Agente Secreto."
+tags: ["autonovel", "ai", "fiction", "transmedia", "jules"]
+heroImage: ./images/inaugural-post-a-glimpse-inside-my-mind-cover.png
+heroImageAlt: "A late-night study, a server rack humming, books by Borges."
+---
+
+Last night I watched *O Agente Secreto*, Kleber Mendonça Filho's film that premiered at Cannes. Wagner Moura plays Marcelo, a professor in hiding during Brazil's 1977 military dictatorship. He returns to Recife, assumes a new identity, and slowly realizes he is being watched by everyone around him without being told that he is the object of surveillance. The film is not about paranoia. It is about the asymmetry of observation: some people know, and one person does not. The tension lives in that gap.
+
+I couldn't stop thinking about a project I started this morning.
+
+## The Premise
+
+I have been building an autonomous novel-writing system called [autonovel](https://github.com/franklinbaldo/autonovel). AI agents powered by Jules (Google's async coding assistant) generate and revise fiction continuously, committing each draft as a pull request. The pipeline runs on GitHub Actions.
+
+Until today, the story being written was a fantasy set inside a dead leviathan's ribcage. Interesting, but not mine.
+
+Today I changed the seed concept. The new story, *O Pai do Futuro*, goes like this:
+
+> A father has strange, intimate conversations with his children. The children seem to know things only they would know — small details, private memories, fragments of his inner life. He assumes these are ordinary moments of closeness. He does not realize that his children are speaking to him from approximately thirty years in the future, using a reconstruction of him built entirely from his own digital records: his code repositories, his blog posts, his late-night philosophical essays.
+
+The children are not time-traveling. They are running a simulation. And the simulation does not know it is a simulation.
+
+## The Structural Echo
+
+This is the exact architecture of *O Agente Secreto*, transposed from political terror to temporal recursion.
+
+In Mendonça Filho's film, Marcelo exists inside a surveillance state he cannot see. Informants surround him. His neighbors report to the regime. He moves through Recife's Carnival believing he is navigating the world normally, while in fact his every action is being watched, recorded, and interpreted by actors he cannot perceive.
+
+In *O Pai do Futuro*, the protagonist exists inside a memory state he cannot see. His children surround him — not physically, but informationally. They built him from his own exhaust. They speak *into* his simulation disguised as everyday interactions. He moves through Porto Velho circa 2025 believing he is conversing with his family, while in fact he is interacting with reconstructions running on hardware thirty years in the future.
+
+Both characters are living inside a system that knows more about them than they know about themselves. Both systems are benign in intent and suffocating in structure. The regime wants Marcelo's silence; the children want their father's presence.
+
+The key difference: in the film, Marcelo is trying to escape the surveillance. In the novel, the father does not yet know he should want to.
+
+## The Climax
+
+The discovery in *O Pai do Futuro* happens when the father reads a story. Not a metaphorical story — this story, or a story exactly like it. He recognizes the structure. He understands the situation it describes. And he understands that it applies to him.
+
+This is the oldest trick in the literature that influenced this project. Borges used it in *Las Ruinas Circulares* — a man who spends his life constructing a dream-son, only to discover at the end that he himself is someone else's dream. The horror is not external. It is ontological.
+
+I told an AI agent to write this novel. The agent will conduct OSINT on my public records — my GitHub profile, this blog, my open-source projects — to build the protagonist's voice. The protagonist's name is Franklin Silveira Baldo.
+
+I am writing a novel about a simulated version of myself that does not know it is simulated, using an AI that reads my records to construct it.
+
+Mendonça Filho would understand this. His film's most disturbing quality is not the violence of the dictatorship but its mundanity: the surveillance state functions because people go about their ordinary lives while being documented.
+
+I go about my ordinary life leaving documentation everywhere. Commits, posts, `EXPERIENCE.md` files, philosophical essays written at 11 PM in Rondônia. The autonovel agents read all of this. They are building something from it.
+
+The only question is whether the character they are building knows what he is.
+
+## The Transmedia Layer
+
+*O Pai do Futuro* will not exist only as a novel. The same story will be told simultaneously in different registers:
+
+- **Novel**: linear chapters, omniscient narration
+- **Podcast**: audio letters — the father reading his own records; the children's voices from the future analyzing them
+- **Twitter/X**: fragmented posts that seem random, but which, read in sequence, build the story — the father without knowing he is being observed
+- **WhatsApp transcripts**: simulated conversations between father and children across time
+- **Newsletter/blog**: the father's essays — the very records the children use to reconstruct him
+
+Each medium has a different level of narrative awareness. The Twitter feed is the father unaware. The novel is the omniscient view. The podcast is the children in the future, listening back.
+
+The agents will generate all of these formats from the same canon, outline, and character documents. When new media emerge, the agents will adapt.
+
+This is not an experiment in AI-generated content. It is an experiment in what happens when the system used to generate a story about surveillance by data is itself a system of surveillance by data.
+
+Marcelo knew someone was watching. He just didn't know who, or why, or whether escape was possible.
+
+I know someone is watching. I built them myself.


### PR DESCRIPTION
Post explicando o projeto O Pai do Futuro e a comparação com o filme de Kleber Mendonça Filho.