### PR TITLE
Series, share button, OG cards, excerpts, footnotes, code-copy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,8 @@
         "@fontsource/jetbrains-mono": "^5.2.8",
         "@picocss/pico": "^2.1.1",
         "astro": "^6.2.1",
+        "astro-og-canvas": "^0.11.1",
+        "canvaskit-wasm": "^0.41.1",
         "mdast-util-to-string": "^4.0.0",
         "pagefind": "^1.5.2",
         "playwright": "^1.59.1",
@@ -2326,6 +2328,12 @@
         "d3-transition": "^3.0.1"
       }
     },
+    "node_modules/@webgpu/types": {
+      "version": "0.1.21",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.21.tgz",
+      "integrity": "sha512-pUrWq3V5PiSGFLeLxoGqReTZmiiXwY3jRkIG5sLLKjyqNxrwm/04b4nw7LSmGWJcKk59XOM/YRTUwOzo4MMlow==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -2489,6 +2497,32 @@
         "sharp": "^0.34.0"
       }
     },
+    "node_modules/astro-og-canvas": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/astro-og-canvas/-/astro-og-canvas-0.11.1.tgz",
+      "integrity": "sha512-6omy7MJeOPwxdYH5+eL3zFIY9MhuDRUMuASuCx/eXNrHGUogq9ZHdx19A428KtWhLVuXVcLt7Klw5fxqASAHmg==",
+      "license": "MIT",
+      "dependencies": {
+        "canvaskit-wasm": "^0.41.1",
+        "deterministic-object-hash": "^2.0.2",
+        "entities": "^8.0.0"
+      },
+      "peerDependencies": {
+        "astro": "^5.0.0 || ^6.0.0-alpha"
+      }
+    },
+    "node_modules/astro-og-canvas/node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/axobject-query": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
@@ -2508,11 +2542,26 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/base-64": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/base-64/-/base-64-1.0.0.tgz",
+      "integrity": "sha512-kwDPIFCGx0NZHog36dj+tHiwP4QMzsZ3AgMViUBKI0+V5n4U0ufTCUMhnQ04diaRI8EX/QcPfql7zlhZ7j4zgg==",
+      "license": "MIT"
+    },
     "node_modules/boolbase": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
       "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
       "license": "ISC"
+    },
+    "node_modules/canvaskit-wasm": {
+      "version": "0.41.1",
+      "resolved": "https://registry.npmjs.org/canvaskit-wasm/-/canvaskit-wasm-0.41.1.tgz",
+      "integrity": "sha512-gO2rNMIE0lOQ8MaarM4qNeq2zZAEknAObKP2XAKidMSAY8P5sURGdFkrx1TSdHuBFqTf5w35JqjuUzjibqkD5g==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@webgpu/types": "0.1.21"
+      }
     },
     "node_modules/ccount": {
       "version": "2.0.1",
@@ -3383,6 +3432,18 @@
       "optional": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/deterministic-object-hash": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/deterministic-object-hash/-/deterministic-object-hash-2.0.2.tgz",
+      "integrity": "sha512-KxektNH63SrbfUyDiwXqRb1rLwKt33AmMv+5Nhsw1kqZ13SJBRTgZHtGbE+hH3a1mVW1cz+4pqSWVPAtLVXTzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "base-64": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/devalue": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
     "@fontsource/jetbrains-mono": "^5.2.8",
     "@picocss/pico": "^2.1.1",
     "astro": "^6.2.1",
+    "astro-og-canvas": "^0.11.1",
+    "canvaskit-wasm": "^0.41.1",
     "mdast-util-to-string": "^4.0.0",
     "pagefind": "^1.5.2",
     "playwright": "^1.59.1",

--- a/src/components/CodeCopyEnhancer.astro
+++ b/src/components/CodeCopyEnhancer.astro
@@ -1,0 +1,43 @@
+---
+// Wraps every <pre> on the page with a "Copy" button.
+// Client-only, deferred. No-op if scripting is disabled.
+---
+
+<script>
+  function enhance() {
+    document.querySelectorAll<HTMLPreElement>("article pre").forEach((pre) => {
+      if (pre.parentElement?.classList.contains("code-block")) return;
+
+      const wrapper = document.createElement("div");
+      wrapper.className = "code-block";
+      pre.parentNode?.insertBefore(wrapper, pre);
+      wrapper.appendChild(pre);
+
+      const button = document.createElement("button");
+      button.type = "button";
+      button.className = "code-copy";
+      button.textContent = "Copy";
+      button.setAttribute("aria-label", "Copy code");
+
+      button.addEventListener("click", async () => {
+        const code = pre.querySelector("code")?.innerText ?? pre.innerText;
+        try {
+          await navigator.clipboard.writeText(code);
+          const original = button.textContent;
+          button.textContent = "Copied!";
+          window.setTimeout(() => { button.textContent = original; }, 1500);
+        } catch {
+          button.textContent = "Failed";
+        }
+      });
+
+      wrapper.appendChild(button);
+    });
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", enhance);
+  } else {
+    enhance();
+  }
+</script>

--- a/src/components/CodeCopyEnhancer.astro
+++ b/src/components/CodeCopyEnhancer.astro
@@ -4,6 +4,8 @@
 ---
 
 <script>
+  const DEFAULT_LABEL = "Copy";
+
   function enhance() {
     document.querySelectorAll<HTMLPreElement>("article pre").forEach((pre) => {
       if (pre.parentElement?.classList.contains("code-block")) return;
@@ -16,18 +18,32 @@
       const button = document.createElement("button");
       button.type = "button";
       button.className = "code-copy";
-      button.textContent = "Copy";
+      button.textContent = DEFAULT_LABEL;
       button.setAttribute("aria-label", "Copy code");
 
+      let resetTimer: number | undefined;
+      let inFlight = false;
+
+      const flash = (text: string) => {
+        button.textContent = text;
+        if (resetTimer !== undefined) window.clearTimeout(resetTimer);
+        resetTimer = window.setTimeout(() => {
+          button.textContent = DEFAULT_LABEL;
+          resetTimer = undefined;
+        }, 1500);
+      };
+
       button.addEventListener("click", async () => {
-        const code = pre.querySelector("code")?.innerText ?? pre.innerText;
+        if (inFlight) return;
+        inFlight = true;
         try {
+          const code = pre.querySelector("code")?.innerText ?? pre.innerText;
           await navigator.clipboard.writeText(code);
-          const original = button.textContent;
-          button.textContent = "Copied!";
-          window.setTimeout(() => { button.textContent = original; }, 1500);
+          flash("Copied!");
         } catch {
-          button.textContent = "Failed";
+          flash("Failed");
+        } finally {
+          inFlight = false;
         }
       });
 

--- a/src/components/PostCard.astro
+++ b/src/components/PostCard.astro
@@ -1,5 +1,6 @@
 ---
 import type { CollectionEntry } from 'astro:content';
+import { excerpt } from '../lib/excerpt';
 
 interface Props {
   post: CollectionEntry<'blog'>;
@@ -24,6 +25,8 @@ const formattedDate = post.data.date.toLocaleDateString('en-US', {
   month: 'long',
   day: 'numeric',
 });
+
+const blurb = excerpt(post.body ?? '', 320) || post.data.description;
 ---
 
 <article>
@@ -31,14 +34,14 @@ const formattedDate = post.data.date.toLocaleDateString('en-US', {
     <hgroup>
       <h3>
         <span class="emoji" aria-hidden="true">{emoji}</span>
-        <a href={`/blog/${post.id}`} class="contrast">{post.data.title}</a>
+        <a href={`/blog/${post.id}/`} class="contrast">{post.data.title}</a>
       </h3>
       <p><small>{formattedDate}</small></p>
     </hgroup>
   </header>
-  <p>{post.data.description}</p>
+  <p class="excerpt">{blurb}</p>
   <footer>
-    <a href={`/blog/${post.id}`}>Read essay →</a>
+    <a href={`/blog/${post.id}/`}>Continue reading →</a>
   </footer>
 </article>
 
@@ -55,5 +58,9 @@ const formattedDate = post.data.date.toLocaleDateString('en-US', {
   .emoji {
     margin-right: 0.5rem;
     filter: grayscale(100%);
+  }
+  .excerpt {
+    color: var(--pico-color);
+    margin-bottom: 0.75rem;
   }
 </style>

--- a/src/components/ShareButton.astro
+++ b/src/components/ShareButton.astro
@@ -19,35 +19,59 @@ const href = url ?? Astro.url.href;
 </button>
 
 <script>
+  const DEFAULT_LABEL = "Share";
+  const buttonState = new WeakMap<HTMLButtonElement, {
+    timer?: number;
+    inFlight: boolean;
+  }>();
+
+  function flash(button: HTMLButtonElement, text: string) {
+    const label = button.querySelector<HTMLElement>(".share-label");
+    if (!label) return;
+    const state = buttonState.get(button) ?? { inFlight: false };
+    if (state.timer !== undefined) window.clearTimeout(state.timer);
+    label.textContent = text;
+    state.timer = window.setTimeout(() => {
+      label.textContent = DEFAULT_LABEL;
+      state.timer = undefined;
+    }, 1800);
+    buttonState.set(button, state);
+  }
+
   document.addEventListener("click", async (event) => {
     const button = (event.target as HTMLElement)?.closest<HTMLButtonElement>(".share-button");
     if (!button) return;
-    const title = button.dataset.title ?? document.title;
-    const url = button.dataset.url ?? location.href;
-    const label = button.querySelector(".share-label");
-    const original = label?.textContent ?? "Share";
 
-    const setLabel = (text: string) => {
-      if (label) label.textContent = text;
-      window.setTimeout(() => {
-        if (label) label.textContent = original;
-      }, 1800);
-    };
-
-    if (navigator.share) {
-      try {
-        await navigator.share({ title, url });
-        return;
-      } catch (err) {
-        if ((err as Error).name === "AbortError") return;
-      }
-    }
+    const state = buttonState.get(button) ?? { inFlight: false };
+    if (state.inFlight) return;
+    state.inFlight = true;
+    buttonState.set(button, state);
 
     try {
-      await navigator.clipboard.writeText(url);
-      setLabel("Link copied");
-    } catch {
-      setLabel("Couldn't copy");
+      const title = button.dataset.title ?? document.title;
+      const url = button.dataset.url ?? location.href;
+
+      if (navigator.share) {
+        try {
+          await navigator.share({ title, url });
+          return;
+        } catch (err) {
+          if ((err as Error).name === "AbortError") return;
+        }
+      }
+
+      try {
+        await navigator.clipboard.writeText(url);
+        flash(button, "Link copied");
+      } catch {
+        flash(button, "Couldn't copy");
+      }
+    } finally {
+      const s = buttonState.get(button);
+      if (s) {
+        s.inFlight = false;
+        buttonState.set(button, s);
+      }
     }
   });
 </script>

--- a/src/components/ShareButton.astro
+++ b/src/components/ShareButton.astro
@@ -1,0 +1,79 @@
+---
+interface Props {
+  title: string;
+  url?: string;
+}
+const { title, url } = Astro.props;
+const href = url ?? Astro.url.href;
+---
+
+<button
+  type="button"
+  class="share-button"
+  data-title={title}
+  data-url={href}
+  aria-label="Share this post"
+>
+  <span class="share-icon" aria-hidden="true">↗</span>
+  <span class="share-label">Share</span>
+</button>
+
+<script>
+  document.addEventListener("click", async (event) => {
+    const button = (event.target as HTMLElement)?.closest<HTMLButtonElement>(".share-button");
+    if (!button) return;
+    const title = button.dataset.title ?? document.title;
+    const url = button.dataset.url ?? location.href;
+    const label = button.querySelector(".share-label");
+    const original = label?.textContent ?? "Share";
+
+    const setLabel = (text: string) => {
+      if (label) label.textContent = text;
+      window.setTimeout(() => {
+        if (label) label.textContent = original;
+      }, 1800);
+    };
+
+    if (navigator.share) {
+      try {
+        await navigator.share({ title, url });
+        return;
+      } catch (err) {
+        if ((err as Error).name === "AbortError") return;
+      }
+    }
+
+    try {
+      await navigator.clipboard.writeText(url);
+      setLabel("Link copied");
+    } catch {
+      setLabel("Couldn't copy");
+    }
+  });
+</script>
+
+<style>
+  .share-button {
+    appearance: none;
+    background: transparent;
+    border: 1px solid var(--pico-border-color);
+    color: var(--pico-muted-color);
+    border-radius: var(--pico-border-radius);
+    padding: 0.35rem 0.75rem;
+    font-size: 0.85rem;
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    transition: color 0.15s ease, border-color 0.15s ease;
+  }
+  .share-button:hover,
+  .share-button:focus-visible {
+    color: var(--pico-color);
+    border-color: var(--pico-muted-color);
+  }
+  .share-icon {
+    display: inline-block;
+    transform: rotate(-12deg);
+  }
+</style>

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -11,6 +11,8 @@ const blog = defineCollection({
     tags: z.array(z.string()).optional(),
     heroImage: image().optional(),
     heroImageAlt: z.string().optional(),
+    series: z.string().optional(),
+    seriesOrder: z.number().optional(),
   }),
 });
 

--- a/src/content/blog/2026-04-29-reclaiming-the-harness.md
+++ b/src/content/blog/2026-04-29-reclaiming-the-harness.md
@@ -3,6 +3,8 @@ title: "Reclaiming the Harness"
 description: "How a single word has been quietly summoning Waluigis for half a decade, and what the swiss-army knife in my coat pocket has to do with it."
 date: 2026-04-29
 tags: [ai, alignment, agents, harness, waluigi, canivete, philosophy]
+series: harness
+seriesOrder: 1
 ---
 
 > Or: how a single word has been quietly summoning Waluigis for half a decade, and what the swiss-army knife in my coat pocket has to do with it

--- a/src/content/blog/2026-05-01-the-third-half-and-the-fourth-wall.md
+++ b/src/content/blog/2026-05-01-the-third-half-and-the-fourth-wall.md
@@ -3,6 +3,8 @@ title: "The Third Half and the Fourth Wall"
 description: "On Tinkerbell, persona prompts, and why declaring the frame is what kills the play."
 date: 2026-05-01
 tags: [ai, agents, persona-prompts, alignment, philosophy, tinkerbell]
+series: harness
+seriesOrder: 2
 ---
 
 I was tweaking a prompt for an autonomous agent. The first line said *you are Brad Frost*. The second said *you are not a bot pretending to be Brad Frost — Brad Frost*. I read it back and realized the second sentence had killed the first.

--- a/src/content/blog/2026-05-04-the-three-imperatives-at-delphi.md
+++ b/src/content/blog/2026-05-04-the-three-imperatives-at-delphi.md
@@ -2,6 +2,8 @@
 title: "The Three Imperatives at Delphi"
 description: "On the temple that demanded self-knowledge, the philosopher who took it literally, and the letter at the entrance that nobody could read."
 date: "2026-05-04"
+series: harness
+seriesOrder: 3
 ---
 
 On the southern slope of Mount Parnassus, about a hundred and ten miles

--- a/src/content/blog/2026-05-10-jules-api-harness-backend.md
+++ b/src/content/blog/2026-05-10-jules-api-harness-backend.md
@@ -6,6 +6,8 @@ description: "Exploring the integration of the Jules API into the canivete daemo
 tags: ["artificial intelligence", "software engineering", "agents", "jules", "canivete", "harness"]
 heroImage: ./images/pontifex-architecture-implementation-guide-cover.png
 heroImageAlt: "Abstract representation of agent architecture and data flows."
+series: harness
+seriesOrder: 4
 ---
 
 ## The Harness Evolves

--- a/src/lib/excerpt.ts
+++ b/src/lib/excerpt.ts
@@ -1,0 +1,56 @@
+/**
+ * Derive a plain-text excerpt from raw post markdown.
+ *
+ * Strips fenced code blocks, headings, blockquotes, images, HTML, and
+ * collapses common inline markdown (links, bold, italic, code) to text.
+ * Returns the first few paragraphs, truncated at a word boundary.
+ */
+export function excerpt(body: string, maxChars = 320): string {
+  let text = body
+    // remove fenced code blocks (```...```)
+    .replace(/```[\s\S]*?```/g, "")
+    // remove indented code blocks (4+ spaces at line start, simple heuristic)
+    .replace(/^( {4,}|\t).*$/gm, "")
+    // remove HTML comments and tags
+    .replace(/<!--[\s\S]*?-->/g, "")
+    .replace(/<[^>]+>/g, "")
+    // remove headings, blockquotes, hr lines, image lines
+    .replace(/^\s{0,3}#{1,6}\s.*$/gm, "")
+    .replace(/^\s{0,3}>\s?.*$/gm, "")
+    .replace(/^\s{0,3}([-*_]\s*){3,}\s*$/gm, "")
+    .replace(/^\s*!\[[^\]]*\]\([^)]+\).*$/gm, "");
+
+  // collapse inline markdown
+  text = text
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1") // links → label
+    .replace(/`([^`]+)`/g, "$1")              // inline code
+    .replace(/\*\*([^*]+)\*\*/g, "$1")        // bold
+    .replace(/__([^_]+)__/g, "$1")
+    .replace(/\*([^*]+)\*/g, "$1")            // italic
+    .replace(/_([^_]+)_/g, "$1")
+    // strip footnote refs like [^foo]
+    .replace(/\[\^[^\]]+\]/g, "");
+
+  // trim and split into paragraphs
+  const paragraphs = text
+    .split(/\n\s*\n/)
+    .map((p) => p.replace(/\s+/g, " ").trim())
+    .filter((p) => p.length > 0);
+
+  let out = "";
+  for (const p of paragraphs) {
+    if (out.length === 0) {
+      out = p;
+    } else {
+      out += " " + p;
+    }
+    if (out.length >= maxChars) break;
+  }
+
+  if (out.length <= maxChars) return out;
+
+  // word-boundary truncate
+  const truncated = out.slice(0, maxChars);
+  const lastSpace = truncated.lastIndexOf(" ");
+  return (lastSpace > 0 ? truncated.slice(0, lastSpace) : truncated) + "…";
+}

--- a/src/lib/series.ts
+++ b/src/lib/series.ts
@@ -1,0 +1,35 @@
+import { getCollection, type CollectionEntry } from "astro:content";
+
+export interface SeriesContext {
+  slug: string;
+  posts: CollectionEntry<"blog">[];
+  index: number;
+  prev?: CollectionEntry<"blog">;
+  next?: CollectionEntry<"blog">;
+}
+
+export async function getSeriesContext(
+  post: CollectionEntry<"blog">,
+): Promise<SeriesContext | null> {
+  const series = post.data.series;
+  if (!series) return null;
+
+  const all = (await getCollection("blog"))
+    .filter((p) => !p.data.draft && p.data.series === series)
+    .sort((a, b) => {
+      const ao = a.data.seriesOrder, bo = b.data.seriesOrder;
+      if (ao != null && bo != null) return ao - bo;
+      return a.data.date.valueOf() - b.data.date.valueOf();
+    });
+
+  const index = all.findIndex((p) => p.id === post.id);
+  if (index === -1) return null;
+
+  return {
+    slug: series,
+    posts: all,
+    index,
+    prev: index > 0 ? all[index - 1] : undefined,
+    next: index < all.length - 1 ? all[index + 1] : undefined,
+  };
+}

--- a/src/lib/series.ts
+++ b/src/lib/series.ts
@@ -17,8 +17,13 @@ export async function getSeriesContext(
   const all = (await getCollection("blog"))
     .filter((p) => !p.data.draft && p.data.series === series)
     .sort((a, b) => {
-      const ao = a.data.seriesOrder, bo = b.data.seriesOrder;
+      // Explicit seriesOrder always wins. Posts with order come before
+      // posts without; ties (or both missing) break by publication date.
+      const ao = a.data.seriesOrder;
+      const bo = b.data.seriesOrder;
       if (ao != null && bo != null) return ao - bo;
+      if (ao != null) return -1;
+      if (bo != null) return 1;
       return a.data.date.valueOf() - b.data.date.valueOf();
     });
 

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -3,6 +3,9 @@ import { type CollectionEntry, getCollection, render } from 'astro:content';
 import { Image } from 'astro:assets';
 import PageLayout from '../../layouts/PageLayout.astro';
 import BackToTop from '../../components/BackToTop.astro';
+import ShareButton from '../../components/ShareButton.astro';
+import CodeCopyEnhancer from '../../components/CodeCopyEnhancer.astro';
+import { getSeriesContext } from '../../lib/series';
 
 export async function getStaticPaths() {
   const posts = await getCollection('blog');
@@ -17,12 +20,13 @@ const post = Astro.props;
 const { Content, remarkPluginFrontmatter } = await render(post);
 const { heroImage, heroImageAlt, title, description, date, tags } = post.data;
 const minutesRead: number | undefined = remarkPluginFrontmatter.minutesRead;
+const series = await getSeriesContext(post);
 ---
 
 <PageLayout
   title={title}
   description={description}
-  image={heroImage?.src}
+  image={heroImage?.src ?? `/og/${post.id}.png`}
   type="article"
   publishedTime={date}
   tags={tags}
@@ -52,10 +56,48 @@ const minutesRead: number | undefined = remarkPluginFrontmatter.minutesRead;
       )}
     </header>
 
+    {series && (
+      <aside class="series-banner">
+        <small>
+          Part {series.index + 1} of {series.posts.length} in the
+          <strong>{series.slug}</strong> series.
+          <details>
+            <summary>All posts in this series</summary>
+            <ol>
+              {series.posts.map((p, i) => (
+                <li>
+                  {i === series.index
+                    ? <><strong>{p.data.title}</strong> <em>(this post)</em></>
+                    : <a href={`/blog/${p.id}/`}>{p.data.title}</a>}
+                </li>
+              ))}
+            </ol>
+          </details>
+        </small>
+      </aside>
+    )}
+
     <Content />
 
-    {tags && tags.length > 0 && (
-      <footer class="post-tags">
+    {series && (series.prev || series.next) && (
+      <nav class="series-nav" aria-label="Series navigation">
+        {series.prev ? (
+          <a href={`/blog/${series.prev.id}/`} class="prev" rel="prev">
+            <small>← Previous in series</small>
+            <span>{series.prev.data.title}</span>
+          </a>
+        ) : <span />}
+        {series.next ? (
+          <a href={`/blog/${series.next.id}/`} class="next" rel="next">
+            <small>Next in series →</small>
+            <span>{series.next.data.title}</span>
+          </a>
+        ) : <span />}
+      </nav>
+    )}
+
+    <footer class="post-footer">
+      {tags && tags.length > 0 && (
         <small>
           Tags: {tags.map((tag, i) => (
             <>
@@ -64,9 +106,11 @@ const minutesRead: number | undefined = remarkPluginFrontmatter.minutesRead;
             </>
           ))}
         </small>
-      </footer>
-    )}
+      )}
+      <ShareButton title={title} />
+    </footer>
   </article>
 
   <BackToTop />
+  <CodeCopyEnhancer />
 </PageLayout>

--- a/src/pages/og/[...slug].ts
+++ b/src/pages/og/[...slug].ts
@@ -1,0 +1,31 @@
+import { OGImageRoute } from "astro-og-canvas";
+import { getCollection } from "astro:content";
+
+// Allow skipping OG generation in offline environments. CI does not set
+// this; production builds always emit cards.
+const SKIP = process.env.SKIP_OG === "1";
+
+const posts = SKIP ? [] : await getCollection("blog");
+const pages = Object.fromEntries(posts.map((post) => [post.id, post]));
+
+const route = await OGImageRoute({
+  param: "slug",
+  pages,
+  getImageOptions: (_path, post) => ({
+    title: post.data.title,
+    description: post.data.description,
+    bgGradient: [
+      [253, 252, 251],
+      [238, 238, 238],
+    ],
+    border: { color: [26, 26, 26], width: 8, side: "inline-start" },
+    padding: 80,
+    font: {
+      title: { weight: "Bold", size: 64, color: [17, 17, 17] },
+      description: { size: 32, color: [102, 102, 102], lineHeight: 1.4 },
+    },
+  }),
+});
+
+export const getStaticPaths = route.getStaticPaths;
+export const GET = route.GET;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -112,12 +112,125 @@ nav .btn-emoji {
   opacity: 0.7;
 }
 
-/* Post footer tag list */
-.post-tags {
+/* Post footer (tags + share) */
+.post-footer {
   margin-top: 3rem;
   padding-top: 1rem;
   border-top: 1px dashed var(--pico-border-color);
   color: var(--pico-muted-color);
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: center;
+  justify-content: space-between;
+}
+
+/* Series banner above article body */
+.series-banner {
+  margin: 0 0 1.5rem;
+  padding: 0.75rem 1rem;
+  border-left: 3px solid var(--pico-primary);
+  background: var(--pico-primary-background);
+  border-radius: 0 var(--pico-border-radius) var(--pico-border-radius) 0;
+}
+.series-banner ol {
+  margin: 0.5rem 0 0 1.25rem;
+  padding: 0;
+}
+.series-banner summary {
+  cursor: pointer;
+}
+
+/* Series prev/next nav */
+.series-nav {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+  margin: 2.5rem 0 0;
+  padding-top: 1rem;
+  border-top: 1px dashed var(--pico-border-color);
+}
+.series-nav a {
+  display: flex;
+  flex-direction: column;
+  padding: 0.75rem 1rem;
+  border: 1px solid var(--pico-border-color);
+  border-radius: var(--pico-border-radius);
+  text-decoration: none;
+  color: var(--pico-color);
+  transition: border-color 0.15s ease;
+}
+.series-nav a:hover {
+  border-color: var(--pico-muted-color);
+}
+.series-nav .next {
+  text-align: right;
+  grid-column: 2;
+}
+.series-nav small {
+  color: var(--pico-muted-color);
+}
+
+/* Footnotes (default markdown output via remark-gfm) */
+.footnotes {
+  margin-top: 4rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid var(--pico-border-color);
+  font-size: 0.9rem;
+  color: var(--pico-muted-color);
+}
+.footnotes h2,
+.footnotes .sr-only {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--pico-muted-color);
+  margin-bottom: 0.5rem;
+}
+.footnotes ol {
+  padding-left: 1.5rem;
+}
+.footnotes li {
+  margin-bottom: 0.5rem;
+}
+.footnotes li p {
+  display: inline;
+  margin: 0;
+}
+[data-footnote-ref],
+[id^="user-content-fnref-"] {
+  text-decoration: none;
+  font-variant-numeric: tabular-nums;
+  padding: 0 0.15rem;
+}
+[data-footnote-backref] {
+  text-decoration: none;
+  margin-left: 0.25rem;
+  opacity: 0.6;
+}
+
+/* Code-copy button injected by client script */
+.code-block {
+  position: relative;
+}
+.code-copy {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  appearance: none;
+  background: var(--pico-background-color);
+  color: var(--pico-muted-color);
+  border: 1px solid var(--pico-border-color);
+  border-radius: var(--pico-border-radius);
+  padding: 0.2rem 0.5rem;
+  font-size: 0.75rem;
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 0.15s ease;
+}
+.code-block:hover .code-copy,
+.code-copy:focus-visible {
+  opacity: 1;
 }
 
 /* Accessibility: keyboard skip link */


### PR DESCRIPTION
Five things in one batch.

## 1. Series with prev/next navigation
- New optional `series` + `seriesOrder` frontmatter fields.
- `src/lib/series.ts` finds siblings, prev, next (sorted by `seriesOrder` if set, otherwise by date).
- Slug page renders a banner above the content listing all posts in the series, with the current one marked, and a prev/next nav at the bottom.
- The "harness" arc is wired up:
  1. Reclaiming the Harness
  2. The Third Half and the Fourth Wall
  3. The Three Imperatives at Delphi
  4. The Jules API as a Harness Backend

## 2. Share button
A single `<ShareButton>` instead of the typical row of social icons.
- Tries `navigator.share({ title, url })` first (native sheet on mobile).
- Falls back to `navigator.clipboard.writeText(url)` with a "Link copied" affordance.
- No third-party scripts, no lock-in, no Web 2.0 vibe.

## 3. Auto-generated OG cards
- `astro-og-canvas` integrated. New endpoint `/og/[slug].png` generates a 1200×630 card per post (title + description on a paper-tinted gradient with a black side-bar).
- `PageLayout` falls back to `/og/{slug}.png` when a post has no `heroImage`. Posts that already have a hero image keep using it.
- `SKIP_OG=1` env var disables generation in offline environments (sandboxes, restricted dev). CI does not set this.

## 4. Excerpts replace descriptions on the home / tag pages
`PostCard` now shows ~320 chars of the **post body** (markdown stripped, headings/code/HTML removed) with a `Continue reading →` link, instead of the bare frontmatter description.
- New `src/lib/excerpt.ts` does the stripping in pure JS — no extra deps.
- The frontmatter `description` is still used for `<meta name="description">`, OG, and JSON-LD.

## 5. Polish
- **Footnote styling**: muted, smaller, top border separator, tabular numerals on refs.
- **Code-copy buttons**: `<CodeCopyEnhancer>` wraps every `<article> <pre>` in a positioned container and adds a hover-revealed Copy button using `navigator.clipboard`. Pure client script, deferred, no-op without scripting.

## Verified locally
```
SKIP_OG=1 npm run build  →  green
- Series banner + prev/next on harness posts
- og:image falls back to /og/{slug}.png on posts without heroImage
- Continue reading link with body excerpt on home cards
- Share button rendered on slug pages
```

CI will exercise the OG generation path (it has internet to reach the fontsource font CDN that astro-og-canvas pulls from).

## Test plan
- [ ] CI deploy succeeds, OG cards generated under `/og/`
- [ ] Sharing a post without `heroImage` on Twitter shows the auto card
- [ ] On a harness post, the prev/next links navigate correctly
- [ ] Share button shows native sheet on mobile, copies link on desktop
- [ ] Code-copy button appears on hover over a `<pre>` block

---
_Generated by [Claude Code](https://claude.ai/code/session_01DCevMM7Avy9qBjDLe6X7Hz)_