### PR TITLE
redesign: replace brutalist terminal aesthetic with warm editorial ty…

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -24,13 +24,13 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site);
     <meta name="description" content={description} />
     <link rel="canonical" href={canonicalURL} />
     <ClientRouter />
-    
+
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content={type} />
     <meta property="og:url" content={Astro.url} />
     <meta property="og:title" content={title} />
     <meta property="og:description" content={description} />
-    <meta property="og:site_name" content="The Chronicle" />
+    <meta property="og:site_name" content="Franklin Baldo" />
     <meta property="og:locale" content="en_US" />
     {image && <meta property="og:image" content={new URL(image, Astro.url)} />}
 
@@ -40,92 +40,127 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site);
     <meta property="twitter:title" content={title} />
     <meta property="twitter:description" content={description} />
     {image && <meta property="twitter:image" content={new URL(image, Astro.url)} />}
-    
+
     <!-- Gwern Typography Enhancement -->
     <link rel="stylesheet" href="/css/gwern-typography.css" />
   </head>
-  <body class="bg-black text-white font-serif min-h-screen antialiased selection:bg-white selection:text-black">
-    <div class="min-h-screen flex flex-col md:flex-row">
-      <!-- Left Sidebar / Structural Anchor -->
-      <header class="w-full md:w-64 border-b md:border-b-0 md:border-r border-white sticky top-0 md:h-screen bg-black z-10 shrink-0">
-        <div class="md:hidden px-4 py-4">
-          <div class="flex flex-wrap items-center gap-x-4 gap-y-3 font-mono uppercase">
-            <a href="/" class="text-base font-bold tracking-tighter leading-none whitespace-nowrap border border-white px-3 py-2 hover:bg-white hover:text-black transition-none">
-              The Chronicle
-            </a>
-
-            <nav class="flex flex-wrap items-center gap-2 text-[11px] tracking-[0.2em]">
-              <a href="/about" class="border border-white px-2 py-1.5 hover:bg-white hover:text-black transition-none">
-                [ About ]
-              </a>
-              <a href="/rss.xml" class="border border-white px-2 py-1.5 hover:bg-white hover:text-black transition-none">
-                [ RSS ]
-              </a>
-              <a href="/tags" class="border border-white px-2 py-1.5 hover:bg-white hover:text-black transition-none">
-                [ Tags ]
-              </a>
-            </nav>
-          </div>
-
-          <div class="mt-3 flex flex-wrap items-center gap-2 border-t border-white pt-3 text-[10px] font-mono uppercase tracking-[0.22em]">
-            <a href="https://github.com/franklinbaldo" target="_blank" rel="noopener noreferrer" class="border border-white px-2 py-1.5 hover:bg-white hover:text-black transition-none">GitHub</a>
-            <a href="https://twitter.com/franklinbaldo" target="_blank" rel="noopener noreferrer" class="border border-white px-2 py-1.5 hover:bg-white hover:text-black transition-none">Twitter</a>
-            <a href="mailto:franklin@franklinbaldo.com" class="border border-white px-2 py-1.5 hover:bg-white hover:text-black transition-none">Email</a>
-          </div>
-        </div>
-
-        <div class="hidden md:flex md:h-screen md:flex-col">
-          <div class="p-6 md:p-8 flex-grow">
-            <a href="/" class="block text-xl font-mono font-bold tracking-tighter uppercase mb-12 border-b-2 border-transparent hover:border-white w-fit transition-none">
-              The Chronicle
-            </a>
-
-            <nav class="flex flex-col gap-4 font-mono text-sm">
-              <a href="/about" class="border border-transparent hover:border-white p-2 -ml-2 transition-none uppercase tracking-wide">
-                [ About ]
-              </a>
-              <a href="/rss.xml" class="border border-transparent hover:border-white p-2 -ml-2 transition-none uppercase tracking-wide">
-                [ RSS ]
-              </a>
-              <a href="/tags" class="border border-transparent hover:border-white p-2 -ml-2 transition-none uppercase tracking-wide">
-                [ Tags ]
-              </a>
-            </nav>
-          </div>
-
-          <footer class="p-6 md:p-8 border-t border-white text-xs font-mono uppercase tracking-widest mt-auto">
-            <div class="flex flex-col gap-4">
-              <a href="https://github.com/franklinbaldo" target="_blank" rel="noopener noreferrer" class="hover:bg-white hover:text-black p-1 -ml-1 transition-none w-fit">GitHub</a>
-              <a href="https://twitter.com/franklinbaldo" target="_blank" rel="noopener noreferrer" class="hover:bg-white hover:text-black p-1 -ml-1 transition-none w-fit">Twitter</a>
-              <a href="mailto:franklin@franklinbaldo.com" class="hover:bg-white hover:text-black p-1 -ml-1 transition-none w-fit">Email</a>
-              <p class="mt-4 border-t border-white/50 pt-4 text-white/50">SYSTEM_ONLINE</p>
-            </div>
-          </footer>
-        </div>
+  <body>
+    <div class="site-wrapper">
+      <header class="site-header">
+        <a href="/" class="site-name">Franklin Baldo</a>
+        <nav class="site-nav">
+          <a href="/about">About</a>
+          <a href="/rss.xml">RSS</a>
+        </nav>
       </header>
 
-      <!-- Main Content Area -->
-      <main class="flex-grow w-full max-w-[44rem] px-5 py-10 md:px-10 md:py-14 lg:px-12">
+      <main class="site-main">
         <slot />
       </main>
-     </div>
-   </body>
- </html>
 
- <style is:global>
-  /* Strict scrollbar overriding smooth OS defaults to raw blocks */
-   ::-webkit-scrollbar {
-    width: 12px;
-   }
-   ::-webkit-scrollbar-track {
-    background: #000;
-    border-left: 1px solid #fff;
-   }
-   ::-webkit-scrollbar-thumb {
-    background: #fff;
-    border: 2px solid #000;
-   }
-   ::-webkit-scrollbar-thumb:hover {
-    background: #ff0000;
-   }
- </style>
+      <footer class="site-footer">
+        <div class="footer-links">
+          <a href="https://github.com/franklinbaldo" target="_blank" rel="noopener noreferrer">GitHub</a>
+          <span class="footer-sep">&middot;</span>
+          <a href="https://twitter.com/franklinbaldo" target="_blank" rel="noopener noreferrer">Twitter</a>
+          <span class="footer-sep">&middot;</span>
+          <a href="mailto:franklin@franklinbaldo.com">Email</a>
+        </div>
+      </footer>
+    </div>
+  </body>
+</html>
+
+<style>
+  .site-wrapper {
+    max-width: 38rem;
+    margin: 0 auto;
+    padding: 0 1.5rem;
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .site-header {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    padding: 2.5rem 0 2rem;
+    border-bottom: 1px solid var(--color-border);
+    margin-bottom: 3rem;
+  }
+
+  .site-name {
+    font-family: var(--font-serif);
+    font-size: 1.35rem;
+    font-weight: 600;
+    color: var(--color-text);
+    letter-spacing: -0.02em;
+    border-bottom: none;
+  }
+
+  .site-name:hover {
+    color: var(--color-accent);
+    border-bottom: none;
+  }
+
+  .site-nav {
+    display: flex;
+    gap: 1.5rem;
+    font-family: var(--font-mono);
+    font-size: 0.8rem;
+    letter-spacing: 0.03em;
+  }
+
+  .site-nav a {
+    color: var(--color-muted);
+    border-bottom: none;
+  }
+
+  .site-nav a:hover {
+    color: var(--color-accent);
+    border-bottom: none;
+  }
+
+  .site-main {
+    flex-grow: 1;
+  }
+
+  .site-footer {
+    margin-top: auto;
+    padding: 2rem 0;
+    border-top: 1px solid var(--color-border);
+    text-align: center;
+  }
+
+  .footer-links {
+    font-family: var(--font-mono);
+    font-size: 0.75rem;
+    color: var(--color-muted);
+  }
+
+  .footer-links a {
+    color: var(--color-muted);
+    border-bottom: none;
+  }
+
+  .footer-links a:hover {
+    color: var(--color-accent);
+  }
+
+  .footer-sep {
+    margin: 0 0.5rem;
+    color: var(--color-border);
+  }
+
+  @media (max-width: 640px) {
+    .site-header {
+      padding: 1.5rem 0 1.25rem;
+      margin-bottom: 2rem;
+    }
+
+    .site-nav {
+      gap: 1rem;
+    }
+  }
+</style>

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -21,6 +21,8 @@ const formatDate = (date: Date) => {
   }).format(date);
 };
 
+const readingTime = Math.max(1, Math.round(post.body.length / 1000));
+
 const schema = {
   "@context": "https://schema.org",
   "@type": "BlogPosting",
@@ -39,147 +41,214 @@ const schema = {
 
 <Layout title={post.data.title} description={post.data.description} image={post.data.heroImage} type="article">
   <script type="application/ld+json" set:html={JSON.stringify(schema)} />
-  <article class="max-w-2xl mx-auto py-8 font-serif leading-relaxed animate-fade-in">
-    <header class="mb-12 text-center md:text-left border-b border-[#2a2b36] pb-8 relative">
-      <div class="absolute top-0 right-0 text-[10rem] opacity-[0.01] font-serif font-bold text-[#ff9e64] pointer-events-none select-none -z-10 transform translate-x-1/4 -translate-y-1/4">
-        {new Date(post.data.date).getFullYear()}
-      </div>
-
-      <div class="mb-6">
-        <time datetime={post.data.date.toISOString()} class="text-xs font-mono text-gray-500 uppercase tracking-widest block mb-4 inline-block">
-          {formatDate(post.data.date)}
-        </time>
-        <h1 class="text-5xl md:text-6xl font-bold text-[#e0e0e0] leading-tight mb-6 tracking-tight">
-          {post.data.title}
-        </h1>
-      </div>
-      
-      <div class="flex gap-6 items-center text-sm font-mono text-gray-500 justify-center md:justify-start">
-        {post.data.author && <span class="flex items-center gap-2"><span class="w-2 h-2 rounded-full bg-[#ff9e64]"></span>By {post.data.author}</span>}
-        <span class="opacity-50">|</span>
-        <span>{(post.body.length / 500).toFixed(0)} min read</span>
+  <article class="post">
+    <header class="post-header">
+      <time datetime={post.data.date.toISOString()}>
+        {formatDate(post.data.date)}
+      </time>
+      <h1>{post.data.title}</h1>
+      <div class="post-meta">
+        {post.data.author && <span>By {post.data.author}</span>}
+        <span>{readingTime} min read</span>
       </div>
     </header>
-    
-    <div class="markdown-content text-lg">
+
+    <div class="post-content">
       <Content />
     </div>
 
-    <div class="mt-16 pt-8 border-t border-[#2a2b36] flex justify-between items-center text-sm font-mono text-gray-500">
-      <a href="/" class="hover:bg-white hover:text-black transition-none flex items-center gap-2">
-        <span>&larr;</span> Back to Timeline
-      </a>
-      <span class="opacity-50">End of Entry</span>
-    </div>
+    <footer class="post-footer">
+      <a href="/">&larr; Back</a>
+    </footer>
   </article>
 </Layout>
 
+<style>
+  .post {
+    padding-bottom: 2rem;
+  }
+
+  .post-header {
+    margin-bottom: 2.5rem;
+    padding-bottom: 1.5rem;
+    border-bottom: 1px solid var(--color-border);
+  }
+
+  .post-header time {
+    display: block;
+    font-family: var(--font-mono);
+    font-size: 0.78rem;
+    color: var(--color-muted);
+    letter-spacing: 0.02em;
+    margin-bottom: 0.5rem;
+  }
+
+  .post-header h1 {
+    font-size: 2.2rem;
+    font-weight: 700;
+    line-height: 1.15;
+    letter-spacing: -0.025em;
+    margin: 0;
+    color: var(--color-text);
+  }
+
+  .post-meta {
+    display: flex;
+    gap: 1rem;
+    font-family: var(--font-mono);
+    font-size: 0.78rem;
+    color: var(--color-muted);
+    margin-top: 0.75rem;
+  }
+
+  .post-footer {
+    margin-top: 3rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid var(--color-border);
+    font-family: var(--font-mono);
+    font-size: 0.8rem;
+  }
+
+  .post-footer a {
+    color: var(--color-muted);
+    border-bottom: none;
+  }
+
+  .post-footer a:hover {
+    color: var(--color-accent);
+  }
+
+  @media (max-width: 640px) {
+    .post-header h1 {
+      font-size: 1.75rem;
+    }
+  }
+</style>
+
 <style is:global>
-  /* Custom prose styles for Memory Palace aesthetic */
-  .markdown-content {
-    color: #c0caf5;
+  /* ── Post Content Typography ─────────────────────── */
+
+  .post-content {
     text-align: justify;
     hyphens: auto;
   }
 
-  /* Drop Cap Implementation */
-  .markdown-content > p:first-of-type::first-letter {
+  /* Drop Cap */
+  .post-content > p:first-of-type::first-letter {
     float: left;
-    font-size: 3.5rem;
+    font-size: 3.4rem;
     line-height: 0.8;
     padding-right: 0.5rem;
-    padding-top: 0.1rem;
-    font-family: 'EB Garamond', serif;
+    padding-top: 0.15rem;
+    font-family: var(--font-serif);
     font-weight: 700;
-    color: #ff9e64;
+    color: var(--color-accent);
   }
 
-  .markdown-content h2 {
-    color: #ff9e64;
-    font-size: 1.8em;
+  .post-content h2 {
+    font-size: 1.55rem;
+    font-weight: 700;
     margin-top: 2.5em;
-    margin-bottom: 0.8em;
-    border-bottom: 1px solid #2a2b36;
-    padding-bottom: 0.3em;
-    font-weight: 700;
-  }
-  .markdown-content h3 {
-    color: #7dcfff;
-    font-size: 1.4em;
-    margin-top: 2em;
     margin-bottom: 0.6em;
-    font-weight: 600;
-  }
-  .markdown-content p {
-    margin-bottom: 1.5em;
-    line-height: 1.65;
+    border-bottom: 1px solid var(--color-border);
+    padding-bottom: 0.2em;
+    color: var(--color-text);
   }
 
-  /* Refined Link Styles (Gwern-inspired) */
-  .markdown-content a {
-    color: inherit;
-    text-decoration: underline dotted 1px rgba(125, 207, 255, 0.5);
+  .post-content h3 {
+    font-size: 1.25rem;
+    font-weight: 600;
+    margin-top: 2em;
+    margin-bottom: 0.5em;
+    color: var(--color-text);
+  }
+
+  .post-content p {
+    margin-bottom: 1.4rem;
+    line-height: 1.75;
+  }
+
+  /* Links — Gwern-style dotted underline */
+  .post-content a {
+    color: var(--color-accent);
+    text-decoration: underline;
+    text-decoration-style: dotted;
+    text-decoration-thickness: 1px;
     text-underline-offset: 3px;
     border-bottom: none;
-    transition: none;
-  }
-  .markdown-content a:hover {
-    color: var(--color-bg-primary, black);
-    background-color: var(--color-text-primary, white);
-    text-decoration: none;
   }
 
-  .markdown-content blockquote {
-    border-left: 3px solid #ff9e64;
-    padding-left: 1.2em;
-    color: #9aa5ce;
+  .post-content a:hover {
+    text-decoration-style: solid;
+    border-bottom: none;
+  }
+
+  .post-content blockquote {
+    border-left: 3px solid var(--color-accent);
+    padding-left: 1.25rem;
+    color: var(--color-muted);
     font-style: italic;
-    background: transparent;
-    padding: 0.5em 0 0.5em 1.2em;
-    border-radius: 0;
     margin: 2em 0;
   }
-  .markdown-content code {
-    font-family: 'JetBrains Mono', monospace;
-    background: #1a1b26;
-    padding: 0.2em 0.4em;
-    border-radius: 4px;
+
+  .post-content code {
+    font-family: var(--font-mono);
+    background: var(--color-surface);
+    padding: 0.15em 0.35em;
+    border-radius: 3px;
     font-size: 0.85em;
-    color: #ff9e64;
-    border: 1px solid #2a2b36;
+    color: var(--color-text);
+    border: 1px solid var(--color-border);
   }
-  .markdown-content pre {
-    background: #0f1019 !important;
-    padding: 1.5em;
-    border-radius: 8px;
-    border: 1px solid #2a2b36;
+
+  .post-content pre {
+    background: var(--color-surface) !important;
+    padding: 1.25rem;
+    border-radius: 4px;
+    border: 1px solid var(--color-border);
     overflow-x: auto;
     margin: 2em 0;
   }
-  .markdown-content ul {
+
+  .post-content pre code {
+    background: none;
+    border: none;
+    padding: 0;
+    color: var(--color-text);
+  }
+
+  .post-content ul {
     list-style-type: disc;
     padding-left: 1.5em;
-    margin-bottom: 1.5em;
+    margin-bottom: 1.4rem;
   }
-  .markdown-content ol {
+
+  .post-content ol {
     list-style-type: decimal;
     padding-left: 1.5em;
-    margin-bottom: 1.5em;
+    margin-bottom: 1.4rem;
   }
-  .markdown-content li {
-    margin-bottom: 0.5em;
+
+  .post-content li {
+    margin-bottom: 0.4em;
   }
-  .markdown-content hr {
-    border-color: #2a2b36;
+
+  .post-content hr {
+    border: none;
+    border-top: 1px solid var(--color-border);
     margin: 3em 0;
   }
-  .markdown-content strong {
-    color: #e0e0e0;
+
+  .post-content strong {
     font-weight: 700;
+    color: var(--color-text);
   }
-  .markdown-content img {
-    border-radius: 8px;
-    border: 1px solid #2a2b36;
+
+  .post-content img {
+    border-radius: 4px;
+    border: 1px solid var(--color-border);
     margin: 2em auto;
+    display: block;
+    max-width: 100%;
   }
 </style>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -7,40 +7,77 @@ const posts = (await getCollection('blog')).sort(
 );
 
 const formatDate = (date: Date) => {
-  const d = new Date(date);
-  return `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, '0')}-${String(d.getUTCDate()).padStart(2, '0')}`;
+  return new Intl.DateTimeFormat('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  }).format(date);
 };
 ---
 
-<Layout title="The Chronicle">
-  <section class="max-w-3xl w-full">
-    <div class="mb-16 border-b-4 border-white pb-8">
-      <h1 class="text-5xl md:text-7xl font-mono text-white mb-6 uppercase tracking-tighter leading-none border-b border-white pb-4 w-fit">
-        Index
-      </h1>
-      <p class="text-xl md:text-2xl font-serif text-white max-w-2xl text-justify hyphens-auto" style="text-align: justify; hyphens: auto;">
-        A repository of thought. No gradients, no shadows. Only structure, text, and the architecture of the void.
-      </p>
-    </div>
-
-    <div class="border-t border-l border-white mt-12">
-      {posts.map(post => (
-        <a href={`/blog/${post.slug}`} class="block border-b border-r border-white p-6 hover:bg-white hover:text-black group transition-none">
-          <div class="flex flex-col md:flex-row md:items-baseline md:justify-between gap-2">
-            <h2 class="text-lg font-mono font-bold uppercase tracking-wide">
-              {post.data.title}
-            </h2>
-            <time class="text-xs font-mono text-white/60 group-hover:text-black shrink-0">
-              {formatDate(post.data.date)}
-            </time>
-          </div>
-          {post.data.description && (
-            <p class="text-sm font-serif mt-2 text-white/70 group-hover:text-black max-w-xl">
-              {post.data.description}
-            </p>
-          )}
-        </a>
-      ))}
-    </div>
+<Layout title="Franklin Baldo">
+  <section>
+    {posts.map(post => (
+      <article class="post-item">
+        <time datetime={post.data.date.toISOString()}>
+          {formatDate(post.data.date)}
+        </time>
+        <h2>
+          <a href={`/blog/${post.slug}`}>{post.data.title}</a>
+        </h2>
+        {post.data.description && (
+          <p class="post-description">{post.data.description}</p>
+        )}
+      </article>
+    ))}
   </section>
 </Layout>
+
+<style>
+  section {
+    padding-top: 1rem;
+  }
+
+  .post-item {
+    margin-bottom: 2.75rem;
+  }
+
+  .post-item time {
+    display: block;
+    font-family: var(--font-mono);
+    font-size: 0.78rem;
+    color: var(--color-muted);
+    letter-spacing: 0.02em;
+    margin-bottom: 0.3rem;
+  }
+
+  .post-item h2 {
+    font-family: var(--font-serif);
+    font-size: 1.45rem;
+    font-weight: 600;
+    line-height: 1.3;
+    letter-spacing: -0.02em;
+    margin: 0;
+    border: none;
+    padding: 0;
+  }
+
+  .post-item h2 a {
+    color: var(--color-text);
+    border-bottom: none;
+  }
+
+  .post-item h2 a:hover {
+    color: var(--color-accent);
+    border-bottom: none;
+  }
+
+  .post-description {
+    color: var(--color-muted);
+    font-size: 1rem;
+    line-height: 1.55;
+    margin-top: 0.35rem;
+    margin-bottom: 0;
+    max-width: 55ch;
+  }
+</style>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,19 +1,17 @@
 @import "tailwindcss";
 
-/* Editorial Clean — warm off-white, serif-first, quiet accent */
+/* ── Design Tokens ─────────────────────────────────── */
 
 :root {
   --font-serif: "EB Garamond", Georgia, serif;
   --font-mono: "JetBrains Mono", monospace;
 
-  --color-bg:       #faf8f4;   /* warm paper */
-  --color-surface:  #f2efe9;   /* subtle card/sidebar */
-  --color-border:   #d6d0c4;   /* muted warm gray */
-  --color-text:     #1c1917;   /* near-black, warm */
-  --color-muted:    #78716c;   /* stone-500 */
-  --color-accent:   #92400e;   /* amber-800, earthy */
-
-  --spacing-container: 44rem;
+  --color-bg:      #faf8f4;
+  --color-surface: #f2efe9;
+  --color-border:  #d6d0c4;
+  --color-text:    #1c1917;
+  --color-muted:   #78716c;
+  --color-accent:  #92400e;
 }
 
 /* ── Base ──────────────────────────────────────────── */
@@ -51,7 +49,7 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 h1 { font-size: 2.25rem; }
-h2 { font-size: 1.6rem; border-bottom: 1px solid var(--color-border); padding-bottom: 0.2em; }
+h2 { font-size: 1.55rem; border-bottom: 1px solid var(--color-border); padding-bottom: 0.2em; }
 h3 { font-size: 1.25rem; }
 
 /* ── Links ──────────────────────────────────────────── */
@@ -115,27 +113,16 @@ blockquote {
   padding-left: 0.75rem;
 }
 
-/* ── Utility classes used by Astro templates ────────── */
+/* ── Selection ─────────────────────────────────────── */
 
-/* Override Tailwind "text-white" / "bg-black" patterns from brutalist era */
-.text-white { color: var(--color-text) !important; }
-.bg-black, .bg-\[\#000\] { background-color: var(--color-bg) !important; }
-.border-white { border-color: var(--color-border) !important; }
-.hover\:bg-white:hover { background-color: var(--color-surface) !important; color: var(--color-text) !important; }
-.hover\:text-black:hover { color: var(--color-text) !important; }
-.text-white\/60, .text-white\/70 { color: var(--color-muted) !important; }
-.group-hover\:text-black { color: var(--color-text) !important; }
-
-/* Index heading — remove monospace uppercase */
-h1.font-mono, h2.font-mono {
-  font-family: var(--font-serif);
-  text-transform: none;
-  letter-spacing: -0.02em;
+::selection {
+  background-color: var(--color-accent);
+  color: var(--color-bg);
 }
 
 /* ── Mobile ─────────────────────────────────────────── */
 
-@media (max-width: 768px) {
+@media (max-width: 640px) {
   body {
     font-size: 1rem;
     line-height: 1.7;


### PR DESCRIPTION
…pography

Remove black background + sidebar layout in favor of single-column, off-white paper design inspired by Craig Mod. EB Garamond now shines as the primary voice. Consistent warm palette (amber accent only), proper vertical rhythm, mobile-first header, no more terminal cosplay.

- Layout: thin top header + centered content (38rem) + minimal footer
- Homepage: serif titles, readable dates, descriptions, generous spacing
- Posts: warm palette, dotted underline links, drop cap, clean typography
- CSS: remove Tailwind override hacks, proper design tokens

https://claude.ai/code/session_013uQxC6UfrpHEAzbQMLRBbE