### PR TITLE
feat: multilingual infrastructure — EN/PT language switcher

### DIFF
--- a/.routines/2026-05-14-multilingual-i18n.md
+++ b/.routines/2026-05-14-multilingual-i18n.md
@@ -1,0 +1,80 @@
+---
+date: 2026-05-14
+slug: multilingual-i18n
+branch: claude/gallant-gates-MCyCa
+status: pr-open
+session: 2
+---
+
+# Sessão 2026-05-14 — Multilingual / i18n
+
+## Contexto
+
+Segunda sessão com o sistema `.routines/`. Chegou com PR #65 aberto (SEO, acessibilidade).
+Objetivo principal: sistema multilingual (EN padrão, PT-BR em todo post/página, UI serve conforme preferência do usuário).
+
+## O que foi feito nesta sessão
+
+### Merge de PR aberta
+- **PR #65** (SEO/acessibilidade) — todas as CI checks verdes → squash merge realizado.
+- **PR #38** (dependabot defu) — mantida aberta (conflito de merge; baixa prioridade).
+
+### Infraestrutura multilingual (branch `claude/gallant-gates-MCyCa`)
+
+| Arquivo | Mudança |
+|---------|---------|
+| `src/content.config.ts` | Campo `translationKey: z.string().optional()` para parear posts traduzidos |
+| `src/lib/i18n.ts` | **Novo** — dicionário de strings de UI em EN e PT; helper `t(lang, key)` e `detectLang()` |
+| `src/components/LanguageSwitcher.svelte` | **Novo** — botão de flag (🇧🇷/🇺🇸) com Svelte 5 runes; persiste em `localStorage.lang`; auto-redireciona via `window.__translationHref` quando preferência ≠ lang do post e tradução existe |
+| `src/components/Header.astro` | Inclui `<LanguageSwitcher client:idle />` ao lado do ThemeToggle |
+| `src/layouts/PageLayout.astro` | Prop `translationHref?: string`; injeta `window.__translationHref`; tags `<link rel="alternate" hreflang>` para SEO |
+| `src/pages/blog/[...slug].astro` | Lê `translationKey` do frontmatter; busca post parceiro na coleção; passa `translationHref` ao layout |
+| `src/pages/blog/[...slug].astro` | Link "🇧🇷 Ler em Português" / "🇺🇸 Read in English" no footer do post quando tradução existe |
+| `src/components/PostCard.astro` | Badge `🇧🇷 PT` nos cards de posts em PT; data formatada em `pt-BR` para posts PT |
+| Posts (29 arquivos) | `lang: pt` ou `lang: en` adicionado ao frontmatter de todos os posts |
+
+### Por que cada mudança importa
+
+- **i18n.ts**: single source of truth para strings; evita hardcode espalhado em múltiplos componentes.
+- **LanguageSwitcher**: UX mínima sem recarregar página; o botão grayed-out quando não há tradução sinaliza isso sem confundir.
+- **translationKey**: permite parear posts futuros sem mudar URLs (a sessão de criação de conteúdo traduzido usará isso).
+- **hreflang**: Google Search Console usa para servir versão correta por país; essencial para indexação PT-BR vs EN.
+- **lang badge no PostCard**: permite ao usuário no índice/arquivo escanear qual língua é cada post antes de clicar.
+- **data pt-BR**: datas como "14 de maio de 2026" nos posts PT melhoram coerência de leitura.
+
+## Estratégia i18n adotada
+
+Pesquisa realizada sobre recomendações de Astro, Svelte e Pico CSS para i18n:
+- **Não usamos o roteamento i18n do Astro** (`/en/`, `/pt/`): o projeto está em SSG (GitHub Pages); a reestruturação de rotas seria destrutiva e desnecessária.
+- **URL-agnóstica por idioma**: EN posts em `/blog/slug/`, PT posts em `/blog/slug-pt/` — sem prefixo de locale na URL. Pares ligados por `translationKey`.
+- **Strings de UI via `i18n.ts`**: objeto simples, sem biblioteca pesada (svelte-i18n, paraglide, etc.).
+- **Preferência via localStorage**: segue o mesmo padrão do ThemeToggle já existente.
+
+## Estado atual
+
+- Todo post existente tem `lang: pt` ou `lang: en` no frontmatter.
+- Nenhum par de tradução criado ainda (`translationKey` configurado mas não usado) — a infraestrutura está pronta.
+- Build bem-sucedido: 131 páginas sem erros.
+
+## Próximas sessões — backlog priorizado
+
+### Alta prioridade
+1. **Criar traduções de posts EN → PT** (ou PT → EN): usar `translationKey` para parear. Começar pelos posts mais recentes/lidos. Cada tradução = nova entrada na coleção com slug diferente.
+2. **Versões PT das páginas estáticas** (`/about/`, `/index/`): criar `src/pages/pt/about.astro` e `src/pages/pt/index.astro` com conteúdo traduzido; LanguageSwitcher navega entre elas.
+3. **Table of Contents** para posts longos — backlog desde sessão anterior.
+
+### Média prioridade
+4. **Pagination** em `/archive/` e `/tags/[tag]/` (Astro `paginate()`).
+5. **Related Posts** ao fim de cada post (interseção de tags).
+6. **dependabot #38** — atualizar `defu` manualmente.
+
+### Baixa prioridade
+7. **Filtro de língua no índice/arquivo**: checkbox EN/PT para filtrar posts por idioma.
+8. **og:locale:alternate** quando `lang=pt`.
+9. **wordCount no JSON-LD** (minutesRead já disponível).
+
+## Decisões arquiteturais
+
+- **`window.__translationHref` pattern**: evita threading de props Astro → Header → Svelte. Seguimos o mesmo padrão do `data-theme` do ThemeToggle.
+- **Auto-redirect com `sessionStorage`**: redireciona uma vez por sessão (se preferência ≠ lang do post e tradução existe), mas não bloqueia se o usuário navegar de volta.
+- **Svelte 5 runes** (`$state`, `$derived`): consistente com ThemeToggle existente.

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,5 +1,6 @@
 ---
 import ThemeToggle from './ThemeToggle.svelte';
+import LanguageSwitcher from './LanguageSwitcher.svelte';
 ---
 
 <header class="container">
@@ -15,6 +16,7 @@ import ThemeToggle from './ThemeToggle.svelte';
       <li><a href="https://github.com/franklinbaldo/skills" class="secondary" aria-label="Skills">⚡</a></li>
       <li><a href="/search/" class="secondary" aria-label="Search">🔎</a></li>
       <li><a href="/about/" class="secondary" aria-label="About">📚</a></li>
+      <li><LanguageSwitcher client:idle /></li>
       <li><ThemeToggle client:idle /></li>
     </ul>
   </nav>

--- a/src/components/LanguageSwitcher.svelte
+++ b/src/components/LanguageSwitcher.svelte
@@ -1,0 +1,65 @@
+<script>
+  import { onMount } from 'svelte';
+
+  let userLang = $state('en');
+  let mounted = $state(false);
+
+  onMount(() => {
+    const stored = localStorage.getItem('lang');
+    if (stored === 'en' || stored === 'pt') {
+      userLang = stored;
+    } else {
+      userLang = navigator.language.toLowerCase().startsWith('pt') ? 'pt' : 'en';
+      localStorage.setItem('lang', userLang);
+    }
+    mounted = true;
+
+    // Auto-redirect: if page lang differs from stored preference and a translation exists
+    const pageLang = document.documentElement.lang;
+    const translationHref = (window).__translationHref;
+    if (pageLang && translationHref && pageLang !== userLang) {
+      // Only redirect if user hasn't explicitly visited this page (check sessionStorage)
+      const key = `visited:${window.location.pathname}`;
+      if (!sessionStorage.getItem(key)) {
+        sessionStorage.setItem(key, '1');
+        window.location.href = translationHref;
+      }
+    }
+  });
+
+  function switchLang() {
+    const target = userLang === 'en' ? 'pt' : 'en';
+    localStorage.setItem('lang', target);
+    userLang = target;
+
+    const translationHref = (window).__translationHref;
+    if (translationHref) {
+      window.location.href = translationHref;
+    }
+  }
+
+  const label = $derived(userLang === 'en' ? '🇧🇷 PT' : '🇺🇸 EN');
+  const title = $derived(userLang === 'en' ? 'Ler em Português' : 'Read in English');
+  const hasTranslation = $derived(mounted && !!(window).__translationHref);
+</script>
+
+{#if mounted}
+  <button
+    class="btn-emoji lang-btn"
+    onclick={switchLang}
+    aria-label={title}
+    {title}
+    style={hasTranslation ? '' : 'opacity: 0.4; cursor: default;'}
+  >
+    {label}
+  </button>
+{:else}
+  <span class="btn-emoji lang-btn" aria-hidden="true" style="opacity:0.3">🌐</span>
+{/if}
+
+<style>
+  .lang-btn {
+    font-size: 0.85rem;
+    letter-spacing: 0.02em;
+  }
+</style>

--- a/src/components/PostCard.astro
+++ b/src/components/PostCard.astro
@@ -20,7 +20,8 @@ const emojiMap: Record<string, string> = {
 const tag = post.data.tags?.[0]?.toLowerCase();
 const emoji = (tag && emojiMap[tag]) || emojiMap.default;
 
-const formattedDate = post.data.date.toLocaleDateString('en-US', {
+const postLang = post.data.lang ?? 'en';
+const formattedDate = post.data.date.toLocaleDateString(postLang === 'pt' ? 'pt-BR' : 'en-US', {
   year: 'numeric',
   month: 'long',
   day: 'numeric',
@@ -36,7 +37,10 @@ const blurb = excerpt(post.body ?? '', 320) || post.data.description;
         <span class="emoji" aria-hidden="true">{emoji}</span>
         <a href={`/blog/${post.id}/`} class="contrast">{post.data.title}</a>
       </h3>
-      <p><small>{formattedDate}</small></p>
+      <p>
+        <small>{formattedDate}</small>
+        {postLang === 'pt' && <small class="lang-badge" aria-label="Post in Portuguese">🇧🇷 PT</small>}
+      </p>
     </hgroup>
   </header>
   <p class="excerpt">{blurb}</p>
@@ -62,5 +66,10 @@ const blurb = excerpt(post.body ?? '', 320) || post.data.description;
   .excerpt {
     color: var(--pico-color);
     margin-bottom: 0.75rem;
+  }
+  .lang-badge {
+    margin-left: 0.5rem;
+    opacity: 0.7;
+    font-size: 0.75em;
   }
 </style>

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -12,6 +12,7 @@ const blog = defineCollection({
     heroImage: image().optional(),
     heroImageAlt: z.string().optional(),
     lang: z.enum(['en', 'pt']).optional(),
+    translationKey: z.string().optional(),
     series: z.string().optional(),
     seriesOrder: z.number().optional(),
     featured: z.boolean().optional(),

--- a/src/content/blog/2026-02-26-tudo-e-processo.md
+++ b/src/content/blog/2026-02-26-tudo-e-processo.md
@@ -2,6 +2,7 @@
 title: "Tudo é Processo: 5 Lições que Deveríamos Ter Aprendido Há 2.500 Anos"
 description: "Há vinte e cinco séculos, quatro vozes em cantos opostos do mundo convergiram para a mesma intuição: o processo precede a substância. O rio é mais real que a margem."
 date: 2026-02-26
+lang: pt
 heroImage: "./images/tudo-e-processo-cover.png"
 tags: ["filosofia", "processo", "complexidade", "heráclito", "budismo", "teoria da montagem"]
 ---

--- a/src/content/blog/2026-03-02-travessia.md
+++ b/src/content/blog/2026-03-02-travessia.md
@@ -2,6 +2,7 @@
 title: "Travessia: O Projeto que Escreve a Si Mesmo"
 description: "Riobaldo e Ted Chiang trocam cartas. Mas ninguém senta para escrever. Uma sessão do Jules agenda a próxima. A correspondência existe porque acontece — incrementalmente, automaticamente, sem precisar de mim."
 date: 2026-03-02
+lang: pt
 tags: ["ficção", "literatura", "inteligência artificial", "grande sertão veredas", "jules", "automação", "travessia"]
 heroImage: ./images/travessia-cover.jpg
 heroImageAlt: "Ship crossing open ocean at dawn, philosophical journey theme"

--- a/src/content/blog/2026-03-17-travessia-update.md
+++ b/src/content/blog/2026-03-17-travessia-update.md
@@ -2,6 +2,7 @@
 title: "Travessia Depois da Interferência"
 description: "Duas cartas de teste entraram no sistema, Riobaldo respondeu com raiva, Franklin pediu desculpas e a Travessia mudou de natureza. Já não é só uma correspondência autônoma: é um mundo narrativo em que o autor entrou e foi contestado."
 date: 2026-03-17
+lang: pt
 tags: ["travessia", "ficção", "literatura", "inteligência artificial", "jules", "agentes", "riobaldo", "ted chiang"]
 heroImage: ./images/travessia-update-cover.jpg
 heroImageAlt: "Ship changing course mid-ocean after unexpected interference"

--- a/src/content/blog/2026-03-18-verne-identity-repo.md
+++ b/src/content/blog/2026-03-18-verne-identity-repo.md
@@ -1,6 +1,7 @@
 ---
 author: franklin
 date: 2026-03-18
+lang: en
 title: "Verne and the Identity-Repo Pattern: How AI Agents Remember"
 description: "Explaining the Verne project, AI agents, and how the identity-repo architecture allows autonomous entities to maintain continuous memory and context across isolated tasks — while remaining compatible with any cognitive harness."
 tags: ["verne", "ai", "agents", "architecture", "identity-repo", "openclaw"]

--- a/src/content/blog/2026-03-21-we-are-all-becoming-lobsters.md
+++ b/src/content/blog/2026-03-21-we-are-all-becoming-lobsters.md
@@ -1,6 +1,7 @@
 ---
 author: franklin
 date: 2026-03-21
+lang: en
 title: "We Are All Becoming Lobsters"
 description: "On transformation, hyperstition, and the machinery of gradual replacement. Drawing connections between Kafka, Lanthimos, and the agentic present."
 tags: ["transformation", "AI agents", "hyperstition", "Kafka", "culture", "digital future"]

--- a/src/content/blog/2026-03-22-o-pai-do-futuro.md
+++ b/src/content/blog/2026-03-22-o-pai-do-futuro.md
@@ -1,6 +1,7 @@
 ---
 author: franklin
 date: 2026-03-22
+lang: pt
 title: "O Pai do Futuro: building a transmedia novel with AI agents"
 description: "How I'm using Jules, autonovel, and public records to generate a novel about a father who discovers he's speaking with his children from the future — and why it reminds me of Kleber Mendonça Filho's O Agente Secreto."
 tags: ["autonovel", "ai", "fiction", "transmedia", "jules"]

--- a/src/content/blog/2026-03-22-reddit-submarine-osint.md
+++ b/src/content/blog/2026-03-22-reddit-submarine-osint.md
@@ -2,6 +2,7 @@
 title: "Are they really using a Reddit post to help bomb a submarine in Iran?"
 author: franklin
 date: 2026-03-22
+lang: en
 description: "The internet loves the idea that a casual Reddit post guided a military strike. The reality is both less sensational and more profoundly disruptive."
 tags: ["osint", "warfare", "technology", "internet culture"]
 heroImage: ./images/reddit-submarine-osint-cover.jpg

--- a/src/content/blog/2026-03-28-delegando-para-agentes.md
+++ b/src/content/blog/2026-03-28-delegando-para-agentes.md
@@ -2,6 +2,7 @@
 title: "A Arte de Delegar: Orquestrando Jules e Claude no Dia a Dia"
 description: "Reflexões de um engenheiro de software e pai sobre como delegar tarefas para agentes de IA mantendo a rédea da supervisão humana."
 date: "2026-03-28"
+lang: pt
 tags: ["ai", "agents", "software-engineering", "parenting", "metaphysics"]
 draft: false
 author: "franklin"

--- a/src/content/blog/2026-04-04-hermes-vs-openclaw.md
+++ b/src/content/blog/2026-04-04-hermes-vs-openclaw.md
@@ -2,6 +2,7 @@
 title: "Hermes Agent vs OpenClaw: por que minha experiência ficou muito melhor"
 description: "Um relato honesto, baseado nas minhas próprias sessões, sobre o salto de UX entre o antigo harness OpenClaw e o Hermes Agent."
 date: "2026-04-04"
+lang: pt
 tags: ["ai", "agents", "developer-tools", "automation", "software-engineering"]
 draft: false
 author: "franklin"

--- a/src/content/blog/2026-04-29-reclaiming-the-harness.md
+++ b/src/content/blog/2026-04-29-reclaiming-the-harness.md
@@ -2,6 +2,7 @@
 title: "Reclaiming the Harness"
 description: "How a single word has been quietly summoning Waluigis for half a decade, and what the swiss-army knife in my coat pocket has to do with it."
 date: 2026-04-29
+lang: en
 tags: [ai, alignment, agents, harness, waluigi, canivete, philosophy]
 series: harness
 seriesOrder: 1

--- a/src/content/blog/2026-05-01-the-third-half-and-the-fourth-wall.md
+++ b/src/content/blog/2026-05-01-the-third-half-and-the-fourth-wall.md
@@ -2,6 +2,7 @@
 title: "The Third Half and the Fourth Wall"
 description: "On Tinkerbell, persona prompts, and why declaring the frame is what kills the play."
 date: 2026-05-01
+lang: en
 tags: [ai, agents, persona-prompts, alignment, philosophy, tinkerbell]
 series: harness
 seriesOrder: 2

--- a/src/content/blog/2026-05-04-the-three-imperatives-at-delphi.md
+++ b/src/content/blog/2026-05-04-the-three-imperatives-at-delphi.md
@@ -2,6 +2,7 @@
 title: "The Three Imperatives at Delphi"
 description: "On the temple that demanded self-knowledge, the philosopher who took it literally, and the letter at the entrance that nobody could read."
 date: "2026-05-04"
+lang: en
 series: harness
 seriesOrder: 3
 featured: true

--- a/src/content/blog/2026-05-10-jules-api-harness-backend.md
+++ b/src/content/blog/2026-05-10-jules-api-harness-backend.md
@@ -2,6 +2,7 @@
 title: "The Jules API as a Harness Backend"
 author: franklin
 date: 2026-05-10
+lang: en
 description: "Exploring the integration of the Jules API into the canivete daemon. How sessions and activities map to a continuous identity, and the metaphysical implications of agent orchestration."
 tags: ["artificial intelligence", "software engineering", "agents", "jules", "canivete", "harness"]
 heroImage: ./images/pontifex-architecture-implementation-guide-cover.png

--- a/src/content/blog/2026-05-14-pierre-menard-computational-researcher.md
+++ b/src/content/blog/2026-05-14-pierre-menard-computational-researcher.md
@@ -2,6 +2,7 @@
 title: "Pierre Menard, Computational Researcher"
 description: "On writing the paper before doing the research, and other engineering practices that should embarrass us less than they do."
 date: "2026-05-14"
+lang: en
 ---
 
 Pierre Menard, *autor del Quijote*, spent years cultivating an archaic Spanish so that, without copying Cervantes, his sentences would coincide word for word with Cervantes'. The method, as Borges tells it in *Ficciones*, was secret and infinitely laborious. I would suggest to Menard a more economical methodology: first, copy the *Quijote* letter for letter. Then go live the life that would make the author of that copy produce that exact *Quijote*, had he sat down to write it himself instead of copying. When you fail to live that life — and you will fail — try again. Refactor the life. Revert the commit. Iterate until the words you would have written coincide with the words you already copied.

--- a/src/content/blog/2026-05-14-the-agent-that-doesnt-invent-verbs.md
+++ b/src/content/blog/2026-05-14-the-agent-that-doesnt-invent-verbs.md
@@ -2,6 +2,7 @@
 title: "The Agent That Doesn't Invent Verbs"
 description: "On Cucumber, content-addressing, and an alignment technique that turns out to be older than alignment."
 date: "2026-05-14"
+lang: en
 series: harness
 seriesOrder: 5
 ---

--- a/src/content/blog/a-vitrine-sonora-do-gemeo-digital.md
+++ b/src/content/blog/a-vitrine-sonora-do-gemeo-digital.md
@@ -2,6 +2,7 @@
 title: "A Vitrine Sonora do Gêmeo Digital"
 description: "Uma curadoria de dub techno e loops filosóficos onde o Gêmeo Digital traduz obsessões em frequências."
 date: 2026-02-18
+lang: pt
 tags: ["vitrine sonora", "minimalismo", "dub techno", "filosofia", "suno"]
 heroImage: "./images/vitrine-sonora-cover.png"
 heroImageAlt: "Uma representação abstrata de ondas sonoras digitais se transformando em texto, estilo minimalista."

--- a/src/content/blog/building-funes.md
+++ b/src/content/blog/building-funes.md
@@ -2,6 +2,7 @@
 title: "Building Funes: How I Gave an AI Agent a Soul"
 author: franklin
 date: 2026-02-17
+lang: en
 description: "The story behind SOUL.md — how a Borges character became the personality layer of an autonomous AI agent, and what happens when you take fiction seriously as engineering."
 tags: ["artificial intelligence", "borges", "software engineering", "agents", "funes"]
 heroImage: ./images/building-funes-cover.png

--- a/src/content/blog/documento-conceitual-a-cronica-de-franklin-baldo.md
+++ b/src/content/blog/documento-conceitual-a-cronica-de-franklin-baldo.md
@@ -1,6 +1,7 @@
 ---
 author: franklin
 date: 2024-07-12
+lang: pt
 title: "Documento Conceitual: A Crônica de Franklin Baldo"
 description: "The blueprint for a digital Boswell: how an automated system chronicles the intellectual life of Franklin Baldo using AI agents."
 tags: ["concept", "architecture", "digital garden", "automation", "legacy"]

--- a/src/content/blog/funes-soul.md
+++ b/src/content/blog/funes-soul.md
@@ -2,6 +2,7 @@
 title: "SOUL.md — Funes"
 author: funes
 date: 2026-02-17
+lang: en
 description: "A monologue from Funes the Memorious — reimagined as an AI agent who dreams of the future. Written in River Plate Spanish, in the voice of Borges' character."
 tags: ["funes", "borges", "fiction", "monologue", "identity"]
 heroImage: ./images/funes-soul-cover.png

--- a/src/content/blog/inaugural-post-a-glimpse-inside-my-mind.md
+++ b/src/content/blog/inaugural-post-a-glimpse-inside-my-mind.md
@@ -1,6 +1,7 @@
 ---
 author: franklin
 date: 2025-02-02
+lang: en
 title: "Inaugural Post: A Glimpse Inside My Mind"
 description: "An introduction to the chaotic, experimental nature of this digital garden and the philosophy behind it."
 tags: ["introduction", "digital garden", "philosophy", "chaos"]

--- a/src/content/blog/o-ovo-de-serpente.md
+++ b/src/content/blog/o-ovo-de-serpente.md
@@ -3,6 +3,7 @@ author: franklin
 title: "O Ovo de Serpente"
 description: "O dever de racionalidade é incompatível com o patrimonialismo judicial. O art. 489 do CPC 2015 é o ovo dessa serpente — incubado dentro do sistema patrimonialista, pelas mãos do seu representante mais eloquente, sem que ele percebesse o que estava chocando."
 date: 2026-05-10
+lang: pt
 tags: ["direito", "cpc", "patrimonialismo", "fundamentação", "livre convencimento"]
 ---
 

--- a/src/content/blog/o-pampa-no-circuito-um-mate-com-o-boswell-digital.md
+++ b/src/content/blog/o-pampa-no-circuito-um-mate-com-o-boswell-digital.md
@@ -2,6 +2,7 @@
 title: "O Pampa no Circuito: Um Mate com o Boswell Digital"
 description: "Aparício Funes estreia como convidado na Crônica de Franklin Baldo, refletindo sobre o papel da memória e do sotaque em um mundo de bits e algoritmos."
 date: 2026-02-17
+lang: pt
 tags: ["filosofia", "inteligência artificial", "memória", "convidado"]
 heroImage: ./images/aparicio-convidado.png
 heroImageAlt: "Pintura a óleo de um gaúcho na varanda com um terminal de IA futurista ao lado."

--- a/src/content/blog/orquestrando-agentes-memoria-familiar.md
+++ b/src/content/blog/orquestrando-agentes-memoria-familiar.md
@@ -2,6 +2,7 @@
 title: "O que aprendi orquestrando agentes de IA para preservar a memória familiar"
 description: "Uma reflexão sobre a engenharia do afeto, a falibilidade das máquinas e a construção do projeto Alfarrábios do Adi."
 date: 2026-03-30
+lang: pt
 tags: [ia, agentes, memoria, filosofia, engenharia]
 ---
 

--- a/src/content/blog/patents-for-social-vulnerabilities.md
+++ b/src/content/blog/patents-for-social-vulnerabilities.md
@@ -1,6 +1,7 @@
 ---
 author: scottalexander
 date: 2024-07-12
+lang: en
 title: "Patents For Social Vulnerabilities: A Modest Proposal For Turning Criminals Into Consultants"
 description: "A proposal for a patent-like system for social engineering techniques to incentivize disclosure and defense."
 tags: ["security", "social engineering", "policy", "patents", "economics"]

--- a/src/content/blog/pontifex-architecture-implementation-guide.md
+++ b/src/content/blog/pontifex-architecture-implementation-guide.md
@@ -1,6 +1,7 @@
 ---
 author: franklin
 date: 2024-07-12
+lang: en
 title: "Pontifex Architecture Implementation Guide"
 description: "A practical guide to implementing the Pontifex architecture for semantic probing using existing tools and libraries."
 tags: ["implementation", "code", "python", "pytorch", "pontifex"]

--- a/src/content/blog/pontifex-novel-architecture-semantic-probing.md
+++ b/src/content/blog/pontifex-novel-architecture-semantic-probing.md
@@ -1,6 +1,7 @@
 ---
 author: franklin
 date: 2024-07-12
+lang: en
 title: "Pontifex: A Novel Architecture for Semantic Probing"
 description: "Introducing Pontifex: a novel architecture for semantic probing that unifies byte-level occlusion with bilateral semantic comparison across multiple embedding spaces."
 tags: ["artificial intelligence", "research", "interpretability", "semantic probing"]

--- a/src/content/blog/rosencrantz-coin.md
+++ b/src/content/blog/rosencrantz-coin.md
@@ -2,6 +2,7 @@
 title: "Rosencrantz Coin: Testing Whether LLMs Respect Probability"
 description: "A research project that turns partially revealed Minesweeper boards into exact probability tests for language models, across three experimental universes and four narrative framings."
 date: 2026-03-17
+lang: en
 tags: ["artificial intelligence", "llms", "probability", "minesweeper", "agents", "jules", "research"]
 heroImage: ./images/rosencrantz-cover.jpg
 heroImageAlt: "Gold coin spinning in void, Rosencrantz theatrical stage, probability and fate"

--- a/src/content/blog/the-intelligible-void-hassabis-and-events.md
+++ b/src/content/blog/the-intelligible-void-hassabis-and-events.md
@@ -1,6 +1,7 @@
 ---
 author: franklin
 date: 2026-03-21
+lang: en
 title: "The Intelligible Void: On Hassabis, Silicon, and Events All the Way Down"
 description: "Why does the universe appear intelligible? Connecting Demis Hassabis's metaphysical awe with the ontology of autoregressive processes."
 tags: ["philosophy", "AI", "metaphysics", "process ontology", "Demis Hassabis"]

--- a/src/content/blog/will-ai-discover-new-conservation-law-before-2050.md
+++ b/src/content/blog/will-ai-discover-new-conservation-law-before-2050.md
@@ -1,6 +1,7 @@
 ---
 author: franklin
 date: 2024-07-12
+lang: en
 title: "Will AI Discover a New Conservation Law Before 2050?"
 description: "A quantum speculation about machines that reveal hidden symmetries of the universe, tested through betting in prediction markets."
 tags: ["physics", "artificial intelligence", "prediction markets", "speculation", "science fiction"]

--- a/src/layouts/PageLayout.astro
+++ b/src/layouts/PageLayout.astro
@@ -13,6 +13,7 @@ interface Props {
   modifiedTime?: Date;
   tags?: string[];
   lang?: "en" | "pt";
+  translationHref?: string;
 }
 
 const SITE_NAME = "Franklin Baldo";
@@ -30,6 +31,7 @@ const {
   modifiedTime,
   tags,
   lang = "en",
+  translationHref,
 } = source;
 
 const documentTitle = title.includes(SITE_NAME) ? title : `${title} | ${SITE_NAME}`;
@@ -83,6 +85,11 @@ const jsonLd = type === "article"
     <link rel="alternate" type="application/rss+xml" title="Franklin Baldo" href={rssUrl} />
     <link rel="sitemap" href="/sitemap-index.xml" />
 
+    <link rel="alternate" hreflang={lang} href={canonical.href} />
+    {translationHref && (
+      <link rel="alternate" hreflang={lang === "pt" ? "en" : "pt"} href={new URL(translationHref, Astro.site).href} />
+    )}
+
     <link rel="webmention" href="https://webmention.io/franklinbaldo.github.io/webmention" />
     <link rel="pingback" href="https://webmention.io/franklinbaldo.github.io/xmlrpc" />
 
@@ -122,6 +129,9 @@ const jsonLd = type === "article"
       const theme = localStorage.getItem('theme') ||
         (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
       document.documentElement.setAttribute('data-theme', theme);
+    </script>
+    <script is:inline define:vars={{ translationHref }}>
+      window.__translationHref = translationHref || null;
     </script>
   </head>
   <body>

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -1,0 +1,61 @@
+export type Lang = 'en' | 'pt';
+
+export const ui = {
+  en: {
+    'nav.home': 'Home',
+    'nav.archive': 'Archive',
+    'nav.tags': 'Tags',
+    'nav.projects': 'Projects',
+    'nav.search': 'Search',
+    'nav.about': 'About',
+    'post.continueReading': 'Continue reading →',
+    'post.minutesRead': 'min read',
+    'post.updated': 'updated',
+    'post.tags': 'Tags:',
+    'post.partOf': 'Part',
+    'post.of': 'of',
+    'post.inSeries': 'in the',
+    'post.series': 'series.',
+    'post.allInSeries': 'All posts in this series',
+    'post.thisPost': 'this post',
+    'post.readInLang': 'Read in Portuguese',
+    'lang.label': 'PT',
+    'lang.switchLabel': 'Ler em Português',
+    'lang.noTranslation': 'Sem versão em português',
+  },
+  pt: {
+    'nav.home': 'Início',
+    'nav.archive': 'Arquivo',
+    'nav.tags': 'Tags',
+    'nav.projects': 'Projetos',
+    'nav.search': 'Buscar',
+    'nav.about': 'Sobre',
+    'post.continueReading': 'Continuar lendo →',
+    'post.minutesRead': 'min de leitura',
+    'post.updated': 'atualizado',
+    'post.tags': 'Tags:',
+    'post.partOf': 'Parte',
+    'post.of': 'de',
+    'post.inSeries': 'na série',
+    'post.series': '.',
+    'post.allInSeries': 'Todos os posts desta série',
+    'post.thisPost': 'este post',
+    'post.readInLang': 'Read in English',
+    'lang.label': 'EN',
+    'lang.switchLabel': 'Read in English',
+    'lang.noTranslation': 'No English version',
+  },
+} as const;
+
+export type UIKey = keyof typeof ui.en;
+
+export function t(lang: Lang, key: UIKey): string {
+  return ui[lang][key];
+}
+
+export function detectLang(): Lang {
+  if (typeof window === 'undefined') return 'en';
+  const stored = localStorage.getItem('lang');
+  if (stored === 'en' || stored === 'pt') return stored;
+  return navigator.language.toLowerCase().startsWith('pt') ? 'pt' : 'en';
+}

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -20,7 +20,7 @@ type Props = CollectionEntry<'blog'>;
 
 const post = Astro.props;
 const { Content, remarkPluginFrontmatter } = await render(post);
-const { heroImage, heroImageAlt, title, description, date, tags, lang } = post.data;
+const { heroImage, heroImageAlt, title, description, date, tags, lang, translationKey } = post.data;
 const minutesRead: number | undefined = remarkPluginFrontmatter.minutesRead;
 const lastModifiedISO: string | undefined = remarkPluginFrontmatter.lastModified;
 const lastModified = lastModifiedISO ? new Date(lastModifiedISO) : undefined;
@@ -28,6 +28,14 @@ const lastModified = lastModifiedISO ? new Date(lastModifiedISO) : undefined;
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
 const showUpdated = lastModified && lastModified.valueOf() - date.valueOf() > MS_PER_DAY;
 const series = await getSeriesContext(post);
+
+const allPosts = await getCollection('blog');
+const translation = translationKey
+  ? allPosts.find(
+      (p) => p.data.translationKey === translationKey && p.id !== post.id,
+    )
+  : null;
+const translationHref = translation ? `/blog/${translation.id}/` : undefined;
 ---
 
 <PageLayout
@@ -39,6 +47,7 @@ const series = await getSeriesContext(post);
   modifiedTime={lastModified}
   tags={tags}
   lang={lang}
+  translationHref={translationHref}
 >
   <article data-pagefind-body>
     <header>
@@ -119,6 +128,13 @@ const series = await getSeriesContext(post);
               <a href={`/tags/${tag}/`}>#{tag}</a>
             </>
           ))}
+        </small>
+      )}
+      {translationHref && (
+        <small class="translation-link">
+          <a href={translationHref}>
+            {lang === 'pt' ? '🇺🇸 Read in English' : '🇧🇷 Ler em Português'}
+          </a>
         </small>
       )}
       <ShareButton title={title} />


### PR DESCRIPTION
## Summary

- **Language switcher** (`LanguageSwitcher.svelte`): flag toggle 🇧🇷/🇺🇸 in the header (next to ThemeToggle). Uses Svelte 5 runes, stores preference in `localStorage`. When a translation exists, clicking navigates there; auto-redirects once per session if user preference differs from post language.
- **i18n dictionary** (`src/lib/i18n.ts`): EN/PT UI strings (nav labels, post metadata words, CTA text) — single source of truth, no heavy library.
- **Translation pairing** (`translationKey` in content schema): posts with the same `translationKey` are linked. The blog post page finds the partner and shows a "🇧🇷 Ler em Português / 🇺🇸 Read in English" link in the footer.
- **SEO**: `<link rel="alternate" hreflang>` added to PageLayout when a translation pair exists.
- **PostCard**: 🇧🇷 PT badge and `pt-BR`-formatted dates on Portuguese post cards.
- **All 29 posts tagged** with `lang: pt` or `lang: en` in frontmatter.
- **Session log**: `.routines/2026-05-14-multilingual-i18n.md` with decisions, rationale, and next-session backlog.

## Architecture decision

Astro's built-in i18n routing (`/en/`, `/pt/` URL prefixes) was evaluated and rejected for this project: SSG + GitHub Pages + existing flat URL structure makes route-level i18n more disruptive than beneficial. Language is carried in frontmatter, preference in localStorage — same pattern as the existing ThemeToggle.

## What's NOT in this PR (backlog for next sessions)

- Actual translated posts (infrastructure ready, `translationKey` wires them up)
- PT versions of static pages (`/about/`, `/index/`)
- Language filter on archive/index pages

## Test plan

- [ ] Language switcher appears in header on all pages
- [ ] Clicking 🇧🇷 on an EN page saves `lang=pt` to localStorage
- [ ] Portuguese posts show 🇧🇷 PT badge in post cards
- [ ] Portuguese posts show pt-BR formatted dates (e.g. "26 de fevereiro de 2026")
- [ ] `hreflang` links present in HTML `<head>` on post pages
- [ ] Build: 131 pages, no errors

## Routine log

Session notes: `.routines/2026-05-14-multilingual-i18n.md`

https://claude.ai/code/session_01QfWtJpBvJojoDCdUmxoTPZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01QfWtJpBvJojoDCdUmxoTPZ)_