### PR TITLE
rel=me links for IndieAuth / webmention.io claim

### DIFF
--- a/src/layouts/PageLayout.astro
+++ b/src/layouts/PageLayout.astro
@@ -72,6 +72,9 @@ const jsonLd = type === "article"
     <link rel="webmention" href="https://webmention.io/franklinbaldo.github.io/webmention" />
     <link rel="pingback" href="https://webmention.io/franklinbaldo.github.io/xmlrpc" />
 
+    <link rel="me" href="https://github.com/franklinbaldo" />
+    <link rel="me" href="https://twitter.com/franklinbaldo" />
+
     <ClientRouter />
 
     <meta property="og:type" content={type} />

--- a/src/pages/about.mdx
+++ b/src/pages/about.mdx
@@ -25,8 +25,8 @@ Most posts are in English; some are in Portuguese.
 
 ## Find me
 
-- GitHub — [@franklinbaldo](https://github.com/franklinbaldo)
-- Twitter / X — [@franklinbaldo](https://twitter.com/franklinbaldo)
+- GitHub — <a href="https://github.com/franklinbaldo" rel="me">github.com/franklinbaldo</a>
+- Twitter / X — <a href="https://twitter.com/franklinbaldo" rel="me">twitter.com/franklinbaldo</a>
 - RSS — [`/rss.xml`](/rss.xml)
 
 ## Colophon

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -27,6 +27,15 @@ const rest = all.filter((p) => !featuredIds.has(p.id));
       technical guides, and philosophical fragments on how we inhabit
       a world increasingly mediated by intelligence.
     </p>
+    <p class="identity-links">
+      <small>
+        <a href="https://github.com/franklinbaldo" rel="me">GitHub</a>
+        ·
+        <a href="https://twitter.com/franklinbaldo" rel="me">Twitter</a>
+        ·
+        <a href="/rss.xml">RSS</a>
+      </small>
+    </p>
   </section>
 
   {featured.length > 0 && (


### PR DESCRIPTION
Adds `rel="me"` links so webmention.io's IndieAuth flow can verify domain ownership.

## What changed
- `<link rel="me" href="...">` for GitHub and Twitter in `<head>` of every page (machine-discoverable).
- Visible identity links in the home hero (`GitHub · Twitter · RSS`) with `rel="me"`.
- About page links upgraded with `rel="me"`.

## Manual step you still need to do
For the bidirectional verification IndieAuth requires:

1. **On GitHub**: edit your profile and set the **Website** field to `https://franklinbaldo.github.io`.
2. **On twitter.com/x.com**: same — put the website URL in your profile.
3. Then visit [webmention.io](https://webmention.io) and sign in with `https://franklinbaldo.github.io`. It'll redirect through GitHub (since the GitHub profile points back at your site, and your site has `rel=me` pointing at GitHub, the loop closes). Webmention.io will start collecting mentions from then on.

That's the same setup aaronpk uses on his own site (the `<a href="https://github.com/aaronpk" rel="me">` you sent).

---
_Generated by [Claude Code](https://claude.ai/code/session_01DCevMM7Avy9qBjDLe6X7Hz)_