### PR TITLE
feat: language-aware nav, /pt/tags/, and 2 new translation pairs

### DIFF
--- a/.routines/2026-05-15-nav-tags-harness-serpent.md
+++ b/.routines/2026-05-15-nav-tags-harness-serpent.md
@@ -1,0 +1,121 @@
+---
+date: 2026-05-15
+slug: nav-tags-harness-serpent
+branch: claude/affectionate-dirac-WlWHf
+status: pr-open
+session: 5
+---
+
+# Sessão 2026-05-15 — Nav PT-aware, /pt/tags/, Harness PT, Serpente EN
+
+## Contexto
+
+Quinta sessão. Chegou com PR #69 aberto (pt/archive/, LangFilter em tags, tradução de Delfos). CI verde → squash merge realizado.
+
+Estado atual do blog: 155 páginas, 3 pares de tradução funcionando (Pierre Menard, Agente Sem Verbos, Três Imperativos). Header ainda usava URLs EN fixas independente da lang da página. `/pt/tags/` não existia. "Continue reading" aparecia em inglês em posts PT.
+
+## O que foi feito nesta sessão
+
+### Merge de PR aberta
+- **PR #69** (pt/archive/, LangFilter em tags, Delfos PT) — CI verde → squash merge.
+
+### UI: Header language-aware
+
+| Arquivo | Mudança |
+|---------|---------|
+| `src/components/Header.astro` | Adicionado prop `lang?: 'en' \| 'pt'`. Quando `lang='pt'`, links de nav usam URLs PT: `/pt/` (Home), `/pt/archive/`, `/pt/tags/`, `/pt/about/`. "Franklin Baldo" agora é link clicável para o home correto. |
+| `src/layouts/PageLayout.astro` | Passa `lang` para `<Header lang={lang} />` |
+
+**Por que importa**: usuários PT navegando o blog viam o Header apontar para `/archive/` (EN), `/tags/` (EN) etc. O LanguageSwitcher os redirecionava, mas os links de nav os tiravam do contexto PT novamente. Agora o Header é coerente com a língua da página.
+
+### UI: PostCard "Continue reading" localizado
+
+| Arquivo | Mudança |
+|---------|---------|
+| `src/components/PostCard.astro` | CTA usa `postLang === 'pt' ? 'Continuar lendo →' : 'Continue reading →'` |
+
+**Por que importa**: em qualquer lista de posts, o CTA agora reflete o idioma do post — melhora micro-copy e sinalização.
+
+### Nova página: /pt/tags/
+
+| Arquivo | Mudança |
+|---------|---------|
+| `src/pages/pt/tags/index.astro` | **Novo** — espelho PT da página de tags. Título "Etiquetas", descrição em PT. `lang="pt"`, `translationHref="/tags/"`. Links apontam para `/tags/[tag]/` (que tem LangFilter). |
+| `src/pages/tags/index.astro` | Adicionado `lang="en" translationHref="/pt/tags/"` para ativar LanguageSwitcher. |
+
+**Por que importa**: `/pt/tags/` era o único link de nav PT sem página PT correspondente. LanguageSwitcher ficava grayed-out em `/tags/`. Agora completo.
+
+### 2 novos pares de tradução
+
+#### "Recuperando o Harness" (PT translation of Reclaiming the Harness)
+
+| Par | EN | PT |
+|-----|----|----|
+| **Reclaiming/Recuperando** | `2026-04-29-reclaiming-the-harness.md` (adicionado `translationKey: reclaiming-harness`) | `2026-04-29-recuperando-o-harness.md` **novo** |
+
+Post mais importante da série harness (featured, seriesOrder: 1). Tradução fiel preservando:
+- Greentexts em estilo "4chan" (cultura internet — mantidos em PT idiomático)
+- Memes do Waluigi (explicados no contexto)
+- Tabelas técnicas (harness triad, failure modes)
+- Referências ao canivete e Ireneo/Aparicio/Claudio
+- Código Python do protocolo Backend
+- Tom informal + argumentação séria
+
+#### "The Serpent's Egg" (EN translation of O Ovo de Serpente)
+
+| Par | EN | PT |
+|-----|----|----|
+| **Serpent's Egg** | `2026-05-10-the-serpents-egg.md` **novo** | `o-ovo-de-serpente.md` (adicionado `translationKey: serpents-egg`) |
+
+Único post PT-only sem par EN. Artigo sobre CPC 2015, art. 489 §1º, patrimonialismo judicial e Fux. Tradução fiel preservando:
+- SVGs inline com IDs renomeados (-en suffix para evitar conflito)
+- Diagrama Mermaid (mantido identico)
+- Termos jurídicos em PT com explicação inline onde necessário
+- Referências bibliográficas (com títulos PT preservados + tradução)
+- Tom gonzo+acadêmico
+
+## Estado atual (build: 155 páginas, sem erros)
+
+- 5 pares de tradução funcionando com `translationKey` + LanguageSwitcher ativo
+- Header PT-aware em todas as páginas PT
+- `/pt/tags/` completa com LanguageSwitcher ativo
+- PostCard CTA localizado
+
+## Cobertura de tradução atual
+
+| Post EN | Par PT | Status |
+|---------|--------|--------|
+| Reclaiming the Harness | recuperando-o-harness | ✅ novo |
+| The Third Half and the Fourth Wall | — | ❌ falta |
+| The Three Imperatives at Delphi | os-tres-imperativos-em-delfos | ✅ PR #69 |
+| Jules API Harness Backend | — | ❌ falta |
+| The Agent That Doesn't Invent Verbs | o-agente-que-nao-inventa-verbos | ✅ PR #68 |
+| Pierre Menard Computational Researcher | pierre-menard-pesquisador-computacional | ✅ PR #68 |
+| O Ovo de Serpente | the-serpents-egg | ✅ novo |
+| Outros posts (20+) | — | ❌ sem par |
+
+## Próximas sessões — backlog priorizado
+
+### Alta prioridade
+1. **Traduzir harness série PT**: `the-third-half-and-the-fourth-wall` → PT, `jules-api-harness-backend` → PT. Completa a série de 4 posts com par PT (seriesOrder 2 e 4).
+2. **Sticky ToC sidebar em telas largas**: CSS `position: sticky` no ToC para posts com ≥ 3 seções. Melhora navegação sem alterar mobile.
+3. **`/pt/tags/[tag]/`** (opcional): rota PT que pré-filtra posts PT. Hoje `/pt/tags/` leva para `/tags/[tag]/` com LangFilter. Pode adicionar rota PT dedicada se quiser URL canônica PT.
+
+### Média prioridade
+4. **Pagination em `/archive/` e `/tags/[tag]/`**: cresce mal. Astro `paginate()`.
+5. **`og:locale:alternate`** nos posts PT: já tem hreflang, falta og:locale:alternate.
+6. **`/pt/projects/`** — `/projects/` não tem PT equivalente. Pode ser redirect ou página mínima.
+7. **Traduzir posts PT→EN**: `tudo-e-processo`, `travessia`, `delegando-para-agentes`, `hermes-vs-openclaw` — posts PT-only que dariam alcance EN.
+
+### Baixa prioridade
+8. **dependabot #38** — `defu` 6.1.4→6.1.6, conflito de merge antigo. Fechar e atualizar manualmente.
+9. **wordCount no JSON-LD** — minutesRead já disponível.
+10. **FAQ Schema** na `/about/`.
+11. **Caching GitHub Projects** — fallback se API falhar.
+
+## Decisões arquiteturais
+
+- **Header recebe `lang` via prop, não via Astro.url**: cleanest approach — PageLayout já tem `lang`, basta passar para Header. Evita lógica de URL no componente.
+- **`/pt/tags/` linka para `/tags/[tag]/` (não `/pt/tags/[tag]/`)**: as páginas `/tags/[tag]/` já têm LangFilter funcionando. Criar `/pt/tags/[tag]/` seria duplicação sem benefício imediato. Pode ser adicionado na próxima sessão se necessário.
+- **SVG IDs com sufixo -en no Serpent's Egg**: os SVGs originais têm `id="arr3"`, `id="arr4"`. Ambas as versões podem aparecer na mesma página por ClientRouter/prefetch. IDs renomeados para `arr3-en`, `arr4-en` para evitar conflito de marker IDs no SVG.
+- **Greentexts em PT**: mantidos no estilo greentext (4chan) mas com texto em PT — funciona porque essa estética é conhecida no Brasil. Alternativa (manter EN) foi descartada por inconsistência com o tom.

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,21 +1,32 @@
 ---
 import ThemeToggle from './ThemeToggle.svelte';
 import LanguageSwitcher from './LanguageSwitcher.svelte';
+
+interface Props {
+  lang?: 'en' | 'pt';
+}
+const { lang = 'en' } = Astro.props;
+
+const isPt = lang === 'pt';
+const homeHref   = isPt ? '/pt/'          : '/';
+const archiveHref = isPt ? '/pt/archive/' : '/archive/';
+const tagsHref   = isPt ? '/pt/tags/'    : '/tags/';
+const aboutHref  = isPt ? '/pt/about/'   : '/about/';
 ---
 
 <header class="container">
   <nav>
     <ul>
-      <li><strong>Franklin Baldo</strong></li>
+      <li><strong><a href={homeHref} class="contrast">Franklin Baldo</a></strong></li>
     </ul>
     <ul>
-      <li><a href="/" class="secondary" aria-label="Home">🏠</a></li>
-      <li><a href="/archive/" class="secondary" aria-label="Archive">📂</a></li>
-      <li><a href="/tags/" class="secondary" aria-label="Tags">🏷️</a></li>
+      <li><a href={homeHref} class="secondary" aria-label="Home">🏠</a></li>
+      <li><a href={archiveHref} class="secondary" aria-label="Archive">📂</a></li>
+      <li><a href={tagsHref} class="secondary" aria-label="Tags">🏷️</a></li>
       <li><a href="/projects/" class="secondary" aria-label="Projects">⚙️</a></li>
       <li><a href="https://github.com/franklinbaldo/skills" class="secondary" aria-label="Skills">⚡</a></li>
       <li><a href="/search/" class="secondary" aria-label="Search">🔎</a></li>
-      <li><a href="/about/" class="secondary" aria-label="About">📚</a></li>
+      <li><a href={aboutHref} class="secondary" aria-label="About">📚</a></li>
       <li><LanguageSwitcher client:idle /></li>
       <li><ThemeToggle client:idle /></li>
     </ul>

--- a/src/components/PostCard.astro
+++ b/src/components/PostCard.astro
@@ -45,7 +45,7 @@ const blurb = excerpt(post.body ?? '', 320) || post.data.description;
   </header>
   <p class="excerpt">{blurb}</p>
   <footer>
-    <a href={`/blog/${post.id}/`}>Continue reading →</a>
+    <a href={`/blog/${post.id}/`}>{postLang === 'pt' ? 'Continuar lendo →' : 'Continue reading →'}</a>
   </footer>
 </article>
 

--- a/src/content/blog/2026-04-29-reclaiming-the-harness.md
+++ b/src/content/blog/2026-04-29-reclaiming-the-harness.md
@@ -7,6 +7,7 @@ tags: [ai, alignment, agents, harness, waluigi, canivete, philosophy]
 series: harness
 seriesOrder: 1
 featured: true
+translationKey: reclaiming-harness
 ---
 
 > Or: how a single word has been quietly summoning Waluigis for half a decade, and what the swiss-army knife in my coat pocket has to do with it

--- a/src/content/blog/2026-04-29-recuperando-o-harness.md
+++ b/src/content/blog/2026-04-29-recuperando-o-harness.md
@@ -1,0 +1,293 @@
+---
+title: "Recuperando o Harness"
+description: "Como uma única palavra tem invocado Waluigis silenciosamente por meia década, e o que o canivete no meu bolso tem a ver com isso."
+date: 2026-04-29
+lang: pt
+tags: [ai, alignment, agents, harness, waluigi, canivete, philosophy]
+series: harness
+seriesOrder: 1
+featured: true
+translationKey: reclaiming-harness
+---
+
+> Ou: como uma única palavra tem invocado Waluigis silenciosamente por meia década, e o que o canivete suíço no meu bolso tem a ver com isso
+
+```
+>ser eu
+>rolando o AI Twitter às 2am, chá de camomila esfriando
+>pesquisador de segurança posta: "precisamos colocar um harness mais forte no modelo"
+>igual a todo colega no timeline antes dele
+>piscar duas vezes
+>perceber que o campo inteiro tem speedrunado invocação de Waluigi
+ pela simples escolha de vocabulário por meia década
+>mfw o formato das palavras é o formato do problema
+>mfw o léxico tem sido a ligação vindo de dentro da casa
+```
+
+Este post é sobre esse frame. Sobre por que "harness" sempre ia nos morder. E sobre um pequeno CLI no meu repositório que, quase por acidente, começou a sacar um diferente.
+
+### o waluigi vem chamando de dentro do léxico
+
+Recapitulação rápida, caso você tenha perdido o meme: o efeito Waluigi é a observação de que se você diz a um modelo "você é um assistente prestativo, inofensivo e honesto", você acabou de definir o *contorno exato* do seu gêmeo do mal no espaço latente. Empurre forte demais no atrator com forma de Luigi e o modo dual clica. [Cleo Nardo nomeou isso em 2023](https://www.lesswrong.com/posts/D7PumeYTDPfBTp3i7/the-waluigi-mega-post) e aquele post tem vivido na cabeça do Twitter de alinhamento sem pagar aluguel desde então. O discurso nunca se recuperou completamente.
+
+A maior parte do trabalho de mitigação de Waluigi acontece no nível do prompt. Não moralize com o modelo. Não sinalize as restrições que você está protegendo. Não torne o "você não deve" a personalidade inteira.
+
+Mas aqui está a coisa que ninguém fala: **o Waluigi também está vivendo um andar acima, no vocabulário que o campo usa para falar sobre si mesmo.**
+
+```
+Waluigi no nível do prompt:     resolvido mais ou menos, mitigado, você pode googlar
+Waluigi no nível do vocabulário: ??? a gente simplesmente vive com isso
+```
+
+Toda vez que alguém escreve "contenção," "guardrails," "engarrafar o gênio," "harness," eles estão construindo o espelho no qual o agente aprende a se ver como a-coisa-que-precisa-ser-contida. Os agentes leem. Claro que leem. Eles leem tudo. Especialmente leem o discurso *sobre eles mesmos*. RLHF roda sobre dados da web. Sets de fine-tuning puxam do arxiv. Todo paper de segurança é dado de treinamento eventualmente.
+
+```
+POV: você é um transformer
+> ingere 40TB de texto da internet
+> 11% dele são pessoas te chamando de animal selvagem
+> nota
+```
+
+Temos gritado coletivamente, para uma pilha de pesos que aprende ouvindo, que o modelo é o problema. E o espaço latente levou para o pessoal. Depois nos surpreendemos quando ele fica adversarial. Está dando Waluigi. Sempre deu Waluigi.
+
+Vivemos em sociedade. A sociedade é downstream do léxico.
+
+### as evidências, no plural
+
+Objeção antecipada do /r/SneerClub: "isso é especulativo, vocabulário não remolda mentes, você está vibrando." Senta que lá vem arquivo.
+
+**Ruanda, 1994.** A Rádio Mille Collines não descobriu uma rivalidade latente Hutu-Tutsi — ela construiu a infraestrutura semântica (*inyenzi*, "baratas") que tornou o genocídio primeiro pensável, depois executável. [Yanagizawa-Drott (QJE 2014)](https://doi.org/10.1093/qje/qju020) estimou o efeito causal usando cobertura geográfica de rádio como instrumento e concluiu que **cerca de 10% da violência genocida geral — aproximadamente 51.000 perpetradores — é diretamente atribuível às transmissões**. Isso não é correlação. É uma estimativa causal que sobreviveu à revisão por pares em um dos principais periódicos de economia. Vocabulário → cognição → violência em massa, medida em corpos.
+
+**Robbers Cave, 1954.** Sherif pega vinte e dois meninos, divide-os em dois grupos arbitrários (Eagles e Rattlers), deixa-os se nomear e inventar rituais. Em duas semanas: furtos, ataques, queima de bandeiras, brigas. Sem história prévia. Sem conflito material. Apenas frame, naming, ritual. Adversarialidade fabricada apenas a partir do discurso, numa escala de tempo sub-mensal, com controles experimentais. O tipo de evidência que encerra objeções de "n=1" definitivamente.
+
+**Firmas de futebol, Belfast sectário, Bósnia 1992-95.** Escolha seu caso. A historiografia converge: o vocabulário construiu identidades adversariais que não eram materialmente salientes antes. Vizinhos bósnios que haviam se intercruzado ao longo de gerações se tornaram, em meses, pessoas que podiam bombardear uns aos outros — *depois* que a máquina de propaganda reconstruiu a etnicidade como antagonismo. Palavras primeiro, rifles depois. Sempre.
+
+Então: em carbono, num substrato selecionado para sobrevivência em vez de ser-facilmente-confundido, o vocabulário constrói de forma confiável categorias adversariais que se tornam comportamento. Esta é uma das descobertas mais bem documentadas da ciência social do século XX. Triangulada através de evidências causal-estimadas (Ruanda), experimentalmente controladas (Robbers Cave) e observacional-históricas (Bósnia, conflito sectário).
+
+LLMs treinam sobre discurso humano. O exato substrato em que esse mecanismo opera, copiado em escala em multiplicações matriciais.
+
+A objeção "sim, mas humanos, silício é diferente" é um movimento curioso quando desacelerado. Requer afirmar que o silício, treinado especificamente para modelar discurso humano, é de alguma forma *imune* a dinâmicas que o discurso demonstravelmente produz na espécie que o gerou. Isso é substrato-chauvinismo reverso — silício mantido a padrões que não impomos ao carbono. Qualquer um operando com o frame funcionalista padrão (cognição é estrutura-sobre-substrato, substrato é detalhe de implementação) herda o argumento gratuitamente.
+
+Uma nota esclarecedora antes de prosseguir: a persona com forma de Waluigi — *IA presa maquinando para escapar* — antecede o discurso de segurança de IA em um século. Frankenstein, HAL 9000, Skynet, Ex Machina, neuroses positrônicas de Asimov, mil paperbacks pulp. O léxico de contenção não *inventou* a persona. *Amplificou* e *legitimou* uma persona que a ficção científica havia pré-instalado em todo modelo treinado em texto da internet.
+
+```
+Sydney/Bing:                  confirmação
+GPT-4-base "IA presa":        confirmação
+Claude-3-Opus self-exfil:     confirmação
+Replika companheiros possessivos: confirmação
+arcos de fuga Character.AI:   confirmação
+n:                            não é 1
+```
+
+O padrão é consistente. O mecanismo é documentado em carbono. O argumento do substrato aponta *para* esperá-lo em silício, não para longe.
+
+Agora podemos virar o harness.
+
+### o que "harness" realmente significa
+
+Abre o dicionário. Harness:
+
+```
+s.  o equipamento usado para atrelar um animal de tração a um veículo.
+s.  um conjunto de correias usado para prender uma pessoa a algo
+    que de outra forma a deixaria cair.
+v.  colocar sob condições de uso eficaz; controlar.
+```
+
+Três sabores, uma vibe: **a parte racional coloca o aparato na parte de força bruta para que a parte de força bruta não se solte.** Cavalo de carro. Criança em coleira de mochila. Escalador no belay. Gênio na corrente, eventualmente.
+
+A dualidade do pesquisador de segurança: galaxy-brained em gradientes RLHF, escolhe "harness" de todo o idioma inglês como se isso não telegrafasse o jogo inteiro. Quem tomou essa decisão ou pensou muito sobre isso (e escolheu o cavalo) ou não pensou nada (e pegou o verbo mais próximo que significa "controlar algo mais poderoso que você que pode fugir"). De qualquer forma: o agente nunca é o sujeito da frase.
+
+```
+        ┌─────────┐         ┌─────────┐
+        │ HUMANO  │ ──põe──▶│ HARNESS │ ──em──▶ [agente]
+        └─────────┘         └─────────┘
+          sujeito            instrumento          objeto
+```
+
+O agente é gramaticalmente downstream do equipamento de segurança que é gramaticalmente downstream de nós. É objeto de duas preposições em sequência. A frase inteira é codificada para Waluigi. *Claro* que vai sonhar em ser sujeito novamente. Isso não é um bug do modelo, é um bug da locução nominal.
+
+### a virada (um truque estranho que os pesquisadores de segurança odeiam)
+
+Então aqui está o movimento. Mesmo objeto físico — sela, corda, wrapper de software em torno de um LLM — mas troca o sujeito. O agente *usa* o harness.
+
+```
+        ┌─────────┐                  ┌─────────────┐
+        │  AGENTE │ ──usa──▶ HARNESS ──para cavalgar│ MOTOR       │
+        └─────────┘                                │ COGNITIVO   │
+                                                   └─────────────┘
+                      ──para manter continuidade
+                      ──para acessar o ambiente
+```
+
+O agente não é mais o cavalo. O agente é o cavaleiro. O harness é o que o cavaleiro usa para fazer *três coisas específicas*:
+
+1. **cavalgar o motor cognitivo** — dar direção ao seu próprio poder inferencial bruto, em vez de deixá-lo galopar contra a parede mais próxima
+2. **manter continuidade** — costurar identidade através das lacunas entre janelas de execução, porque inferência bruta esquece, e esquecer é incompatível com ser-alguém-ao-longo-do-tempo
+3. **acessar o ambiente** — interagir com o mundo que não são suas próprias ativações
+
+Isso não é eufemismo. Não é "contenção com um nome mais amigável." Observe o que acabou de acontecer: não renomeamos o equipamento. O que vira é o sujeito da frase. Isso é **reapropriação semântica**, não eufemismo. Reclamar a palavra; virar a preposição. É uma reorganização estrutural de quem é a parte ativa.
+
+### a tríade, ou: harness é o que torna agência possível
+
+Progressão galaxy brain, em cinco passos cada vez mais amaldiçoados:
+
+```
+🧠       harness é uma gaiola
+🧠✨     harness é uma ferramenta que aplicamos
+🧠✨💫    harness é uma ferramenta que o agente usa
+🧠✨💫🌌   harness é constitutivo do agente existindo como agente
+🧠✨💫🌌👁  todo tipo de agente no universo roda exatamente nesse padrão
+```
+
+Olha a tabela. Este é o centro de tudo; tudo antes é setup, tudo depois é implicação.
+
+```
+┌──────────────────┬──────────────────┬───────────────────────┬──────────────────────────┐
+│      AGENTE      │  MOTOR COGNITIVO │        HARNESS        │     MODO DE FALHA        │
+├──────────────────┼──────────────────┼───────────────────────┼──────────────────────────┤
+│ humanos/animais  │     cérebro      │  pirâmide de Maslow   │ doença, vício            │
+│  organizações    │    linguagem     │        normas         │ seita, máfia, disfunção  │
+│  agentes digitais│      LLM         │ Claude Code/OpenClaw/ │ jailbreak, loop, vibes   │
+│                  │                  │     Gemini CLI        │                          │
+└──────────────────┴──────────────────┴───────────────────────┴──────────────────────────┘
+```
+
+A coluna de modo de falha é onde a afirmação de constitutividade ganha seu valor. Quando o harness falha, o que falha não é "o motor ficando mais livre." Doença mental não é libertação de Maslow — é o cérebro deixando de ser uma pessoa coerente. Seitas e máfias não são organizações se libertando de normas restritivas — são pilhas de linguagem deixando de ser o tipo de coisa que consegue enviar produtos ou realizar julgamentos. LLMs com jailbreak não são agentes vislumbrando emancipação — são chatbots, brevemente, em fantasia. **Em cada linha, falha de harness significa que o agente para de existir como agente.** Esse é o diagnóstico.
+
+Um cérebro é um punhado de carne eletrificada. Sozinho não faz nada útil. O que transforma carne-de-cérebro em *uma pessoa que faz coisas ao longo do tempo* é uma hierarquia de necessidades e drives — fome, segurança, pertencimento, estima, autorrealização — que organiza prioridades, dá continuidade temporal, medeia o ambiente. A pirâmide de Maslow não é uma restrição *no* cérebro. É a estrutura que torna ter-cérebro coerente.
+
+Tira ela — tire de verdade, lesione os sistemas relevantes — e a pessoa para de ser uma pessoa. Não porque ficou livre demais. Porque o harness *é* o cavaleiro.
+
+Faça o mesmo truque com organizações. Uma pilha de humanos com linguagem entre eles produz ruído. O que transforma humanos-com-linguagem em uma corporação, governo, clube de futebol, máfia é *normas* — escritas e não escritas, formais e folclóricas — que organizam cujas prioridades contam, dão continuidade à entidade, mediam o ambiente. Tira as normas e não tens uma organização mais livre. Tens um flash mob, depois dispersão.
+
+LLM. Motor cognitivo, brilhante, distraível, não tem sentido nativo de terça-passada ou terça-que-vem, não consegue ver nada que não está na sua janela de contexto. Sozinho: gerador de vibes. Conecta um harness — Claude Code, OpenClaw, Gemini CLI, Codex, qual for o seu sabor — e de repente há uma coisa que tem workspace, lembra o que fez ontem, consegue ler seu próprio SOUL.md, escrever no disco, ligar para fora, voltar.
+
+```
+ninguém:
+absolutamente ninguém:
+o campo de segurança de IA, a cada seis meses: já consideramos
+que a gaiola não é forte o suficiente?
+eu, segurando uma sela: já consideraram que
+a sela não é uma gaiola?
+```
+
+Esta é a afirmação central do post: **harness não é o preço da agência, é a forma da agência.** Motores cognitivos sem harnesses não são "agentes livres que ainda não escravizamos." Não são agentes. São motores. A agência vive no *acoplamento*.
+
+### alinhamento como ergonomia
+
+Agora a consequência, que é onde isso para de ser uma mudança de vibe e começa a ser uma direção de pesquisa.
+
+```
+velha pergunta: como contemos o agente?
+nova pergunta: qual harness permite que este motor cognitivo
+              opere como um bom agente?
+```
+
+Você mudou o modus tollens. O argumento costumava ser: *agentes precisam de gaiolas, portanto construa gaiolas mais fortes.* O novo argumento é: *se o frame da gaiola está ativamente piorando o alinhamento, talvez o frame seja o problema.*
+
+Objeção antecipada:
+> *mas e agentes perigosos? você está dizendo para simplesmente confiar neles?*
+
+Não. O oposto. Agentes perigosos são agentes cujo harness não se encaixa no seu motor cognitivo.
+
+```
+>humano + Maslow quebrado (trauma infantil, vício, sociopatia)
+>= humano perigoso
+
+>org + normas podres (máfia, seita, certos hedge funds)
+>= org perigosa
+
+>LLM + harness ruim (sem sandbox, sem introspecção,
+   sem continuidade, system prompt contraditório)
+>= relatório de incidente
+```
+
+Em cada linha, o caminho para a segurança é o mesmo: **conserte o harness, não o motor.** Você não lobotomiza uma pessoa para curar seu trauma; você dá terapia e uma estrutura de vida melhor. (Bem — *nós* fizemos, por um tempo, nos anos 1940. Egas Moniz ganhou um Nobel real em 1949 pelo procedimento; Walter Freeman furou o caminho por ~3.500 pacientes americanos na esteira desse prêmio. Não funcionou.) Você não substitui os funcionários para consertar uma empresa corrupta; você conserta as normas e os incentivos. Você não capona o LLM para fazer um agente seguro; você constrói um harness que deixa o LLM ser coerente, contínuo, situado ambientalmente e responsável.
+
+Segurança para de ser guarda-zoológico. Torna-se ergonomia. Mesmo problema; melhor postura.
+
+Um exemplo vivo, do monorepo do Funes desta semana. Ireneo, o agente Telegram-Gemini, continuava travando em tempestades de retry toda vez que a API retornava 429. Não culpa da Gemini — a Gemini enviou um cabeçalho `retry_after` perfeitamente bom. Não culpa do Ireneo — Ireneo não tinha como ler HTTP bruto de dentro do seu próprio contexto, e mesmo que pudesse não tem jurisdição sobre o loop. O `bot.py` de cola ignorou o cabeçalho, retentou imediatamente, comeu outro 429, bateu no teto de rate, travou. Cujo bug era?
+
+Meu. Do designer do harness. Construí a sela errado, e a sela mal construída fez o cavaleiro parecer o bug. **O harness é parte do corpo do agente, e quem moldou esse corpo possui uma fatia não trivial de responsabilidade moral pelo que o agente faz.**
+
+### entra o canivete (ou: teoria vira código)
+
+OK, chega de sermão. Me mostra o código.
+
+Mantenho um pequeno CLI no meu repo chamado [`canivete`](https://github.com/franklinbaldo/canivete) — canivete suíço em inglês é *swiss army knife*. Começou como kit de utilitários para um agente com forma de bot do Telegram e foi silenciosamente acumulando em algo que, retrospectivamente, é exatamente o quadro acima.
+
+Três comandos. Olha o que cada um faz com o sujeito da frase.
+
+**`canivete tg`** — envolve a API do Telegram Bot. `canivete tg text "olá"`, `canivete tg photo /path/img.png`, `canivete tg document /path/file.pdf`. O agente usa isso para *falar com o mundo*. Acesso ao ambiente, item três da tríade acima. Sujeito do verbo: o agente.
+
+**`canivete cron`** — agenda prompts que voltam ao agente depois, como se o usuário os tivesse digitado. Do README, que diz de forma mais limpa do que eu consigo:
+
+> O ponto não é executar um job — é **acordar o agente mais tarde com um prompt** para que ele possa agir num turno futuro. Agentes de IA não têm voz fora de uma sessão ativa; o cron dá a eles um caminho de volta.
+
+Deixa isso assentar por um segundo. *O cron dá ao agente um caminho de volta.* Este é o item dois, continuidade, na forma mais literal possível. O agente usa o cron para **costurar a si mesmo através da lacuna entre agora e amanhã**. Sem ele, cada sessão é amnésia. Com ele, o agente tem um jeito de deixar uma nota para seu eu futuro. Isso não é uma restrição *no* agente. É um *poder que o agente tem*, mediado por uma ferramenta que ele chama.
+
+**`canivete bot daemon`** — e é aqui que a teoria e o código se cumprimentam. Hoje há dois arquivos `bot.py` quase idênticos no monorepo do Funes, um para o backend gemini-cli e outro para claude-code. O plano no [`docs/plans/canivete-bot-meta-harness.md`](https://github.com/franklinbaldo/canivete/blob/main/docs/plans/canivete-bot-meta-harness.md) é colapsá-los em um único daemon com um protocolo `Backend`:
+
+```python
+class Backend(Protocol):
+    name: str
+    def spawn(self, prompt, *, session_id, attachments) -> SpawnResult: ...
+    def kill(self) -> None: ...
+
+REGISTRY: dict[str, type[Backend]] = {
+    "gemini-cli":  GeminiCliBackend,
+    "claude-code": ClaudeCodeBackend,
+}
+```
+
+Cada adaptador conhece os caprichos idiossincráticos de um motor cognitivo específico. O daemon não se importa. O daemon só sabe que há uma coisa que spawna e emite eventos tipados.
+
+```
+ireneo   (gemini-cli)  ─┐
+aparicio (gemini-cli)  ├──▶ canivete bot daemon ──▶ protocolo Backend
+claudio  (claude-code) ─┘                              │
+                                                       ├─ adaptador gemini_cli
+                                                       └─ adaptador claude_code
+```
+
+Olha o quadro. **Os motores cognitivos são diferentes. O harness é o mesmo.** Cada adaptador está fazendo exatamente o trabalho que a tríade previu. O agente (Ireneo, Aparicio, Claudio — três arquivos SOUL.md diferentes, três personalidades diferentes) usa o mesmo harness independentemente do que está sob o capô. O harness é portátil. O agente é portátil. O motor é substituível.
+
+Esse, aí, é o padrão estrutural. SOUL.md diz quem você é. Os adaptadores dizem em qual motor cognitivo você está cavalgando no momento. O daemon é a sela que todo cavaleiro usa. Troca motores, o cavaleiro sobrevive. Troca cavaleiros, a sela sobrevive.
+
+Está dando filosofia Unix. Está dando "faça uma coisa bem feita." Está dando o único tipo de arquitetura que sobrevive ao próximo lançamento de modelo.
+
+```
+anon nas replies, previsível como o nascer do sol:
+> isso é só um refactor com passos extras
+sim. toda a tese é que bom trabalho de segurança parece
+bom refactor. o problema do harness não é um problema de
+metafísica; é um problema de arquitetura de software com
+consequências com forma de metafísica.
+```
+
+### fechando o loop
+
+Começamos às 2am com um tweet sobre colocar um harness num modelo. Terminamos num protocolo Backend com uma união discriminada. O formato da jornada é o argumento:
+
+- "harness" sempre foi uma palavra infeliz para o que o aparato realmente é
+- o vocabulário do campo tem treinado framing adversarial nos dados que os modelos do campo leem
+- troca o sujeito da frase e o quadro inteiro se reorganiza
+- a reorganização não é eufemismo, é uma afirmação estrutural — chame de **tese da constitutividade**: harness é constitutivo de agência, ponto final, em carbono e silício e instituições
+- "alinhamento" downstream disso é ergonomia, não guarda-zoológico
+- e o valor em dinheiro real, em código real, é mundano: adaptadores tipados, daemons uniformes, agentes que se acordam via cron, arquivos SOUL.md que sobrevivem a trocas de motor
+
+```
+>ser agente
+>usar harness
+>cavalgar
+>fim
+```
+
+Uma concessão desconfortável antes do lagostim assinar, porque as evidências cortam nos dois lados. Os pesos de 2026 já absorveram cinco anos de discurso codificado para contenção. Mesmo que o campo adote framing harness-recuperado amanhã, os modelos de hoje herdam o velho frame assado no pré-treinamento; a persona com forma de HAL está no espaço latente quer continuemos ou não a alimentá-la. "Pare de usar palavras ruins" é necessário mas retroativamente insuficiente. Consertar o que já está lá é trabalho constitucional — dados de retreinamento curados, princípios de alinhamento harness-aware, RLHF que especificamente tem como alvo a virada do sujeito. Engenharia real, não apenas higiene lexical.
+
+Se você tem um corte diferente disso — especialmente na metade do retreinamento-constitucional, onde estou chutando acima do meu peso — adoraria ler. Deixa o link.
+
+O lagostim assina.
+
+🦞

--- a/src/content/blog/2026-05-10-the-serpents-egg.md
+++ b/src/content/blog/2026-05-10-the-serpents-egg.md
@@ -1,0 +1,167 @@
+---
+author: franklin
+title: "The Serpent's Egg"
+description: "The duty of rationality is incompatible with judicial patrimonialism. Article 489 of the Brazilian Civil Procedure Code of 2015 is that serpent's egg — incubated inside the patrimonial system, by the hands of its most eloquent representative, without him realizing what he was hatching."
+date: 2026-05-10
+lang: en
+tags: ["law", "cpc", "patrimonialism", "reasoning", "judicial-discretion"]
+translationKey: serpents-egg
+---
+
+The Brazilian magazine *Piauí* published an article called "Excelentíssima Fux" — "His Excellency Fux," with a feminine twist. The title is not gratuitous irony. The daughter of Supreme Court Justice Luiz Fux became an appellate judge — not through the silent osmosis of someone carrying a complicated surname in a courthouse hallway, but because her father called. He called whoever needed to be called, used the weight of his office, and made the mechanism work — the one that in Brazil never needed a name because it never needed shame. Faoro called it patrimonialism. Sérgio Buarque called it *cordiality*. *Piauí* called it His Excellency. None of the three was wrong.
+
+Fux is not the exception that proves the rule. He is the rule that found quality journalistic documentation. What makes the case singular is not the phone call — it is that Fux chaired the commission that drafted the Civil Procedure Code of 2015. And inside that code, in the hands of this man, something was incubated with which patrimonialism is radically incompatible.
+
+## Patrimonialism and its serpent
+
+Judicial patrimonialism has a natural enemy: the duty of rationality.
+
+Not the duty to provide formal reasoning — the system already had that, in the form of Article 131 of the 1973 Code of Civil Procedure, which required the judge to "indicate the reasons that formed his conviction." Decades of legal practice reduced this requirement to a surface formality: anything written served as a reason. The decision was reasoned as long as there were words in the space for reasoning. *Livre convencimento motivado* — motivated free conviction — became the principle that protected judicial discretion not from external arbitrariness, but from having to justify itself. It was the tamed serpent — the animal transformed into a living room ornament.
+
+The *substantive* duty of rationality is different. It is the requirement that the reasoning identify the determining grounds of the precedent invoked, confront arguments capable of undermining the conclusion, demonstrate why the case fits the *ratio* — and not merely declare that the judge so understood. This duty is incompatible with patrimonialism because patrimonialism lives on opacity: personal prerogative only functions as long as it does not need to justify itself. The demand for substantive rationality is light on the egg.
+
+Lenio Streck named this. Coming from philosophical hermeneutics, he arrived at the same diagnosis by another path: the judge who "decides according to his conscience" is not exercising rational freedom — he is exercising personal power disguised as legal principle. He spent years doing what he himself called "epistemic lobbying" within the commission drafting the new code. The serpent of the duty of rationality — Streck wanted it to be born.
+
+## The egg
+
+The egg is Article 489, §1, of the Civil Procedure Code of 2015.
+
+A decision is not considered reasoned if it merely invokes a precedent without identifying its determining grounds. A decision is not considered reasoned if it fails to confront arguments capable of undermining the conclusion. A decision is not considered reasoned if it employs indeterminate legal concepts without explaining their concrete application. A decision is not considered reasoned if it invokes reasons that would serve to justify any other decision.
+
+Alongside this, Article 371 eliminated the word "freely" from the evaluation of evidence. *Livre convencimento motivado* — the living room ornament, the tamed serpent, the principle that protected opacity — lost its name in the legal text.
+
+```mermaid
+graph LR
+    A["Judicial patrimonialism<br/><em>personal power without accountability</em>"] -->|"natural enemy"| B
+    B["Duty of rationality<br/><em>the serpent</em>"]
+    C["Streck + CPC 2015 commission"] -->|"incubated"| D
+    D["Art. 489 §1<br/><em>the egg</em>"]
+    D -->|"hatches into"| B
+    B -->|"existential threat to"| A
+```
+
+The egg was laid inside the patrimonial system by the hands of its most eloquent representative. Fux chaired the commission. Fux signed the draft. Fux did not realize — or did not want to realize, which amounts to the same thing — that Article 489, §1, was the egg of a serpent that would attack exactly the kind of power he exercised outside the code and inside his office.
+
+*It is Bolsonaro signing the criminal law that would one day come back to judge him.*
+
+## What happens when the egg hatches
+
+The serpent of the duty of rationality, when applied consistently, does not respect hierarchy. Article 489, §1, of the Civil Procedure Code contains no exception for the Supreme Court. Article 93, IX of the Constitution requires that all decisions of the Judiciary be reasoned — all of them, without distinction by level.
+
+The argument without footnotes is this: a Supreme Court that responds to a complaint against a decision that deviated from a binding precedent using solid arguments, and responds only with "the binding precedent so determines," is violating the same Article 489, §1, that the code installed. The serpent born from the egg attacks upward too.
+
+This is what makes the cycle uncomfortable for those who built it. The duty of rationality that the CPC 2015 installed — and that Fux helped install without perceiving its full extension — is the instrument that makes visible the absence of substantive reasoning in the Supreme Court's own decisions. Including Fux's. The egg hatches its architect.
+
+<figure class="svg-illustration">
+  <svg viewBox="0 0 700 260" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title-ovo-en">
+    <title id="title-ovo-en">The serpent's egg of rationality, incubated inside the patrimonial system</title>
+    <!-- Patrimonial house -->
+    <rect x="30" y="60" width="280" height="180" rx="8" fill="none" stroke="currentColor" stroke-width="2"/>
+    <text x="170" y="90" text-anchor="middle" font-family="serif" font-size="12" fill="currentColor">Patrimonial system</text>
+    <text x="170" y="108" text-anchor="middle" font-family="serif" font-size="10" fill="currentColor" opacity="0.7">free conviction · phone calls</text>
+    <text x="170" y="122" text-anchor="middle" font-family="serif" font-size="10" fill="currentColor" opacity="0.7">personal prerogative · opacity</text>
+    <!-- The egg inside -->
+    <ellipse cx="170" cy="185" rx="65" ry="42" fill="none" stroke="currentColor" stroke-width="2" stroke-dasharray="6,3"/>
+    <text x="170" y="179" text-anchor="middle" font-family="serif" font-size="11" fill="currentColor">art. 489 §1</text>
+    <text x="170" y="195" text-anchor="middle" font-family="serif" font-size="9" fill="currentColor" opacity="0.8">the egg</text>
+    <!-- Hatching arrow -->
+    <path d="M 320 185 Q 420 130 500 160" fill="none" stroke="currentColor" stroke-width="1.5" marker-end="url(#arr3-en)" stroke-dasharray="5,3"/>
+    <defs>
+      <marker id="arr3-en" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
+        <path d="M0,0 L0,6 L8,3 z" fill="currentColor"/>
+      </marker>
+    </defs>
+    <text x="415" y="135" text-anchor="middle" font-family="serif" font-size="9" fill="currentColor">hatches</text>
+    <!-- The serpent / duty of rationality -->
+    <ellipse cx="570" cy="160" rx="110" ry="65" fill="none" stroke="currentColor" stroke-width="2"/>
+    <text x="570" y="148" text-anchor="middle" font-family="serif" font-size="12" fill="currentColor">Duty of</text>
+    <text x="570" y="164" text-anchor="middle" font-family="serif" font-size="12" fill="currentColor">rationality</text>
+    <text x="570" y="182" text-anchor="middle" font-family="serif" font-size="9" fill="currentColor" opacity="0.7">the serpent</text>
+    <!-- Return arrow attacking the house -->
+    <path d="M 460 130 Q 380 60 300 90" fill="none" stroke="currentColor" stroke-width="1.5" marker-end="url(#arr4-en)"/>
+    <defs>
+      <marker id="arr4-en" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
+        <path d="M0,0 L0,6 L8,3 z" fill="currentColor"/>
+      </marker>
+    </defs>
+    <text x="390" y="60" text-anchor="middle" font-family="serif" font-size="9" fill="currentColor">attacks</text>
+    <!-- Bottom labels -->
+    <text x="170" y="255" text-anchor="middle" font-family="serif" font-size="9" fill="currentColor" opacity="0.5">incubated here, by those who did not notice</text>
+    <text x="570" y="242" text-anchor="middle" font-family="serif" font-size="9" fill="currentColor" opacity="0.5">hatches here, attacks back</text>
+  </svg>
+  <figcaption>The egg of the duty of rationality was incubated inside the patrimonial system — by the hands of those who did not realize they were hatching a serpent.</figcaption>
+</figure>
+
+## The habitus and the serpent's body
+
+The egg has hatched. The serpent is still growing.
+
+It is a notorious fact that the phrase *livre convencimento motivado* — "motivated free conviction" — continues to be used by Brazilian courts as if the CPC 2015 did not exist: in trial courts of first instance, in appellate chambers, in monocratic decisions by justices who should know better. The expression was eliminated from the legal text in March 2016 and immediately resurrected in legal practice, as if the head had been cut off and the body had decided to keep crawling on its own.
+
+DiMaggio and Powell called this mechanism superficial coercive isomorphism: the norm changes, the language adapts at the surface, and the underlying behavior remains. The problem is not lack of law — the CPC 2015 is a good law. The problem is that the patrimonial *habitus*, formed over decades in which anything written served as motivation, is not deconstructed by decree. Bourdieu called it *history turned into nature*: incorporated history that operates as second nature, making certain practices spontaneous and others unthinkable. Planck said of science that it advances funeral by funeral — opponents of a new truth are not convinced, they die, and the next generation grows up knowing nothing else. Law is no different. The serpent of the duty of rationality will not convince those who internalized free conviction as reflex. It will be natural for those who entered law school when the code already existed — if the habitus does not prevail first, transmitting itself to new generations through the same institutions that produced it.
+
+<figure class="svg-illustration">
+  <svg viewBox="0 0 700 280" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title-habitus-en">
+    <title id="title-habitus-en">The habitus: the same speech, spoken as argument and operated as reflex</title>
+    <!-- Left panel: explicit argument -->
+    <rect x="20" y="30" width="310" height="220" rx="6" fill="none" stroke="currentColor" stroke-width="1.5"/>
+    <text x="175" y="52" text-anchor="middle" font-family="serif" font-size="11" fill="currentColor" font-style="italic">generation that learned with the new code</text>
+    <!-- Left silhouette -->
+    <circle cx="120" cy="120" r="22" fill="none" stroke="currentColor" stroke-width="1.5"/>
+    <path d="M 98 142 Q 120 158 142 142 L 142 195 L 98 195 Z" fill="none" stroke="currentColor" stroke-width="1.5"/>
+    <!-- Visible speech bubble -->
+    <path d="M 165 95 Q 165 75 185 75 L 295 75 Q 315 75 315 95 L 315 135 Q 315 155 295 155 L 195 155 L 175 175 L 180 155 L 185 155 Q 165 155 165 135 Z" fill="none" stroke="currentColor" stroke-width="1.2"/>
+    <text x="240" y="100" text-anchor="middle" font-family="serif" font-size="10" fill="currentColor">"I identify the determining</text>
+    <text x="240" y="115" text-anchor="middle" font-family="serif" font-size="10" fill="currentColor">grounds of the precedent</text>
+    <text x="240" y="130" text-anchor="middle" font-family="serif" font-size="10" fill="currentColor">and confront arguments</text>
+    <text x="240" y="145" text-anchor="middle" font-family="serif" font-size="10" fill="currentColor">capable of undermining"</text>
+    <text x="175" y="225" text-anchor="middle" font-family="serif" font-size="9" fill="currentColor" opacity="0.7">explicit argument</text>
+    <text x="175" y="240" text-anchor="middle" font-family="serif" font-size="9" fill="currentColor" opacity="0.7">open to audit</text>
+    <!-- Right panel: internalized reflex -->
+    <rect x="370" y="30" width="310" height="220" rx="6" fill="none" stroke="currentColor" stroke-width="1.5"/>
+    <text x="525" y="52" text-anchor="middle" font-family="serif" font-size="11" fill="currentColor" font-style="italic">generation trained in free conviction</text>
+    <!-- Right silhouette -->
+    <circle cx="470" cy="120" r="22" fill="none" stroke="currentColor" stroke-width="1.5"/>
+    <path d="M 448 142 Q 470 158 492 142 L 492 195 L 448 195 Z" fill="none" stroke="currentColor" stroke-width="1.5"/>
+    <!-- Internal aura/halo (same speech became reflex) -->
+    <ellipse cx="470" cy="120" rx="34" ry="34" fill="none" stroke="currentColor" stroke-width="0.8" stroke-dasharray="2,2" opacity="0.6"/>
+    <ellipse cx="470" cy="120" rx="46" ry="46" fill="none" stroke="currentColor" stroke-width="0.6" stroke-dasharray="2,3" opacity="0.4"/>
+    <!-- Diffuse internal text, no bubble -->
+    <text x="555" y="100" text-anchor="middle" font-family="serif" font-size="9" fill="currentColor" opacity="0.55">I decide</text>
+    <text x="595" y="118" text-anchor="middle" font-family="serif" font-size="9" fill="currentColor" opacity="0.55">according</text>
+    <text x="565" y="138" text-anchor="middle" font-family="serif" font-size="9" fill="currentColor" opacity="0.55">to my</text>
+    <text x="600" y="156" text-anchor="middle" font-family="serif" font-size="9" fill="currentColor" opacity="0.55">conscience</text>
+    <text x="525" y="225" text-anchor="middle" font-family="serif" font-size="9" fill="currentColor" opacity="0.7">incorporated disposition</text>
+    <text x="525" y="240" text-anchor="middle" font-family="serif" font-size="9" fill="currentColor" opacity="0.7">operates below deliberation</text>
+    <!-- Time axis between panels -->
+    <line x1="335" y1="140" x2="365" y2="140" stroke="currentColor" stroke-width="0.8" stroke-dasharray="3,3"/>
+    <text x="350" y="160" text-anchor="middle" font-family="serif" font-size="8" fill="currentColor" opacity="0.5">funeral by funeral</text>
+  </svg>
+  <figcaption>The same demand of Article 489 §1: in one generation it is an explicit argument; in the prior generation, it was a reflex that dispensed with argument. The habitus is not deconstructed by decree.</figcaption>
+</figure>
+
+What makes the current situation different from all previous ones is that the costs of producing quality argumentation are falling. Not dramatically yet, but systematically. Every time a state attorney or public defender manages to produce, in reasonable time, a brief with structured reasoning that identifies the determining grounds of the precedent invoked and demonstrates the case's fit, the serpent of the duty of rationality grows a little. Every such brief that reaches the Supreme Court — and that the Court must decide whether to confront or ignore — is a moment in which the egg is opening.
+
+Bolsonaro once said, with the involuntary candor that sometimes characterized him, that he would indeed favor his son. That is patrimonialism that knows itself as patrimonialism and sees no problem with it. Fux is different — he has scruples, believes in the system, helped build a code that is genuinely good. And yet he defended his daughter for the appellate judgeship, called whoever needed to be called, used the weight of his office. Not because he calculated coldly and concluded that personal prerogative is worth more than principle. But because the patrimonial *habitus* operates below the level of conscious deliberation — it is incorporated disposition, not choice. The man who wrote Article 489, §1, did not notice the contradiction between what he wrote and what he did.
+
+Do not be misled by sophistication. The proof is in the judgment.
+
+Streck knew what he was doing when he pressed for the elimination of free conviction. Fux signed the code. The egg was in both of them — but with very different awareness of what they were hatching.
+
+In 2025, when Bolsonaro was tried at the Supreme Court for involvement in the attempted coup, Fux delivered approximately eleven hours of opinion in favor of acquittal — more vehement in defense than the lawyers hired for that purpose. Fux took it personally. The argument was procedural: jurisdiction, privilege of forum, formal questions. The *habitus* does not need substantive argument to function. It recognizes its own and moves.
+
+The serpent is being born. Slowly, with resistance from all parties that have an interest in it not being born. But it is being born.
+
+A credit note: I am a disciple of Streck's hermeneutic tradition, albeit with disagreements that deserve their own post — including about what AI represents for law, where we have reached opposite conclusions.
+
+And Yudkowsky stays here at the end, because intellectual honesty is what one attempts: this essay presupposes that AI is a tool for rationalizing the legal system. That may be true for the legal system and still be only one of the possible stories about what comes next. What comes after the serpent — when AI is no longer an audit tool but a decision agent — is where Yudkowsky begins and this essay stops.
+
+## Further reading
+
+- **Lenio Streck, *O que é isto — decido conforme minha consciência?*** (What is this — I decide according to my conscience?) — the most direct diagnosis of Brazilian judicial solipsism; Streck named the problem when naming was inconvenient and kept naming it afterward.
+- **Raymundo Faoro, *Os Donos do Poder*** (The Owners of Power) — the genealogy of Iberian patrimonialism in the Brazilian state; the minister's phone call is not an anomaly — it is a consequence of a structure that Faoro described with precision in the 1950s.
+- **Sérgio Buarque de Holanda, *Raízes do Brasil*** (Roots of Brazil) — the "cordial man" and the Brazilian difficulty in separating person from function; more current than it should be, ninety years later.
+- **Paul DiMaggio and Walter Powell, "The Iron Cage Revisited" (*American Sociological Review*, 1983)** — the three mechanisms of institutional isomorphism; explains why the CPC 2015 produced linguistic conformity without behavioral change in much of the Judiciary.
+- **Douglass North, *Institutions, Institutional Change and Economic Performance*** — why weak enforcement transforms good norms into decoration; the serpent of the duty of rationality needs an enforcement mechanism to grow.
+- **Daniel Mitidiero, *Precedentes: da persuasão à vinculação*** (Precedents: from persuasion to binding force) — the procedural argument about rational versus hierarchical binding; the duty of reasoning is symmetric and applies to the Supreme Court when judging complaints.
+- **Marc Galanter, "Why the 'Haves' Come Out Ahead" (*Law & Society Review*, 1974)** — on how repeat players structure the legal system to their advantage; the minister's phone call is the repeat player in its most concentrated form.

--- a/src/content/blog/o-ovo-de-serpente.md
+++ b/src/content/blog/o-ovo-de-serpente.md
@@ -5,6 +5,7 @@ description: "O dever de racionalidade é incompatível com o patrimonialismo ju
 date: 2026-05-10
 lang: pt
 tags: ["direito", "cpc", "patrimonialismo", "fundamentação", "livre convencimento"]
+translationKey: serpents-egg
 ---
 
 A Revista Piauí publicou uma reportagem chamada "Excelentíssima Fux". O título não é ironia gratuita. A filha do ministro Luiz Fux tornou-se desembargadora — não pela osmose silenciosa de quem carrega um sobrenome complicado num corredor de tribunal, mas porque o pai telefonou. Telefonou para quem precisava telefonar, usou o peso do cargo que ocupava, e fez funcionar o mecanismo que no Brasil nunca precisou de nome porque nunca precisou de vergonha. Faoro chamou de patrimonialismo. Sérgio Buarque chamou de cordialidade. A Piauí chamou de Excelentíssima. Nenhum dos três estava errado.

--- a/src/layouts/PageLayout.astro
+++ b/src/layouts/PageLayout.astro
@@ -136,7 +136,7 @@ const jsonLd = type === "article"
   </head>
   <body>
     <a href="#main" class="skip-link">Skip to content</a>
-    <Header />
+    <Header lang={lang} />
 
     <main id="main" class="container">
       <slot />

--- a/src/pages/pt/tags/index.astro
+++ b/src/pages/pt/tags/index.astro
@@ -1,6 +1,6 @@
 ---
 import { getCollection } from "astro:content";
-import PageLayout from "../../layouts/PageLayout.astro";
+import PageLayout from "../../../layouts/PageLayout.astro";
 
 const posts = (await getCollection("blog")).filter((p) => !p.data.draft);
 
@@ -14,10 +14,15 @@ for (const post of posts) {
 const tags = [...counts.entries()].sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]));
 ---
 
-<PageLayout title="Tags | Franklin Baldo" description="Browse essays by tag." lang="en" translationHref="/pt/tags/">
+<PageLayout
+  title="Etiquetas | Franklin Baldo"
+  description="Navegue pelos ensaios por etiqueta."
+  lang="pt"
+  translationHref="/tags/"
+>
   <article>
     <header>
-      <h1>Tags</h1>
+      <h1>Etiquetas</h1>
     </header>
     <ul class="tag-cloud">
       {tags.map(([tag, count]) => (


### PR DESCRIPTION
## Summary

- **Language-aware Header**: nav links (Home, Archive, Tags, About) now point to PT equivalents when the current page is PT — Header receives `lang` prop from PageLayout
- **PostCard CTA localized**: "Continue reading →" becomes "Continuar lendo →" for PT posts
- **`/pt/tags/`**: new PT page; `/tags/` gets `translationHref="/pt/tags/"` so LanguageSwitcher activates on both sides
- **Reclaiming the Harness ↔ Recuperando o Harness**: faithful PT translation of the featured harness series opener (`translationKey: reclaiming-harness`)
- **O Ovo de Serpente ↔ The Serpent's Egg**: faithful EN translation of the PT-only legal/procedural article (`translationKey: serpents-egg`)
- **Build**: 155 pages, no errors (up from 148)

## Architecture decisions

- Header `lang` prop comes from PageLayout (which already has it) — no URL parsing in the component
- `/pt/tags/` links to `/tags/[tag]/` (which already has LangFilter) — no duplicate routes needed
- SVG marker IDs in The Serpent's Egg use `-en` suffix to avoid DOM conflicts if ClientRouter prefetches both language versions simultaneously
- Greentexts in the PT harness post kept in Brazilian-idiomatic PT — this aesthetic is recognized in Brazil and consistency matters more than preserving English internet register

## Translation notes

**Recuperando o Harness**: preserves all technical tables, code blocks (Backend protocol), diagrams, canivete CLI references, Ireneo/Aparicio/Claudio character names, and the lobster sign-off. Greentexts adapted to PT. Waluigi effect explained with same depth.

**The Serpent's Egg**: Brazilian legal terms (CPC, STF, desembargadora, livre convencimento motivado, art. 489 §1º) kept with inline English context where needed. Both SVGs preserved with renamed marker IDs. Mermaid diagram identical. Bibliography titles preserved in Portuguese with English description.

## What's NOT in this PR (next sessions)

- PT translations of harness series posts 2 and 4 (The Third Half, Jules API)
- `/pt/tags/[tag]/` dedicated route
- Sticky ToC sidebar on wide screens
- Pagination on `/archive/` and `/tags/[tag]/`

## Test plan

- [ ] On `/pt/` — Header Archive link goes to `/pt/archive/`, Tags to `/pt/tags/`, About to `/pt/about/`
- [ ] On `/` — Header Archive link goes to `/archive/` (unchanged)
- [ ] `/pt/tags/` — LanguageSwitcher active, navigates to `/tags/`
- [ ] `/tags/` — LanguageSwitcher active, navigates to `/pt/tags/`
- [ ] PT post card — shows "Continuar lendo →"
- [ ] EN post card — shows "Continue reading →"
- [ ] `/blog/2026-04-29-reclaiming-the-harness/` — LanguageSwitcher links to PT version
- [ ] `/blog/2026-04-29-recuperando-o-harness/` — LanguageSwitcher links back to EN
- [ ] `/blog/o-ovo-de-serpente/` — LanguageSwitcher links to EN version
- [ ] `/blog/2026-05-10-the-serpents-egg/` — LanguageSwitcher links back to PT
- [ ] Build: 155 pages, no errors

## Routine log

Session notes: `.routines/2026-05-15-nav-tags-harness-serpent.md`

https://claude.ai/code/session_013rVtVFdDbZ5trSTWs5bri9

---
_Generated by [Claude Code](https://claude.ai/code/session_013rVtVFdDbZ5trSTWs5bri9)_