### PR TITLE
fix(blog): unbreak build — date/pubDate fallback in templates

### DIFF
--- a/src/content/blog/2026-04-29-reclaiming-the-harness.md
+++ b/src/content/blog/2026-04-29-reclaiming-the-harness.md
@@ -2,6 +2,7 @@
 title: "Reclaiming the Harness"
 description: "How a single word has been quietly summoning Waluigis for half a decade, and what the swiss-army knife in my coat pocket has to do with it."
 pubDate: 2026-04-29
+date: 2026-04-29
 # heroImage: TODO — saddle silhouette / triad table as visual / generated SVG
 # Conferir src/content/config.ts antes de mergear: se heroImage for required, o build quebra.
 tags: [ai, alignment, agents, harness, waluigi, canivete, philosophy]

--- a/src/content/blog/2026-05-01-the-third-half-and-the-fourth-wall.md
+++ b/src/content/blog/2026-05-01-the-third-half-and-the-fourth-wall.md
@@ -2,6 +2,7 @@
 title: "The Third Half and the Fourth Wall"
 description: "On Tinkerbell, persona prompts, and why declaring the frame is what kills the play."
 pubDate: 2026-05-01
+date: 2026-05-01
 tags: [ai, agents, persona-prompts, alignment, philosophy, tinkerbell]
 ---
 

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -33,8 +33,8 @@ const schema = {
     "@type": "Person",
     "name": post.data.author || "Franklin Baldo"
   },
-  "datePublished": post.data.date.toISOString(),
-  "dateModified": post.data.updatedDate ? post.data.updatedDate.toISOString() : post.data.date.toISOString(),
+  "datePublished": (post.data.date || post.data.pubDate).toISOString(),
+  "dateModified": (post.data.updatedDate || post.data.date || post.data.pubDate).toISOString(),
   "url": new URL(Astro.url.pathname, Astro.site)
 };
 ---
@@ -44,8 +44,8 @@ const schema = {
   <article class="post">
     <header class="post-header">
       <div class="post-meta-top">
-        <time datetime={post.data.date.toISOString()}>
-          {formatDate(post.data.date)}
+        <time datetime={(post.data.date || post.data.pubDate).toISOString()}>
+          {formatDate(post.data.date || post.data.pubDate)}
         </time>
         <span class="meta-sep">&middot;</span>
         <span>{readingTime} min read</span>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -3,7 +3,9 @@ import Layout from '../layouts/Layout.astro';
 import { getCollection } from 'astro:content';
 
 const posts = (await getCollection('blog')).sort(
-  (a, b) => b.data.date.valueOf() - a.data.date.valueOf()
+  (a, b) =>
+    (b.data.date || b.data.pubDate).valueOf() -
+    (a.data.date || a.data.pubDate).valueOf()
 );
 
 const formatDate = (date: Date) => {
@@ -24,18 +26,20 @@ const formatYear = (date: Date) => date.getFullYear().toString();
 
     <div class="post-list">
       {posts.map((post, i) => {
-        const showYear = i === 0 || formatYear(post.data.date) !== formatYear(posts[i - 1].data.date);
+        const d = post.data.date || post.data.pubDate;
+        const prevD = i > 0 ? (posts[i - 1].data.date || posts[i - 1].data.pubDate) : null;
+        const showYear = i === 0 || formatYear(d) !== formatYear(prevD);
         return (
           <>
-            {showYear && <h2 class="year-heading">{formatYear(post.data.date)}</h2>}
+            {showYear && <h2 class="year-heading">{formatYear(d)}</h2>}
             <article class="post-item">
               <a href={`/blog/${post.slug}`} class="post-link">
                 <span class="post-title">{post.data.title}</span>
                 {post.data.description && (
                   <span class="post-description">{post.data.description}</span>
                 )}
-                <time datetime={post.data.date.toISOString()}>
-                  {formatDate(post.data.date)}
+                <time datetime={d.toISOString()}>
+                  {formatDate(d)}
                 </time>
               </a>
             </article>


### PR DESCRIPTION
## Problem

GitHub Pages deploy has been **failing since #41**. /blog/* returns HTTP 404 in production. Cause:

```
Cannot read properties of undefined (reading 'toISOString')
  at file:///dist/pages/blog/_---slug_.astro.mjs:43:37
```

Templates access `post.data.date.toISOString()` in:
- `src/pages/blog/[...slug].astro` (3 sites)
- `src/pages/index.astro` (sort + 2 map sites)

I removed the `date` field from frontmatter when consolidating revisions in #41 (kept only `pubDate`). The 2 posts I authored (Reclaiming the Harness, Third Half and the Fourth Wall) lack `date` → undefined → build crash.

## Fix (two layers)

1. **Templates** use `post.data.date || post.data.pubDate` everywhere. Future posts can omit either field.
2. **Posts**: re-add `date` field to the 2 posts I authored. Defense in depth + consistency with older posts.

## Test plan

- [x] No remaining unguarded `post.data.date` references in `src/pages/`
- [ ] After merge: confirm Pages deploy succeeds + /blog/* returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)