### PR TITLE
feat: PT static pages (/pt/, /pt/about/) and language filter on index/archive

### DIFF
--- a/.routines/2026-05-14-pt-pages-lang-filter.md
+++ b/.routines/2026-05-14-pt-pages-lang-filter.md
@@ -1,0 +1,96 @@
+---
+date: 2026-05-14
+slug: pt-pages-lang-filter
+branch: claude/affectionate-dirac-S75Iu
+status: pr-open
+session: 3
+---
+
+# Sessão 2026-05-14 — Páginas PT estáticas e filtro de idioma
+
+## Contexto
+
+Terceira sessão com o sistema `.routines/`. Chegou com PR #66 aberto
+(infraestrutura multilingual: LanguageSwitcher, i18n.ts, todos os posts tagueados).
+Objetivo: completar a cobertura multilingual com páginas estáticas PT e filtro de
+idioma no índice e arquivo.
+
+## O que foi feito nesta sessão
+
+### Merge de PR aberta
+- **PR #66** (multilingual infrastructure) — merge squash realizado.
+- **PR #38** (dependabot defu) — mantida aberta (conflito de merge; baixa prioridade).
+
+### Implementações nesta branch (`claude/affectionate-dirac-S75Iu`)
+
+| Arquivo | Mudança |
+|---------|---------|
+| `src/components/LangFilter.svelte` | **Novo** — filtro All / 🇺🇸 EN / 🇧🇷 PT com Svelte 5 runes; persiste preferência em `localStorage.lang`; aplica `display:none` em `[data-post-lang]` |
+| `src/components/PostCard.astro` | `data-post-lang={postLang}` no `<article>` — permite que LangFilter filtre cards |
+| `src/pages/index.astro` | `translationHref="/pt/"` no PageLayout + `<LangFilter client:load />` |
+| `src/pages/about.mdx` | `lang: en` e `translationHref: /pt/about/` no frontmatter |
+| `src/pages/archive.astro` | `<LangFilter client:load />` + `data-post-lang` em cada `<li>` + flag 🇧🇷 nos posts PT |
+| `src/pages/pt/index.astro` | **Novo** — homepage em PT (`lang="pt"`, `translationHref="/"`, hero em português) |
+| `src/pages/pt/about.astro` | **Novo** — página sobre em PT (`lang="pt"`, `translationHref="/about/"`) |
+
+### Por que cada mudança importa
+
+- **LangFilter**: usuários PT chegam ao índice via auto-redirect do LanguageSwitcher, veem
+  posts filtrados por preferência sem clicar em nada — UX de zero fricção.
+- **data-post-lang no PostCard**: sem este atributo o LangFilter não tem âncora no DOM.
+- **translationHref nas páginas estáticas**: sem isso o LanguageSwitcher ficava grayed-out
+  (sem tradução) em `/` e `/about/` — agora navega corretamente entre os pares.
+- **PT pages (`/pt/`, `/pt/about/`)**: completam o requisito "todo post e página tem versão
+  PT-BR". `lang="pt"` dispara o auto-redirect do LanguageSwitcher para usuários PT.
+- **hreflang em pares**: todas as 4 páginas estáticas (/, /pt/, /about/, /pt/about/)
+  têm `<link rel="alternate" hreflang>` cruzados — Google Search Console servirá a versão
+  correta por região.
+- **Flag 🇧🇷 no archive**: permite escanear visualmente o idioma antes de clicar, sem
+  ocupar espaço de coluna extra.
+
+## Estado atual do sistema multilingual
+
+- [x] LanguageSwitcher com auto-redirect e localStorage (PR #66)
+- [x] Todos os posts tagueados com `lang: en` ou `lang: pt` (PR #66)
+- [x] Infraestrutura `translationKey` para pares de tradução (PR #66)
+- [x] Filtro de idioma em `/` e `/archive/` (esta sessão)
+- [x] Páginas estáticas `/pt/` e `/pt/about/` (esta sessão)
+- [ ] Traduções reais de posts (translationKey ainda sem uso)
+- [ ] Filtro de idioma em `/tags/` e `/search/`
+- [ ] PT versions of `/archive/` e `/tags/`
+
+## Próximas sessões — backlog priorizado
+
+### Alta prioridade
+1. **Criar pares de tradução de posts** — usar `translationKey` para linkar. Começar
+   pelos 3 posts mais recentes em EN (The Agent That Doesn't Invent Verbs,
+   Pierre Menard, The Three Imperatives). Cada tradução = novo arquivo `.md` com slug PT.
+2. **Table of Contents** para posts longos — headings via rehypeSlug já existem;
+   componente Astro que gera `<nav>` com âncoras de H2/H3.
+3. **Related Posts** ao fim de cada post — interseção de tags, ordenado por data.
+
+### Média prioridade
+4. **LangFilter em /tags/ e /search/** — consistência UX.
+5. **PT version de /archive/** — URL `/pt/archive/` com textos em PT.
+6. **Pagination** em `/archive/` e `/tags/[tag]/` (Astro `paginate()`).
+7. **dependabot #38** — atualizar `defu` manualmente (baixo risco).
+
+### Baixa prioridade
+8. **og:locale:alternate** quando `lang=pt`.
+9. **wordCount no JSON-LD** (minutesRead já disponível).
+10. **FAQ Schema** na /about/ e /pt/about/.
+11. **Focus management** nas transições de página (ClientRouter).
+
+## Decisões arquiteturais
+
+- **`client:load` vs `client:idle` para LangFilter**: usamos `client:load` para aplicar o
+  filtro sem flash perceptível. `client:idle` causaria flash pois hidrataria só quando o
+  browser estivesse ocioso — posts PT apareceriam brevemente antes de serem escondidos.
+- **CSS `display:none` vs remoção do DOM**: `display:none` é mais simples e não causa
+  reflow pesado; Svelte gerencia o estado, HTML mantém todos os artigos no DOM.
+- **`data-post-lang` no article do PostCard**: seguiu o padrão de `data-theme` no ThemeToggle
+  — atributos `data-*` como ponte entre Astro (SSR) e Svelte (CSR).
+- **PT páginas como `.astro`, não `.mdx`**: páginas `.astro` permitem passar `translationHref`
+  diretamente como prop, sem depender do parsing de frontmatter MDX.
+- **`/pt/about/` como .astro inline**: conteúdo suficientemente curto para não precisar de
+  arquivo `.md` separado; mantém coerência com `/pt/index.astro`.

--- a/src/components/LangFilter.svelte
+++ b/src/components/LangFilter.svelte
@@ -1,0 +1,60 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+
+  type Filter = 'all' | 'en' | 'pt';
+  const filters: Filter[] = ['all', 'en', 'pt'];
+  const labels: Record<Filter, string> = { all: 'All', en: '🇺🇸 EN', pt: '🇧🇷 PT' };
+
+  let filter = $state<Filter>('all');
+
+  onMount(() => {
+    const stored = localStorage.getItem('lang');
+    if (stored === 'en' || stored === 'pt') filter = stored as Filter;
+    applyFilter(filter);
+  });
+
+  function applyFilter(f: Filter) {
+    document.querySelectorAll<HTMLElement>('[data-post-lang]').forEach((el) => {
+      el.style.display = f === 'all' || el.dataset.postLang === f ? '' : 'none';
+    });
+  }
+
+  function setFilter(f: Filter) {
+    filter = f;
+    if (f !== 'all') localStorage.setItem('lang', f);
+    applyFilter(f);
+  }
+</script>
+
+<div class="lang-filter" role="group" aria-label="Filter posts by language">
+  {#each filters as f (f)}
+    <button
+      class="lang-filter-btn"
+      aria-pressed={filter === f}
+      onclick={() => setFilter(f)}
+    >{labels[f]}</button>
+  {/each}
+</div>
+
+<style>
+  .lang-filter {
+    display: flex;
+    gap: 0.5rem;
+    margin-bottom: 1.5rem;
+  }
+  .lang-filter-btn {
+    padding: 0.3rem 0.8rem;
+    font-size: 0.82rem;
+    margin-bottom: 0;
+    border-radius: var(--pico-border-radius, 0.375rem);
+    border: 1px solid var(--pico-primary);
+    background: transparent;
+    color: var(--pico-primary);
+    cursor: pointer;
+    transition: background 0.15s, color 0.15s;
+  }
+  .lang-filter-btn[aria-pressed="true"] {
+    background: var(--pico-primary);
+    color: var(--pico-primary-inverse);
+  }
+</style>

--- a/src/components/PostCard.astro
+++ b/src/components/PostCard.astro
@@ -30,7 +30,7 @@ const formattedDate = post.data.date.toLocaleDateString(postLang === 'pt' ? 'pt-
 const blurb = excerpt(post.body ?? '', 320) || post.data.description;
 ---
 
-<article>
+<article data-post-lang={postLang}>
   <header>
     <hgroup>
       <h3>

--- a/src/pages/about.mdx
+++ b/src/pages/about.mdx
@@ -2,6 +2,8 @@
 layout: ../layouts/PageLayout.astro
 title: "About | Franklin Baldo"
 description: "Lawyer, State Attorney, and digital gardener — exploring AI agency, process metaphysics, and legal design."
+lang: en
+translationHref: /pt/about/
 ---
 
 # About

--- a/src/pages/archive.astro
+++ b/src/pages/archive.astro
@@ -1,6 +1,7 @@
 ---
 import { getCollection } from "astro:content";
 import PageLayout from "../layouts/PageLayout.astro";
+import LangFilter from "../components/LangFilter.svelte";
 
 const posts = (await getCollection("blog"))
   .filter((p) => !p.data.draft)
@@ -22,16 +23,21 @@ const years = [...byYear.keys()].sort((a, b) => b - a);
       <p><small>{posts.length} essays</small></p>
     </header>
 
+    <LangFilter client:load />
+
     {years.map((year) => (
       <section>
         <h2>{year}</h2>
         <ul class="archive-list">
           {byYear.get(year)!.map((post) => (
-            <li>
+            <li data-post-lang={post.data.lang ?? 'en'}>
               <time datetime={post.data.date.toISOString()}>
                 {post.data.date.toLocaleDateString("en-US", { month: "short", day: "2-digit" })}
               </time>
-              <a href={`/blog/${post.id}/`}>{post.data.title}</a>
+              <span class="archive-title">
+                <a href={`/blog/${post.id}/`}>{post.data.title}</a>
+                {post.data.lang === 'pt' && <small class="lang-flag" aria-label="Post in Portuguese">🇧🇷</small>}
+              </span>
             </li>
           ))}
         </ul>
@@ -54,5 +60,14 @@ const years = [...byYear.keys()].sort((a, b) => b - a);
   .archive-list time {
     color: var(--pico-muted-color);
     font-variant-numeric: tabular-nums;
+  }
+  .archive-title {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+  }
+  .lang-flag {
+    opacity: 0.7;
+    font-size: 0.75em;
   }
 </style>

--- a/src/pages/pt/about.astro
+++ b/src/pages/pt/about.astro
@@ -1,0 +1,55 @@
+---
+import PageLayout from "../../layouts/PageLayout.astro";
+---
+
+<PageLayout
+  title="Sobre | Franklin Baldo"
+  description="Advogado, Procurador do Estado e jardineiro digital — explorando agentes de IA, metafísica do processo e design jurídico."
+  lang="pt"
+  translationHref="/about/"
+>
+  <article data-pagefind-body>
+    <h1>Sobre</h1>
+
+    <p>
+      Sou <strong>advogado e Procurador do Estado</strong> no Brasil,
+      explorando os limites dos agentes de IA, metafísica do processo e design jurídico.
+      Construo pequenas ferramentas para o pensamento, a transparência e a memória familiar.
+    </p>
+
+    <h2>O que vive aqui</h2>
+
+    <p>
+      Este espaço é um jardim digital — uma acumulação lenta de ensaios, guias
+      técnicos e fragmentos filosóficos sobre como habitamos um mundo cada vez mais
+      mediado pela inteligência. Alguns fios recorrentes:
+    </p>
+
+    <ul>
+      <li><strong>O Harness</strong> — agentes, alinhamento e a linguagem com que construímos as jaulas.</li>
+      <li><strong>Processo</strong> — Whitehead, Heráclito e a computação como devir.</li>
+      <li><strong>Design jurídico</strong> — direito público na era dos sistemas probabilísticos.</li>
+      <li><strong>Memória familiar</strong> — o que significa arquivar uma vida com a ajuda de uma máquina.</li>
+    </ul>
+
+    <p>A maioria dos posts é em inglês; alguns são em português.</p>
+
+    <h2>Onde me encontrar</h2>
+
+    <ul>
+      <li>GitHub — <a href="https://github.com/franklinbaldo" rel="me">github.com/franklinbaldo</a></li>
+      <li>Twitter / X — <a href="https://twitter.com/franklinbaldo" rel="me">twitter.com/franklinbaldo</a></li>
+      <li>RSS — <a href="/rss.xml">/rss.xml</a></li>
+    </ul>
+
+    <h2>Colofão</h2>
+
+    <p>
+      Construído com <a href="https://astro.build/">Astro</a>, <a href="https://picocss.com/">Pico.css</a>
+      e algumas ilhas <a href="https://svelte.dev/">Svelte</a>. Tipografia EB Garamond para o corpo e
+      JetBrains Mono para o código. Busca alimentada por <a href="https://pagefind.app/">Pagefind</a>.
+      O fonte está em
+      <a href="https://github.com/franklinbaldo/franklinbaldo.github.io">franklinbaldo/franklinbaldo.github.io</a>.
+    </p>
+  </article>
+</PageLayout>

--- a/src/pages/pt/index.astro
+++ b/src/pages/pt/index.astro
@@ -1,9 +1,9 @@
 ---
 import { getCollection } from "astro:content";
-import PageLayout from "../layouts/PageLayout.astro";
-import PostList from "../components/PostList.astro";
-import PostCard from "../components/PostCard.astro";
-import LangFilter from "../components/LangFilter.svelte";
+import PageLayout from "../../layouts/PageLayout.astro";
+import PostList from "../../components/PostList.astro";
+import PostCard from "../../components/PostCard.astro";
+import LangFilter from "../../components/LangFilter.svelte";
 
 const all = (await getCollection("blog"))
   .filter((post) => !post.data.draft)
@@ -15,20 +15,20 @@ const rest = all.filter((p) => !featuredIds.has(p.id));
 ---
 
 <PageLayout
-  title="Home"
-  description="Lawyer and State Attorney. Exploring the intersections of process metaphysics, AI agency, and the architecture of legal systems."
-  lang="en"
-  translationHref="/pt/"
+  title="Início"
+  description="Advogado e Procurador do Estado. Explorando as interseções entre metafísica do processo, agentes de IA e a arquitetura dos sistemas jurídicos."
+  lang="pt"
+  translationHref="/"
 >
   <section id="hero" style="margin-bottom: 4rem;">
     <hgroup>
       <h1>Franklin Baldo</h1>
-      <p>Lawyer and State Attorney. Exploring the boundaries of AI agents, process metaphysics, and legal design.</p>
+      <p>Advogado e Procurador do Estado. Explorando os limites dos agentes de IA, metafísica do processo e design jurídico.</p>
     </hgroup>
     <p>
-      This space serves as my digital garden—a collection of essays,
-      technical guides, and philosophical fragments on how we inhabit
-      a world increasingly mediated by intelligence.
+      Este espaço é o meu jardim digital — uma coleção de ensaios,
+      guias técnicos e fragmentos filosóficos sobre como habitamos
+      um mundo cada vez mais mediado pela inteligência.
     </p>
     <p class="identity-links">
       <small>
@@ -45,7 +45,7 @@ const rest = all.filter((p) => !featuredIds.has(p.id));
 
   {featured.length > 0 && (
     <section id="featured">
-      <h2>Featured</h2>
+      <h2>Destaques</h2>
       {featured.map((post) => <PostCard post={post} />)}
     </section>
   )}


### PR DESCRIPTION
## Summary

- **`/pt/` and `/pt/about/`**: Portuguese versions of the home and about pages (`lang="pt"`, Portuguese hero/content, `translationHref` pointing back to EN counterparts). LanguageSwitcher now navigates between the static page pairs instead of staying grayed-out.
- **`LangFilter.svelte`**: All / 🇺🇸 EN / 🇧🇷 PT filter buttons on the index and archive pages. Reads `localStorage.lang` on mount, applies filter immediately (`client:load` to avoid flash). Clicking EN or PT also updates `localStorage.lang` so LanguageSwitcher stays in sync.
- **`data-post-lang` on PostCard**: attribute that LangFilter targets via `querySelectorAll('[data-post-lang]')` — bridge between Astro SSR and Svelte CSR, same pattern as `data-theme` in ThemeToggle.
- **Bidirectional `hreflang`**: all 4 static page pairs (`/` ↔ `/pt/`, `/about/` ↔ `/pt/about/`) have cross-linked `<link rel="alternate" hreflang>` for correct Google Search Console region serving.
- **PT flag in archive**: 🇧🇷 visible next to PT posts in `/archive/` list — scannable without extra column width.
- **Session log**: `.routines/2026-05-14-pt-pages-lang-filter.md` with decisions, rationale, and prioritized backlog for next sessions.

## Architecture decisions

- `client:load` (not `client:idle`) for LangFilter: avoids visible flash where PT posts appear then disappear.
- CSS `display:none` over DOM removal: simpler, no heavy reflow, all posts stay in DOM for Pagefind indexing.
- PT pages as `.astro` (not `.mdx`): direct prop passing for `translationHref` without MDX frontmatter parsing edge cases.

## What's NOT in this PR (next sessions)

- Actual translated post pairs (infrastructure from PR #66 ready, `translationKey` unused)
- PT versions of `/archive/` and `/tags/`
- LangFilter on `/tags/` and `/search/`
- Table of Contents for long posts
- Related posts

## Test plan

- [ ] `/pt/` renders Portuguese hero text, `lang="pt"` on `<html>`
- [ ] `/pt/about/` renders Portuguese content, `lang="pt"` on `<html>`
- [ ] LanguageSwitcher on `/` navigates to `/pt/` (not grayed-out)
- [ ] LanguageSwitcher on `/pt/` navigates to `/` 
- [ ] LangFilter on index: All shows everything, EN hides PT posts, PT hides EN posts
- [ ] LangFilter on archive: same filtering, PT posts show 🇧🇷 flag
- [ ] hreflang pairs present in HTML `<head>` on all 4 static pages
- [ ] Build: 133 pages, no errors

## Routine log

Session notes: `.routines/2026-05-14-pt-pages-lang-filter.md`

https://claude.ai/code/session_01XRFxs9kTmEKDveMp6tERCy

---
_Generated by [Claude Code](https://claude.ai/code/session_01XRFxs9kTmEKDveMp6tERCy)_