### PR TITLE
perf(katex): conditional loading — KaTeX only on posts with math

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@ dist/
 # generated types
 .astro/
 
+# copied at build time from node_modules/katex by scripts/copy-katex.mjs
+public/katex/
+
 # dependencies
 node_modules/
 

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -9,6 +9,7 @@ import rehypeSlug from 'rehype-slug';
 import rehypeAutolinkHeadings from 'rehype-autolink-headings';
 import { remarkReadingTime } from './src/lib/remark-reading-time.mjs';
 import { remarkGitModified } from './src/lib/remark-git-modified.mjs';
+import { remarkHasMath } from './src/lib/remark-has-math.mjs';
 import { rehypeWrapTables } from './src/lib/rehype-wrap-tables.mjs';
 
 // https://astro.build/config
@@ -19,7 +20,7 @@ export default defineConfig({
     defaultStrategy: 'viewport',
   },
   markdown: {
-    remarkPlugins: [remarkMath, remarkReadingTime, remarkGitModified],
+    remarkPlugins: [remarkMath, remarkHasMath, remarkReadingTime, remarkGitModified],
     rehypePlugins: [
       rehypeKatex,
       rehypeSlug,

--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
     "node": ">=22.12.0"
   },
   "scripts": {
+    "prebuild": "node scripts/copy-katex.mjs",
+    "predev": "node scripts/copy-katex.mjs",
     "dev": "astro dev",
     "build": "astro build && pagefind --site dist",
     "preview": "astro preview",

--- a/scripts/copy-katex.mjs
+++ b/scripts/copy-katex.mjs
@@ -1,0 +1,18 @@
+// Copy katex.min.css + fonts to public/katex/ so PageLayout can
+// conditionally <link> the stylesheet only on posts with math.
+import { cp, mkdir, rm } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = resolve(__dirname, '..');
+
+const src = resolve(root, 'node_modules/katex/dist');
+const dest = resolve(root, 'public/katex');
+
+await rm(dest, { recursive: true, force: true });
+await mkdir(dest, { recursive: true });
+await cp(`${src}/katex.min.css`, `${dest}/katex.min.css`);
+await cp(`${src}/fonts`, `${dest}/fonts`, { recursive: true });
+
+console.log(`[copy-katex] copied katex.min.css + fonts to ${dest}`);

--- a/src/layouts/PageLayout.astro
+++ b/src/layouts/PageLayout.astro
@@ -14,6 +14,7 @@ interface Props {
   tags?: string[];
   lang?: "en" | "pt";
   translationHref?: string;
+  hasMath?: boolean;
 }
 
 const SITE_NAME = "Franklin Baldo";
@@ -32,6 +33,7 @@ const {
   tags,
   lang = "en",
   translationHref,
+  hasMath,
 } = source;
 
 const documentTitle = title.includes(SITE_NAME) ? title : `${title} | ${SITE_NAME}`;
@@ -84,6 +86,7 @@ const jsonLd = type === "article"
     <link rel="canonical" href={canonical.href} />
     <link rel="alternate" type="application/rss+xml" title="Franklin Baldo" href={rssUrl} />
     <link rel="sitemap" href="/sitemap-index.xml" />
+    {hasMath && <link rel="stylesheet" href="/katex/katex.min.css" />}
 
     <link rel="alternate" hreflang={lang} href={canonical.href} />
     {translationHref && (

--- a/src/lib/remark-has-math.mjs
+++ b/src/lib/remark-has-math.mjs
@@ -15,6 +15,8 @@ export function remarkHasMath() {
         return false;
       }
     });
-    data.astro.frontmatter.hasMath = hasMath;
+    if (data?.astro?.frontmatter) {
+      data.astro.frontmatter.hasMath = hasMath;
+    }
   };
 }

--- a/src/lib/remark-has-math.mjs
+++ b/src/lib/remark-has-math.mjs
@@ -1,0 +1,20 @@
+import { visit } from 'unist-util-visit';
+
+/**
+ * Set frontmatter.hasMath = true when the markdown AST contains
+ * a math node (inlineMath or math, produced by remark-math).
+ *
+ * Used by PageLayout to conditionally include the KaTeX stylesheet.
+ */
+export function remarkHasMath() {
+  return (tree, { data }) => {
+    let hasMath = false;
+    visit(tree, (node) => {
+      if (node.type === 'math' || node.type === 'inlineMath') {
+        hasMath = true;
+        return false;
+      }
+    });
+    data.astro.frontmatter.hasMath = hasMath;
+  };
+}

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -26,6 +26,7 @@ const post = Astro.props;
 const { Content, headings, remarkPluginFrontmatter } = await render(post);
 const { heroImage, heroImageAlt, title, description, date, tags, lang, translationKey } = post.data;
 const minutesRead: number | undefined = remarkPluginFrontmatter.minutesRead;
+const hasMath: boolean = !!remarkPluginFrontmatter.hasMath;
 const lastModifiedISO: string | undefined = remarkPluginFrontmatter.lastModified;
 const lastModified = lastModifiedISO ? new Date(lastModifiedISO) : undefined;
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
@@ -51,6 +52,7 @@ const translationHref = translation ? `/blog/${translation.id}/` : undefined;
   tags={tags}
   lang={lang}
   translationHref={translationHref}
+  hasMath={hasMath}
 >
   <div id="read-progress" aria-hidden="true"></div>
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,6 +1,5 @@
 @import "@picocss/pico/css/pico.orange.min.css";
 @import "@fontsource/inter";
-@import "katex/dist/katex.min.css";
 
 :root {
   --pico-font-family-sans-serif: "Inter", system-ui, -apple-system, sans-serif;


### PR DESCRIPTION
## Summary

KaTeX CSS + fonts (~150 KB) were being loaded on every page via `global.css`, even though only **1 of 35 posts** (`pontifex-novel-architecture-semantic-probing`) actually contains math syntax. 34 posts and every static page were paying a 150 KB tax for nothing.

This PR makes the stylesheet conditional.

## How

- **`src/lib/remark-has-math.mjs`** (new): walks the markdown AST after `remark-math` has run; if any `math` or `inlineMath` node exists, sets `frontmatter.hasMath = true`.
- **`PageLayout.astro`**: accepts a new `hasMath` prop and renders `<link rel="stylesheet" href="/katex/katex.min.css">` in `<head>` only when true.
- **`blog/[...slug].astro`**: reads `remarkPluginFrontmatter.hasMath` and passes it to `PageLayout`.
- **`scripts/copy-katex.mjs`** (new): copies `katex.min.css` + the 60 font files from `node_modules/katex/dist` to `public/katex/`. Hooked into npm `prebuild` and `predev` so it runs automatically before `astro build` / `astro dev`. CI runs `npm run build` which triggers `prebuild` automatically.
- **`global.css`**: removed the `@import "katex/dist/katex.min.css"`.
- **`.gitignore`**: `public/katex/` (regenerated at build time, not committed).

## Verification

Locally:
- Built dist: only `/blog/pontifex-novel-architecture-semantic-probing/index.html` contains a `<link href="/katex/katex.min.css">`.
- All other post HTMLs, archive, tags, about, 404, search: no KaTeX reference.
- Math renders correctly on the pontifex post.

## Test plan

- [ ] `npm run build` → `prebuild` runs `scripts/copy-katex.mjs`; `public/katex/katex.min.css` and `public/katex/fonts/` exist.
- [ ] DevTools Network on a non-math post: no katex.min.css request.
- [ ] DevTools Network on `/blog/pontifex-novel-architecture-semantic-probing/`: katex.min.css loads, math renders.
- [ ] Build passes in CI (where the existing `astro-og-canvas` font-fetch sometimes flakes, unrelated to this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Reevxv9GRiX7vKAdvxqmMP)_