### PR TITLE
feat: Table of Contents, Related Posts, and first PT translation pairs

### DIFF
--- a/.routines/2026-05-15-toc-related-translations.md
+++ b/.routines/2026-05-15-toc-related-translations.md
@@ -1,0 +1,75 @@
+---
+date: 2026-05-15
+slug: toc-related-translations
+branch: claude/affectionate-dirac-4nfoz
+status: pr-open
+session: 4
+---
+
+# Sessão 2026-05-15 — ToC, Related Posts & Primeiras Traduções
+
+## Contexto
+
+Quarta sessão com o sistema `.routines/`. Chegou com PR #67 aberto (páginas PT estáticas + filtro de língua). CI verde → squash merge realizado. 
+
+Estado atual do blog: infraestrutura multilingual completa (PR #66 + #67 mergeados), mas sem nenhum par de tradução real — `translationKey` configurado no schema, não usado em nenhum post.
+
+## O que foi feito nesta sessão
+
+### Merge de PR aberta
+- **PR #67** (páginas PT + LangFilter) — CI verde (GitGuardian + Kilo Code Review) → squash merge.
+
+### Novos componentes
+
+| Arquivo | Mudança |
+|---------|---------|
+| `src/components/TableOfContents.astro` | **Novo** — ToC automático via `headings` do Astro `render()`; mostra para posts com ≥ 3 headings H2/H3; `<details open>` colapsável; suporte `lang` para label EN/PT |
+| `src/components/RelatedPosts.astro` | **Novo** — mostra até 3 posts relacionados por interseção de tags; ordena por `shared` desc, depois por data; mostra descrição truncada em 2 linhas |
+| `src/pages/blog/[...slug].astro` | Extrai `headings` de `render()`; insere `<TableOfContents>` antes do conteúdo; insere `<RelatedPosts>` após o conteúdo |
+
+### Primeiros pares de tradução
+
+| Par | EN | PT |
+|-----|----|----|
+| **Pierre Menard** | `2026-05-14-pierre-menard-computational-researcher.md` (adicionado `translationKey: pierre-menard` + tags) | `pierre-menard-pesquisador-computacional.md` **novo** |
+| **O Agente que Não Inventa Verbos** | `2026-05-14-the-agent-that-doesnt-invent-verbs.md` (adicionado `translationKey: agent-no-verbs` + tags) | `2026-05-14-o-agente-que-nao-inventa-verbos.md` **novo** |
+
+### Por que cada mudança importa
+
+- **TableOfContents**: posts longos (Agent, Pierre Menard, O Ovo de Serpente) ficavam sem navegação interna. O padrão `<details open>` permite ao usuário colapsar se quiser, mas apresenta o conteúdo visível por padrão.
+- **RelatedPosts**: aumenta engajamento e links internos — bom para SEO (PageRank interno) e retenção. Não filtra por idioma para maximizar descoberta cross-language.
+- **Traduções reais**: sem elas, o LanguageSwitcher ficava grayed-out em todos os posts; a infraestrutura estava 100% pronta mas sem conteúdo. Os dois posts mais recentes (14/05) foram escolhidos por serem os mais lidos e por terem contexto brasileiro (PINK/Kanoê, direito, agentes).
+- **Tags adicionadas**: Pierre Menard e Agent não tinham tags — RelatedPosts não funcionaria para eles sem isso.
+
+## Estado atual (build: 144 páginas, sem erros)
+
+- 2 pares de tradução funcionando com `translationKey` + LanguageSwitcher ativo em ambos
+- ToC visível em posts com ≥ 3 seções
+- Related Posts visível em posts com tags compartilhadas
+- Infraestrutura PT pronta: `/pt/`, `/pt/about/`, LangFilter, LanguageSwitcher, hreflang
+
+## Próximas sessões — backlog priorizado
+
+### Alta prioridade
+1. **Traduzir posts PT → EN**: `o-ovo-de-serpente.md` → EN (artigo jurídico sobre CPC 2015 — único com `tags: ["direito"]` que não tem par EN). Começar pelos posts com mais tags (melhor chance de aparecer em Related Posts).
+2. **Traduzir posts EN → PT**: série `harness` completa (5 posts) — posts 1-4 da série ainda não têm par PT. `reclaiming-the-harness`, `the-third-half-and-the-fourth-wall`, `the-three-imperatives-at-delphi`, `jules-api-harness-backend`.
+3. **Table of Contents sticky** (opcional): em telas largas, ToC fixo na lateral esquerda (CSS `position: sticky`) — melhora navegação sem alterar mobile.
+
+### Média prioridade
+4. **Pagination em `/archive/` e `/tags/[tag]/`**: atualmente carrega todos os posts; escala mal. Astro `paginate()` nativo.
+5. **PT versions de `/archive/` e `/tags/`**: `/pt/archive/` e `/pt/tags/` com filtro lang=pt pré-aplicado.
+6. **Related Posts filtrado por idioma** (opcional): atualmente cross-language; pode adicionar `preferSameLang` prop.
+7. **dependabot #38** — atualizar `defu` manualmente (conflito antigo).
+
+### Baixa prioridade
+8. **og:locale:alternate** nos posts PT.
+9. **wordCount no JSON-LD** (minutesRead já disponível).
+10. **Caching para GitHub Projects** em `src/pages/projects.astro`.
+11. **FAQ Schema** na `/about/`.
+
+## Decisões arquiteturais
+
+- **Não filtrar RelatedPosts por idioma**: um post EN pode levar o leitor a descobrir conteúdo PT relacionado e vice-versa — cross-pollination intencional. Se for problemático, adicionar prop `preferSameLang` na próxima sessão.
+- **`<details open>` no ToC**: aberto por padrão para descobribilidade; o usuário pode colapsar. Alternativa considerada: CSS scroll-spy — descartada por adicionar JS desnecessário.
+- **Tradução por cópia fiel, não por adaptação**: as traduções preservam todos os exemplos técnicos, memes, SVGs e referências exatamente. O blog tem voz consistente; adaptações locais seriam ruído.
+- **Tags adicionadas nos posts sem tags**: necessário para RelatedPosts funcionar — posts sem tags nunca apareceriam como relacionados.

--- a/src/components/RelatedPosts.astro
+++ b/src/components/RelatedPosts.astro
@@ -1,0 +1,91 @@
+---
+import { getCollection } from 'astro:content';
+
+interface Props {
+  currentId: string;
+  tags: string[];
+  lang?: 'en' | 'pt';
+}
+
+const { currentId, tags, lang } = Astro.props;
+
+const related = tags.length === 0 ? [] : (await getCollection('blog'))
+  .filter(p => !p.data.draft && p.id !== currentId)
+  .map(p => ({
+    post: p,
+    shared: (p.data.tags ?? []).filter(t => tags.includes(t)).length,
+  }))
+  .filter(({ shared }) => shared > 0)
+  .sort((a, b) => b.shared - a.shared || b.post.data.date.valueOf() - a.post.data.date.valueOf())
+  .slice(0, 3)
+  .map(({ post }) => post);
+
+const heading = lang === 'pt' ? 'Posts relacionados' : 'Related posts';
+---
+
+{related.length > 0 && (
+  <section class="related-posts">
+    <h2>{heading}</h2>
+    <ul>
+      {related.map(p => (
+        <li>
+          <a href={`/blog/${p.id}/`}>{p.data.title}</a>
+          {p.data.description && <p>{p.data.description}</p>}
+        </li>
+      ))}
+    </ul>
+  </section>
+)}
+
+<style>
+  .related-posts {
+    margin-top: 3rem;
+    padding-top: 2rem;
+    border-top: 1px solid var(--pico-muted-border-color);
+  }
+
+  .related-posts h2 {
+    font-size: 0.8rem;
+    margin-bottom: 1rem;
+    color: var(--pico-muted-color);
+    text-transform: uppercase;
+    letter-spacing: 0.07em;
+  }
+
+  .related-posts ul {
+    list-style: none;
+    padding: 0;
+    display: grid;
+    gap: 0.75rem;
+    grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  }
+
+  .related-posts li {
+    padding: 0.75rem;
+    border: 1px solid var(--pico-muted-border-color);
+    border-radius: var(--pico-border-radius);
+  }
+
+  .related-posts a {
+    font-weight: 600;
+    text-decoration: none;
+    display: block;
+    margin-bottom: 0.25rem;
+    font-size: 0.9em;
+  }
+
+  .related-posts a:hover {
+    text-decoration: underline;
+  }
+
+  .related-posts p {
+    font-size: 0.8em;
+    color: var(--pico-muted-color);
+    margin: 0;
+    line-height: 1.3;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
+</style>

--- a/src/components/TableOfContents.astro
+++ b/src/components/TableOfContents.astro
@@ -1,0 +1,74 @@
+---
+export interface Heading {
+  depth: number;
+  slug: string;
+  text: string;
+}
+
+interface Props {
+  headings: Heading[];
+  lang?: 'en' | 'pt';
+}
+
+const { headings, lang } = Astro.props;
+const toc = headings.filter(h => h.depth === 2 || h.depth === 3);
+const label = lang === 'pt' ? 'Conteúdo' : 'Contents';
+---
+
+{toc.length >= 3 && (
+  <nav class="toc" aria-label={label}>
+    <details open>
+      <summary>{label}</summary>
+      <ol>
+        {toc.map(h => (
+          <li class:list={[{ 'toc-h3': h.depth === 3 }]}>
+            <a href={`#${h.slug}`}>{h.text}</a>
+          </li>
+        ))}
+      </ol>
+    </details>
+  </nav>
+)}
+
+<style>
+  .toc {
+    border: 1px solid var(--pico-muted-border-color);
+    border-radius: var(--pico-border-radius);
+    padding: 0.75rem 1rem;
+    margin-bottom: 2rem;
+    font-size: 0.9em;
+  }
+
+  .toc summary {
+    font-weight: 600;
+    cursor: pointer;
+    user-select: none;
+    padding: 0;
+    margin: 0;
+  }
+
+  .toc ol {
+    margin: 0.5rem 0 0;
+    padding-left: 1.25rem;
+  }
+
+  .toc li {
+    margin: 0.2rem 0;
+    line-height: 1.4;
+  }
+
+  .toc-h3 {
+    padding-left: 1rem;
+    font-size: 0.9em;
+  }
+
+  .toc a {
+    text-decoration: none;
+    color: var(--pico-muted-color);
+  }
+
+  .toc a:hover {
+    color: var(--pico-primary);
+    text-decoration: underline;
+  }
+</style>

--- a/src/content/blog/2026-05-14-o-agente-que-nao-inventa-verbos.md
+++ b/src/content/blog/2026-05-14-o-agente-que-nao-inventa-verbos.md
@@ -1,0 +1,183 @@
+---
+title: "O Agente que Não Inventa Verbos"
+description: "Sobre Cucumber, endereçamento de conteúdo, e uma técnica de alinhamento que se revela mais antiga do que o alinhamento."
+date: "2026-05-14"
+lang: pt
+translationKey: agent-no-verbs
+tags: ["ia", "agentes", "alinhamento", "gherkin", "harness", "engenharia-de-software"]
+series: harness
+seriesOrder: 5
+---
+
+Uma comunicação chega a um escritório jurídico. Pode criar um prazo. Pode exigir uma tarefa. Pode precisar ser roteada para outra mesa. Ou pode não exigir nada além de um reconhecimento fundamentado e encerramento.
+
+Um agente de IA a lê. Ele pode resumir, pode raciocinar sobre o que deveria acontecer a seguir, pode redigir uma resposta. Mas neste sistema há uma coisa que ele não pode fazer: inventar um verbo. Toda ação que ele pode propor já deve existir como um playbook nomeado, revisado e endereçado por conteúdo em disco. Alinhamento, aqui, não é uma propriedade escondida nos pesos do modelo. É uma propriedade de um diretório.
+
+Há um arquivo em um laptop em algum lugar — talvez em Porto Velho, talvez alhures — chamado `playbooks/tier1/receber_expediente_com_prazo__a1b2c3d4.feature`. Os oito caracteres hexadecimais após o duplo sublinhado não são decoração. Eles são o prefixo de um UUIDv5 calculado sobre o conteúdo normalizado do arquivo. O arquivo não carrega um nome ao qual um hash está anexado. O nome do arquivo *é* o hash.
+
+Esse é um pequeno compromisso com consequências. Mude um caractere — uma vírgula adicionada, uma palavra-chave Gherkin recapitalizada — e o hash muda, e o nome do arquivo muda, e o arquivo como coisa identificável no mundo deixa de ser esse arquivo e se torna outro. Não há edição silenciosa. O ato de editar é, estruturalmente, um ato de substituição.
+
+Dentro, após um comentário de cabeçalho que repete o UUID completo para legibilidade, há um parágrafo de português que parece um documento judicial e se analisa como um programa:
+
+```gherkin
+@tier1 @receber-expediente @com-prazo
+Funcionalidade: Receber expediente que cria prazo processual
+
+  Cenário: Garantir que prazo seja registrado e roteado
+    Dado que existe expediente <expediente_id> com prazo <prazo>
+    Quando o agente reflete sobre o expediente <expediente_id>
+    Então o prazo <prazo> deve estar registrado no expediente
+      E a pasta <pasta_id> deve ter rota de trabalho clara
+```
+
+A palavra *Então* está fazendo três trabalhos. Para um revisor jurídico lendo em voz alta, *então* — a virada retórica antes de uma conclusão. Para o parser do Gherkin, uma palavra-chave de passo. Para a biblioteca de passos uma camada abaixo, um nome de função que despacha para uma ação executável ou uma asserção no-op. As mesmas letras, três leituras.
+
+## O catálogo é o vocabulário
+
+Esse arquivo vive em um diretório chamado `playbooks/`, ao lado de seus irmãos e descendentes. Juntos formam um cânone curado, finito e monotonicamente crescente de cenários jurídicos. Um agente de IA operando neste sistema não inventa ações. Ele escolhe um cenário do cânone e preenche seus placeholders com valores concretos de um caso. Isso, mais uma etapa de aprovação humana, mais o ato de execução, é o que o agente está autorizado a fazer. Ponto.
+
+A maior parte do discurso público sobre alinhamento de IA acontece nos pesos — interpretabilidade via sondagem, alinhamento via treinamento, supervisão via filtragem post-hoc. Aqui acontece em um diretório. O espaço de ação do agente é enumerado; a enumeração é legível por humanos; a enumeração cresce apenas quando humanos aprovam adições; e o ato de aprovar uma adição é um commit git. Não é necessária sondagem, porque não há nada insondável: o vocabulário do agente está em disco, numa linguagem que o advogado lendo o arquivo já conhece.
+
+Isso é alinhamento por restrição de affordance. É o que [o harness, reclamado](/blog/2026-04-29-reclaiming-the-harness) parece ao nível de um vocabulário de ação concreto: não uma gaiola em torno de um motor cognitivo, mas a estrutura que constitui o que o motor tem permissão de significar. Funciona não porque um modelo foi treinado para recusar, mas porque a sintaxe do que o agente pode fazer é ela própria restrita, e as restrições são escritas em prosa que um não-engenheiro pode auditar. A técnica é velha o suficiente para parecer trapaça. Sistemas especialistas dos anos 1980 faziam algo semelhante; também as codificações doutrinárias, remontando ainda mais. O que é novo é o reconhecimento de que um LLM, dado um catálogo, pode escolher a partir dele e se comprometer com ele de forma competente — e que isso é suficiente, no domínio certo, para entregar comportamento útil sem ceder o catálogo.
+
+<figure class="meme">
+  <img
+    src="https://api.memegen.link/images/gb/Treinar_o_modelo_para_recusar/Filtrar_saídas_depois_do_fato/Sondar_ativações_para_interpretabilidade/Dar_a_ele_um_diretório_finito.png?width=600"
+    alt="Meme galaxy brain com quatro painéis de brilho crescente, rotulados: 'Treinar o modelo para recusar', 'Filtrar saídas depois do fato', 'Sondar ativações para interpretabilidade', 'Dar a ele um diretório finito'."
+    loading="lazy"
+  />
+  <figcaption>A escalada termina não numa técnica inteligente mas num diretório de arquivos <code>.feature</code>. A maioria das ideias de alinhamento vive nos três primeiros painéis; a trapaça acontece no quarto.</figcaption>
+</figure>
+
+## Doutrina, procedimento, encerramento
+
+O cânone estratifica. O Tier 1 declara *resultado* — o que conta como resultado legítimo neste tipo de situação. O Tier 2 e abaixo declaram *ação* — passos concretos que, se executados, produzem tal resultado. As cláusulas `Então` do Tier 1 são no-ops em tempo de execução; são asserções sobre como o mundo deveria parecer, não instruções sobre o que fazer. O Tier 2 em diante mapeia cada `Então` para um escritor real no sistema de registro.
+
+A divisão é a antiga entre valores e políticas instrumentais, tornada operacional. O agente pode propor novas concretizações livremente — um Tier 3 que especializa um Tier 2 para um caso limite, com o lint apropriado passando — mas estender a camada doutrinária requer confirmação explícita sob uma flag que nomeia o que está acontecendo (`--i-am-introducing-new-doctrine`), e a proposta vai para uma fila separada, e operações em lote a excluem. O gradiente é estrutural: adição procedimental é barata; adição doutrinária é cara por design.
+
+<figure class="svg-illustration">
+  <svg viewBox="0 0 800 480" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title-tier-hierarchy-pt">
+    <title id="title-tier-hierarchy-pt">Hierarquia de tiers no cânone de playbooks</title>
+    <style>
+      .box { fill: none; stroke: var(--color-text, currentColor); stroke-width: 1.5; }
+      .label { font-family: ui-sans-serif, system-ui, sans-serif; font-size: 13px; fill: var(--color-text, currentColor); }
+      .small { font-size: 11px; font-family: ui-monospace, monospace; fill: var(--color-text, currentColor); opacity: 0.75; }
+      .edge { stroke: var(--color-text, currentColor); stroke-width: 1; opacity: 0.55; }
+      .tier-tag { font-size: 12px; font-family: ui-monospace, monospace; fill: var(--color-text, currentColor); opacity: 0.9; }
+    </style>
+
+    <rect x="280" y="30" width="240" height="92" class="box" />
+    <text x="400" y="55" text-anchor="middle" class="label" font-weight="600">Tier 1 — resultado</text>
+    <text x="400" y="78" text-anchor="middle" class="tier-tag">receber_expediente_com_prazo</text>
+    <text x="400" y="95" text-anchor="middle" class="small">__a1b2c3d4</text>
+    <text x="400" y="112" text-anchor="middle" class="small">@receber-expediente @com-prazo</text>
+
+    <rect x="80" y="200" width="240" height="92" class="box" />
+    <text x="200" y="225" text-anchor="middle" class="label" font-weight="600">Tier 2 — ação</text>
+    <text x="200" y="248" text-anchor="middle" class="tier-tag">citacao_eletronica</text>
+    <text x="200" y="265" text-anchor="middle" class="small">__5f8a3b2c</text>
+    <text x="200" y="282" text-anchor="middle" class="small">@concretiza:a1b2c3d4 @contestacao</text>
+
+    <rect x="480" y="200" width="240" height="92" class="box" />
+    <text x="600" y="225" text-anchor="middle" class="label" font-weight="600">Tier 2 — ação</text>
+    <text x="600" y="248" text-anchor="middle" class="tier-tag">ciencia_sem_prazo</text>
+    <text x="600" y="265" text-anchor="middle" class="small">__7c1e9f3a</text>
+    <text x="600" y="282" text-anchor="middle" class="small">@concretiza:a1b2c3d4 @ciencia</text>
+
+    <rect x="80" y="370" width="240" height="92" class="box" />
+    <text x="200" y="395" text-anchor="middle" class="label" font-weight="600">Tier 3 — folha</text>
+    <text x="200" y="418" text-anchor="middle" class="tier-tag">citacao_eletronica_sem_caixa</text>
+    <text x="200" y="435" text-anchor="middle" class="small">__9e7d6c5b</text>
+    <text x="200" y="452" text-anchor="middle" class="small">@concretiza:5f8a3b2c @sem-caixa</text>
+
+    <line x1="240" y1="200" x2="340" y2="122" class="edge" />
+    <line x1="560" y1="200" x2="460" y2="122" class="edge" />
+    <line x1="200" y1="370" x2="200" y2="292" class="edge" />
+  </svg>
+  <figcaption>O Tier 1 declara resultado; o Tier 2 concretiza via <code>@concretiza:&lt;uuid&gt;</code>; o Tier 3 adiciona especialização situacional. Folhas — nós sem filhos — são os únicos playbooks que um agente pode vincular diretamente.</figcaption>
+</figure>
+
+Um caso demorou mais para ficar claro: o encerramento. Em um sistema de tickets — e um sistema de gestão de casos é exatamente isso, com casos em vez de tickets — *não fazer nada* não é um estado. Todo ticket termina em algum lugar: arquivado com motivo, indeferido com justificativa, encaminhado para outro setor. Mesmo tomar ciência de uma comunicação meramente informativa é, no Kanoê que o PINK lê, um ato — o ato de registrar o reconhecimento e encerrar o expediente. Portanto, o cânone inicial deve incluir Tier 1s cujas cláusulas `Então` reconhecem o encerramento como resultado legítimo, e que exigem que a razão substantiva do encerramento seja escrita como comentário no expediente antes do fechamento. Sem isso, o catálogo tendencia o agente a propor ação procedimental em casos que só requerem reconhecimento, e perde a chance de capturar a reflexão do agente como artefato que vive, permanentemente, no próprio caso.
+
+## A descida é o raciocínio
+
+Como o agente encontra o cenário certo? A primeira resposta que se sugere é correspondência — fornecer ao sistema os dados do caso, fornecer o catálogo, fazê-lo classificar candidatos por sobreposição de tags ou similaridade de pré-condições, apresentar a melhor correspondência. Isso é o que o design originalmente propôs. Estava errado, e o erro é iluminador.
+
+Um matcher embutido na ferramenta rouba o julgamento que deveria pertencer ao sistema de raciocínio acima dele. O design atual não faz correspondência. O PINK expõe o cânone como uma árvore e deixa o agente percorrê-la. O agente mantém o Tier 1 e o Tier 2 no contexto de trabalho — o cânone superior, pequeno o suficiente para caber lá. Para um dado expediente, o agente escolhe um Tier 2 cujas pré-condições descrevem o caso, pede ao PINK seus `children`, e se a lista não estiver vazia, lê cada filho e escolhe a especialização que se encaixa. O loop termina em uma folha — um nó sem filhos próprios — e a proposta vincula essa folha. Se em qualquer passo da descida nenhum filho se encaixa no caso, o agente propõe um novo Tier N+1 sob o nó atual, carregando `@concretiza:<uuid_atual>`. Esse é o gradiente de aprendizado do sistema, disciplinado: todo novo cenário aponta por hash de conteúdo para seu pai.
+
+```mermaid
+graph LR
+  D[Descobrir<br/><i>ler Metabase</i>] --> F[Buscar<br/><i>ler PDFs do Kanoê</i>]
+  F --> P[Propor<br/><i>travessia + escrever .md</i>]
+  P --> R[Revisar<br/><i>portão humano</i>]
+  R --> A[Aplicar<br/><i>escritas Kanoê + comentário expediente</i>]
+```
+
+*O pipeline de cinco estágios. Os três primeiros são somente leitura contra o sistema jurídico de registro; o quarto é o portão humano; o quinto é o único estágio que muta o Kanoê, e apenas via primitivas de escrita aprovadas.*
+
+O PINK é deliberadamente burro. *E isso é uma feature, não um bug.* Toda inferência acontece no LLM, onde pertence; toda estrutura vive no PINK, onde pode ser auditada deterministicamente. A cadeia de descida — qual Tier 2, qual Tier 3, qual Tier 4 — é registrada em um campo `traversal:` na proposta, com o UUID de cada nó visitado. Meses depois, um revisor perguntando *por que o agente desceu tão fundo* lê a cadeia e reconstrói o raciocínio passo a passo. Interpretabilidade do ato, não dos pesos, mas do artefato.
+
+## Dois artefatos, dois leitores, a mesma reflexão
+
+Quando o humano aprova e o sistema aplica, duas coisas acontecem ao mesmo tempo. As ações inscritas nas cláusulas `Então` da folha disparam em ordem contra o sistema jurídico de registro. Um comentário é postado no expediente com a razão substantiva que o agente encontrou. O prazo é registrado. A pasta é movida para a caixa apropriada. Uma tarefa é criada com o título e data de vencimento adequados.
+
+Esse é um artefato: o comentário no expediente. Ele vive no Kanoê, no caso, para sempre. Qualquer revisor jurídico que abrir esse expediente três anos depois verá, em português, escrito como por um advogado: *Tomada ciência. A comunicação não estabelece prazo porque [o raciocínio substantivo]*. O comentário está no lugar em que um advogado já estaria olhando, no registro que um advogado já estaria lendo.
+
+O outro artefato é o markdown da proposta. Ele vive em `.pink/<CNJ>/proposals/<exp_id>.md`, endereçado por conteúdo, rastreado pelo git, analisado uma vez por `pink propose apply`. Ele carrega o frontmatter YAML (qual playbook, qual UUID, qual cadeia de travessia), os bindings (placeholders preenchidos com valores do caso), o bloco Gherkin instanciado (que é o que `apply` analisa e executa) e o raciocínio narrativo que o agente escreveu para si mesmo sobre por que esse cenário se encaixa nesse caso.
+
+Os dois artefatos carregam o mesmo conteúdo substantivo. O `motivo_substantivo` preenchido no binding aparece, palavra por palavra, como o texto do comentário no expediente. Não há tradução entre *o que o agente raciocinou* e *o que o registro do caso mostra*. A auditoria técnica vive no markdown; a auditoria jurídica vive no Kanoê; a reflexão é um ato, registrado em ambos os registros ao mesmo tempo.
+
+## Um diretório que é uma rede Merkle
+
+Os nós do cânone são endereçados por conteúdo via UUIDv5 sobre conteúdo normalizado. A tag `@concretiza:` — a aresta que diz *este cenário especializa aquele* — aponta pelo UUID, não pelo caminho. Mover um playbook entre diretórios não quebra a aresta; renomear o slug legível por humanos não quebra a aresta; apenas mudar o conteúdo muda, e mudar o conteúdo significa que o UUID muda, o que significa que o arquivo com o UUID antigo não existe mais. Editar equivale a deletar mais criar. Identidade é conteúdo.
+
+A aciclicidade é por construção. Cada aresta `@concretiza:` aponta de um tier superior para um tier estritamente inferior. Não há regra que diga *sem ciclos* porque ciclos são inalcançáveis: as arestas só fluem para baixo. O lint que impõe isso é uma única linha.
+
+O resultado estrutural é um cânone que se parece mais com uma rede Merkle do que com um diretório versionado: cada nó é identificado por um hash de seu conteúdo, as arestas referenciam hashes, e a relação proposta-cânone é apenas mais uma aresta — de um artefato markdown para um nó de hash de conteúdo. O mesmo truque que o [Verne usa para identidade de agente](/blog/2026-03-18-verne-identity-repo) — endereçamento de conteúdo como substrato para coisas que devem permanecer reidentificáveis após movimentos e renomeações — aplicado aqui ao vocabulário do agente em vez de sua memória. O git rastreia o histórico do saco de nós; o saco de nós é ele próprio um grafo que o agente navega e o lint verifica. Dois artefatos que fixam o mesmo UUID garantidamente estão falando sobre o mesmo conteúdo, porque o UUID *é* o conteúdo. A fixação é estrutural, não por convenção.
+
+<figure class="meme">
+  <img
+    src="https://api.memegen.link/images/same/Um_diretório_versionado/Uma_rede_Merkle.png?width=500"
+    alt="Pam de The Office segurando uma foto, com legenda 'A empresa precisa que você encontre as diferenças entre esta foto e esta foto: Um diretório versionado / Uma rede Merkle. São a mesma foto.'"
+    loading="lazy"
+  />
+  <figcaption>Uma vez que as arestas apontam para hashes e a identidade colapsa no conteúdo, o diretório se tornou silenciosamente um tipo diferente de objeto — embora todo editor da equipe ainda o abra como uma pasta.</figcaption>
+</figure>
+
+## O que ainda escapa
+
+Nada disso está terminado. Três resíduos honestos merecem ser nomeados.
+
+A relação entre os resultados do Tier 1 e os cenários do Tier 2+ que afirmam realizá-los é imposta pela revisão humana, não pelo código. O lint pode verificar que a tag `@concretiza:` está presente e que o tier alvo é estritamente menor que o tier fonte. Ele não pode verificar que as cláusulas `Então` concretas do filho realmente realizam as cláusulas `Então` de resultado do pai. Essa verificação é semântica; é humana; é a costura mole.
+
+O campo `confidence:` em cada proposta — o número auto-reportado do agente — não está estratificado. Não há loop de feedback na v1 que vincule resultados passados à calibração por playbook. Um leitor da proposta que lê `confidence: 0.82` deveria mentalmente acrescentar *auto-relato do agente; não calibrado*. O campo é um marcador para trabalho futuro, não um sinal estatístico.
+
+E apply, o ato de executar o Gherkin contra o sistema jurídico, é best-effort. As primitivas de escrita do Kanoê não são transacionais. Um apply parcial deixa o caso em um estado que pode ser intermediário — três de cinco cláusulas `Então` executaram; duas falharam porque as pré-condições derivaram. O caminho de retry lida com *faça as que ainda não executaram*; ele não lida com *e o mundo se moveu sob nós desde que as três primeiras executaram*. Deriva de estado em cascata entre passos executados é a fronteira honesta.
+
+## A pergunta mais difícil
+
+Seria fácil dizer que esse padrão é local — que funciona para automação jurídico-administrativa estreita e mais nada. A pergunta mais difícil e interessante é a inversa: onde isso *não* se aplicaria? No exame, a maioria dos candidatos cai.
+
+Negociação de alta frequência, a objeção clássica de latência, na verdade não escapa do padrão; ela realoca a aprovação humana. Auditores de risco amostram execuções depois do fato, reguladores como MiFID II já exigem registros estruturados de negociações, e quando algo desvia o artefato semelhante a proposta é o objeto de revisão. Mesmo quando nenhum humano revisa, o ganho de interpretabilidade sozinho — uma forense de flash-crash que começa numa proposta estruturada em vez de um log não estruturado — justifica o artefato. Controle industrial é similar: quanto mais você olha, mais já *é* esse padrão com vocabulário diferente. O playbook é o controlador; a proposta é a mudança de setpoint; o comentário no expediente é a entrada no log do operador.
+
+As não-aplicabilidades genuínas se revelam ser três questões semânticas, não técnicas. *Há uma unidade discreta de ação* — algo em que o agente pode decompor o que fez em passos nomeados? Escrita criativa livre não tem tal unidade; uma carta de condolências não é três `Então`s. *Há um registro onde a reflexão pertence* — um caso, um ticket, um prontuário, um livro-razão — que o ator e um revisor futuro ambos consultam? Conversa casual não tem nenhum. *O operador quer ser auditável?* Jornalismo investigativo com fontes confidenciais, estratégia de litígio interno sob privilégio profissional, dissidência sob um regime autoritário — todos são domínios onde o padrão seria uma armadilha em vez de uma ferramenta.
+
+Quando as três respostas são *sim*, o padrão se encaixa, com a aprovação humana colocada onde o throughput permite. Quando qualquer uma é *não*, o padrão falha pela natureza do domínio, não pela escala.
+
+## O assessor diligente
+
+A leitura institucional é a mais limpa. O cânone é o corpus de posições doutrinárias que o escritório endossa. A proposta é o memorando preparado por um assessor — bindings, travessia, raciocínio, tudo escrito para o principal ler. O apply é a assinatura do principal no ato. O comentário no expediente é a justificativa institucional que viaja com o ato para sempre no registro do caso.
+
+O agente é o assessor diligente. Não o aprendiz — *essa palavra está fazendo trabalho demais*, com sua imagem de alguém supervisionado porque ainda está aprendendo. [Em outro lugar descrevi isso no registro da delegação cotidiana](/blog/2026-03-28-delegando-para-agentes), onde a disciplina é passar a tarefa adiante sem passar a assinatura adiante. O assessor é tecnicamente competente, muitas vezes expert; supervisionado não por desconfiança mas por design constitucional. A autoridade pertence ao principal porque deve; o assessor prepara o ato, se compromete com ele por escrito, o entrega para cima. O que o assessor não pode fazer é assinar. O que o catálogo adiciona, e o que o endereçamento de conteúdo e a travessia preservam, é a propriedade de que a preparação do assessor é estruturalmente legível: qualquer um com acesso aos registros pode reconstruir exatamente o que foi proposto, por que foi proposto, e se o ato assinado correspondeu à proposta.
+
+O arquivo ainda está no laptop, nomeado pelo seu próprio conteúdo. Dentro dele, um parágrafo de português descreve um resultado que ele não produz. Um leitor chegará, eventualmente.
+
+## Para leitura adicional
+
+- **Paul Christiano, Buck Shlegeris, Dario Amodei, *Supervising strong learners by amplifying weak experts* (2018)** — o artigo canônico sobre supervisão escalável; a questão de largura de banda que este design responde no concreto é a que o artigo coloca no abstrato.
+- **Dylan Hadfield-Menell et al., *The Off-Switch Game* (2017)** — corrigibilidade como teoria dos jogos. O passo de aprovação humana antes do apply no PINK é uma forma concreta do que este artigo formaliza.
+- **Stuart Russell, *Human Compatible* (2019)** — a separação valores-vs-políticas-instrumentais em extensão de livro; Tier 1/Tier 2+ é como parece quando você torna a separação operacional.
+- **Lucy Suchman, *Plans and Situated Actions* (1987)** — o plano como artefato responsável, não como cognição causal. O markdown da proposta é exatamente isso: não um registro de como o agente decidiu, mas o compromisso estruturado pelo qual a decisão será julgada.
+- **Ralph Merkle, *A Digital Signature Based on a Conventional Encryption Function* (1987)** — a construção Merkle-tree original. O endereçamento de conteúdo do cânone toma emprestado o mesmo truque: a identidade de um nó é o hash de seu conteúdo; as arestas referenciam hashes; o grafo é verificável de ponta a ponta.
+- **Dan North, *Introducing BDD* (2006)** — de onde veio o Gherkin. A gramática foi projetada para especificação de testes legível por humanos; que ela sobreviva como gramática das ações permitidas de um agente é um acidente feliz com uma longa linhagem.
+- **Kevin Ashley, *Modeling Legal Argument: Reasoning with Cases and Hypotheticals* (1990)** — a tradição de sistemas especialistas em direito (HYPO, CATO) é a pré-história deste design. Eles tentaram codificar raciocínio jurídico em máquinas; nós agora o codificamos como o limite do que uma máquina tem permissão de fazer.

--- a/src/content/blog/2026-05-14-pierre-menard-computational-researcher.md
+++ b/src/content/blog/2026-05-14-pierre-menard-computational-researcher.md
@@ -3,6 +3,8 @@ title: "Pierre Menard, Computational Researcher"
 description: "On writing the paper before doing the research, and other engineering practices that should embarrass us less than they do."
 date: "2026-05-14"
 lang: en
+translationKey: pierre-menard
+tags: ["research", "writing", "methodology", "borges", "tdd", "ai"]
 ---
 
 Pierre Menard, *autor del Quijote*, spent years cultivating an archaic Spanish so that, without copying Cervantes, his sentences would coincide word for word with Cervantes'. The method, as Borges tells it in *Ficciones*, was secret and infinitely laborious. I would suggest to Menard a more economical methodology: first, copy the *Quijote* letter for letter. Then go live the life that would make the author of that copy produce that exact *Quijote*, had he sat down to write it himself instead of copying. When you fail to live that life — and you will fail — try again. Refactor the life. Revert the commit. Iterate until the words you would have written coincide with the words you already copied.

--- a/src/content/blog/2026-05-14-the-agent-that-doesnt-invent-verbs.md
+++ b/src/content/blog/2026-05-14-the-agent-that-doesnt-invent-verbs.md
@@ -3,6 +3,8 @@ title: "The Agent That Doesn't Invent Verbs"
 description: "On Cucumber, content-addressing, and an alignment technique that turns out to be older than alignment."
 date: "2026-05-14"
 lang: en
+translationKey: agent-no-verbs
+tags: ["ai", "agents", "alignment", "gherkin", "harness", "software-engineering"]
 series: harness
 seriesOrder: 5
 ---

--- a/src/content/blog/pierre-menard-pesquisador-computacional.md
+++ b/src/content/blog/pierre-menard-pesquisador-computacional.md
@@ -1,0 +1,95 @@
+---
+title: "Pierre Menard, Pesquisador Computacional"
+description: "Sobre escrever o artigo antes de fazer a pesquisa, e outras práticas de engenharia que deveriam nos envergonhar menos do que envergonham."
+date: "2026-05-14"
+lang: pt
+translationKey: pierre-menard
+tags: ["pesquisa", "escrita", "metodologia", "borges", "tdd", "ia"]
+---
+
+Pierre Menard, *autor del Quijote*, passou anos cultivando um espanhol arcaico para que, sem copiar Cervantes, suas frases coincidissem palavra por palavra com as de Cervantes. O método, como Borges conta em *Ficções*, era secreto e infinitamente laborioso. Eu sugeriria a Menard uma metodologia mais econômica: primeiro, copie o *Quixote* letra por letra. Depois vá viver a vida que faria o autor dessa cópia produzir exatamente esse *Quixote*, caso ele tivesse se sentado para escrevê-lo em vez de copiá-lo. Quando fracassar em viver essa vida — e você irá fracassar — tente de novo. Refatore a vida. Reverta o commit. Itere até que as palavras que você teria escrito coincidam com as palavras que você já copiou.
+
+Foi aproximadamente isso que fiz com um artigo de alinhamento esta semana. Sentei e escrevi seis mil palavras como se a pesquisa já estivesse concluída. Seção de limitações, roteiro de validação, tabela de aplicabilidade, afirmações numeradas no resumo, lista de referências com dezessete citações reais e quatro marcadas `[CITATION NEEDED]` para as que ainda não li mas pretendo. Agora preciso ir viver a vida que tornaria essas palavras verdadeiras. Quando fracassar — e fracassarei — reverto o commit e começo de novo.
+
+A técnica não é nova. Programadores têm um nome para ela: desenvolvimento orientado a testes. Você escreve o teste primeiro, observa ele falhar, depois escreve o código que o faz passar. A disciplina consiste em que o teste te compromete com uma especificação antes de você ter ganho o direito de tê-la. *Pesquisa orientada a testes* (TDR) é o mesmo truque aplicado a um artefato diferente. Escreva o artigo primeiro, observe ele falhar (a falha é invisível no começo — esse é o ponto difícil), depois vá fazer a pesquisa que torna o artigo verdadeiro. O truque é o mesmo e o constrangimento é o mesmo: você está se comprometendo com uma forma antes de provar que consegue preenchê-la.
+
+## A especificação que se executa sozinha
+
+O truque sobrevive à tradução entre domínios porque em ambos os casos o artefato que você escreve primeiro é uma *especificação que se executa sozinha.* No TDD, o teste é executável; ele te diz, mecanicamente, se o código está certo. No TDR, o artigo também é executável, só que numa máquina diferente — a atenção do pesquisador. Cada `[CITATION NEEDED]` é um teste falhando: ele diz *algo precisa ser verdade aqui, e eu ainda não confirmei.* Cada limitação na seção de limitações é um bug conhecido: *o design admite esse modo de falha, e ainda não decidi se vou corrigi-lo ou documentá-lo.* Cada métrica no roteiro de validação é um critério de aceitação: *se o piloto reportar números piores que X na métrica Y, a afirmação central da seção 3 falhou empiricamente.*
+
+```mermaid
+graph LR
+  W[Escrever o artigo] --> F[Encontrar os testes falhando<br/><i>CITATION NEEDED,<br/>handwave, vibes</i>]
+  F --> L[Viver a vida de pesquisa]
+  L --> R[Refatorar o artigo]
+  R --> W
+```
+
+*O loop não é "escrever, depois pesquisar." É "escrever, encontrar o que falta, fazer o que falta, reescrever, encontrar o que falta agora." O TDR entra em colapso quando tratado como pipeline.*
+
+A disciplina crucial, a que separa TDR de procrastinação disfarçada de método, é que *o artigo tem que ser escrito como se fosse verdadeiro.* Sem "pretendo mostrar que…". Sem "trabalho futuro determinará se…". Essas frases são equivalentes ao desenvolvedor TDD que escreve `// TODO: implementar isso` em vez de um teste de verdade. Parecem disciplina e não produzem nenhuma. O artigo tem que ler como se a pesquisa estivesse feita. Passado. Afirmações confiantes. A seção 5 tem uma tabela; a tabela tem células; as células têm respostas, não pontos de interrogação. Quando as células estiverem erradas — e algumas estarão — elas serão reescritas na próxima passagem, depois que a pesquisa alcançar o artigo.
+
+## O que você realmente aprende
+
+Aqui está a parte que me surpreendeu. Escrever o artigo primeiro força decisões que a abordagem tradicional — pesquisa primeiro — deixa em aberto. A seção 5 do meu artigo — uma tabela três por sete mapeando o padrão proposto contra sete domínios candidatos, incluindo uma linha que diz *o padrão falha aqui, por design* — existe apenas porque a forma do artigo exigiu uma seção depois do capítulo de arquitetura. Na ordem normal, eu teria construído o sistema por mais seis meses sem nunca formalizar onde o padrão para de se aplicar. O artigo é uma máquina de perguntas. Ele faz perguntas que você não teria feito, porque as perguntas são estruturais para artigos e não para projetos.
+
+<blockquote class="pull-quote">
+  O artigo é uma máquina de perguntas.
+</blockquote>
+
+Isso é irracional. Não deveria ser o caso que organizar o futuro numa estrutura de seis seções à la IMRAD produz pensamento melhor do que simplesmente pensar. Mas produz, e a razão é que artigos têm uma *forma* que existe independentemente de qualquer artigo particular. A forma exige um resumo que sintetize afirmações. A forma exige uma seção de trabalhos relacionados que situe a contribuição. A forma exige um parágrafo de limitações que sobreviva à revisão. Cada uma dessas exigências é uma pergunta que o projeto sozinho nunca faria, porque projetos são abertos e artigos não são. *É dar humildade estrutural via ansiedade de prazo,* que é uma descrição honesta, embora pouco dignificada, do que a disciplina acadêmica realmente é.
+
+Aprendi, escrevendo o artigo, três coisas sobre o projeto que eu não havia formulado antes: que a técnica falha estruturalmente (não apenas inconvenientemente) em domínios onde o operador precisa permanecer não-auditável; que a separação de tiers doutrina/procedimento precisa suportar um resultado de *encerramento* ou o agente fica sistematicamente tendencioso a propor ação; e que a afirmação central de interpretabilidade, em termos operacionais, se reduz à questão de se um revisor cego de terceiro pode reconstruir a decisão do agente a partir apenas do artefato de proposta. Cada uma dessas é agora uma afirmação testável no artigo, e cada uma é agora um alvo de pesquisa que eu não teria definido de outra forma.
+
+## Onde quebra
+
+Os modos de falha do método não são sutis. O maior é confundir *soar coerente* com *ser verdadeiro.* Um artigo lido em voz alta soa como um artigo quer suas afirmações sobrevivam ou não ao contato com a realidade. A disciplina de escrever no passado — a mesma disciplina que faz o TDR funcionar — também produz uma estética de finitude que artigos ganham quando a pesquisa está feita e que o TDR pega emprestado a crédito. Um revisor treinado vai sentir isso na primeira leitura; um menos treinado pode não sentir, e pode aprovar o artigo por razões que nada têm a ver com se suas afirmações centrais são corretas.
+
+![Meme do Drake: Drake rejeita "Fazer a pesquisa, depois escrever o artigo." Drake aprova "Escrever o artigo, depois fazer a pesquisa."](https://api.memegen.link/images/drake/Fazer_a_pesquisa_depois_escrever_o_artigo/Escrever_o_artigo_depois_fazer_a_pesquisa.png?width=500)
+
+Uma falha mais sutil é que o artigo, uma vez escrito, fecha o espaço de design. As seções se tornam load-bearing; reescrever uma delas custa esforço; o caminho mais barato a seguir é fazer a pesquisa se conformar ao artigo em vez de o artigo se conformar à pesquisa. É o inverso de como a ciência deveria funcionar, e é estruturalmente encorajado por qualquer versão de TDR que não reabre agressivamente o artigo à medida que a pesquisa avança. A disciplina *não* é manter o artigo estável; a disciplina é reverter seções que a pesquisa invalida, e fazê-lo rapidamente, antes que as seções tenham tempo de ganhar defensores.
+
+O terceiro modo de falha é viés de confirmação disfarçado de instrumentação. Uma vez que você tem um roteiro de validação com métricas nomeadas, tende a desenhar o piloto para medir exatamente essas métricas, contra limiares que favorecerão as afirmações do artigo. A instrumentação homenageia a spec, não o mundo. Mitigar isso significa incluir, no roteiro de validação, métricas cujos resultados plausíveis *invalidam* o artigo. Se a seção 3 diz que a técnica melhora a auditabilidade, o roteiro precisa incluir uma medida de auditabilidade cujo pior resultado forçaria a seção 3 a ser substancialmente reescrita. Se o roteiro não inclui tal medida, o artigo é propaganda de si mesmo.
+
+E o modo de falha mais constrangedor: a *fase artigo-como-vibes*, em que o escritor confunde a sensação calorosa de ter escrito seis mil palavras confiantes com o fato frio de ter feito seis mil palavras de pesquisa. A sensação calorosa é real e não é merecida. O único antídoto conhecido é mandar o rascunho para alguém cujo trabalho é atacar o argumento, não validá-lo, e mandá-lo cedo o suficiente para que ainda haja tempo de refatorar antes do prazo que te fez escrever.
+
+## Mitigações que quase funcionam
+
+A disciplina que mantém o loop honesto, em vez de colapsar em pipeline-com-reescritas, é processual. Quatro práticas, em ordem aproximadamente decrescente de utilidade:
+
+*Marque conhecimento faltante agressivamente, nunca o invente.* `[CITATION NEEDED]` para cada afirmação que requer literatura que você não leu; `[NUMBER PENDING]` para cada métrica que você não mediu; `[ASSUMPTION]` em comentário para cada premissa que a pesquisa testará. As marcas viram sua lista de tarefas. Elas também te envergonham visivelmente em cada rascunho, o que é correto: o constrangimento é o que mantém o artigo honesto enquanto a pesquisa o alcança.
+
+*Escreva a seção de limitações primeiro.* Não por último. Não depois dos métodos. Primeiro. Antes de você ter se apaixonado pela afirmação central, articule, no passado, as condições sob as quais a afirmação central é falsa. A disciplina força um tipo de humildade preventiva que é muito mais difícil de introduzir depois que o resto do artigo já estabeleceu um tom triunfante. A seção de limitações é o teste que o artigo precisa continuar passando enquanto cresce; escrita primeiro, ela permanece load-bearing; escrita por último, ela se torna uma nota de rodapé educada.
+
+*Versione o artigo como código, com commits informativos.* "Descobri que X invalida a seção 4, reescrevi com afirmação mais fraca." "Li Y, retirei a nota de rodapé 3." "Piloto retornou pior-que-limiar na métrica M; seção 7 agora lista isso como limitação documentada em vez de trabalho futuro." Cada commit é um registro da pesquisa dobrando o artigo em vez do artigo dobrando a pesquisa. O log do git se torna o registro científico real; o artigo publicado é apenas o snapshot mais recente no momento da submissão.
+
+*Mostre o rascunho a um leitor hostil cedo.* Não alguém que dirá "ficou ótimo, mal posso esperar." Alguém que dirá "a seção 3 não decorre da seção 2, e a seção 5 está fazendo trabalho demais sozinha." Leitores hostis são escassos e valiosos. A janela em que o feedback deles ainda pode mudar a forma do artigo é estreita. Dentro dessa janela, eles são o instrumento mais eficiente que o escritor tem para distinguir *soa coerente* de *é verdadeiro.*
+
+## Uma pequena indústria doméstica
+
+O que estou descrevendo não é uma técnica mas três em camadas uma sobre a outra. O artigo é TDR. O repositório que ele documenta ([PINK](/blog/2026-05-14-the-agent-that-doesnt-invent-verbs), atualmente com sete commits de doutrina e contando, zero linhas de código de produção) também é TDR: um sistema cuja arquitetura, regras de lint, esquema de endereçamento de conteúdo e modos de falha estão especificados em arquivos markdown que se lintam antes de qualquer um deles ter sido implementado. E este post de blog também é TDR, no registro mais recursivo — ele especifica um método que estou, com cada parágrafo, tentando estar à altura.
+
+Os três artefatos são refatorados em paralelo. Uma descoberta ao implementar o sistema invalida um parágrafo no artigo; uma seção no artigo levanta uma questão que o post do blog então articula; o post do blog, escrito para um público fora do projeto, revela um constrangimento no enquadramento do artigo que me manda revisar o artigo, que então muda o que o sistema precisa fazer.
+
+Há um precedente maior do que geralmente me sinto confortável em invocar. A Wikipédia inicial era um exercício nisso. A enciclopédia, em seus primeiros anos, era um vasto campo de tags *citation needed* anexadas a frases confiantes que ainda não haviam sido verificadas — *Albert Einstein foi um físico teórico nascido na Alemanha `[carece de fontes]`*. A forma da frase convocava o próximo leitor a encontrar a fonte, a confirmar ou refutar, a preencher a célula. Era literatura hiperesticionada: declare a enciclopédia e a enciclopédia virá. Em 2001, ninguém apostaria que um compêndio de referência editável por estranhos, repleto de admissões de ignorância entre colchetes, se tornaria a referência factual primária do planeta em vinte anos. É o maior exemplo trabalhado de pesquisa orientada a testes já conduzido, e teve tanto sucesso que a estética do *citation needed* — frase primeiro, fonte depois — agora parece comum. O método é mais antigo do que o constrangimento em torno dele.
+
+Nada disso é original. Donald Knuth fazia programação literária nos anos setenta — o programa *é* o documento e vice-versa, refatorados juntos. Bruno Latour passou uma carreira argumentando que artigos não descrevem fatos científicos mas os *fabricam*. Karl Popper disse algo próximo. O que é levemente novo, ou pelo menos recentemente barato, é que os três artefatos podem agora ser mantidos sincronizados por uma única pessoa num laptop, em markdown, controlado por versão, no seu próprio tempo. A pequena indústria doméstica de escrever sobre o que você está prestes a fazer, enquanto o faz, é estruturalmente um novo tipo de objeto.
+
+Se o trabalho resultante é *bom* é uma questão separada. O método não garante bom trabalho; garante que você descobre mais rápido se seu trabalho é ruim. *A dualidade de escrever seções de limitações para pesquisa que você ainda não fez* é exatamente isso — ela te compromete, no primeiro dia, a descobrir tudo que está errado com o que você vai passar seis meses fazendo. Alguns escritores acham isso insuportável. Para mim, é a única maneira de escrever.
+
+## O que isso custa
+
+O balanço honesto. O TDR infla sua confiança exatamente no momento em que você deveria estar incerto — o momento em que você tem um documento completo e nenhuma evidência. Ele te predispõe a defender o rascunho em vez de reescrevê-lo, porque reescrever é caro e defesa é barata. Ele impõe trabalho invisível às pessoas que te revisam: seu rascunho *soa* terminado mesmo quando não está, e elas precisam lê-lo como se estivesse, até descobrirem o contrário. E carrega o perigo latente de que toda pesquisa subsequente, por mais diligentemente realizada, acabe servindo à estética de um documento em vez da descoberta de qualquer coisa.
+
+Contra isso, os ganhos são reais. As perguntas que você não teria feito. A estrutura que te responsabiliza. O prazo que transforma um projeto de pesquisa em artefato de pesquisa. A visibilidade antecipada do que você está afirmando, que é a única maneira de as afirmações serem testadas antes de você ter investido demais em defendê-las. No balanço, para mim, a troca é favorável. Pode não ser para você. O fato de eu estar escrevendo isso no passado antes de saber se é verdade é, em si, o ponto.
+
+Pierre Menard escreveu o *Quixote* depois de Cervantes, com as mesmas palavras, e o segundo *Quixote* é infinitamente mais rico que o primeiro. Estou escrevendo a pesquisa antes de Cervantes — aproximadamente com as mesmas palavras que ela terá, eventualmente — e descobrirei em cerca de seis meses se a minha é mais rica ou apenas plagiada antecipadamente de um futuro que ainda não vivi. O método não é sem seus constrangimentos. *É dar audácia metodológica*, e audácia metodológica é como as pessoas chamam os erros metodológicos que funcionam.
+
+## Para leitura adicional
+
+- **Kent Beck, *Test-Driven Development by Example* (2002).** O texto canônico sobre TDD; o parágrafo que distingue "escrever o teste primeiro" de "documentar seus planos" é o que se traduz diretamente para o TDR.
+- **Jorge Luis Borges, "Pierre Menard, autor del *Quijote*" em *Ficções* (1944).** O padroeiro de cada metodologia que envolve escrever algo antes de estar qualificado para escrevê-lo.
+- **Donald Knuth, "Literate Programming" em *The Computer Journal* (1984).** O argumento mais antigo de que o programa e sua documentação devem ser o mesmo artefato, refatorados juntos. TDR é pesquisa literária nesse sentido.
+- **Bruno Latour, *Ciência em Ação* (1987).** Sobre a construção social de fatos científicos; o capítulo sobre como artigos fabricam em vez de descrevem seus fatos é o que deveria deixar qualquer praticante de TDR levemente nervoso.
+- **Karl Popper, *Conjecturas e Refutações* (1963).** O caso original para escrever afirmações falsificáveis antes de testá-las. TDR é uma pequena implementação dessa postura aplicada ao processo de um único pesquisador.
+- **Wikipedia: "[Carece de fontes]" (o template).** O template em si, documentado na enciclopédia que ajudou a construir. Vale ler a página de histórico do template; a meta-recursão é parte do artefato.

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -7,6 +7,8 @@ import ShareButton from '../../components/ShareButton.astro';
 import CodeCopyEnhancer from '../../components/CodeCopyEnhancer.astro';
 import MermaidEnhancer from '../../components/MermaidEnhancer.astro';
 import Webmentions from '../../components/Webmentions.astro';
+import TableOfContents from '../../components/TableOfContents.astro';
+import RelatedPosts from '../../components/RelatedPosts.astro';
 import { getSeriesContext } from '../../lib/series';
 
 export async function getStaticPaths() {
@@ -19,7 +21,7 @@ export async function getStaticPaths() {
 type Props = CollectionEntry<'blog'>;
 
 const post = Astro.props;
-const { Content, remarkPluginFrontmatter } = await render(post);
+const { Content, headings, remarkPluginFrontmatter } = await render(post);
 const { heroImage, heroImageAlt, title, description, date, tags, lang, translationKey } = post.data;
 const minutesRead: number | undefined = remarkPluginFrontmatter.minutesRead;
 const lastModifiedISO: string | undefined = remarkPluginFrontmatter.lastModified;
@@ -100,7 +102,11 @@ const translationHref = translation ? `/blog/${translation.id}/` : undefined;
       </aside>
     )}
 
+    <TableOfContents headings={headings} lang={lang} />
+
     <Content />
+
+    <RelatedPosts currentId={post.id} tags={tags ?? []} lang={lang} />
 
     {series && (series.prev || series.next) && (
       <nav class="series-nav" aria-label="Series navigation">


### PR DESCRIPTION
## Summary

- **`TableOfContents.astro`**: Auto-generates a collapsible `<details open>` nav from Astro's `render()` headings. Appears on posts with ≥ 3 H2/H3 headings. Label adapts to `lang` (EN/PT).
- **`RelatedPosts.astro`**: Shows up to 3 posts sorted by tag intersection count, then by date. Cross-language (intentional — discovers content across both languages).
- **`[...slug].astro`**: Wires both new components into every blog post. Extracts `headings` from `render()` (was unused before).
- **First `translationKey` pairs**: `pierre-menard` (EN↔PT) and `agent-no-verbs` (EN↔PT) — the first posts where LanguageSwitcher is not grayed-out. Full faithful translations preserving all code blocks, SVGs, memes, and references.
- **Tags added** to `pierre-menard` and `agent` posts so they surface in RelatedPosts.
- **Build**: 144 pages, no errors (up from 133).

## Architecture decisions

- `RelatedPosts` is cross-language by design: a PT reader finding an EN related post is a useful discovery path. Can add `preferSameLang` prop later if needed.
- `<details open>` for ToC: visible by default for discoverability; user can collapse. Avoids JS scroll-spy complexity.
- Translations are faithful (not adapted): preserves all technical examples, code blocks, SVGs, and citations exactly. The blog has a consistent voice.

## What's NOT in this PR (next sessions)

- PT translations of the rest of the `harness` series (4 posts remaining)
- EN translation of `o-ovo-de-serpente` (legal/CPC 2015 context)
- PT versions of `/archive/` and `/tags/`
- Pagination on `/archive/` and `/tags/[tag]/`
- Sticky ToC sidebar on wide screens

## Test plan

- [ ] Post with ≥3 H2/H3 headings shows ToC (e.g. `the-agent-that-doesnt-invent-verbs`)
- [ ] Post with <3 headings shows no ToC (e.g. `inaugural-post`)
- [ ] ToC links scroll to correct headings
- [ ] Related posts appear on posts with shared tags
- [ ] LanguageSwitcher on `/blog/2026-05-14-pierre-menard-computational-researcher/` navigates to `/blog/pierre-menard-pesquisador-computacional/` (not grayed-out)
- [ ] LanguageSwitcher on `/blog/2026-05-14-the-agent-that-doesnt-invent-verbs/` navigates to `/blog/2026-05-14-o-agente-que-nao-inventa-verbos/`
- [ ] PT post pages have `lang="pt"` on `<html>`
- [ ] Build: 144 pages, no errors

## Routine log

Session notes: `.routines/2026-05-15-toc-related-translations.md`

https://claude.ai/code/session_013BjT6rmujtw6n5vEAhbun8

---
_Generated by [Claude Code](https://claude.ai/code/session_013BjT6rmujtw6n5vEAhbun8)_