### PR TITLE
feat: SEO, accessibility and multilingual improvements

### DIFF
--- a/.routines/2026-05-14-seo-ux-accessibility.md
+++ b/.routines/2026-05-14-seo-ux-accessibility.md
@@ -1,0 +1,73 @@
+---
+date: 2026-05-14
+slug: seo-ux-accessibility
+branch: claude/trusting-fermi-IbmMb
+status: pr-open
+---
+
+# Sessão 2026-05-14 — SEO, UX & Acessibilidade
+
+## Contexto
+
+Primeira sessão com o sistema `.routines/`. O blog estava bem estruturado
+(OG images dinâmicas, JSON-LD, RSS, sitemap), mas com lacunas identificadas
+num audit completo.
+
+## O que foi feito nesta sessão
+
+### PR aberto — dependabot #38
+- `defu` 6.1.4 → 6.1.6 tem conflito de merge; não foi possível fazer merge.
+  Ação: fechar manualmente e atualizar o lock file na próxima sessão.
+
+### Melhorias implementadas (branch `claude/trusting-fermi-IbmMb`)
+
+| Arquivo | Mudança |
+|---------|---------|
+| `src/components/Header.astro` | `aria-label` em todos os links de nav (acessibilidade WCAG 2.1) |
+| `src/layouts/PageLayout.astro` | `twitter:site`, `twitter:creator`, `og:locale` dinâmico, `og:image:alt`, `twitter:image:alt` |
+| `src/layouts/PageLayout.astro` | BreadcrumbList JSON-LD para artigos (Home > Blog > Post) |
+| `src/layouts/PageLayout.astro` | Prop `lang` passada até o `<html lang>` |
+| `src/content.config.ts` | Campo `lang: z.enum(['en','pt']).optional()` no schema |
+| `src/pages/blog/[...slug].astro` | Passa `lang` do frontmatter para o layout |
+| `public/robots.txt` | Criado: permite tudo, bloqueia `/og/`, aponta para sitemap |
+
+### Por que cada mudança importa
+
+- **aria-labels no nav**: leitores de tela anunciavam só o emoji — inútil sem label.
+- **twitter:creator/site**: posts compartilhados no X não tinham atribuição ao autor.
+- **og:locale dinâmico**: posts em PT eram indexados como `en_US` pelo Facebook/LinkedIn.
+- **BreadcrumbList**: Google Search Console mostra breadcrumbs nos rich results; melhora CTR.
+- **lang no HTML**: requisito de acessibilidade; posts em PT precisavam de `lang="pt"`.
+- **robots.txt**: sem ele, crawlers não sabiam evitar `/og/` (imagens internas de OG).
+
+## Próximas sessões — backlog priorizado
+
+### Alta prioridade
+1. **Table of Contents automático** para posts longos — usar headings rehypeSlug já
+   existentes. Componente Astro que gera `<nav>` com âncoras dos H2/H3.
+2. **Pagination em /archive/ e /tags/[tag]/** — carregar todos os posts de uma vez
+   vai escalar mal; Astro suporta `paginate()` nativo.
+3. **Related Posts** — ao final de cada post, mostrar 2-3 posts com tags em comum.
+   Algoritmo simples: interseção de tags, ordenado por data.
+
+### Média prioridade
+4. **dependabot #38** — atualizar `defu` manualmente (npm update defu, commitar lock file).
+5. **og:locale:alternate** — quando `lang=pt`, adicionar `<meta property="og:locale:alternate" content="en_US">`.
+6. **wordCount no JSON-LD** — `minutesRead` já está disponível via remark plugin; passar
+   para o BlogPosting schema.
+7. **Caching para GitHub Projects** — `src/pages/projects.astro` faz fetch live; se
+   a API falhar o build quebra. Adicionar fallback com dados cacheados.
+
+### Baixa prioridade
+8. **FAQ Schema** na página /about/.
+9. **Focus management** nas transições de página (ClientRouter).
+10. **Testar posts em PT** adicionando `lang: pt` no frontmatter dos posts PT existentes
+    (e.g., `o-ovo-de-serpente.md`).
+
+## Decisões arquiteturais
+
+- **Não implementei pagination agora**: mudança com impacto maior, precisa de
+  revisão de UX (infinita scroll vs. paginação clássica?).
+- **`lang` como enum `['en','pt']`**: extensível para outros idiomas; simples de validar.
+- **BreadcrumbList no layout, não no template**: evita duplicação se outros tipos de
+  página quiserem breadcrumbs futuramente.

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,5 @@
+User-agent: *
+Allow: /
+Disallow: /og/
+
+Sitemap: https://franklinbaldo.github.io/sitemap-index.xml

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -8,13 +8,13 @@ import ThemeToggle from './ThemeToggle.svelte';
       <li><strong>Franklin Baldo</strong></li>
     </ul>
     <ul>
-      <li><a href="/" class="secondary">🏠</a></li>
-      <li><a href="/archive/" class="secondary">📂</a></li>
-      <li><a href="/tags/" class="secondary">🏷️</a></li>
-      <li><a href="/projects/" class="secondary">⚙️</a></li>
-      <li><a href="https://github.com/franklinbaldo/skills" class="secondary" title="Skills">⚡</a></li>
-      <li><a href="/search/" class="secondary">🔎</a></li>
-      <li><a href="/about/" class="secondary">📚</a></li>
+      <li><a href="/" class="secondary" aria-label="Home">🏠</a></li>
+      <li><a href="/archive/" class="secondary" aria-label="Archive">📂</a></li>
+      <li><a href="/tags/" class="secondary" aria-label="Tags">🏷️</a></li>
+      <li><a href="/projects/" class="secondary" aria-label="Projects">⚙️</a></li>
+      <li><a href="https://github.com/franklinbaldo/skills" class="secondary" aria-label="Skills">⚡</a></li>
+      <li><a href="/search/" class="secondary" aria-label="Search">🔎</a></li>
+      <li><a href="/about/" class="secondary" aria-label="About">📚</a></li>
       <li><ThemeToggle client:idle /></li>
     </ul>
   </nav>

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -11,6 +11,7 @@ const blog = defineCollection({
     tags: z.array(z.string()).optional(),
     heroImage: image().optional(),
     heroImageAlt: z.string().optional(),
+    lang: z.enum(['en', 'pt']).optional(),
     series: z.string().optional(),
     seriesOrder: z.number().optional(),
     featured: z.boolean().optional(),

--- a/src/layouts/PageLayout.astro
+++ b/src/layouts/PageLayout.astro
@@ -12,6 +12,7 @@ interface Props {
   publishedTime?: Date;
   modifiedTime?: Date;
   tags?: string[];
+  lang?: "en" | "pt";
 }
 
 const SITE_NAME = "Franklin Baldo";
@@ -28,6 +29,7 @@ const {
   publishedTime,
   modifiedTime,
   tags,
+  lang = "en",
 } = source;
 
 const documentTitle = title.includes(SITE_NAME) ? title : `${title} | ${SITE_NAME}`;
@@ -35,6 +37,18 @@ const documentTitle = title.includes(SITE_NAME) ? title : `${title} | ${SITE_NAM
 const canonical = new URL(Astro.url.pathname, Astro.site);
 const ogImage = image ? new URL(image, Astro.site).href : undefined;
 const rssUrl = new URL("rss.xml", Astro.site);
+
+const breadcrumbLd = type === "article"
+  ? {
+      "@context": "https://schema.org",
+      "@type": "BreadcrumbList",
+      itemListElement: [
+        { "@type": "ListItem", position: 1, name: "Home", item: Astro.site?.href },
+        { "@type": "ListItem", position: 2, name: "Blog", item: new URL("/archive/", Astro.site).href },
+        { "@type": "ListItem", position: 3, name: title, item: canonical.href },
+      ],
+    }
+  : null;
 
 const jsonLd = type === "article"
   ? {
@@ -58,7 +72,7 @@ const jsonLd = type === "article"
 ---
 
 <!doctype html>
-<html lang="en">
+<html lang={lang}>
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -82,7 +96,9 @@ const jsonLd = type === "article"
     <meta property="og:description" content={description} />
     <meta property="og:url" content={canonical.href} />
     <meta property="og:site_name" content="Franklin Baldo" />
+    <meta property="og:locale" content={lang === "pt" ? "pt_BR" : "en_US"} />
     {ogImage && <meta property="og:image" content={ogImage} />}
+    {ogImage && <meta property="og:image:alt" content={title} />}
     {publishedTime && (
       <meta property="article:published_time" content={publishedTime.toISOString()} />
     )}
@@ -92,11 +108,15 @@ const jsonLd = type === "article"
     {tags?.map((tag) => <meta property="article:tag" content={tag} />)}
 
     <meta name="twitter:card" content={ogImage ? "summary_large_image" : "summary"} />
+    <meta name="twitter:site" content="@franklinbaldo" />
+    <meta name="twitter:creator" content="@franklinbaldo" />
     <meta name="twitter:title" content={title} />
     <meta name="twitter:description" content={description} />
     {ogImage && <meta name="twitter:image" content={ogImage} />}
+    {ogImage && <meta name="twitter:image:alt" content={title} />}
 
     <script type="application/ld+json" set:html={JSON.stringify(jsonLd)} is:inline />
+    {breadcrumbLd && <script type="application/ld+json" set:html={JSON.stringify(breadcrumbLd)} is:inline />}
 
     <script is:inline>
       const theme = localStorage.getItem('theme') ||

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -20,7 +20,7 @@ type Props = CollectionEntry<'blog'>;
 
 const post = Astro.props;
 const { Content, remarkPluginFrontmatter } = await render(post);
-const { heroImage, heroImageAlt, title, description, date, tags } = post.data;
+const { heroImage, heroImageAlt, title, description, date, tags, lang } = post.data;
 const minutesRead: number | undefined = remarkPluginFrontmatter.minutesRead;
 const lastModifiedISO: string | undefined = remarkPluginFrontmatter.lastModified;
 const lastModified = lastModifiedISO ? new Date(lastModifiedISO) : undefined;
@@ -38,6 +38,7 @@ const series = await getSeriesContext(post);
   publishedTime={date}
   modifiedTime={lastModified}
   tags={tags}
+  lang={lang}
 >
   <article data-pagefind-body>
     <header>


### PR DESCRIPTION
## Summary

- **Accessibility**: Add `aria-label` to all header navigation emoji links (WCAG 2.1 compliance — screen readers were announcing just emoji characters)
- **SEO meta tags**: Add `twitter:site`, `twitter:creator`, `og:locale` (dynamic per post language), `og:image:alt`, `twitter:image:alt`
- **Structured data**: Add `BreadcrumbList` JSON-LD schema on all blog posts (Home → Blog → Post), enabling Google rich results
- **Multilingual**: Add `lang` field (`en`/`pt`) to blog content schema; propagated to `<html lang>` attribute via layout prop
- **robots.txt**: Create `public/robots.txt` — explicitly allows crawling, disallows `/og/` (internal OG image generation), points to sitemap

## Why these changes

The blog already had solid OG/JSON-LD foundations. These changes fill the specific gaps an audit found: Twitter attribution was missing, Portuguese posts were indexed as `en_US`, breadcrumbs weren't signaled to search engines, and navigation was inaccessible to screen readers.

## Test plan

- [ ] Check that `<html lang="pt">` renders for a post with `lang: pt` in frontmatter
- [ ] Verify `og:locale` is `pt_BR` for PT posts, `en_US` for EN posts
- [ ] Confirm breadcrumb JSON-LD appears in page source for blog posts
- [ ] Run Lighthouse accessibility audit — nav links should now have accessible names
- [ ] Verify `/robots.txt` is served correctly on production

## Routine log

Session notes saved to `.routines/2026-05-14-seo-ux-accessibility.md` with next-session backlog.

https://claude.ai/code/session_01FEnfgo7fsgEsRxzxbtie8c

---
_Generated by [Claude Code](https://claude.ai/code/session_01FEnfgo7fsgEsRxzxbtie8c)_