### PR TITLE
Add blog post: The Agent That Doesn't Invent Verbs

### DIFF
--- a/src/content/blog/2026-05-14-pierre-menard-computational-researcher.md
+++ b/src/content/blog/2026-05-14-pierre-menard-computational-researcher.md
@@ -1,0 +1,94 @@
+---
+title: "Pierre Menard, Computational Researcher"
+description: "On writing the paper before doing the research, and other engineering practices that should embarrass us less than they do."
+date: "2026-05-14"
+---
+
+Pierre Menard, *autor del Quijote*, spent years cultivating an archaic Spanish so that, without copying Cervantes, his sentences would coincide word for word with Cervantes'. The method, as recorded in *Ficciones*, was secret and infinitely laborious. I would suggest to Menard a more economical methodology: first, copy the *Quijote* letter for letter. Then go live the life that would make the author of that copy produce that exact *Quijote*, had he sat down to write it himself instead of copying. When you fail to live that life — and you will fail — try again. Refactor the life. Revert the commit. Iterate until the words you would have written coincide with the words you already copied.
+
+This is roughly what I did with an alignment paper this week. I sat down and wrote six thousand words as if the research were done. Limitations section, validation roadmap, applicability table, numbered claims in the abstract, references list with seventeen real citations and four marked `[CITATION NEEDED]` for the ones I haven't read yet but plan to. Now I need to go live the life that would make those words true. When I fail — and I will fail — I revert the commit and try again.
+
+The technique is not new. Programmers have a name for it: test-driven development. You write the test first, watch it fail, then write the code that makes the test pass. The discipline is that the test commits you to a specification before you've earned the right to one. Test-driven *research* is the same trick on a different artifact. Write the paper first, watch it fail (the failure is invisible at first — that's the hard part), then go do the research that makes the paper true. The trick is the same and the embarrassment is the same: you're committing to a shape before you've proven you can fill it.
+
+## The spec that runs itself
+
+The trick survives translation between domains because in both cases the artifact you write first is a *spec that runs itself.* In TDD, the test is executable; it tells you, mechanically, whether the code is right. In TDR, the paper is executable too, just on a different machine — the researcher's attention. Every `[CITATION NEEDED]` is a failing test: it says *something must be true here, and I have not yet confirmed it.* Every limitation in the limitations section is a known bug: *the design admits this failure mode, and I haven't decided whether to fix it or document it.* Every metric in the validation roadmap is an acceptance criterion: *if the pilot deployment reports numbers worse than X on metric Y, the central claim of section 3 has empirically failed.*
+
+```mermaid
+graph LR
+  W[Write the paper] --> F[Find the failing tests<br/><i>CITATION NEEDED,<br/>handwave, vibes</i>]
+  F --> L[Live the research life]
+  L --> R[Refactor the paper]
+  R --> W
+```
+
+*The loop is not "write, then research." It's "write, find what's missing, do the missing thing, rewrite, find what's missing now." TDR collapses when treated as a pipeline.*
+
+The crucial discipline, the one that separates TDR from procrastination dressed as method, is that *the paper has to be written as if it were true.* No "I plan to show that…" No "future work will determine whether…" Those phrases are the equivalent of a TDD developer writing `// TODO: implement this` instead of an actual failing test. They look like discipline and produce none. The paper has to read like the research is done. Past tense. Confident claims. Section 5 has a table; the table has cells; the cells have answers, not question marks. When the cells are wrong — and some will be wrong — they get rewritten in the next pass after the research catches up.
+
+## What you actually learn
+
+Here is the part that surprised me. Writing the paper first forces decisions that doing-the-research-first leaves floating. Section 5 of my paper — a three-by-seven table mapping the proposed pattern against seven candidate domains, including a row that says *the pattern fails here, by design* — exists only because the paper's shape demanded a section after the architecture chapter. In normal order, I would have built the system for another six months without ever formalizing where the pattern stops applying. The paper is a question machine. It asks questions you would not have asked, because the questions are structural to papers and not structural to projects.
+
+<blockquote class="pull-quote">
+  The paper is a question machine.
+</blockquote>
+
+This is unreasonable. It should not be the case that arranging the future into a six-section IMRAD-ish structure produces better thinking than just thinking. But it does, and the reason is that papers have a *shape* that exists independently of any particular paper. The shape demands an abstract that summarizes claims. The shape demands a related-work section that situates the contribution. The shape demands a limitations paragraph that survives review. Each of those demands is a question the project alone would never ask, because projects are open-ended and papers are not. *It's giving structural humility through deadline anxiety,* which is an honest if undignified description of what most academic discipline really is.
+
+I learned, by writing the paper, three things about the project that I had not previously formulated: that the technique fails structurally (not just inconveniently) in domains where the operator must remain unauditable; that the doctrine/procedure tier separation has to support a *closure* outcome or the agent is systematically biased toward proposing action; and that the central interpretability claim, in operational terms, reduces to whether a blind third-party reviewer can reconstruct the agent's decision from the proposal artifact alone. Each of those is now a testable claim in the paper, and each of those is now a research target I would not have set for myself otherwise.
+
+## Where it breaks
+
+The method's failure modes are not subtle. The largest is that you can confuse *sounding coherent* with *being true.* A paper read aloud sounds like a paper whether or not its claims survive contact with reality. The discipline of writing in past tense — the very discipline that makes TDR work — also produces an aesthetic of finitude that papers earn when the research is done and that TDR borrows on credit. A trained reviewer will smell this on the first read; a less trained one might not, and may approve the paper for reasons that have nothing to do with whether its central claims are correct.
+
+![Drake meme: Drake rejects "Doing the research, then writing the paper." Drake approves "Writing the paper, then doing the research."](https://api.memegen.link/images/drake/Doing_the_research_then_writing_the_paper/Writing_the_paper_then_doing_the_research.png?width=500)
+
+A subtler failure is that the paper, once written, closes the design space. Sections become load-bearing; rewriting one of them costs effort; the cheapest path forward is to make the research conform to the paper rather than the paper conform to the research. This is the inverse of how science is supposed to work, and it's structurally encouraged by every version of TDR that doesn't aggressively re-open the paper as the research proceeds. The discipline is *not* to keep the paper stable; the discipline is to revert sections that the research invalidates, and to do so quickly, before the sections have time to grow defenders.
+
+The third failure mode is confirmation bias dressed in instrumentation. Once you have a validation roadmap with named metrics, you tend to design the pilot to measure exactly those metrics, against thresholds that will favor the paper's claims. The instrumentation honors the spec, not the world. Mitigating this means including, in the validation roadmap, metrics whose plausible outcomes *invalidate* the paper. If section 3 says the technique improves auditability, the roadmap has to include a measure of auditability whose worst-case outcome would force section 3 to be substantially rewritten. If the roadmap doesn't include such a measure, the paper is propaganda for itself.
+
+And the most embarrassing failure: the *paper-as-vibes phase*, in which the writer mistakes the warm feeling of having written six thousand confident words for the cold fact of having done six thousand words of research. The warm feeling is real and it is unearned. The only known antidote is to send the draft to someone whose job is to attack the argument, not to validate it, and to send it early enough that there's still time to refactor before the deadline that made you write it.
+
+## Mitigations that almost work
+
+The discipline that keeps the loop honest, rather than collapsing into pipeline-with-rewrites, is procedural. Four practices, in roughly decreasing order of usefulness:
+
+*Mark missing knowledge aggressively, never invent it.* `[CITATION NEEDED]` for every claim that requires literature you haven't read; `[NUMBER PENDING]` for every metric you haven't measured; `[ASSUMPTION]` in a comment for every premise that the research will test. The marks become your to-do list. They also embarrass you visibly in every draft, which is correct: the embarrassment is what keeps the paper honest while the research catches up.
+
+*Write the limitations section first.* Not last. Not after the methods. First. Before you've fallen in love with the central claim, articulate, in past tense, the conditions under which the central claim is false. The discipline forces a kind of pre-emptive humility that is much harder to introduce once the rest of the paper has already established a triumphant tone. The limitations section is the test that the paper has to keep passing as it grows; written first, it stays load-bearing; written last, it becomes a polite footnote.
+
+*Version the paper as code, with informative commits.* "Discovered X invalidates section 4, rewrote with weaker claim." "Read Y, retracted footnote 3." "Pilot returned worse-than-threshold on metric M; section 7 now lists this as a documented limitation rather than a future-work item." Each commit is a record of the research bending the paper rather than the paper bending the research. The git log becomes the actual scientific record; the published paper is just the snapshot most recent at submission time.
+
+*Show the draft to a hostile reader early.* Not someone who will say "looks great, can't wait." Someone who will say "section 3 doesn't follow from section 2, and section 5 is doing too much work alone." Hostile readers are scarce and valuable. The window in which their feedback can still change the shape of the paper is narrow. Inside that window, they are the most efficient instrument the writer has for distinguishing *sounds coherent* from *is true.*
+
+## A small home industry
+
+What I am describing is not one technique but three layered on top of each other. The paper is TDR. The repository it documents ([PINK](/blog/2026-05-14-the-agent-that-doesnt-invent-verbs), currently seven commits of doctrine and counting, zero lines of production code) is also TDR: a system whose architecture, lint rules, content-addressing scheme, and failure modes are specified in markdown files that lint themselves before any of them have been implemented. And this blog post is TDR too, in the most recursive register — it specifies a method that I am, with each paragraph, attempting to live up to.
+
+The three artifacts are refactored in parallel. A discovery while implementing the system invalidates a paragraph in the paper; a section in the paper raises a question the blog post then articulates; the blog post, written for an audience outside the project, surfaces an embarrassment in the paper's framing that sends me back to revise the paper, which then changes what the system has to do.
+
+There is a larger precedent than I am usually comfortable invoking. Early Wikipedia was an exercise in this. The encyclopedia, in its first years, was a vast field of *citation needed* tags attached to confident sentences that had not yet been verified — *Albert Einstein was a German-born theoretical physicist `[citation needed]`*. The form of the sentence summoned the next reader to find the source, to confirm or refute, to fill the cell. It was hyperstition-driven literature: assert the encyclopedia and the encyclopedia will follow. In 2001 nobody would have bet that a reference compendium editable by strangers, padded with bracketed admissions of ignorance, would become the planet's primary factual reference inside twenty years. It is the largest worked example of test-driven research ever conducted, and it succeeded so completely that the *citation needed* aesthetic — sentence first, source later — now looks unremarkable. The method is older than the embarrassment around it.
+
+None of this is original. Donald Knuth was doing literate programming in the seventies — the program *is* the document and vice versa, refactored together. Bruno Latour spent a career arguing that papers don't describe scientific facts so much as *manufacture* them. Karl Popper said something nearby. What is mildly new, or at least newly cheap, is that the three artifacts can now be kept synchronized by a single person on a laptop, in markdown, version-controlled, in their own time. The small home industry of writing about what you are about to do, while you are doing it, is structurally a new kind of object.
+
+Whether the resulting work is *good* is a separate question. The method does not guarantee good work; it guarantees that you find out faster whether your work is bad. *The duality of writing limitations sections for research you have not done yet* is exactly this — it commits you, on the first day, to discovering everything that is wrong with what you are about to spend six months doing. Some writers find this unbearable. I find it the only way to write at all.
+
+## What this costs you
+
+The honest tally. TDR inflates your confidence at exactly the moment you should be uncertain — the moment you have a complete document and no evidence. It biases you toward defending the draft rather than rewriting it, because rewriting is expensive and defense is cheap. It imposes invisible work on the people who review you: your draft *sounds* finished even when it is not, and they have to read it as if it were, until they discover otherwise. And it carries the latent danger that all subsequent research, however diligently performed, ends up serving the aesthetics of a document rather than the discovery of anything.
+
+Against this, the gains are real. The questions you would not have asked. The structure that holds you accountable. The deadline that turns a research project into a research artifact. The early visibility of what you are claiming, which is the only way for the claims to be tested before you've invested too much in defending them. On balance, for me, the trade is favorable. It might not be for you. The fact that I'm writing this in past tense before knowing whether it's true is, itself, the point.
+
+Pierre Menard wrote the *Quijote* after Cervantes, in the same words, and the second *Quijote* is infinitely richer than the first. I am writing the research before Cervantes — in roughly the same words it will have, eventually — and I will find out in about six months whether mine is richer or just plagiarized in advance from a future I have not yet lived. The method is not without its embarrassments. *It's giving methodological audacity*, and methodological audacity is what people call methodological mistakes that happen to work.
+
+## For further reading
+
+- **Kent Beck, *Test-Driven Development by Example* (2002).** The canonical text on TDD; the paragraph that distinguishes "writing the test first" from "documenting your plans" is the one that translates directly to TDR.
+- **Jorge Luis Borges, "Pierre Menard, autor del *Quijote*" in *Ficciones* (1944).** The patron saint of every methodology that involves writing a thing before being qualified to write it.
+- **Donald Knuth, "Literate Programming" in *The Computer Journal* (1984).** The earliest sustained argument that the program and its documentation should be the same artifact, refactored together. TDR is literate research in this sense.
+- **Bruno Latour, *Science in Action* (1987).** On the social construction of scientific facts; the chapter on how papers manufacture rather than describe their facts is the one that should make any TDR practitioner slightly nervous.
+- **Imre Lakatos, *The Methodology of Scientific Research Programmes* (1970).** On the difference between a degenerating and a progressive research programme — useful for noticing when your TDR paper has stopped being a productive question machine and started being a sunk cost.
+- **Robert Sutton and Barry Staw, "What Theory is Not" in *Administrative Science Quarterly* (1995).** A brief, frequently cited paper on the distinction between *sounds like a contribution* and *is a contribution.* Recommended reading before every TDR revision.
+- **Karl Popper, *Conjectures and Refutations* (1963).** The original case for writing falsifiable claims before testing them. TDR is a small implementation of this stance, applied to a single researcher's process.
+- **Wikipedia: "[Citation needed]" (the template, *Wikipedia: Template:Citation needed*).** The template itself, documented in the encyclopedia it helped build. Worth reading the template's history page; the meta-recursion is part of the artifact.

--- a/src/content/blog/2026-05-14-the-agent-that-doesnt-invent-verbs.md
+++ b/src/content/blog/2026-05-14-the-agent-that-doesnt-invent-verbs.md
@@ -100,8 +100,6 @@ How does the agent find the right scenario? The first answer that suggests itsel
 
 A matcher built into the tool steals the judgment that should belong to the reasoning system above it. The current design does no matching. PINK exposes the canon as a tree and lets the agent walk it. The agent keeps Tier 1 and Tier 2 in working context — the upper canon, small enough to fit there. For a given expediente, the agent picks a Tier 2 whose preconditions describe the case, asks PINK for its `children`, and if the list is non-empty, reads each child and chooses the specialization that fits. The loop terminates at a leaf — a node with no children of its own — and the proposal binds that leaf. If at any descent step no child fits the case, the agent proposes a new Tier N+1 under the current node, carrying `@concretiza:<current_uuid>`. That is the system's learning gradient, disciplined: every new scenario points by content-hash to its parent.
 
-<figure class="mermaid-diagram">
-
 ```mermaid
 graph LR
   D[Discover<br/><i>read Metabase</i>] --> F[Fetch<br/><i>read Kanoê PDFs</i>]
@@ -110,8 +108,7 @@ graph LR
   R --> A[Apply<br/><i>kanoe writes + expediente comment</i>]
 ```
 
-<figcaption>The five-stage pipeline. The first three are read-only against the legal system of record; the fourth is human gating; the fifth is the only stage that mutates Kanoê, and only via approved write primitives.</figcaption>
-</figure>
+*The five-stage pipeline. The first three are read-only against the legal system of record; the fourth is human gating; the fifth is the only stage that mutates Kanoê, and only via approved write primitives.*
 
 PINK is deliberately stupid. *And it's a feature, not a bug.* All inference happens in the LLM, where it belongs; all structure lives in PINK, where it can be audited deterministically. The chain of descent — which Tier 2, which Tier 3, which Tier 4 — is recorded in a `traversal:` field on the proposal, with the UUID of each visited node. Months later, a reviewer asking *why did the agent descend this far* reads the chain and reconstructs the reasoning step by step. Interpretability of the act, not from weights but from artifact.
 

--- a/src/content/blog/2026-05-14-the-agent-that-doesnt-invent-verbs.md
+++ b/src/content/blog/2026-05-14-the-agent-that-doesnt-invent-verbs.md
@@ -4,6 +4,10 @@ description: "On Cucumber, content-addressing, and an alignment technique that t
 date: "2026-05-14"
 ---
 
+A communication arrives in a legal office. It may create a deadline. It may require a task. It may need to be routed to another desk. Or it may require nothing except a reasoned acknowledgment and closure.
+
+An AI agent reads it. It can summarize, it can reason about what should happen next, it can draft a response. But in this system there is one thing it cannot do: invent a verb. Every action it may propose must already exist as a named, reviewed, content-addressed playbook on disk. Alignment, here, is not a property hidden in the model's weights. It is a property of a directory.
+
 There is a file on a laptop somewhere — perhaps in Porto Velho, perhaps elsewhere — called `playbooks/tier1/receber_expediente_com_prazo__a1b2c3d4.feature`. The eight hex characters after the double underscore are not decoration. They are the prefix of a UUIDv5 computed over the file's normalized content. The file does not carry a name to which a hash is attached. The file's name *is* the hash.
 
 This is a small commitment with consequences. Change a character — a comma added, a Gherkin keyword recapitalized — and the hash changes, and the filename changes, and the file as an identifiable thing in the world ceases to be that file and becomes another. There is no silent edit. The act of editing is, structurally, an act of replacement.
@@ -151,15 +155,6 @@ And apply, the act of executing the Gherkin against the legal system, is best-ef
 ## The harder question
 
 It would be easy to say this pattern is local — that it works for narrow legal-administrative automation and nothing else. The harder, more interesting question is the inverse: where would this *not* apply? On examination most of the candidates fall.
-
-<figure class="meme">
-  <img
-    src="https://api.memegen.link/images/drake/Closed_domain_vs_open_domain/Three_semantic_questions_about_the_domain.png?width=500"
-    alt="Drake meme: Drake rejecting 'Closed domain vs open domain' in the top panel, approving 'Three semantic questions about the domain' in the bottom panel."
-    loading="lazy"
-  />
-  <figcaption>The lazy binary is "domains where this generalizes vs. domains where it doesn't." The honest question is finer: it asks three things about the domain before it asks anything about scale.</figcaption>
-</figure>
 
 Trading at high frequency, the textbook latency objection, does not actually escape the pattern; it relocates the human approval. Risk auditors sample executions after the fact, regulators like MiFID II already require structured trade records, and when something deviates the proposal-like artifact is the object of review. Even when no human reviews, the interpretability gain alone — a flash-crash forensic that begins at a structured proposal instead of an unstructured log — justifies the artifact. Industrial control is similar: the more you look at it, the more it already *is* this pattern with different vocabulary. The playbook is the controller; the proposal is the setpoint change; the comment on the expediente is the entry in the operator log.
 

--- a/src/content/blog/2026-05-14-the-agent-that-doesnt-invent-verbs.md
+++ b/src/content/blog/2026-05-14-the-agent-that-doesnt-invent-verbs.md
@@ -2,6 +2,8 @@
 title: "The Agent That Doesn't Invent Verbs"
 description: "On Cucumber, content-addressing, and an alignment technique that turns out to be older than alignment."
 date: "2026-05-14"
+series: harness
+seriesOrder: 5
 ---
 
 A communication arrives in a legal office. It may create a deadline. It may require a task. It may need to be routed to another desk. Or it may require nothing except a reasoned acknowledgment and closure.
@@ -33,7 +35,7 @@ This file lives in a directory called `playbooks/`, alongside its siblings and d
 
 Most of the public discourse on AI alignment happens in the weights — interpretability via probing, alignment via training, oversight via post-hoc filtering. Here it happens in a directory. The agent's action space is enumerated; the enumeration is human-readable; the enumeration grows only when humans approve additions; and the act of approving an addition is a git commit. There is no probing required, because there is nothing inscrutable: the agent's vocabulary is on disk, in a language the lawyer reading the file already knows.
 
-This is alignment-by-affordance-restriction. It works not because a model was trained to refuse, but because the syntax of what the agent can do is itself constrained, and the constraints are written in prose that a non-engineer can audit. The technique is old enough to feel like cheating. Expert systems in the 1980s did something like it; so did doctrinal codifications, going back further. What is new is the recognition that an LLM, given a catalog, can pick from it and bind to it competently — and that this is enough, in the right domain, to deliver useful behavior without ceding the catalog.
+This is alignment-by-affordance-restriction. It is what [the harness, reclaimed](/blog/2026-04-29-reclaiming-the-harness), looks like at the level of a concrete action vocabulary: not a cage around a cognitive engine, but the structure that constitutes what the engine is allowed to mean. It works not because a model was trained to refuse, but because the syntax of what the agent can do is itself constrained, and the constraints are written in prose that a non-engineer can audit. The technique is old enough to feel like cheating. Expert systems in the 1980s did something like it; so did doctrinal codifications, going back further. What is new is the recognition that an LLM, given a catalog, can pick from it and bind to it competently — and that this is enough, in the right domain, to deliver useful behavior without ceding the catalog.
 
 <figure class="meme">
   <img
@@ -128,7 +130,7 @@ The canon's nodes are content-addressed via UUIDv5 over normalized content. The 
 
 Acyclicity is by construction. Every `@concretiza:` edge points from a higher tier to a strictly lower tier. There is no rule that says *no cycles* because cycles are unreachable: edges only flow downward. The lint that enforces this is a single line.
 
-The structural result is a canon that resembles a Merkle network more than a versioned directory: every node is identified by a hash of its content, edges reference hashes, and the proposal-to-canon relationship is just another edge — from a markdown artifact to a content-hash node. Git tracks the history of the bag of nodes; the bag of nodes is itself a graph that the agent navigates and the lint verifies. Two artifacts that pin the same UUID are guaranteed to be talking about the same content, because the UUID *is* the content. The pinning is structural, not by convention.
+The structural result is a canon that resembles a Merkle network more than a versioned directory: every node is identified by a hash of its content, edges reference hashes, and the proposal-to-canon relationship is just another edge — from a markdown artifact to a content-hash node. The same trick [Verne uses for agent identity](/blog/2026-03-18-verne-identity-repo) — content-addressing as the substrate for things that must remain reidentifiable across moves and renames — applied here to the agent's vocabulary instead of its memory. Git tracks the history of the bag of nodes; the bag of nodes is itself a graph that the agent navigates and the lint verifies. Two artifacts that pin the same UUID are guaranteed to be talking about the same content, because the UUID *is* the content. The pinning is structural, not by convention.
 
 <figure class="meme">
   <img
@@ -163,7 +165,7 @@ When the three answers are *yes*, the pattern fits, with the human approval plac
 
 The institutional reading is the cleanest. The canon is the corpus of doctrinal positions the office endorses. The proposal is the brief prepared by an advisor — bindings, traversal, reasoning, all written down for the principal to read. The apply is the principal's signature on the act. The comment on the expediente is the institutional justification that travels with the act forever in the case record.
 
-The agent is the diligent counsel. Not the apprentice — *that word is doing too much*, with its picture of someone supervised because they are still learning. The counsel is technically competent, often expert; supervised not by distrust but by constitutional design. The authority belongs to the principal because it must; the counsel prepares the act, commits to it in writing, hands it up. What the counsel cannot do is sign. What the catalog adds, and what content-addressing and traversal preserve, is the property that the counsel's preparation is structurally legible: anyone with access to the records can reconstruct exactly what was proposed, why it was proposed, and whether the signed act matched the proposal.
+The agent is the diligent counsel. Not the apprentice — *that word is doing too much*, with its picture of someone supervised because they are still learning. [Elsewhere I have described this in the register of daily delegation](/blog/2026-03-28-delegando-para-agentes), where the discipline is to hand the task down without handing the signature down. The counsel is technically competent, often expert; supervised not by distrust but by constitutional design. The authority belongs to the principal because it must; the counsel prepares the act, commits to it in writing, hands it up. What the counsel cannot do is sign. What the catalog adds, and what content-addressing and traversal preserve, is the property that the counsel's preparation is structurally legible: anyone with access to the records can reconstruct exactly what was proposed, why it was proposed, and whether the signed act matched the proposal.
 
 The file is still on the laptop, named for its own content. Inside it, a paragraph of Portuguese describes a result it does not produce. A reader will arrive, eventually.
 

--- a/src/content/blog/2026-05-14-the-agent-that-doesnt-invent-verbs.md
+++ b/src/content/blog/2026-05-14-the-agent-that-doesnt-invent-verbs.md
@@ -1,0 +1,186 @@
+---
+title: "The Agent That Doesn't Invent Verbs"
+description: "On Cucumber, content-addressing, and an alignment technique that turns out to be older than alignment."
+date: "2026-05-14"
+---
+
+There is a file on a laptop somewhere — perhaps in Porto Velho, perhaps elsewhere — called `playbooks/tier1/receber_expediente_com_prazo__a1b2c3d4.feature`. The eight hex characters after the double underscore are not decoration. They are the prefix of a UUIDv5 computed over the file's normalized content. The file does not carry a name to which a hash is attached. The file's name *is* the hash.
+
+This is a small commitment with consequences. Change a character — a comma added, a Gherkin keyword recapitalized — and the hash changes, and the filename changes, and the file as an identifiable thing in the world ceases to be that file and becomes another. There is no silent edit. The act of editing is, structurally, an act of replacement.
+
+Inside, after a header comment that repeats the full UUID for legibility, there is a paragraph of Portuguese that looks like a court document and parses like a program:
+
+```gherkin
+@tier1 @receber-expediente @com-prazo
+Funcionalidade: Receber expediente que cria prazo processual
+
+  Cenário: Garantir que prazo seja registrado e roteado
+    Dado que existe expediente <expediente_id> com prazo <prazo>
+    Quando o agente reflete sobre o expediente <expediente_id>
+    Então o prazo <prazo> deve estar registrado no expediente
+      E a pasta <pasta_id> deve ter rota de trabalho clara
+```
+
+The word *Então* is doing three jobs. To a legal reviewer reading it out loud, *then* — the rhetorical turn before a conclusion. To Gherkin's parser, a step keyword. To the step library a layer down, a function name that dispatches to either an executable action or a no-op assertion. The same letters, three readings.
+
+## The catalog is the vocabulary
+
+This file lives in a directory called `playbooks/`, alongside its siblings and descendants. Together they form a curated, finite, monotonically growing canon of legal scenarios. An AI agent operating in this system does not invent actions. It picks a scenario from the canon and fills its placeholders with concrete values from a case. That, plus a human approval step, plus the act of execution, is what the agent is allowed to do. Period.
+
+Most of the public discourse on AI alignment happens in the weights — interpretability via probing, alignment via training, oversight via post-hoc filtering. Here it happens in a directory. The agent's action space is enumerated; the enumeration is human-readable; the enumeration grows only when humans approve additions; and the act of approving an addition is a git commit. There is no probing required, because there is nothing inscrutable: the agent's vocabulary is on disk, in a language the lawyer reading the file already knows.
+
+This is alignment-by-affordance-restriction. It works not because a model was trained to refuse, but because the syntax of what the agent can do is itself constrained, and the constraints are written in prose that a non-engineer can audit. The technique is old enough to feel like cheating. Expert systems in the 1980s did something like it; so did doctrinal codifications, going back further. What is new is the recognition that an LLM, given a catalog, can pick from it and bind to it competently — and that this is enough, in the right domain, to deliver useful behavior without ceding the catalog.
+
+<figure class="meme">
+  <img
+    src="https://api.memegen.link/images/gb/Train_the_model_to_refuse/Filter_outputs_after_the_fact/Probe_activations_for_interpretability/Give_it_a_finite_directory.png?width=600"
+    alt="Galaxy brain meme with four panels of escalating brightness, labelled: 'Train the model to refuse', 'Filter outputs after the fact', 'Probe activations for interpretability', 'Give it a finite directory'."
+    loading="lazy"
+  />
+  <figcaption>The escalation ends not in a clever technique but in a directory of <code>.feature</code> files. Most alignment ideas live in the first three panels; the cheating happens in the fourth.</figcaption>
+</figure>
+
+## Doctrine, procedure, closure
+
+The canon stratifies. Tier 1 declares *outcome* — what counts as a legitimate result in this kind of situation. Tier 2 and below declare *action* — concrete steps that, if executed, produce such an outcome. Tier 1's `Então` clauses are no-ops at runtime; they are assertions about what the world should look like, not instructions about what to do. Tier 2 onward map each `Então` to a real writer in the system of record.
+
+The split is the old one between values and instrumental policies, made operational. The agent can propose new concretizations freely — a Tier 3 that specializes a Tier 2 for an edge case, with the appropriate lint passing — but extending the doctrinal layer requires explicit confirmation under a flag that names what is happening (`--i-am-introducing-new-doctrine`), and the proposal goes into a separate queue, and batch operations exclude it. The gradient is structural: procedural addition is cheap; doctrinal addition is expensive on purpose.
+
+<figure class="svg-illustration">
+  <svg viewBox="0 0 800 480" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title-tier-hierarchy">
+    <title id="title-tier-hierarchy">Hierarchy of tiers in the playbook canon</title>
+    <style>
+      .box { fill: none; stroke: var(--color-text, currentColor); stroke-width: 1.5; }
+      .label { font-family: ui-sans-serif, system-ui, sans-serif; font-size: 13px; fill: var(--color-text, currentColor); }
+      .small { font-size: 11px; font-family: ui-monospace, monospace; fill: var(--color-text, currentColor); opacity: 0.75; }
+      .edge { stroke: var(--color-text, currentColor); stroke-width: 1; opacity: 0.55; }
+      .tier-tag { font-size: 12px; font-family: ui-monospace, monospace; fill: var(--color-text, currentColor); opacity: 0.9; }
+    </style>
+
+    <rect x="280" y="30" width="240" height="92" class="box" />
+    <text x="400" y="55" text-anchor="middle" class="label" font-weight="600">Tier 1 — outcome</text>
+    <text x="400" y="78" text-anchor="middle" class="tier-tag">receber_expediente_com_prazo</text>
+    <text x="400" y="95" text-anchor="middle" class="small">__a1b2c3d4</text>
+    <text x="400" y="112" text-anchor="middle" class="small">@receber-expediente @com-prazo</text>
+
+    <rect x="80" y="200" width="240" height="92" class="box" />
+    <text x="200" y="225" text-anchor="middle" class="label" font-weight="600">Tier 2 — action</text>
+    <text x="200" y="248" text-anchor="middle" class="tier-tag">citacao_eletronica</text>
+    <text x="200" y="265" text-anchor="middle" class="small">__5f8a3b2c</text>
+    <text x="200" y="282" text-anchor="middle" class="small">@concretiza:a1b2c3d4 @contestacao</text>
+
+    <rect x="480" y="200" width="240" height="92" class="box" />
+    <text x="600" y="225" text-anchor="middle" class="label" font-weight="600">Tier 2 — action</text>
+    <text x="600" y="248" text-anchor="middle" class="tier-tag">ciencia_sem_prazo</text>
+    <text x="600" y="265" text-anchor="middle" class="small">__7c1e9f3a</text>
+    <text x="600" y="282" text-anchor="middle" class="small">@concretiza:a1b2c3d4 @ciencia</text>
+
+    <rect x="80" y="370" width="240" height="92" class="box" />
+    <text x="200" y="395" text-anchor="middle" class="label" font-weight="600">Tier 3 — leaf</text>
+    <text x="200" y="418" text-anchor="middle" class="tier-tag">citacao_eletronica_sem_caixa</text>
+    <text x="200" y="435" text-anchor="middle" class="small">__9e7d6c5b</text>
+    <text x="200" y="452" text-anchor="middle" class="small">@concretiza:5f8a3b2c @sem-caixa</text>
+
+    <line x1="240" y1="200" x2="340" y2="122" class="edge" />
+    <line x1="560" y1="200" x2="460" y2="122" class="edge" />
+    <line x1="200" y1="370" x2="200" y2="292" class="edge" />
+  </svg>
+  <figcaption>Tier 1 declares outcome; Tier 2 concretizes via <code>@concretiza:&lt;uuid&gt;</code>; Tier 3 adds situational specialization. Leaves — nodes with no children — are the only playbooks an agent may bind directly.</figcaption>
+</figure>
+
+One case took longer to see clearly: closure. In a ticket system — and a case management system is exactly that, with cases instead of tickets — *do nothing* is not a state. Every ticket terminates somewhere: archived with reason, dismissed with justification, forwarded to another sector. Even taking notice of a merely informative communication is, in the Kanoê that PINK reads, an act — the act of registering acknowledgment and closing the expediente. So the seed canon must include Tier 1s whose `Então` clauses recognize closure as legitimate outcome, and which require the substantive reason for closure to be written as a comment on the expediente before the close. Without that, the catalog biases the agent toward proposing procedural action in cases that only require acknowledgment, and loses the chance to capture the agent's reflection as an artifact that lives, permanently, in the case itself.
+
+## The descent is the reasoning
+
+How does the agent find the right scenario? The first answer that suggests itself is matching — give the system the case data, give it the catalog, have it rank candidates by tag overlap or precondition similarity, present the top match. This is what the design originally proposed. It was wrong, and the wrongness is illuminating.
+
+A matcher built into the tool steals the judgment that should belong to the reasoning system above it. The current design does no matching. PINK exposes the canon as a tree and lets the agent walk it. The agent keeps Tier 1 and Tier 2 in working context — the upper canon, small enough to fit there. For a given expediente, the agent picks a Tier 2 whose preconditions describe the case, asks PINK for its `children`, and if the list is non-empty, reads each child and chooses the specialization that fits. The loop terminates at a leaf — a node with no children of its own — and the proposal binds that leaf. If at any descent step no child fits the case, the agent proposes a new Tier N+1 under the current node, carrying `@concretiza:<current_uuid>`. That is the system's learning gradient, disciplined: every new scenario points by content-hash to its parent.
+
+<figure class="mermaid-diagram">
+
+```mermaid
+graph LR
+  D[Discover<br/><i>read Metabase</i>] --> F[Fetch<br/><i>read Kanoê PDFs</i>]
+  F --> P[Propose<br/><i>traversal + write .md</i>]
+  P --> R[Review<br/><i>human gate</i>]
+  R --> A[Apply<br/><i>kanoe writes + expediente comment</i>]
+```
+
+<figcaption>The five-stage pipeline. The first three are read-only against the legal system of record; the fourth is human gating; the fifth is the only stage that mutates Kanoê, and only via approved write primitives.</figcaption>
+</figure>
+
+PINK is deliberately stupid. *And it's a feature, not a bug.* All inference happens in the LLM, where it belongs; all structure lives in PINK, where it can be audited deterministically. The chain of descent — which Tier 2, which Tier 3, which Tier 4 — is recorded in a `traversal:` field on the proposal, with the UUID of each visited node. Months later, a reviewer asking *why did the agent descend this far* reads the chain and reconstructs the reasoning step by step. Interpretability of the act, not from weights but from artifact.
+
+## Two artifacts, two readers, the same reflection
+
+When the human approves and the system applies, two things happen at once. The actions inscribed in the leaf's `Então` clauses fire in order against the legal system of record. A comment is posted to the expediente with the substantive reason the agent found. The deadline is registered. The pasta is moved to the appropriate box. A task is created with the appropriate title and due date.
+
+That is one artifact: the comment on the expediente. It lives in Kanoê, on the case, forever. Any legal reviewer who opens that expediente three years later sees, in Portuguese, written as if by a lawyer: *Acknowledged. The communication establishes no deadline because [the substantive reasoning]*. The comment is in the place a lawyer would already be looking, in the register a lawyer would already be reading.
+
+The other artifact is the proposal markdown. It lives at `.pink/<CNJ>/proposals/<exp_id>.md`, content-addressed, git-tracked, parsed once by `pink propose apply`. It carries the YAML frontmatter (which playbook, which UUID, which traversal chain), the bindings (placeholders filled with case values), the instantiated Gherkin block (which is what `apply` parses and executes), and the narrative reasoning the agent wrote to itself about why this scenario fits this case.
+
+The two artifacts carry the same substantive content. The `motivo_substantivo` filled into the binding appears, word for word, as the text of the comment on the expediente. There is no translation between *what the agent reasoned* and *what the case record shows*. The technical audit lives in the markdown; the legal audit lives in Kanoê; the reflection is one act, recorded in both registers at once.
+
+## A directory that is a Merkle network
+
+The canon's nodes are content-addressed via UUIDv5 over normalized content. The `@concretiza:` tag — the edge that says *this scenario specializes that one* — points by UUID, not by path. Moving a playbook between directories does not break the edge; renaming the human-readable slug does not break the edge; only changing the content does, and changing the content means the UUID changes, which means the file with the old UUID no longer exists. Edit equals delete plus create. Identity is content.
+
+Acyclicity is by construction. Every `@concretiza:` edge points from a higher tier to a strictly lower tier. There is no rule that says *no cycles* because cycles are unreachable: edges only flow downward. The lint that enforces this is a single line.
+
+The structural result is a canon that resembles a Merkle network more than a versioned directory: every node is identified by a hash of its content, edges reference hashes, and the proposal-to-canon relationship is just another edge — from a markdown artifact to a content-hash node. Git tracks the history of the bag of nodes; the bag of nodes is itself a graph that the agent navigates and the lint verifies. Two artifacts that pin the same UUID are guaranteed to be talking about the same content, because the UUID *is* the content. The pinning is structural, not by convention.
+
+<figure class="meme">
+  <img
+    src="https://api.memegen.link/images/same/A_versioned_directory/A_Merkle_network.png?width=500"
+    alt="Pam from The Office holding up a photo, captioned 'Corporate needs you to find the differences between this picture and this picture: A versioned directory / A Merkle network. They're the same picture.'"
+    loading="lazy"
+  />
+  <figcaption>Once edges point at hashes and identity collapses into content, the directory has quietly become a different kind of object — though every editor on the team still opens it as a folder.</figcaption>
+</figure>
+
+## What still escapes
+
+None of this is finished. Three honest residuals deserve naming.
+
+The relationship between Tier 1 outcomes and the Tier 2+ scenarios that claim to realize them is enforced by human review, not by code. The lint can verify that the `@concretiza:` tag is present and that the target tier is strictly less than the source. It cannot verify that the concrete `Então` clauses of the child actually realize the outcome `Então` clauses of the parent. That check is semantic; it is human; it is the soft seam.
+
+The `confidence:` field on each proposal — the agent's self-reported number — is unstratified. There is no feedback loop in v1 that ties past outcomes to per-playbook calibration. A reader of the proposal who reads `confidence: 0.82` should mentally append *agent self-report; uncalibrated*. The field is a marker for future work, not a statistical signal.
+
+And apply, the act of executing the Gherkin against the legal system, is best-effort. The Kanoê write primitives are not transactional. A partial apply leaves the case in a state that may be intermediate — three of five `Então` clauses landed; two failed because preconditions drifted. The retry path handles *do the ones that didn't land yet*; it does not handle *and the world has moved underneath us since the first three landed*. Cascading state drift between executed steps is the honest frontier.
+
+## The harder question
+
+It would be easy to say this pattern is local — that it works for narrow legal-administrative automation and nothing else. The harder, more interesting question is the inverse: where would this *not* apply? On examination most of the candidates fall.
+
+<figure class="meme">
+  <img
+    src="https://api.memegen.link/images/drake/Closed_domain_vs_open_domain/Three_semantic_questions_about_the_domain.png?width=500"
+    alt="Drake meme: Drake rejecting 'Closed domain vs open domain' in the top panel, approving 'Three semantic questions about the domain' in the bottom panel."
+    loading="lazy"
+  />
+  <figcaption>The lazy binary is "domains where this generalizes vs. domains where it doesn't." The honest question is finer: it asks three things about the domain before it asks anything about scale.</figcaption>
+</figure>
+
+Trading at high frequency, the textbook latency objection, does not actually escape the pattern; it relocates the human approval. Risk auditors sample executions after the fact, regulators like MiFID II already require structured trade records, and when something deviates the proposal-like artifact is the object of review. Even when no human reviews, the interpretability gain alone — a flash-crash forensic that begins at a structured proposal instead of an unstructured log — justifies the artifact. Industrial control is similar: the more you look at it, the more it already *is* this pattern with different vocabulary. The playbook is the controller; the proposal is the setpoint change; the comment on the expediente is the entry in the operator log.
+
+The genuine non-applicabilities turn out to be three semantic questions, not technical ones. *Is there a discrete unit of action* — something the agent can decompose what it did into named steps? Free creative writing has no such unit; a condolence letter is not three `Então`s. *Is there a record where the reflection belongs* — a case, a ticket, a chart, a ledger — that the actor and a future reviewer both consult? Casual conversation has none. *Does the operator want to be auditable?* Investigative journalism with confidential sources, internal litigation strategy under professional privilege, dissent under an authoritarian regime — all are domains where the pattern would be a trap rather than a tool.
+
+When the three answers are *yes*, the pattern fits, with the human approval placed wherever throughput permits. When any is *no*, the pattern fails by nature of the domain, not by scale.
+
+## The diligent counsel
+
+The institutional reading is the cleanest. The canon is the corpus of doctrinal positions the office endorses. The proposal is the brief prepared by an advisor — bindings, traversal, reasoning, all written down for the principal to read. The apply is the principal's signature on the act. The comment on the expediente is the institutional justification that travels with the act forever in the case record.
+
+The agent is the diligent counsel. Not the apprentice — *that word is doing too much*, with its picture of someone supervised because they are still learning. The counsel is technically competent, often expert; supervised not by distrust but by constitutional design. The authority belongs to the principal because it must; the counsel prepares the act, commits to it in writing, hands it up. What the counsel cannot do is sign. What the catalog adds, and what content-addressing and traversal preserve, is the property that the counsel's preparation is structurally legible: anyone with access to the records can reconstruct exactly what was proposed, why it was proposed, and whether the signed act matched the proposal.
+
+The file is still on the laptop, named for its own content. Inside it, a paragraph of Portuguese describes a result it does not produce. A reader will arrive, eventually.
+
+## For further reading
+
+- **Paul Christiano, Buck Shlegeris, Dario Amodei, *Supervising strong learners by amplifying weak experts* (2018)** — the canonical paper on scalable oversight; the bandwidth question this design answers in the concrete is the one the paper poses in the abstract.
+- **Dylan Hadfield-Menell et al., *The Off-Switch Game* (2017)** — corrigibility as game theory. The human-approval-before-apply step in PINK is a concrete shape of what this paper formalizes.
+- **Stuart Russell, *Human Compatible* (2019)** — the values-vs-instrumental-policies separation at book length; Tier 1/Tier 2+ is what it looks like when you make the separation operational.
+- **Lucy Suchman, *Plans and Situated Actions* (1987)** — the plan as accountable artifact, not as causal cognition. The proposal markdown is exactly this: not a record of how the agent decided, but the structured commitment by which the decision will be judged.
+- **Ralph Merkle, *A Digital Signature Based on a Conventional Encryption Function* (1987)** — the original Merkle-tree construction. The canon's content-addressing borrows the same trick: a node's identity is the hash of its content; edges reference hashes; the graph is verifiable end to end.
+- **Dan North, *Introducing BDD* (2006)** — where Gherkin came from. The grammar was designed for human-readable test specification; that it survives as the grammar of an agent's allowed actions is a happy accident with a long lineage.
+- **Kevin Ashley, *Modeling Legal Argument: Reasoning with Cases and Hypotheticals* (1990)** — the expert-systems-in-law tradition (HYPO, CATO) is the prehistory of this design. They tried to encode legal reasoning in machines; we are now encoding it as the boundary of what a machine is allowed to do.


### PR DESCRIPTION
## Summary
- Adds new blog post dated 2026-05-14: *The Agent That Doesn't Invent Verbs*
- On Cucumber, content-addressing, and an alignment technique that turns out to be older than alignment
- Frontmatter normalized to the collection schema (`date` instead of `pubDate`)

## Test plan
- [ ] `npm run build` succeeds with the new post included
- [ ] Post renders at `/blog/2026-05-14-the-agent-that-doesnt-invent-verbs/`
- [ ] Embedded SVG, Mermaid diagram, and meme figures display correctly

https://claude.ai/code/session_01LQhUAqavb7XXDz9MNi4DhP

---
_Generated by [Claude Code](https://claude.ai/code/session_01LQhUAqavb7XXDz9MNi4DhP)_