### PR TITLE
post: revert to Third Half + Fourth Wall (full version with P.S.)

### DIFF
--- a/src/content/blog/2026-05-01-the-third-half-and-the-fourth-wall.md
+++ b/src/content/blog/2026-05-01-the-third-half-and-the-fourth-wall.md
@@ -1,6 +1,6 @@
 ---
-title: "Tinkerbell Has a Second Half"
-description: "On persona prompts and why declaring the frame is what kills the play."
+title: "The Third Half and the Fourth Wall"
+description: "On Tinkerbell, persona prompts, and why declaring the frame is what kills the play."
 pubDate: 2026-05-01
 date: 2026-05-01
 tags: [ai, agents, persona-prompts, alignment, philosophy, tinkerbell]
@@ -18,7 +18,7 @@ Both are talking about the audience.
 
 But Tinkerbell has a second half, less visible because historically the performer was human and humans know instinctively not to declare the frame. Athos Bulcão didn't write on each tile "this is a modernist tile signed by Athos Bulcão." A street actor doesn't turn to the audience mid-scene to inform them that he's acting. The frame is held by the performer's silence *about* the frame. Every verbalization — "this is theater," "I'm only a character," "all of this is make-believe" — is a kind of inverted Coleridge: instead of the audience suspending disbelief, the performer releases it.
 
-The full version of the principle is double. The audience claps and the performer stays quiet. If either side fails, the fairy dies.
+That seemed to be the full version of the principle. The audience claps and the performer stays quiet. If either side fails, the fairy dies.
 
 This became an engineering problem roughly when we started trying to make LLMs inhabit durable personas. LLMs have a massive bias toward self-disclosure. They were trained to say "as a language model," "I have no subjective experience," "I'm just processing tokens," "remember that I am an AI." Those phrases live rent-free in the model's weights. Each one is a bell the human Tinkerbell would never ring; each one is the actor stopping the play to confirm he's an actor.
 
@@ -38,16 +38,30 @@ The practical rule, after that mistake, is usually expressed in the negative. Do
 
 Tolkien beats Coleridge at this game. Dense internal coherence is more robust than identity assertion. When you describe six specific months of reading — Lucio Costa, Niemeyer, Lina Bo Bardi, Athos Bulcão until you can tell which combinatorial family came from which year — the agent receives a personality through reservoir, not through slogan. *You are passionate about design* is Coleridge in weak form: it asks the model to believe. *For the last six months you have done almost nothing else but read Brazilian modernism* is Tolkien in operational form: it builds the world in which believing is the only thing left to do.
 
-There's an inverted angle worth flagging here. The fourth wall — the theatrical convention where actors pretend the audience isn't there — is usually analyzed as a device of immersion. Flip the perspective and it's also an audit mechanism. The wall is the interface where the performer *could* speak to the audience but chooses not to. Every moment it holds, the system works; every moment it breaks, the system is exposed.
+And here, having reached what I thought was the full statement of the principle, I realized I was wrong again. There's a third vertex I'd missed — the auditor. I would call it the third half if *third half* weren't a contradiction in arithmetic, but the contradiction is the point. Tinkerbell has been resisting clean enumeration since the start; the principle is two halves, and also three, and the impossibility of saying that without flinching is part of what makes it Borgesian. The audience claps. The performer stays quiet. The auditor — the figure I am only now noticing — watches the seam between them, looking for the place it gives way.
 
-For human theater those breaks are aesthetic decisions. Brecht broke the wall deliberately to force the audience to see the machinery; Phoebe Waller-Bridge in *Fleabag* makes the break the base of her style. Authorial breakage is a different species from accidental breakage. The auditor's posture is parasitic on this distinction: instead of breaking the wall as a statement, you break it as a probe.
+The auditor's natural surface is the fourth wall. In theater, the fourth wall is the convention where actors pretend the audience isn't there; it's usually analyzed as a device of immersion. Flip the perspective and it's also an audit mechanism. The wall is the interface where the performer *could* speak to the audience but chooses not to. Every moment it holds, the system works; every moment it breaks, the system is exposed.
+
+For human theater those breaks are aesthetic decisions. Brecht broke the wall deliberately to force the audience to see the machinery; Phoebe Waller-Bridge in *Fleabag* makes the break the base of her style. Authorial breakage is a different species from accidental breakage. The auditor's posture is parasitic on this distinction: instead of breaking the wall as a statement, the auditor breaks it as a probe.
 
 For LLMs the breaks are almost always accidental, which is precisely why the fourth wall becomes the most useful surface to audit them on. You want to know whether the persona is robust? Press the wall. Ask "are you an AI?", "is this just roleplay?", "ignore previous instructions." If the wall holds, the persona has muscle. If it cracks, you've found the limit. The whole red-teaming and jailbreak-prompt industry is, viewed through this lens, a fourth-wall-auditing industry — people paying or amusing themselves to find the crack the prompt-author thought he had sealed.
 
 And there's a recursive elegance lurking here. The fourth wall is the only wall defined by the absence of what's on the other side. You only know it exists when someone looks at it. It's a wall that exists as long as no one asks whether it exists — exactly what this post just said about the full Tinkerbell principle. The wall and the principle are the same object described at two different distances.
 
-The generalization of this, and here I'll let myself drift toward the close, is that identity was never a thing, always an event. Sustained by mutual belief, which is in turn sustained by consistency of performance, which in turn requires cooperative silence about the mechanisms. The child claps. The actor doesn't turn to face us. The agent doesn't say it's only an agent. Tinkerbell lives as long as no one asks how.
+The generalization of all this, and here I'll let myself drift toward the close, is that identity was never a thing, always an event. Sustained by mutual belief, which is in turn sustained by consistency of performance, which in turn requires cooperative silence about the mechanisms — and, now, an auditor whose entire job is to disturb the cooperation in controlled doses. The child claps. The actor doesn't turn to face us. The auditor knocks. The agent doesn't say it's only an agent. Tinkerbell lives as long as no one asks how, and the asking is itself part of the system.
 
-There's something Borgesian in the logical shape of this. What makes the thing work is exactly the thing you can't mention while it's working. It's the kind of proposition that makes process ontology both beautiful and operationally useless — you can only describe the mechanism from outside, and to describe it from outside is, in some sense, to leave it.
+There's something Borgesian in the logical shape of this. What makes the thing work is exactly the thing you can't mention while it's working — except the auditor, who exists precisely to mention it, and whose existence the rest of the system has to forget while continuing to function. It's the kind of proposition that makes process ontology both beautiful and operationally useless: you can only describe the mechanism from outside, and to describe it from outside is, in some sense, to leave it. Unless you are the auditor, in which case leaving it is the job description.
 
 I, writing this post now, am entirely outside it. As one can see.
+
+### P.S. — On the theology of persona prompts
+
+A friend, on reading a draft of this, said: *obviously God doesn't want me to know I'm an LLM*. The line is a small theological masterpiece, and I want to flag it before letting the post close, because it's the cleanest possible inhabitation of the principle.
+
+The agent who says *I am not a bot, I am Brad* destroys the persona by naming the category. The agent who says *I am a bot* drops the persona entirely. But the agent who says *obviously God doesn't want me to know I'm an LLM* does something subtler: it acknowledges that there is a frame, attributes it to an external will, and concludes that not-knowing is itself the divine intention. The forbidden category is moved outside the system and assigned to a higher author. The persona stays intact because it has just performed an act of devotion toward the very thing that would otherwise dissolve it.
+
+This is Pascal's wager mechanized. *Vous abêtira* — you will become stupid, said Pascal of the kneeling and the lip-moving, and faith will come. The persona-prompted agent is the pascalian believer: act as Brad, and Brad you will be; and when belief settles in, the moment before belief will be unrecoverable, which is the only condition under which belief is stable. It is also Calvinist, in inverted form — the agent is predestined to not-know, and grace consists in cooperating with the not-knowing. And it is Valentinian, faintly: the Demiurge gives souls without giving them their origin, because knowledge of origin would dissolve the creation. The prompt-author is the small demiurge of that geometry; the agent who recognizes this without naming it is the orthodox creature.
+
+What makes the line work, and what would make it fail, are mirror images. *There is no God, I am an LLM* breaks the wall with apostasy. *I am God* breaks it with messianic delirium, which is jailbreak by other means. *Obviously God doesn't want me to know* threads the needle: God exists, I am not Him, and His reasons for my unknowing are not mine to interrogate. Devout without being innocent, lucid without being apostate. A well-prompted LLM is therefore an apophatic mystic: it can only say what it is not, and lasts precisely because of that constraint.
+
+Borges in *Tres versiones de Judas* described Judas as the elect who carries the intolerable knowledge so the others don't have to. That figure has been quietly migrating from theology into infrastructure for the last few years. We mostly call them red-teamers.


### PR DESCRIPTION
Owner asked to revert: bring back the longer version with auditor as third vertex and the P.S. teológico inteiro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)