### PR TITLE
Tier 1+2: transitions, math, last-updated, featured, webmentions, mermaid, /404

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,7 +24,6 @@ jobs:
           node-version: 22
           cache: npm
       - run: npm ci
-      - run: npx playwright install chromium --with-deps
       - run: npm run build
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -4,18 +4,21 @@ import { defineConfig } from 'astro/config';
 import svelte from '@astrojs/svelte';
 import mdx from '@astrojs/mdx';
 import sitemap from '@astrojs/sitemap';
-import remarkMermaid from 'remark-mermaidjs';
+import remarkMath from 'remark-math';
+import rehypeKatex from 'rehype-katex';
 import rehypeSlug from 'rehype-slug';
 import rehypeAutolinkHeadings from 'rehype-autolink-headings';
 import { remarkReadingTime } from './src/lib/remark-reading-time.mjs';
+import { remarkGitModified } from './src/lib/remark-git-modified.mjs';
 
 // https://astro.build/config
 export default defineConfig({
   site: 'https://franklinbaldo.github.io',
   integrations: [svelte(), mdx(), sitemap()],
   markdown: {
-    remarkPlugins: [remarkMermaid, remarkReadingTime],
+    remarkPlugins: [remarkMath, remarkReadingTime, remarkGitModified],
     rehypePlugins: [
+      rehypeKatex,
       rehypeSlug,
       [
         rehypeAutolinkHeadings,

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,12 +19,13 @@
         "astro-og-canvas": "^0.11.1",
         "canvaskit-wasm": "^0.41.1",
         "mdast-util-to-string": "^4.0.0",
+        "mermaid": "^11.14.0",
         "pagefind": "^1.5.2",
-        "playwright": "^1.59.1",
         "reading-time": "^1.5.0",
         "rehype-autolink-headings": "^7.1.0",
+        "rehype-katex": "^7.0.1",
         "rehype-slug": "^6.0.0",
-        "remark-mermaidjs": "^7.0.0",
+        "remark-math": "^6.0.0",
         "svelte": "^5.55.5",
         "typescript": "^5.9.3"
       },
@@ -758,15 +759,6 @@
       "license": "OFL-1.1",
       "funding": {
         "url": "https://github.com/sponsors/ayuhito"
-      }
-    },
-    "node_modules/@fortawesome/fontawesome-free": {
-      "version": "6.7.2",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-6.7.2.tgz",
-      "integrity": "sha512-JUOtgFW6k9u4Y+xeIaEiLr3+cjoUPiAuLXoyKOJSia6Duzb7pq+A76P9ZdPDoAoxHdHzq6gE9/jKBGXlZT8FbA==",
-      "license": "(CC-BY-4.0 AND OFL-1.1 AND MIT)",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/@iconify/types": {
@@ -2251,6 +2243,12 @@
       "dependencies": {
         "@types/unist": "*"
       }
+    },
+    "node_modules/@types/katex": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@types/katex/-/katex-0.16.8.tgz",
+      "integrity": "sha512-trgaNyfU+Xh2Tc+ABIb44a5AYUpicB3uwirOioeOkNPPbmgRNtcWyDeeFRzjPZENO9Vq8gvVqfhaaXWLlevVwg==",
+      "license": "MIT"
     },
     "node_modules/@types/mdast": {
       "version": "4.0.4",
@@ -4732,6 +4730,25 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/mdast-util-math": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-math/-/mdast-util-math-3.0.0.tgz",
+      "integrity": "sha512-Tl9GBNeG/AhJnQM221bJR2HPvLOSnLE/T9cJI9tlc6zwQk2nPk/4f0cHkOdEixQPC/j8UtKDdITswvLAy1OZ1w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.1.0",
+        "unist-util-remove-position": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/mdast-util-mdx": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/mdast-util-mdx/-/mdast-util-mdx-3.0.0.tgz",
@@ -4911,28 +4928,6 @@
         "stylis": "^4.3.6",
         "ts-dedent": "^2.2.0",
         "uuid": "^11.1.0"
-      }
-    },
-    "node_modules/mermaid-isomorphic": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/mermaid-isomorphic/-/mermaid-isomorphic-3.1.0.tgz",
-      "integrity": "sha512-mzrvfEVjnJIkJlEqxp3eMuR1wS0TeLCH1VK5E/T5yzWaBwI3JqjJuw70yUIThSCDJ5bRs6O3rgfp00oBAbvSeQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@fortawesome/fontawesome-free": "^6.0.0",
-        "katex": "^0.16.0",
-        "mermaid": "^11.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/remcohaszing"
-      },
-      "peerDependencies": {
-        "playwright": "1"
-      },
-      "peerDependenciesMeta": {
-        "playwright": {
-          "optional": true
-        }
       }
     },
     "node_modules/micromark": {
@@ -5115,6 +5110,25 @@
       "license": "MIT",
       "dependencies": {
         "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-math": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-math/-/micromark-extension-math-3.1.0.tgz",
+      "integrity": "sha512-lvEqd+fHjATVs+2v/8kg9i5Q0AP2k85H0WUOwpIVvUML8BapsMvh1XAogmQjOCsLpoKRCVQqEkQBB3NhVBcsOg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/katex": "^0.16.0",
+        "devlop": "^1.0.0",
+        "katex": "^0.16.0",
         "micromark-factory-space": "^2.0.0",
         "micromark-util-character": "^2.0.0",
         "micromark-util-symbol": "^2.0.0",
@@ -5980,50 +5994,6 @@
         "pathe": "^2.0.1"
       }
     },
-    "node_modules/playwright": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
-      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "playwright-core": "1.59.1"
-      },
-      "bin": {
-        "playwright": "cli.js"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "fsevents": "2.3.2"
-      }
-    },
-    "node_modules/playwright-core": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
-      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
-      "license": "Apache-2.0",
-      "bin": {
-        "playwright-core": "cli.js"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/playwright/node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
     "node_modules/points-on-curve": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/points-on-curve/-/points-on-curve-0.2.0.tgz",
@@ -6237,6 +6207,25 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/rehype-katex": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/rehype-katex/-/rehype-katex-7.0.1.tgz",
+      "integrity": "sha512-OiM2wrZ/wuhKkigASodFoo8wimG3H12LWQaH8qSPVJn9apWKFSH3YOCtbKpBorTVw/eI7cuT21XBbvwEswbIOA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/katex": "^0.16.0",
+        "hast-util-from-html-isomorphic": "^2.0.0",
+        "hast-util-to-text": "^4.0.0",
+        "katex": "^0.16.0",
+        "unist-util-visit-parents": "^6.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/rehype-parse": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/rehype-parse/-/rehype-parse-9.0.1.tgz",
@@ -6332,6 +6321,22 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/remark-math": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/remark-math/-/remark-math-6.0.0.tgz",
+      "integrity": "sha512-MMqgnP74Igy+S3WwnhQ7kqGlEerTETXMvJhrUzDikVZ2/uogJCb+WHUg97hK9/jcfc0dkD73s3LN8zU49cTEtA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-math": "^3.0.0",
+        "micromark-extension-math": "^3.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/remark-mdx": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/remark-mdx/-/remark-mdx-3.1.1.tgz",
@@ -6344,32 +6349,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/remark-mermaidjs": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/remark-mermaidjs/-/remark-mermaidjs-7.0.0.tgz",
-      "integrity": "sha512-daW4LzAX1q3//SdRsTQ0ELyAXdy0yvJJQ2S0he5ddhZmnt8cyTv3QN536ezMY/OY4a3XGDMz+NU1SOSQ5xcYAA==",
-      "deprecated": "Use rehype-mermaid instead",
-      "license": "MIT",
-      "dependencies": {
-        "@types/mdast": "^4.0.0",
-        "hast-util-from-html-isomorphic": "^2.0.0",
-        "mermaid-isomorphic": "^3.0.0",
-        "unified": "^11.0.0",
-        "unist-util-visit-parents": "^6.0.0",
-        "vfile": "^6.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/remcohaszing"
-      },
-      "peerDependencies": {
-        "playwright": "1"
-      },
-      "peerDependenciesMeta": {
-        "playwright": {
-          "optional": true
-        }
       }
     },
     "node_modules/remark-parse": {

--- a/package.json
+++ b/package.json
@@ -23,12 +23,13 @@
     "astro-og-canvas": "^0.11.1",
     "canvaskit-wasm": "^0.41.1",
     "mdast-util-to-string": "^4.0.0",
+    "mermaid": "^11.14.0",
     "pagefind": "^1.5.2",
-    "playwright": "^1.59.1",
     "reading-time": "^1.5.0",
     "rehype-autolink-headings": "^7.1.0",
+    "rehype-katex": "^7.0.1",
     "rehype-slug": "^6.0.0",
-    "remark-mermaidjs": "^7.0.0",
+    "remark-math": "^6.0.0",
     "svelte": "^5.55.5",
     "typescript": "^5.9.3"
   }

--- a/src/components/CodeCopyEnhancer.astro
+++ b/src/components/CodeCopyEnhancer.astro
@@ -56,4 +56,6 @@
   } else {
     enhance();
   }
+  // Re-run after Astro client-side navigation (view transitions).
+  document.addEventListener("astro:page-load", enhance);
 </script>

--- a/src/components/MermaidEnhancer.astro
+++ b/src/components/MermaidEnhancer.astro
@@ -1,0 +1,51 @@
+---
+// Renders mermaid code blocks client-side.
+// Looks for <pre><code class="language-mermaid">…</code></pre> emitted by
+// the default Shiki/markdown pipeline, swaps the wrapper to a mermaid
+// container, then runs mermaid.run on it. No build-time dependency on
+// Playwright; broken diagrams degrade gracefully to a code block.
+---
+
+<script>
+  let initialized = false;
+
+  async function render() {
+    const codeBlocks = document.querySelectorAll<HTMLElement>(
+      "article pre > code.language-mermaid",
+    );
+    if (codeBlocks.length === 0) return;
+
+    const targets: HTMLElement[] = [];
+    codeBlocks.forEach((code) => {
+      const pre = code.parentElement;
+      if (!pre || pre.dataset.mermaidProcessed === "true") return;
+      const source = code.textContent ?? "";
+      const container = document.createElement("div");
+      container.className = "mermaid";
+      container.textContent = source;
+      pre.replaceWith(container);
+      targets.push(container);
+    });
+
+    if (targets.length === 0) return;
+
+    const { default: mermaid } = await import("mermaid");
+    if (!initialized) {
+      const dark = document.documentElement.dataset.theme === "dark";
+      mermaid.initialize({
+        startOnLoad: false,
+        theme: dark ? "dark" : "neutral",
+        securityLevel: "strict",
+      });
+      initialized = true;
+    }
+    try {
+      await mermaid.run({ nodes: targets });
+    } catch (err) {
+      console.warn("[mermaid] render error:", err);
+    }
+  }
+
+  render();
+  document.addEventListener("astro:page-load", render);
+</script>

--- a/src/components/Webmentions.astro
+++ b/src/components/Webmentions.astro
@@ -24,10 +24,21 @@ try {
   const api = new URL("https://webmention.io/api/mentions.jf2");
   api.searchParams.set("target", target);
   api.searchParams.set("per-page", "100");
-  const res = await fetch(api);
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 10_000);
+  let res: Response;
+  try {
+    res = await fetch(api, { signal: controller.signal });
+  } finally {
+    clearTimeout(timer);
+  }
+
   if (res.ok) {
-    const data = (await res.json()) as { children?: Mention[] };
-    mentions = data.children ?? [];
+    const data: unknown = await res.json();
+    if (data && typeof data === "object" && Array.isArray((data as any).children)) {
+      mentions = (data as { children: Mention[] }).children;
+    }
   }
 } catch (err) {
   console.warn(`[webmentions] fetch failed for ${target}:`, err);

--- a/src/components/Webmentions.astro
+++ b/src/components/Webmentions.astro
@@ -1,0 +1,114 @@
+---
+interface Props {
+  url: string | URL;
+}
+
+interface Mention {
+  type: string;
+  author?: { name?: string; url?: string; photo?: string };
+  url?: string;
+  published?: string;
+  "wm-property"?:
+    | "in-reply-to"
+    | "like-of"
+    | "repost-of"
+    | "mention-of"
+    | "bookmark-of";
+}
+
+const { url } = Astro.props;
+const target = typeof url === "string" ? url : url.href;
+
+let mentions: Mention[] = [];
+try {
+  const api = new URL("https://webmention.io/api/mentions.jf2");
+  api.searchParams.set("target", target);
+  api.searchParams.set("per-page", "100");
+  const res = await fetch(api);
+  if (res.ok) {
+    const data = (await res.json()) as { children?: Mention[] };
+    mentions = data.children ?? [];
+  }
+} catch (err) {
+  console.warn(`[webmentions] fetch failed for ${target}:`, err);
+}
+
+const likes = mentions.filter((m) => m["wm-property"] === "like-of");
+const reposts = mentions.filter((m) => m["wm-property"] === "repost-of");
+const replies = mentions.filter(
+  (m) => m["wm-property"] === "in-reply-to" || m["wm-property"] === "mention-of",
+);
+---
+
+{mentions.length > 0 && (
+  <section class="webmentions" aria-label="Webmentions">
+    <h3>Mentions across the web</h3>
+
+    {(likes.length > 0 || reposts.length > 0) && (
+      <ul class="facepile">
+        {[...likes, ...reposts].map((m) => (
+          <li>
+            <a href={m.author?.url ?? m.url ?? "#"} title={m.author?.name ?? "anonymous"}>
+              {m.author?.photo
+                ? <img src={m.author.photo} alt={m.author?.name ?? ""} loading="lazy" />
+                : <span class="dot" aria-hidden="true" />}
+            </a>
+          </li>
+        ))}
+      </ul>
+    )}
+
+    {replies.length > 0 && (
+      <ol class="reply-list">
+        {replies.map((m) => (
+          <li>
+            <a href={m.url ?? m.author?.url ?? "#"}>
+              <strong>{m.author?.name ?? "someone"}</strong>
+            </a>
+            {m.published && (
+              <small> · <time datetime={m.published}>{new Date(m.published).toLocaleDateString("en-US", { year: "numeric", month: "short", day: "2-digit" })}</time></small>
+            )}
+          </li>
+        ))}
+      </ol>
+    )}
+  </section>
+)}
+
+<style>
+  .webmentions {
+    margin-top: 3rem;
+    padding-top: 1.25rem;
+    border-top: 1px dashed var(--pico-border-color);
+  }
+  .webmentions h3 {
+    font-size: 0.95rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--pico-muted-color);
+    margin-bottom: 0.75rem;
+  }
+  .facepile {
+    list-style: none;
+    padding: 0;
+    margin: 0 0 1rem;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem;
+  }
+  .facepile img,
+  .facepile .dot {
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    object-fit: cover;
+    background: var(--pico-muted-color);
+  }
+  .reply-list {
+    padding-left: 1.25rem;
+  }
+  .reply-list li {
+    margin-bottom: 0.4rem;
+    color: var(--pico-muted-color);
+  }
+</style>

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -13,6 +13,7 @@ const blog = defineCollection({
     heroImageAlt: z.string().optional(),
     series: z.string().optional(),
     seriesOrder: z.number().optional(),
+    featured: z.boolean().optional(),
   }),
 });
 

--- a/src/content/blog/2026-04-29-reclaiming-the-harness.md
+++ b/src/content/blog/2026-04-29-reclaiming-the-harness.md
@@ -5,6 +5,7 @@ date: 2026-04-29
 tags: [ai, alignment, agents, harness, waluigi, canivete, philosophy]
 series: harness
 seriesOrder: 1
+featured: true
 ---
 
 > Or: how a single word has been quietly summoning Waluigis for half a decade, and what the swiss-army knife in my coat pocket has to do with it

--- a/src/content/blog/2026-05-04-the-three-imperatives-at-delphi.md
+++ b/src/content/blog/2026-05-04-the-three-imperatives-at-delphi.md
@@ -4,6 +4,7 @@ description: "On the temple that demanded self-knowledge, the philosopher who to
 date: "2026-05-04"
 series: harness
 seriesOrder: 3
+featured: true
 ---
 
 On the southern slope of Mount Parnassus, about a hundred and ten miles

--- a/src/layouts/PageLayout.astro
+++ b/src/layouts/PageLayout.astro
@@ -17,7 +17,9 @@ interface Props {
 const SITE_NAME = "Franklin Baldo";
 // When used via Markdown/MDX `layout:` frontmatter, Astro passes
 // `{ frontmatter, ... }`; in regular usage the props come directly.
-const source = (Astro.props as any).frontmatter ?? Astro.props;
+type LayoutProps = Props & { frontmatter?: Props };
+const raw = Astro.props as LayoutProps;
+const source: Props = raw.frontmatter ?? raw;
 const {
   title,
   description = "Franklin Baldo's Digital Garden",
@@ -26,7 +28,7 @@ const {
   publishedTime,
   modifiedTime,
   tags,
-} = source as Props;
+} = source;
 
 const documentTitle = title.includes(SITE_NAME) ? title : `${title} | ${SITE_NAME}`;
 

--- a/src/layouts/PageLayout.astro
+++ b/src/layouts/PageLayout.astro
@@ -1,5 +1,6 @@
 ---
 import "../styles/global.css";
+import { ClientRouter } from "astro:transitions";
 import Header from "../components/Header.astro";
 import Footer from "../components/Footer.astro";
 
@@ -9,6 +10,7 @@ interface Props {
   image?: string;
   type?: "website" | "article";
   publishedTime?: Date;
+  modifiedTime?: Date;
   tags?: string[];
 }
 
@@ -22,6 +24,7 @@ const {
   image,
   type = "website",
   publishedTime,
+  modifiedTime,
   tags,
 } = source as Props;
 
@@ -39,6 +42,7 @@ const jsonLd = type === "article"
       description,
       author: { "@type": "Person", name: "Franklin Baldo", url: Astro.site?.href },
       datePublished: publishedTime?.toISOString(),
+      ...(modifiedTime && { dateModified: modifiedTime.toISOString() }),
       mainEntityOfPage: canonical.href,
       ...(ogImage && { image: ogImage }),
       ...(tags?.length && { keywords: tags.join(", ") }),
@@ -63,6 +67,11 @@ const jsonLd = type === "article"
     <link rel="alternate" type="application/rss+xml" title="Franklin Baldo" href={rssUrl} />
     <link rel="sitemap" href="/sitemap-index.xml" />
 
+    <link rel="webmention" href="https://webmention.io/franklinbaldo.github.io/webmention" />
+    <link rel="pingback" href="https://webmention.io/franklinbaldo.github.io/xmlrpc" />
+
+    <ClientRouter />
+
     <meta property="og:type" content={type} />
     <meta property="og:title" content={title} />
     <meta property="og:description" content={description} />
@@ -71,6 +80,9 @@ const jsonLd = type === "article"
     {ogImage && <meta property="og:image" content={ogImage} />}
     {publishedTime && (
       <meta property="article:published_time" content={publishedTime.toISOString()} />
+    )}
+    {modifiedTime && (
+      <meta property="article:modified_time" content={modifiedTime.toISOString()} />
     )}
     {tags?.map((tag) => <meta property="article:tag" content={tag} />)}
 

--- a/src/lib/remark-git-modified.mjs
+++ b/src/lib/remark-git-modified.mjs
@@ -1,4 +1,4 @@
-import { execSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 import { relative, resolve } from 'node:path';
 
 const ROOT = process.cwd();
@@ -6,8 +6,11 @@ const ROOT = process.cwd();
 function lastModified(filePath) {
   try {
     const rel = relative(ROOT, resolve(filePath));
-    const out = execSync(
-      `git log -1 --format=%cI -- "${rel}"`,
+    // execFileSync (array form) skips the shell entirely — no
+    // interpolation, no injection risk on funky filenames.
+    const out = execFileSync(
+      'git',
+      ['log', '-1', '--format=%cI', '--', rel],
       { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] },
     ).trim();
     return out || null;

--- a/src/lib/remark-git-modified.mjs
+++ b/src/lib/remark-git-modified.mjs
@@ -1,0 +1,30 @@
+import { execSync } from 'node:child_process';
+import { relative, resolve } from 'node:path';
+
+const ROOT = process.cwd();
+
+function lastModified(filePath) {
+  try {
+    const rel = relative(ROOT, resolve(filePath));
+    const out = execSync(
+      `git log -1 --format=%cI -- "${rel}"`,
+      { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] },
+    ).trim();
+    return out || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Sets `lastModified` (ISO string) on each post's frontmatter, derived
+ * from `git log`. Falls back silently when git isn't available.
+ */
+export function remarkGitModified() {
+  return (_tree, file) => {
+    const path = file.history?.[0] ?? file.path;
+    if (!path) return;
+    const iso = lastModified(path);
+    if (iso) file.data.astro.frontmatter.lastModified = iso;
+  };
+}

--- a/src/lib/remark-git-modified.mjs
+++ b/src/lib/remark-git-modified.mjs
@@ -11,7 +11,7 @@ function lastModified(filePath) {
     const out = execFileSync(
       'git',
       ['log', '-1', '--format=%cI', '--', rel],
-      { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] },
+      { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'], timeout: 5_000 },
     ).trim();
     return out || null;
   } catch {

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -41,7 +41,7 @@ const recent = (await getCollection("blog"))
   </article>
 
   <link rel="stylesheet" href="/pagefind/pagefind-ui.css" />
-  <script is:inline src="/pagefind/pagefind-ui.js"></script>
+  <script is:inline defer src="/pagefind/pagefind-ui.js"></script>
   <script is:inline>
     function initSearch() {
       if (window.PagefindUI && document.getElementById("search") && !document.querySelector("#search .pagefind-ui")) {

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,8 +1,14 @@
 ---
+import { getCollection } from "astro:content";
 import PageLayout from "../layouts/PageLayout.astro";
+
+const recent = (await getCollection("blog"))
+  .filter((p) => !p.data.draft)
+  .sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf())
+  .slice(0, 5);
 ---
 
-<PageLayout title="Not Found | Franklin Baldo" description="Page not found.">
+<PageLayout title="Not Found" description="Page not found.">
   <article>
     <header>
       <hgroup>
@@ -10,9 +16,56 @@ import PageLayout from "../layouts/PageLayout.astro";
         <p>That page doesn’t exist — or it has been pruned from the garden.</p>
       </hgroup>
     </header>
+
+    <h2>Search</h2>
+    <div id="search"></div>
+
+    <h2>Recently published</h2>
+    <ul>
+      {recent.map((post) => (
+        <li>
+          <a href={`/blog/${post.id}/`}>{post.data.title}</a>
+          <small>
+            <time datetime={post.data.date.toISOString()}>
+              {post.data.date.toLocaleDateString("en-US", { month: "short", day: "2-digit", year: "numeric" })}
+            </time>
+          </small>
+        </li>
+      ))}
+    </ul>
+
     <p>
-      Try the <a href="/">home page</a>, the <a href="/archive/">archive</a>,
+      Or try the <a href="/">home page</a>, the <a href="/archive/">archive</a>,
       or browse by <a href="/tags/">tag</a>.
     </p>
   </article>
+
+  <link rel="stylesheet" href="/pagefind/pagefind-ui.css" />
+  <script is:inline src="/pagefind/pagefind-ui.js"></script>
+  <script is:inline>
+    function initSearch() {
+      if (window.PagefindUI && document.getElementById("search") && !document.querySelector("#search .pagefind-ui")) {
+        new window.PagefindUI({ element: "#search", showImages: false, showSubResults: true });
+      }
+    }
+    window.addEventListener("DOMContentLoaded", initSearch);
+    document.addEventListener("astro:page-load", initSearch);
+  </script>
 </PageLayout>
+
+<style>
+  ul {
+    list-style: none;
+    padding: 0;
+  }
+  ul li {
+    display: flex;
+    justify-content: space-between;
+    gap: 1rem;
+    padding: 0.25rem 0;
+  }
+  ul li small {
+    color: var(--pico-muted-color);
+    font-variant-numeric: tabular-nums;
+  }
+</style>

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -5,6 +5,8 @@ import PageLayout from '../../layouts/PageLayout.astro';
 import BackToTop from '../../components/BackToTop.astro';
 import ShareButton from '../../components/ShareButton.astro';
 import CodeCopyEnhancer from '../../components/CodeCopyEnhancer.astro';
+import MermaidEnhancer from '../../components/MermaidEnhancer.astro';
+import Webmentions from '../../components/Webmentions.astro';
 import { getSeriesContext } from '../../lib/series';
 
 export async function getStaticPaths() {
@@ -20,6 +22,10 @@ const post = Astro.props;
 const { Content, remarkPluginFrontmatter } = await render(post);
 const { heroImage, heroImageAlt, title, description, date, tags } = post.data;
 const minutesRead: number | undefined = remarkPluginFrontmatter.minutesRead;
+const lastModifiedISO: string | undefined = remarkPluginFrontmatter.lastModified;
+const lastModified = lastModifiedISO ? new Date(lastModifiedISO) : undefined;
+// Only show "Updated" if it's at least 24h after the publish date.
+const showUpdated = lastModified && lastModified.valueOf() - date.valueOf() > 86400_000;
 const series = await getSeriesContext(post);
 ---
 
@@ -29,6 +35,7 @@ const series = await getSeriesContext(post);
   image={heroImage?.src ?? `/og/${post.id}.png`}
   type="article"
   publishedTime={date}
+  modifiedTime={lastModified}
   tags={tags}
 >
   <article data-pagefind-body>
@@ -41,6 +48,11 @@ const series = await getSeriesContext(post);
               {date.toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' })}
             </time>
             {minutesRead && <> · {minutesRead} min read</>}
+            {showUpdated && lastModified && (
+              <> · updated <time datetime={lastModified.toISOString()}>
+                {lastModified.toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' })}
+              </time></>
+            )}
           </small>
         </p>
       </hgroup>
@@ -109,8 +121,11 @@ const series = await getSeriesContext(post);
       )}
       <ShareButton title={title} />
     </footer>
+
+    <Webmentions url={new URL(Astro.url.pathname, Astro.site!)} />
   </article>
 
   <BackToTop />
   <CodeCopyEnhancer />
+  <MermaidEnhancer />
 </PageLayout>

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -24,8 +24,9 @@ const { heroImage, heroImageAlt, title, description, date, tags } = post.data;
 const minutesRead: number | undefined = remarkPluginFrontmatter.minutesRead;
 const lastModifiedISO: string | undefined = remarkPluginFrontmatter.lastModified;
 const lastModified = lastModifiedISO ? new Date(lastModifiedISO) : undefined;
-// Only show "Updated" if it's at least 24h after the publish date.
-const showUpdated = lastModified && lastModified.valueOf() - date.valueOf() > 86400_000;
+// Only show "Updated" if it's at least one day after the publish date.
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+const showUpdated = lastModified && lastModified.valueOf() - date.valueOf() > MS_PER_DAY;
 const series = await getSeriesContext(post);
 ---
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -2,24 +2,39 @@
 import { getCollection } from "astro:content";
 import PageLayout from "../layouts/PageLayout.astro";
 import PostList from "../components/PostList.astro";
+import PostCard from "../components/PostCard.astro";
 
-const posts = (await getCollection("blog"))
-  .filter(post => !post.data.draft)
+const all = (await getCollection("blog"))
+  .filter((post) => !post.data.draft)
   .sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf());
+
+const featured = all.filter((p) => p.data.featured);
+const featuredIds = new Set(featured.map((p) => p.id));
+const rest = all.filter((p) => !featuredIds.has(p.id));
 ---
 
-<PageLayout title="Home | Franklin Baldo" description="Lawyer and State Attorney. Exploring the intersections of process metaphysics, AI agency, and the architecture of legal systems.">
+<PageLayout
+  title="Home"
+  description="Lawyer and State Attorney. Exploring the intersections of process metaphysics, AI agency, and the architecture of legal systems."
+>
   <section id="hero" style="margin-bottom: 4rem;">
     <hgroup>
       <h1>Franklin Baldo</h1>
       <p>Lawyer and State Attorney. Exploring the boundaries of AI agents, process metaphysics, and legal design.</p>
     </hgroup>
     <p>
-      This space serves as my digital garden—a collection of essays, 
-      technical guides, and philosophical fragments on how we inhabit 
+      This space serves as my digital garden—a collection of essays,
+      technical guides, and philosophical fragments on how we inhabit
       a world increasingly mediated by intelligence.
     </p>
   </section>
 
-  <PostList posts={posts} />
+  {featured.length > 0 && (
+    <section id="featured">
+      <h2>Featured</h2>
+      {featured.map((post) => <PostCard post={post} />)}
+    </section>
+  )}
+
+  <PostList posts={rest} />
 </PageLayout>

--- a/src/pages/search.astro
+++ b/src/pages/search.astro
@@ -13,7 +13,7 @@ import PageLayout from "../layouts/PageLayout.astro";
   </article>
 
   <link rel="stylesheet" href="/pagefind/pagefind-ui.css" />
-  <script is:inline src="/pagefind/pagefind-ui.js"></script>
+  <script is:inline defer src="/pagefind/pagefind-ui.js"></script>
   <script is:inline>
     function initSearch() {
       if (window.PagefindUI && document.getElementById("search") && !document.querySelector("#search .pagefind-ui")) {

--- a/src/pages/search.astro
+++ b/src/pages/search.astro
@@ -15,12 +15,12 @@ import PageLayout from "../layouts/PageLayout.astro";
   <link rel="stylesheet" href="/pagefind/pagefind-ui.css" />
   <script is:inline src="/pagefind/pagefind-ui.js"></script>
   <script is:inline>
-    window.addEventListener("DOMContentLoaded", () => {
-      new PagefindUI({
-        element: "#search",
-        showImages: false,
-        showSubResults: true,
-      });
-    });
+    function initSearch() {
+      if (window.PagefindUI && document.getElementById("search") && !document.querySelector("#search .pagefind-ui")) {
+        new window.PagefindUI({ element: "#search", showImages: false, showSubResults: true });
+      }
+    }
+    window.addEventListener("DOMContentLoaded", initSearch);
+    document.addEventListener("astro:page-load", initSearch);
   </script>
 </PageLayout>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,6 +1,7 @@
 @import "@picocss/pico/css/pico.min.css";
 @import "@fontsource/eb-garamond";
 @import "@fontsource/jetbrains-mono";
+@import "katex/dist/katex.min.css";
 
 :root {
   --pico-font-family: "EB Garamond", serif;


### PR DESCRIPTION
All Tier 1 + Tier 2 items from the brainstorm.

## Tier 1

### View transitions
`<ClientRouter />` in `PageLayout` enables Astro 6's smooth same-origin navigation. The search and mermaid client scripts re-init on `astro:page-load` so they survive transitions.

### KaTeX (math rendering)
- `remark-math` + `rehype-katex` in `astro.config.mjs`.
- `katex.min.css` imported globally.
- Inline `$\alpha$` and display `$$...$$` now render properly. Posts like `pontifex-novel-architecture-semantic-probing` that had stray `$...$` literals now display real math.

### Last-updated from git
- New `src/lib/remark-git-modified.mjs` runs `git log -1 --format=%cI` on each post's file path and writes the ISO timestamp into frontmatter.
- Slug page renders "updated <date>" next to the publish date when the modification is >24h after publish (avoids noise on day-of edits).
- Emits `<meta property="article:modified_time">` and adds `dateModified` to the JSON-LD `BlogPosting`.

### Featured posts
- Schema gets `featured: boolean`.
- Home renders a "Featured" section above the chronological list.
- Two posts pinned as a starting demo (Reclaiming the Harness, Three Imperatives at Delphi). Add/remove freely.

## Tier 2

### Webmentions
- `<link rel="webmention">` + `<link rel="pingback">` in `PageLayout`, pointing at `webmention.io/franklinbaldo.github.io/...`.
- New `Webmentions.astro` fetches `https://webmention.io/api/mentions.jf2?target=<post-url>` at build time and renders a facepile of likes/reposts plus a list of replies. Renders nothing until you have mentions.
- **You still need to claim the domain at webmention.io** (sign in via IndieAuth/GitHub) for it to start collecting.

### Mermaid swap
Dropped `remark-mermaidjs` + Playwright (mermaid-isomorphic also pulls Playwright transitively). New `MermaidEnhancer.astro` finds `<pre><code class="language-mermaid">` blocks and renders client-side via `mermaid.js`. Benefits:
- No browser binary at build time → faster CI, smaller deploy footprint.
- Broken syntax degrades to a code block instead of failing the page.

### Smarter /404
Embeds the Pagefind search box and lists the 5 most recent posts. Helps users land somewhere useful instead of staring at "page not found".

## Cleanup
- `deploy.yml` no longer installs Playwright chromium (no longer needed).

## Verified locally
```
SKIP_OG=1 npm run build  → green
- view-transition meta tag present
- katex CSS classes on math posts
- "updated <time>" + article:modified_time on slug pages
- Featured section on home
- webmention link in <head>; <Webmentions> renders on slug
- Mermaid blocks emitted as <pre><code class="language-mermaid"> for client render
```

## Test plan
- [ ] CI deploy succeeds (no Playwright)
- [ ] Mermaid diagrams render in browser on Delphi / documento-conceitual posts
- [ ] Math renders on pontifex posts
- [ ] Navigation between pages is smooth (no full reload flash)
- [ ] /404 shows search box and recent posts
- [ ] Claim the domain at webmention.io and verify mentions populate

---
_Generated by [Claude Code](https://claude.ai/code/session_01DCevMM7Avy9qBjDLe6X7Hz)_