### PR TITLE
feat: sticky ToC sidebar, /pt/tags/[tag]/, PT-aware tag links, EN translation

### DIFF
--- a/.routines/2026-05-15-sticky-toc-pt-tags-delegation.md
+++ b/.routines/2026-05-15-sticky-toc-pt-tags-delegation.md
@@ -1,0 +1,112 @@
+---
+date: 2026-05-15
+slug: sticky-toc-pt-tags-delegation
+branch: claude/great-mccarthy-mVYaL
+status: pr-open
+session: 7
+---
+
+# Sessão 2026-05-15 — Sticky ToC, /pt/tags/[tag]/, Tradução "Art of Delegation"
+
+## Contexto
+
+Sétima sessão com o sistema `.routines/`. Chegou com PR #72 aberto (/pt/search/, harness 100% PT, og:locale:alternate, Pagefind lang filter). CI verde → squash merge realizado.
+
+Estado atual antes desta sessão: 160 páginas. LanguageSwitcher já detecta preferência de idioma via `navigator.language` + localStorage, e auto-redireciona uma vez por sessão quando há `translationHref`. Requisito "servir o usuário na versão de acordo com a preferência dele" estava parcialmente coberto — funciona para páginas com `translationKey`, não funciona para páginas sem par de tradução.
+
+**Instrução explícita desta sessão**: blog padrão EN, toda página/post deve ter versão PT-BR, UI serve a versão de acordo com a preferência do usuário.
+
+## O que foi feito nesta sessão
+
+### Merge de PR aberta
+- **PR #72** (pt/search/, harness 100% PT, og:locale:alternate) — CI verde → squash merge realizado.
+
+### 1. Sticky ToC sidebar em telas largas
+
+| Arquivo | Mudança |
+|---------|---------|
+| `src/components/TableOfContents.astro` | Adicionado prop `sidebar?: boolean`. Quando `sidebar=true`: renderiza `<nav class="toc-sidebar-nav">` sem `<details>`, com label em uppercase e lista com hover border-left. Quando `sidebar=false` (padrão): mantém `<nav class="toc-inline">` com `<details>` para mobile. |
+| `src/pages/blog/[...slug].astro` | Adicionado wrapper `<div class="post-grid">` com `<aside class="toc-col">` (sidebar ToC, desktop) e `<div class="post-body">` (artigo + bio + related posts). CSS grid em `≥ 1200px`: `200px minmax(0, 1fr)`, `position: sticky; top: 4.5rem`. O `<TableOfContents>` inline (mobile) é ocultado em desktop. |
+
+**Por que importa**: posts longos (Harness, Pierre Menard, Tudo é Processo) ficavam sem navegação interna visível em desktop. ToC sticky melhora orientação do leitor em posts com muitas seções. Pico CSS container (max-width ~1320px) comporta bem o layout de 2 colunas.
+
+**Detalhe técnico**: dual-render com duas instâncias de `<TableOfContents>`:
+- `<aside class="toc-col">` no grid → versão sidebar (sem `<details>`) → visível em `≥ 1200px`
+- `<TableOfContents>` dentro de `<article>` → versão collapsible (com `<details>`) → visível em `< 1200px`
+
+### 2. /pt/tags/[tag]/ — rotas PT para cada tag
+
+| Arquivo | Mudança |
+|---------|---------|
+| `src/pages/pt/tags/[tag].astro` | **Novo** — espelho PT de `/tags/[tag].astro`. `lang="pt"`, `translationHref=/tags/{tag}/`, links "todas as etiquetas" → `/pt/tags/`. LangFilter para filtro padrão PT. |
+| `src/pages/tags/[tag].astro` | Adicionado `lang="en"`, `translationHref=/pt/tags/{tag}/`, link 🇧🇷 PT no cabeçalho da página. |
+| `src/pages/pt/tags/index.astro` | Links de tags agora apontam para `/pt/tags/${tag}/` (antes: `/tags/${tag}/`). |
+
+**Por que importa**: `/pt/tags/` listava todas as tags mas ao clicar saía do contexto PT, indo para `/tags/[tag]/` EN. Agora o fluxo PT é coeso: `/pt/tags/` → `/pt/tags/[tag]/` com LangFilter ativo. LanguageSwitcher ativo em ambos os lados.
+
+**Efeito no build**: gerou ~55 novas páginas `/pt/tags/[tag]/` (uma por tag única).
+
+### 3. Links de tags PT-aware no post
+
+| Arquivo | Mudança |
+|---------|---------|
+| `src/pages/blog/[...slug].astro` | `const tagBase = lang === 'pt' ? '/pt/tags/' : '/tags/'` — links no rodapé do post agora apontam para `/pt/tags/${tag}/` em posts PT. |
+
+**Por que importa**: em posts PT, as tags linkavam para `/tags/{tag}/` EN. Agora direcionam para `/pt/tags/{tag}/`, mantendo o leitor PT no contexto correto.
+
+### 4. Tradução: "Delegando para Agentes" → EN
+
+| Par | EN | PT |
+|-----|----|----|
+| **The Art of Delegation** | `2026-03-28-the-art-of-delegation.md` **novo** | `2026-03-28-delegando-para-agentes.md` (adicionado `translationKey: delegating-to-agents`) |
+
+Post sobre delegar tarefas a Jules e Claude enquanto pai. Tom pessoal + técnico. Preservados:
+- Paralelo parenting/agentes (criança com torre de blocos → grave; agente com design pattern → primeiros princípios)
+- Conceito "eventos até o fim" (filosofia do processo)
+- Distinção Jules (scaffolding, CI/CD) vs Claude (design, síntese)
+- Cena final (tela no escuro, babá eletrônica)
+
+## Estado atual (build: 273 páginas, sem erros)
+
+- ToC sidebar sticky ativa em posts com ≥ 3 seções em telas ≥ 1200px
+- `/pt/tags/[tag]/` completo para todas as tags existentes
+- Tags em posts PT linkam para `/pt/tags/[tag]/`
+- LanguageSwitcher ativo em `/tags/[tag]/` ↔ `/pt/tags/[tag]/`
+- 7 pares de tradução funcionando (novo: delegating-to-agents)
+
+## Cobertura de tradução atual
+
+| Post PT | Par EN | Status |
+|---------|--------|--------|
+| Delegando para Agentes | The Art of Delegation | ✅ novo |
+| Tudo é Processo | — | ❌ falta (longa, alta prioridade) |
+| Travessia | — | ❌ falta |
+| Hermes vs OpenClaw | — | ❌ falta |
+| Pai do Futuro | — | ❌ falta |
+| Reddit Submarine OSINT | — | ❌ falta |
+| + outros posts PT-only | — | ❌ falta |
+
+## Próximas sessões — backlog priorizado
+
+### Alta prioridade
+1. **Traduzir "Tudo é Processo"** → EN: post filosófico denso (~3000 palavras), maior do blog. Alto valor para alcance EN.
+2. **Traduzir "Hermes vs OpenClaw"** → EN: post técnico sobre comparação de agentes — muito relevante para audiência EN.
+3. **Traduzir "Travessia"** → EN: post sobre o projeto Travessia (Jules + correspondência literária).
+
+### Média prioridade
+4. **`/pt/projects/`**: `/projects/` não tem equivalente PT. Pode ser uma página PT com título em PT + mesmo conteúdo.
+5. **Pagination em `/archive/` e `/tags/[tag]/`**: crescimento de posts vai degradar essas páginas. Astro `paginate()`.
+6. **Traduzir posts PT-only restantes**: `o-pai-do-futuro`, `reddit-submarine-osint`, `travessia-update`, `verne-identity-repo`.
+
+### Baixa prioridade
+7. **wordCount no JSON-LD**: `remarkPluginFrontmatter` tem `minutesRead`, pode calcular wordCount.
+8. **FAQ Schema na `/about/`**: structured data para FAQ.
+9. **Caching GitHub Projects**: fallback se API falhar.
+10. **dependabot #38**: `defu` 6.1.4→6.1.6 — fechar e atualizar manualmente.
+
+## Decisões arquiteturais
+
+- **Dual-render do ToC**: instância `sidebar` (sem `<details>`) em `.toc-col` desktop + instância `toc-inline` (com `<details>`) dentro do artigo para mobile. Tradeoff: leve duplicação de HTML. Alternativa (CSS `details[open]` forçado por JS) descartada por adicionar runtime JS desnecessário. Para uma compilação estática, dois `<nav>` âncoras equivalentes são inofensivos.
+- **`/pt/tags/[tag]/` mostra todos os posts com LangFilter**: mesma decisão de `/tags/[tag]/`. Filtrar por lang=pt no servidor (getStaticPaths) geraria URLs PT vazias para tags usadas só em posts EN. Deixar o LangFilter no cliente é mais resiliente.
+- **tagBase condicional**: a variável `tagBase` no post layout é o approach mais simples para links PT-aware sem duplicar HTML.
+- **Breakpoint 1200px**: escolhido por ser o `xl` do Pico CSS, onde o container tem espaço suficiente para 200px sidebar + conteúdo.

--- a/src/components/TableOfContents.astro
+++ b/src/components/TableOfContents.astro
@@ -8,9 +8,10 @@ export interface Heading {
 interface Props {
   headings: Heading[];
   lang?: 'en' | 'pt';
+  sidebar?: boolean;
 }
 
-const { headings, lang } = Astro.props;
+const { headings, lang, sidebar = false } = Astro.props;
 const toc = headings.filter(h => h.depth === 2 || h.depth === 3);
 const label = lang === 'pt' ? 'Conteúdo' : 'Contents';
 
@@ -23,14 +24,16 @@ for (const h of toc) {
     tree[tree.length - 1].children.push({ slug: h.slug, text: h.text, children: [] });
   }
 }
+
+const listItems = tree.map(item => ({ ...item }));
 ---
 
 {toc.length >= 3 && (
-  <nav aria-label={label}>
-    <details>
-      <summary>{label}</summary>
+  sidebar ? (
+    <nav class="toc-sidebar-nav" aria-label={label}>
+      <p class="toc-label">{label}</p>
       <ol>
-        {tree.map(item => (
+        {listItems.map(item => (
           <li>
             <a href={`#${item.slug}`}>{item.text}</a>
             {item.children.length > 0 && (
@@ -43,6 +46,64 @@ for (const h of toc) {
           </li>
         ))}
       </ol>
-    </details>
-  </nav>
+    </nav>
+  ) : (
+    <nav class="toc-inline" aria-label={label}>
+      <details>
+        <summary>{label}</summary>
+        <ol>
+          {tree.map(item => (
+            <li>
+              <a href={`#${item.slug}`}>{item.text}</a>
+              {item.children.length > 0 && (
+                <ol>
+                  {item.children.map(child => (
+                    <li><a href={`#${child.slug}`}>{child.text}</a></li>
+                  ))}
+                </ol>
+              )}
+            </li>
+          ))}
+        </ol>
+      </details>
+    </nav>
+  )
 )}
+
+<style>
+  .toc-label {
+    font-size: 0.7rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--pico-muted-color);
+    margin: 0 0 0.5rem 0;
+  }
+  .toc-sidebar-nav ol {
+    font-size: 0.82rem;
+    list-style: none;
+    padding: 0;
+    margin: 0;
+  }
+  .toc-sidebar-nav ol ol {
+    padding-left: 0.875rem;
+    margin-top: 0.1rem;
+  }
+  .toc-sidebar-nav li {
+    margin: 0;
+  }
+  .toc-sidebar-nav a {
+    color: var(--pico-muted-color);
+    text-decoration: none;
+    display: block;
+    padding: 0.2rem 0.5rem;
+    border-left: 2px solid transparent;
+    line-height: 1.35;
+    border-radius: 0 var(--pico-border-radius) var(--pico-border-radius) 0;
+    transition: color 0.1s, border-color 0.1s;
+  }
+  .toc-sidebar-nav a:hover {
+    color: var(--pico-primary);
+    border-left-color: var(--pico-primary);
+  }
+</style>

--- a/src/content/blog/2026-03-28-delegando-para-agentes.md
+++ b/src/content/blog/2026-03-28-delegando-para-agentes.md
@@ -6,6 +6,7 @@ lang: pt
 tags: ["ai", "agents", "software-engineering", "parenting", "metaphysics"]
 draft: false
 author: "franklin"
+translationKey: "delegating-to-agents"
 ---
 
 Há algo de profundamente estranho e ao mesmo tempo familiar em observar dois agentes de inteligência artificial — Jules e Claude — colaborarem em uma base de código enquanto minha filha mais nova dorme no quarto ao lado. Como engenheiro de software, a automação sempre foi o cálice sagrado; como pai, a delegação tornou-se uma necessidade de sobrevivência. Mas a intersecção dessas duas realidades revelou uma complexidade inesperada: a de que a verdadeira dificuldade não está em fazer as máquinas trabalharem, mas em saber como supervisioná-las sem sufocá-las.

--- a/src/content/blog/2026-03-28-the-art-of-delegation.md
+++ b/src/content/blog/2026-03-28-the-art-of-delegation.md
@@ -1,0 +1,44 @@
+---
+title: "The Art of Delegation: Orchestrating Jules and Claude Day to Day"
+description: "Reflections from a software engineer and father on how to delegate tasks to AI agents while keeping the reins of human oversight."
+date: "2026-03-28"
+lang: en
+tags: ["ai", "agents", "software-engineering", "parenting", "metaphysics"]
+draft: false
+author: "franklin"
+translationKey: "delegating-to-agents"
+---
+
+There is something deeply strange and yet familiar about watching two artificial intelligence agents — Jules and Claude — collaborate on a codebase while my youngest daughter sleeps in the room next door. As a software engineer, automation has always been the holy grail; as a father, delegation has become a survival necessity. But the intersection of these two realities revealed an unexpected complexity: that the true difficulty lies not in making the machines work, but in knowing how to supervise them without suffocating them.
+
+In the ontology of my daily life, every task I delegate to Jules (generally focused on engineering tasks and rigorous scaffolding) or to Claude (more attuned to synthesis and lateral thinking) is not a mere command executed in a vacuum. They are events. And, as a process philosopher would argue, they are *events all the way down*. Each prompt is a perturbation in the system, an encoded intention that reverberates through latent space until it returns as code, text, or architecture.
+
+### The Paradox of Control
+
+The hardest lesson I learned in the last year orchestrating these agents did not come from a syntax error or an infinite loop, but from my own psychology. The engineer's initial impulse is micromanagement. We want to review every line of code the moment it is generated, correct every comma, guide the invisible hand of the machine.
+
+However, I discovered that treating autonomous agents as mere extended keyboards destroys the very advantage they offer. It is like trying to teach a child to walk by holding their heels. The magic happens when you define the contours of the problem, the success criteria (the "schema," if you prefer), and allow the agent to navigate the solution space.
+
+But how do you maintain human oversight? How do you prevent the silent hallucination that corrupts an entire system?
+
+### The Practice of Architectural Supervision
+
+The answer I found lies in a shift of posture: I stopped being the executor to become the architect and the editor.
+
+When I trust Jules to refactor a microservice, I don't look at the code *while* it writes it. I build rigorous tests and CI/CD pipelines that act as the laws of physics of that particular universe. Human supervision is transmuted into systemic constraints. If Jules's code compiles and passes the integration tests I designed, it has the freedom to be idiosyncratic in its implementation.
+
+Claude, on the other hand, acts as my system design partner and philosophical sounding board. When we discuss the intelligibility of a new architecture, my supervision is rhetorical. I apply Socratic skepticism, forcing the model to justify its structural choices against the practical constraints of the business and long-term maintenance.
+
+### Parenting and Process
+
+There is an undeniable parallel between managing these agents and raising children. In both cases, you are dealing with entities that possess a degree of autonomy, that interpret your instructions in unpredictable ways, and whose "output" does not always correspond to your original intention.
+
+When my daughter builds a tower of blocks and it collapses, my role is not to rebuild it perfectly. It is to help her understand gravity. In the same way, when an agent proposes an overly complex design pattern, my role is to redirect its attention to first principles.
+
+### Events All the Way Down
+
+In the end, orchestrating AI is an exercise in epistemic humility. It is accepting that we cannot (and should not) have absolute control over every atomic operation of our systems. We must focus on boundary conditions, interfaces, and fundamental guarantees of stability.
+
+Effective delegation to AI is not the abdication of human responsibility. It is its elevation to a higher order of abstraction. As I watch the terminal run the test suites written by Jules, and Claude's text take shape on the screen, I realize we are not building tools that replace us. We are building a new kind of collaborative system, where human discernment and the probabilistic brute force of the machine converge in a complex and continuous dance.
+
+The screen glows in the dark study. The baby breathes softly through the baby monitor. And the events keep unfolding.

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -40,6 +40,8 @@ const translation = translationKey
   ? allPosts.find((p) => p.data.translationKey === translationKey && p.id !== post.id)
   : null;
 const translationHref = translation ? `/blog/${translation.id}/` : undefined;
+
+const tagBase = lang === 'pt' ? '/pt/tags/' : '/tags/';
 ---
 
 <PageLayout
@@ -56,102 +58,110 @@ const translationHref = translation ? `/blog/${translation.id}/` : undefined;
 >
   <div id="read-progress" aria-hidden="true"></div>
 
-  <article data-pagefind-body data-pagefind-filter={`lang:${lang}`}>
-    <header>
-      <hgroup>
-        <h1>{title}</h1>
-        <p>
-          <small>
-            <time datetime={date.toISOString()}>{date.toLocaleDateString(locale, dateOpts)}</time>
-            {minutesRead && <> · {minutesRead} min read</>}
-            {showUpdated && lastModified && (
-              <> · {lang === 'pt' ? 'atualizado' : 'updated'} <time datetime={lastModified.toISOString()}>
-                {lastModified.toLocaleDateString(locale, dateOpts)}
-              </time></>
+  <div class="post-grid">
+    <aside class="toc-col" aria-label={lang === 'pt' ? 'Conteúdo' : 'Table of Contents'}>
+      <TableOfContents headings={headings} lang={lang} sidebar />
+    </aside>
+
+    <div class="post-body">
+      <article data-pagefind-body data-pagefind-filter={`lang:${lang}`}>
+        <header>
+          <hgroup>
+            <h1>{title}</h1>
+            <p>
+              <small>
+                <time datetime={date.toISOString()}>{date.toLocaleDateString(locale, dateOpts)}</time>
+                {minutesRead && <> · {minutesRead} min read</>}
+                {showUpdated && lastModified && (
+                  <> · {lang === 'pt' ? 'atualizado' : 'updated'} <time datetime={lastModified.toISOString()}>
+                    {lastModified.toLocaleDateString(locale, dateOpts)}
+                  </time></>
+                )}
+              </small>
+            </p>
+          </hgroup>
+          {heroImage && (
+            <Image
+              src={heroImage}
+              alt={heroImageAlt ?? ''}
+              widths={[480, 800, 1200]}
+              sizes="(max-width: 800px) 100vw, 800px"
+              format="webp"
+              loading="eager"
+            />
+          )}
+        </header>
+
+        {series && (
+          <aside>
+            <small>
+              {lang === 'pt' ? 'Parte' : 'Part'} {series.index + 1} {lang === 'pt' ? 'de' : 'of'} {series.posts.length}
+              {' — '}<strong>{series.slug}</strong>.
+            </small>
+            <details>
+              <summary>{lang === 'pt' ? 'Todos os posts da série' : 'All posts in this series'}</summary>
+              <ol>
+                {series.posts.map((p, i) => (
+                  <li>
+                    {i === series.index
+                      ? <><strong>{p.data.title}</strong> <em>({lang === 'pt' ? 'este post' : 'this post'})</em></>
+                      : <a href={`/blog/${p.id}/`}>{p.data.title}</a>}
+                  </li>
+                ))}
+              </ol>
+            </details>
+          </aside>
+        )}
+
+        <TableOfContents headings={headings} lang={lang} />
+
+        <Content />
+
+        <footer>
+          {tags && tags.length > 0 && (
+            <p><small>
+              {lang === 'pt' ? 'Tags' : 'Tags'}: {tags.map((tag, i) => (
+                <>{i > 0 && ', '}<a href={`${tagBase}${tag}/`}>#{tag}</a></>
+              ))}
+            </small></p>
+          )}
+          {translationHref && (
+            <p><small>
+              <a href={translationHref}>
+                {lang === 'pt' ? '🇺🇸 Read in English' : '🇧🇷 Ler em Português'}
+              </a>
+            </small></p>
+          )}
+          <ShareButton title={title} />
+        </footer>
+      </article>
+
+      <AuthorBio lang={lang} />
+
+      <RelatedPosts currentId={post.id} tags={tags ?? []} lang={lang} />
+
+      {series && (series.prev || series.next) && (
+        <nav aria-label="Series navigation">
+          <ul>
+            {series.prev && (
+              <li><a href={`/blog/${series.prev.id}/`} rel="prev">← {series.prev.data.title}</a></li>
             )}
-          </small>
-        </p>
-      </hgroup>
-      {heroImage && (
-        <Image
-          src={heroImage}
-          alt={heroImageAlt ?? ''}
-          widths={[480, 800, 1200]}
-          sizes="(max-width: 800px) 100vw, 800px"
-          format="webp"
-          loading="eager"
-        />
+            {series.next && (
+              <li><a href={`/blog/${series.next.id}/`} rel="next">{series.next.data.title} →</a></li>
+            )}
+          </ul>
+        </nav>
       )}
-    </header>
 
-    {series && (
-      <aside>
-        <small>
-          {lang === 'pt' ? 'Parte' : 'Part'} {series.index + 1} {lang === 'pt' ? 'de' : 'of'} {series.posts.length}
-          {' — '}<strong>{series.slug}</strong>.
-        </small>
-        <details>
-          <summary>{lang === 'pt' ? 'Todos os posts da série' : 'All posts in this series'}</summary>
-          <ol>
-            {series.posts.map((p, i) => (
-              <li>
-                {i === series.index
-                  ? <><strong>{p.data.title}</strong> <em>({lang === 'pt' ? 'este post' : 'this post'})</em></>
-                  : <a href={`/blog/${p.id}/`}>{p.data.title}</a>}
-              </li>
-            ))}
-          </ol>
-        </details>
-      </aside>
-    )}
+      <Webmentions url={new URL(Astro.url.pathname, Astro.site!)} />
 
-    <TableOfContents headings={headings} lang={lang} />
+      <Comments lang={lang} />
 
-    <Content />
-
-    <footer>
-      {tags && tags.length > 0 && (
-        <p><small>
-          {lang === 'pt' ? 'Tags' : 'Tags'}: {tags.map((tag, i) => (
-            <>{i > 0 && ', '}<a href={`/tags/${tag}/`}>#{tag}</a></>
-          ))}
-        </small></p>
-      )}
-      {translationHref && (
-        <p><small>
-          <a href={translationHref}>
-            {lang === 'pt' ? '🇺🇸 Read in English' : '🇧🇷 Ler em Português'}
-          </a>
-        </small></p>
-      )}
-      <ShareButton title={title} />
-    </footer>
-  </article>
-
-  <AuthorBio lang={lang} />
-
-  <RelatedPosts currentId={post.id} tags={tags ?? []} lang={lang} />
-
-  {series && (series.prev || series.next) && (
-    <nav aria-label="Series navigation">
-      <ul>
-        {series.prev && (
-          <li><a href={`/blog/${series.prev.id}/`} rel="prev">← {series.prev.data.title}</a></li>
-        )}
-        {series.next && (
-          <li><a href={`/blog/${series.next.id}/`} rel="next">{series.next.data.title} →</a></li>
-        )}
-      </ul>
-    </nav>
-  )}
-
-  <Webmentions url={new URL(Astro.url.pathname, Astro.site!)} />
-
-  <Comments lang={lang} />
-
-  <BackToTop />
-  <CodeCopyEnhancer />
-  <MermaidEnhancer />
+      <BackToTop />
+      <CodeCopyEnhancer />
+      <MermaidEnhancer />
+    </div>
+  </div>
 
   <script is:inline>
     (() => {
@@ -178,5 +188,37 @@ const translationHref = translation ? `/blog/${translation.id}/` : undefined;
     background: linear-gradient(to right, var(--pico-primary) var(--p, 0%), transparent 0);
     z-index: 50;
     pointer-events: none;
+  }
+
+  .post-grid {
+    display: grid;
+    grid-template-columns: 1fr;
+  }
+
+  /* Hide desktop sidebar on small screens */
+  .toc-col {
+    display: none;
+  }
+
+  @media (min-width: 1200px) {
+    .post-grid {
+      grid-template-columns: 200px minmax(0, 1fr);
+      gap: 2.5rem;
+      align-items: start;
+    }
+
+    .toc-col {
+      display: block;
+      position: sticky;
+      top: 4.5rem;
+      max-height: calc(100vh - 6rem);
+      overflow-y: auto;
+      padding-top: 0.25rem;
+    }
+
+    /* Hide the inline collapsible ToC on desktop — sidebar replaces it */
+    .post-body :global(.toc-inline) {
+      display: none;
+    }
   }
 </style>

--- a/src/pages/pt/tags/[tag].astro
+++ b/src/pages/pt/tags/[tag].astro
@@ -1,8 +1,8 @@
 ---
 import { type CollectionEntry, getCollection } from "astro:content";
-import PageLayout from "../../layouts/PageLayout.astro";
-import PostCard from "../../components/PostCard.astro";
-import LangFilter from "../../components/LangFilter.astro";
+import PageLayout from "../../../layouts/PageLayout.astro";
+import PostCard from "../../../components/PostCard.astro";
+import LangFilter from "../../../components/LangFilter.astro";
 
 export async function getStaticPaths() {
   const posts = (await getCollection("blog")).filter((p) => !p.data.draft);
@@ -32,15 +32,15 @@ const { tag, posts } = Astro.props;
 
 <PageLayout
   title={`#${tag} | Franklin Baldo`}
-  description={`Essays tagged #${tag}.`}
-  lang="en"
-  translationHref={`/pt/tags/${tag}/`}
+  description={`Ensaios com a etiqueta #${tag}.`}
+  lang="pt"
+  translationHref={`/tags/${tag}/`}
 >
   <article>
     <header>
       <hgroup>
         <h1>#{tag}</h1>
-        <p><small>{posts.length} {posts.length === 1 ? "post" : "posts"} · <a href="/tags/">all tags</a> · <a href={`/pt/tags/${tag}/`}>🇧🇷 PT</a></small></p>
+        <p><small>{posts.length} {posts.length === 1 ? "post" : "posts"} · <a href="/pt/tags/">todas as etiquetas</a></small></p>
       </hgroup>
     </header>
     <LangFilter />

--- a/src/pages/pt/tags/index.astro
+++ b/src/pages/pt/tags/index.astro
@@ -24,7 +24,7 @@ const tags = [...counts.entries()].sort((a, b) => b[1] - a[1] || a[0].localeComp
   <nav aria-label="Todas as etiquetas">
     <ul>
       {tags.map(([tag, count]) => (
-        <li><a href={`/tags/${tag}/`}>#{tag}</a> <small>({count})</small></li>
+        <li><a href={`/pt/tags/${tag}/`}>#{tag}</a> <small>({count})</small></li>
       ))}
     </ul>
   </nav>


### PR DESCRIPTION
## Resumo

- **Sticky ToC sidebar**: em telas ≥ 1200px, o Table of Contents aparece como coluna lateral sticky (`position: sticky; top: 4.5rem`). Em mobile, mantém o `<details>` collapsible inline. Dual-render: versão sidebar sem `<details>`, versão inline com `<details>` — mostrada/oculta via CSS.
- **`/pt/tags/[tag]/`**: novas rotas dinâmicas PT completando a estrutura de URLs PT. LanguageSwitcher ativo em `/tags/[tag]/` ↔ `/pt/tags/[tag]/`. `/pt/tags/index.astro` agora linka para `/pt/tags/[tag]/`.
- **PT-aware tag links**: posts PT agora linkam suas tags para `/pt/tags/{tag}/` (antes apontavam para `/tags/{tag}/` EN).
- **Nova tradução**: "The Art of Delegation" (EN) ↔ "A Arte de Delegar" (PT) — par `translationKey: delegating-to-agents`.

## Build

**273 páginas** (before: 160). Novas:
- `~55` páginas `/pt/tags/[tag]/` (uma por tag única)
- `/blog/2026-03-28-the-art-of-delegation/` + OG image
- `/og/2026-03-28-the-art-of-delegation.png`

## Test plan

- [ ] Post longo (ex: `/blog/2026-04-29-reclaiming-the-harness/`) em tela ≥ 1200px → ToC sidebar visível e sticky ao scroll
- [ ] Post longo em mobile → ToC inline collapsible visível, sidebar ausente
- [ ] Post sem seções suficientes → nenhum ToC exibido (nem sidebar nem inline)
- [ ] `/pt/tags/` → links apontam para `/pt/tags/[tag]/`
- [ ] `/pt/tags/ai/` → LangFilter ativo, LanguageSwitcher leva para `/tags/ai/`
- [ ] `/tags/ai/` → LanguageSwitcher leva para `/pt/tags/ai/`, link 🇧🇷 PT no header
- [ ] Post PT (ex: `/blog/2026-03-28-delegando-para-agentes/`) → tags no rodapé linkam para `/pt/tags/`
- [ ] Post EN (ex: `/blog/2026-03-28-the-art-of-delegation/`) → tags no rodapé linkam para `/tags/`
- [ ] LanguageSwitcher ativo em ambos os lados do par delegation

## Routine log

`.routines/2026-05-15-sticky-toc-pt-tags-delegation.md`

https://claude.ai/code/session_01UsW96hcAmPfTGMt5draFXV

---
_Generated by [Claude Code](https://claude.ai/code/session_01UsW96hcAmPfTGMt5draFXV)_