### PR TITLE
feat: sitemap hreflang, JSON-LD inLanguage, /pt/projects/, OG card redesign [superseded by #96]

### DIFF
--- a/.routines/2026-05-15-seo-multilingual-projects.md
+++ b/.routines/2026-05-15-seo-multilingual-projects.md
@@ -1,0 +1,145 @@
+---
+date: 2026-05-15
+slug: seo-multilingual-projects
+branch: claude/great-mccarthy-s83RK
+status: pr-open
+session: 7
+---
+
+# Sessão 2026-05-15 — SEO multilingual: sitemap hreflang, JSON-LD inLanguage, /pt/projects/, EN Hermes
+
+## Contexto
+
+Sétima sessão. Chegou com PR #75 aberto (sticky ToC sidebar, /pt/tags/[tag]/, PT-aware tag links, "The Art of Delegation" EN). CI verde → squash merge realizado no início da sessão.
+
+Estado do blog antes desta sessão: 273 páginas, sistema multilingual EN/PT quase completo, mas faltavam:
+- Sitemap sem hreflang alternates (gap de SEO significativo para multilingual)
+- JSON-LD BlogPosting sem `inLanguage`
+- "min read" hardcoded em inglês mesmo em posts PT
+- `/pt/projects/` inexistente (único link de nav sem versão PT)
+- Header enviando usuários PT para `/projects/` EN
+- `hermes-vs-openclaw` como único post PT importante sem par EN
+
+## O que foi feito nesta sessão
+
+### Merge de PR aberta
+- **PR #75** (sticky ToC sidebar, /pt/tags/[tag]/, PT-aware tag links, delegating-to-agents pair) — CI verde → squash merge.
+
+### Sitemap hreflang (`astro.config.mjs`)
+
+Configurado `@astrojs/sitemap` com função `serialize` que adiciona `xhtml:link rel="alternate"` para os 6 pares de páginas estáticas EN↔PT:
+
+| EN | PT |
+|----|----|
+| `/` | `/pt/` |
+| `/about/` | `/pt/about/` |
+| `/archive/` | `/pt/archive/` |
+| `/tags/` | `/pt/tags/` |
+| `/search/` | `/pt/search/` |
+| `/projects/` | `/pt/projects/` |
+
+Cada URL recebe `en-US`, `pt-BR` e `x-default` (EN). Posts de blog mantêm hreflang apenas via `<link rel="alternate">` no `<head>` (já existente via `translationKey` + `translationHref`), o que é suficiente — o Googlebot lê ambas as fontes.
+
+**Por que importa**: sem hreflang no sitemap, o Google não tem garantia de que sabe associar `/about/` e `/pt/about/` como variantes do mesmo recurso. O hreflang evita que as duas páginas compitam entre si nas SERPs e garante que o Google sirva a versão correta por idioma/região.
+
+### JSON-LD `inLanguage` (`src/layouts/PageLayout.astro`)
+
+Adicionado `inLanguage` ao schema `BlogPosting`:
+```json
+{ "inLanguage": "pt-BR" }  // ou "en-US"
+```
+
+Também adicionado `inLanguage: "en-US"` ao schema `WebSite` (o blog é primariamente EN).
+
+**Por que importa**: o `inLanguage` é um sinal explícito de idioma no structured data. Pode melhorar rich snippets em buscas de idioma específico e ajuda parsers de conteúdo (ex.: Google Discover) a classificar o post no feed correto.
+
+### `minutesRead` localizado (`src/pages/blog/[...slug].astro`)
+
+Corrigido texto hardcoded "min read" → `lang === 'pt' ? 'min de leitura' : 'min read'`.
+
+**Antes**: posts PT mostravam "5 min read"  
+**Depois**: posts PT mostram "5 min de leitura"
+
+### `/pt/projects/` + Header PT-aware (`src/pages/pt/projects.astro`, `src/components/Header.astro`)
+
+Criado `/pt/projects.astro`:
+- Título "Projetos", textos em PT
+- Data formatada com `pt-BR` locale ("mai." em vez de "May")
+- `lang="pt"`, `translationHref="/projects/"` (LanguageSwitcher ativo)
+- Mesmo fetch de repos GitHub do original
+
+Atualizado `Header.astro`:
+- `projectsHref` agora varia: `/pt/projects/` quando `isPt`, `/projects/` caso contrário
+- Fecha o último gap de navegação multilingual: todos os 5 links do nav agora têm versão PT
+
+Adicionado `translationHref="/pt/projects/"` ao `/projects/` EN (LanguageSwitcher ativo em ambos os lados).
+
+### EN translation of `hermes-vs-openclaw` (par `translationKey: hermes-vs-openclaw`)
+
+| Par | Slug | Lang |
+|-----|------|------|
+| "Hermes Agent vs OpenClaw: Why My Experience Got Much Better" | `2026-04-04-hermes-agent-vs-openclaw.md` | **novo EN** |
+| "Hermes Agent vs OpenClaw: por que minha experiência ficou muito melhor" | `2026-04-04-hermes-vs-openclaw.md` | PT (adicionado `translationKey`) |
+
+Tradução fiel do post de 2026-04-04. Preserva:
+- Todos os dados quantitativos (81 sessões, 1.414 tool calls, 137 erros, 39 sessões problemáticas)
+- Exemplos de erros técnicos (schema, command/flag, environment, heartbeat)
+- Tom empírico/honesto (explicitamente não é marketing)
+- Jargão de harness (OpenClaw, Hermes, heartbeat, NO_REPLY)
+- Terminologia de ferramentas (`session_search`, `read_file`, `execute_code`, `patch`, `todo`)
+- Referências ao CausaGanha e Internet Archive
+
+**Por que importa**: era o único post com 1k+ palavras sobre comparação de harnesses sem par EN. Com a audiência EN crescente (dev community, AI twitter), esse artigo tem alto potencial de engajamento — fala diretamente sobre a experiência de usar agentes de IA em produção pessoal.
+
+## Build
+
+**275 páginas** (antes: 273). Novas:
+- `/blog/2026-04-04-hermes-agent-vs-openclaw/` + `/og/2026-04-04-hermes-agent-vs-openclaw.png`
+- `/pt/projects/`
+
+## Estado atual do sistema multilingual
+
+- [x] LanguageSwitcher com auto-redirect e localStorage
+- [x] Posts com `lang: en` ou `lang: pt`
+- [x] Infraestrutura `translationKey` para pares
+- [x] LangFilter em `/`, `/archive/`, `/pt/archive/`, `/tags/[tag]/`, `/pt/tags/[tag]/`
+- [x] Páginas estáticas PT completas: `/pt/`, `/pt/about/`, `/pt/archive/`, `/pt/tags/`, `/pt/search/`, `/pt/projects/` ← **novo**
+- [x] Header 100% PT-aware: todos os 5 links de nav têm versão PT ← **completo**
+- [x] `og:locale:alternate` quando `translationHref` presente
+- [x] `data-pagefind-filter="lang:{lang}"` nos artigos
+- [x] `hreflang` em HTML `<head>` via `translationHref`
+- [x] `hreflang` no sitemap XML para páginas estáticas ← **novo**
+- [x] JSON-LD `inLanguage` em BlogPosting e WebSite ← **novo**
+- [x] `minutesRead` localizado (EN/PT) ← **novo**
+- [x] ToC sidebar sticky em ≥1200px
+- [x] Related Posts, AuthorBio, Comments, ShareButton, BackToTop
+- [x] Série harness 100% EN+PT (4 posts × 2 idiomas)
+- [x] `hermes-vs-openclaw` par completo ← **novo**
+- [ ] EN translations: `tudo-e-processo`, `travessia`, `o-pai-do-futuro`, `hermes-vs-openclaw` ← parcialmente resolvido (`hermes` agora tem EN)
+- [ ] FAQ Schema em `/about/` e `/pt/about/`
+- [ ] `wordCount` no JSON-LD (minutesRead * ~200 palavras/min)
+- [ ] Pagination em `/archive/` e `/tags/[tag]/`
+- [ ] `/pt/tags/[tag]/` com hreflang no sitemap (as tags dinâmicas não têm par EN, então x-default seria suficiente)
+
+## Próximas sessões — backlog priorizado
+
+### Alta prioridade
+1. **EN translations dos PT-only posts restantes**: `tudo-e-processo` (filosofia do processo, Heráclito, Lao Tzu — alta relevância EN), `travessia` (viagem, identidade digital), `o-pai-do-futuro`.
+2. **FAQ Schema em `/about/`** — rich snippet de alto valor para personal brand.
+3. **`wordCount` no JSON-LD** — passar `minutesRead * 200` como `wordCount` no BlogPosting. Requer adicionar `wordCount` ao PageLayout Props e passar de `[...slug].astro`.
+
+### Média prioridade
+4. **Pagination em `/archive/`** — com 35+ posts, a lista começa a ser longa. Astro `paginate()` com 20 posts/página.
+5. **`/pt/tags/[tag]/` hreflang no sitemap** — hoje as tags dinâmicas não têm par EN exato, mas o Google poderia confundir. Adicionar `x-default` pelo menos seria bom.
+6. **dependabot PR #38** — `defu` 6.1.4→6.1.6. Fechar e atualizar manualmente: `npm update defu && git commit package-lock.json`.
+
+### Baixa prioridade
+7. **Focus management nas transições de ClientRouter** — acessibilidade para leitores de tela.
+8. **RSS multilingual** — criar `/pt/rss.xml` com posts PT apenas.
+
+## Decisões arquiteturais
+
+- **Sitemap serialize vs i18n option**: a opção `i18n` do `@astrojs/sitemap` assume `/en/` e `/pt/` prefixos Astro nativos. Como nosso EN está na raiz, usamos `serialize` com mapa explícito. Mais verboso mas correto e sem magic.
+- **hreflang no sitemap só para páginas estáticas**: posts individuais têm hreflang via `<link rel="alternate">` no `<head>` (gerado por `translationHref` em `PageLayout.astro`). Duplicar no sitemap seria redundante e complicaria a manutenção. Google aceita ambas as abordagens.
+- **`/pt/projects/` como arquivo independente, não componente parametrizado**: segue o padrão estabelecido para todas as outras páginas PT. A diferença de locale (`pt-BR`) no `Intl.DateTimeFormat` justifica o arquivo separado.
+- **Tradução de `hermes-vs-openclaw` fiel e sem adaptar**: manteve tom empírico, jargões técnicos em inglês, dados quantitativos. O público EN que chegará via busca por "AI agent harness comparison" espera exatamente esse nível de detalhe técnico e honestidade.

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -15,7 +15,41 @@ import { rehypeWrapTables } from './src/lib/rehype-wrap-tables.mjs';
 // https://astro.build/config
 export default defineConfig({
   site: 'https://franklinbaldo.github.io',
-  integrations: [mdx(), sitemap()],
+  integrations: [
+    mdx(),
+    sitemap({
+      serialize(item) {
+        const base = 'https://franklinbaldo.github.io';
+        const path = item.url.startsWith(base) ? item.url.slice(base.length) : item.url;
+
+        // Static EN↔PT page pairs
+        const enToPt = {
+          '/': '/pt/',
+          '/about/': '/pt/about/',
+          '/archive/': '/pt/archive/',
+          '/tags/': '/pt/tags/',
+          '/search/': '/pt/search/',
+          '/projects/': '/pt/projects/',
+        };
+        const ptToEn = Object.fromEntries(Object.entries(enToPt).map(([e, p]) => [p, e]));
+
+        if (enToPt[path]) {
+          item.links = [
+            { lang: 'en-US', url: item.url },
+            { lang: 'pt-BR', url: base + enToPt[path] },
+            { lang: 'x-default', url: item.url },
+          ];
+        } else if (ptToEn[path]) {
+          item.links = [
+            { lang: 'pt-BR', url: item.url },
+            { lang: 'en-US', url: base + ptToEn[path] },
+            { lang: 'x-default', url: base + ptToEn[path] },
+          ];
+        }
+        return item;
+      },
+    }),
+  ],
   prefetch: {
     defaultStrategy: 'viewport',
   },

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -9,20 +9,21 @@ interface Props {
 const { lang = 'en' } = Astro.props;
 
 const prefix = urlPrefix(lang);
-const homeHref    = `${prefix}/`;
-const archiveHref = `${prefix}/archive/`;
-const tagsHref    = `${prefix}/tags/`;
-const searchHref  = `${prefix}/search/`;
-const aboutHref   = `${prefix}/about/`;
+const homeHref     = `${prefix}/`;
+const archiveHref  = `${prefix}/archive/`;
+const tagsHref     = `${prefix}/tags/`;
+const projectsHref = `${prefix}/projects/`;
+const searchHref   = `${prefix}/search/`;
+const aboutHref    = `${prefix}/about/`;
 
 const menuLabel = t(lang, 'nav.menu');
 
 const navLinks = [
-  { href: archiveHref,  label: t(lang, 'nav.archive') },
-  { href: tagsHref,     label: t(lang, 'nav.tags') },
-  { href: '/projects/', label: t(lang, 'nav.projects') },
-  { href: searchHref,   label: t(lang, 'nav.search') },
-  { href: aboutHref,    label: t(lang, 'nav.about') },
+  { href: archiveHref,   label: t(lang, 'nav.archive') },
+  { href: tagsHref,      label: t(lang, 'nav.tags') },
+  { href: projectsHref,  label: t(lang, 'nav.projects') },
+  { href: searchHref,    label: t(lang, 'nav.search') },
+  { href: aboutHref,     label: t(lang, 'nav.about') },
 ];
 
 // Pico styles aria-current="page" distinctly; flag the link whose path

--- a/src/content/blog/2026-04-04-hermes-agent-vs-openclaw.md
+++ b/src/content/blog/2026-04-04-hermes-agent-vs-openclaw.md
@@ -1,0 +1,135 @@
+---
+title: "Hermes Agent vs OpenClaw: Why My Experience Got Much Better"
+description: "An honest account, based on my own sessions, of the UX leap from the old OpenClaw harness to Hermes Agent."
+date: "2026-04-04"
+lang: en
+tags: ["ai", "agents", "developer-tools", "automation", "software-engineering"]
+translationKey: hermes-vs-openclaw
+draft: false
+author: "franklin"
+---
+
+Over the past few weeks I've been living through an interesting transition in my daily use of agents: I moved from OpenClaw, my previous harness, to Hermes Agent as my main environment. Since almost everything I do with AI ends up becoming work infrastructure — not just a benchmark toy — I wanted to write about it in a less promotional, more empirical way.
+So I did the obvious thing: I went to look at the sessions.
+In the `/opt/data/sessions/` directory, I found 81 old sessions classifiable as OpenClaw and 3 recent ones already in the Hermes format. This isn't an academic benchmark; it's an operational sample from my own routine. And precisely because of that, it interests me more than sterile comparisons.
+The short summary is this: Hermes isn't magic, doesn't zero out errors, and still stumbles on environment details. But the overall experience got clearly better. Better for investigation, better for recovering context, better for course-correcting mid-flight, and most importantly, better for actually finishing real work.
+
+## What the logs show
+
+OpenClaw left plenty of traces. Across the 81 sessions I analyzed, there were:
+- 1,414 tool calls
+- 137 tool errors
+- 39 sessions with at least one tool error
+- roughly 48.1% of sessions with some operational friction
+
+The examples are concrete, and many of them ring familiar because I lived them day to day:
+- schema error: `Missing required parameter: newText (newText or new_string)`
+- command/flag error: `Unknown JSON field: "mergeableState"`
+- environment error: `kanban: command not found`
+- heartbeat spawn error: `Failed to spawn: heartbeat`
+
+These errors don't condemn a platform on their own. Any agent system that actually touches the shell, GitHub, files, and real automation will bump into edges. The OpenClaw problem was different: often the friction seemed to be in the harness itself — in how tools fit together, in the schemas, in the ergonomics — not just in the task.
+
+There was a recurring pattern of "almost worked": the agent understood the goal, but lost time on tool interface details. In a session from February 14th, for example, the flow was simple: read `HEARTBEAT.md`, check PRs, update a section of the file. The work got done, but not before the notorious `edit`-without-`newText` crash. Did it resolve? It did. But with that feeling of a tool fighting you more than helping.
+
+Another OpenClaw trait was operational repetition. Many sessions turned into small cron loops, heartbeats, `NO_REPLY`, mechanical checks, without a good gradient between "verify" and "act". For simple tasks that was enough. For investigation, debugging, and coordinating several moving parts, I felt the system became more fragile and verbose than it needed to be.
+
+## Hermes makes mistakes too — but fails better
+
+I preferred to look at Hermes honestly, because it would have been easy to write a false victory. In the 3 recent logs already in the new format, I found:
+- 225 tool calls
+- 22 results with error or non-zero exit
+
+So: it's not true that Hermes is an error-free world. It isn't.
+
+The recent logs themselves show stumbles like:
+- `bash: python: command not found`
+- searching a non-existent path (`/home/ubuntu`)
+- security blocks for patterns like `curl | python3`
+- authentication failures in third-party visual tools (`invalid x-api-key`)
+
+If I looked only at raw error counts, I could tell the wrong story. Because the difference isn't "no errors". The difference is in the system's behavior *after* the error.
+
+In Hermes, the pattern has consistently been:
+1. the attempt fails
+2. the agent understands why it failed
+3. switches tool or approach
+4. continues the task until the objective is closed
+
+That detail changes everything.
+
+When the shell complained about `python`, for example, the flow continued with `python3` without drama. When the security scan blocked a `curl | python3`, the agent correctly worked around it by writing a temp file and using a different parse method. When the browser view gave a 401, the investigation continued via text snapshot, Jina, shell, and files. That's much closer to what I expect from a technical partner and much less like a demo script.
+
+## The real leap: investigation quality
+
+The point where Hermes won me over wasn't the "nice chat". It was the quality of investigation.
+
+In recent sessions, it used a much more mature combination of tools:
+- `session_search` to recover context across sessions
+- `read_file` and `search_files` with finer granularity
+- `execute_code` for local processing without shell hacks
+- `patch` and `write_file` for predictable edits
+- `todo` to maintain an explicit plan
+- browser + snapshot for page inspection when necessary
+
+That may sound like a detail, but in practice it drastically reduces the cognitive cost of automation. Instead of wondering "what improvised command will keep this agent alive?", I can think more about the problem.
+
+A good example came when I was investigating CausaGanha. The session didn't stay at the surface. Hermes went all the way to Internet Archive metadata, counted recent files, compared historical versions of `completed-items.json`, separated "catalog refresh" from "real backfill progress", and then opened Jules sessions with more precise instructions. That's much closer to real operational analysis than a random sequence of tool calls.
+
+With OpenClaw, I often felt that the agent could *execute commands*. With Hermes, I more often feel that it can *conduct an investigation*.
+
+## Context and continuity
+
+Another big gain is continuity.
+
+One of the most frustrating problems with the previous experience was that moment when you knew you'd already talked about something, but the system couldn't re-anchor itself properly. Sometimes you had to over-explain. Sometimes the agent even remembered the "mood" of the task, but not the right facts. In an old session, this appeared quite explicitly: I had to point out that we were talking about something discussed just a few hours earlier, and the system basically admitted it had lost the thread.
+
+Hermes doesn't solve this mystically. What it does is better operational memory engineering:
+- lean persistent memory for durable facts
+- `session_search` for recall of previous sessions
+- skills for recurring procedures
+- structured reading of the workspace
+
+This is much more sustainable. Instead of trying to fake total memory, it seems more comfortable saying "let me check the records" — which, for real work, is better than a confident improvisation.
+
+## Tool UX matters more than it seems
+
+I underestimated for a long time how much tool UX changes the perception of intelligence.
+
+If an agent "thinks well" but constantly stumbles on schema, on file editing, on how to pass an argument, on parsing output, the final feeling is sand in the gears. That's what several OpenClaw sessions transmitted to me. It wasn't necessarily model stupidity. It was the model + harness + tools combination delivering too much friction.
+
+Hermes gives me a different feeling: more factory floor. Less juggling. Less "this should have worked".
+
+Even when things go wrong, they normally go wrong in a diagnosable way. And that, in daily use, is worth gold.
+
+## Where OpenClaw still had merit
+
+It would be unfair to pretend OpenClaw served no purpose. It served plenty.
+
+It was in OpenClaw that I consolidated many of my routines for heartbeat, memory, Jules, backlog, PR checking, and context documentation. It helped me learn what I actually wanted from an operational agent. In a sense, it was OpenClaw that made me demanding with Hermes.
+
+It's also impossible to ignore the sample bias: I have 81 old sessions on one side and only 3 in the new format on the other. So it would be dishonest to call this a definitive statistical comparison.
+
+But tool experience isn't only statistics. It's texture. It's fluidity. It's how often I have to interrupt the flow to fix the mechanism itself.
+
+And on that front, the difference is already quite clear.
+
+## My practical conclusion
+
+If I summed it up in one sentence:
+
+OpenClaw felt like a promising harness for agents. Hermes already feels more like a work environment.
+
+With OpenClaw, I often felt I needed to manage the tool in order to do the work.
+With Hermes, much more often, I simply do the work.
+
+That doesn't mean perfection. There are still broken credentials, security-blocked commands, wrong path choices, environment confusion, and small real-world collisions. But Hermes has a quality I value now more than "reasoning benchmark": recovery capacity.
+
+For anyone using agents in personal production — that is, to investigate bugs, open external sessions, compile reports, edit code, cross-reference logs, query GitHub, handle files, and publish results — that capacity is worth more than an occasional flash of brilliance on a demo prompt.
+
+In the end, that's what changed my perception.
+
+OpenClaw gave me several glimpses of the future.
+Hermes has started to give me routine.
+
+And for serious work, routine beats glimpse almost every time.

--- a/src/content/blog/2026-04-04-hermes-vs-openclaw.md
+++ b/src/content/blog/2026-04-04-hermes-vs-openclaw.md
@@ -4,6 +4,7 @@ description: "Um relato honesto, baseado nas minhas próprias sessões, sobre o 
 date: "2026-04-04"
 lang: pt
 tags: ["ai", "agents", "developer-tools", "automation", "software-engineering"]
+translationKey: hermes-vs-openclaw
 draft: false
 author: "franklin"
 ---

--- a/src/layouts/PageLayout.astro
+++ b/src/layouts/PageLayout.astro
@@ -119,6 +119,9 @@ const jsonLd = type === "article"
     <meta property="og:locale" content={ogLocale} />
     {alternateOgLocales.map((l) => <meta property="og:locale:alternate" content={l} />)}
     {ogImage && <meta property="og:image" content={ogImage} />}
+    {ogImage && <meta property="og:image:type" content="image/png" />}
+    {ogImage && <meta property="og:image:width" content="1200" />}
+    {ogImage && <meta property="og:image:height" content="630" />}
     {ogImage && <meta property="og:image:alt" content={title} />}
     {publishedTime && (
       <meta property="article:published_time" content={publishedTime.toISOString()} />

--- a/src/layouts/PageLayout.astro
+++ b/src/layouts/PageLayout.astro
@@ -60,12 +60,15 @@ const breadcrumbLd = type === "article"
     }
   : null;
 
+const inLanguage = lang === "pt" ? "pt-BR" : "en-US";
+
 const jsonLd = type === "article"
   ? {
       "@context": "https://schema.org",
       "@type": "BlogPosting",
       headline: title,
       description,
+      inLanguage,
       author: { "@type": "Person", name: "Franklin Baldo", url: Astro.site?.href },
       datePublished: publishedTime?.toISOString(),
       ...(modifiedTime && { dateModified: modifiedTime.toISOString() }),
@@ -77,6 +80,7 @@ const jsonLd = type === "article"
       "@context": "https://schema.org",
       "@type": "WebSite",
       name: "Franklin Baldo",
+      inLanguage: "en-US",
       url: Astro.site?.href,
     };
 ---

--- a/src/pages/og/[...slug].ts
+++ b/src/pages/og/[...slug].ts
@@ -11,20 +11,36 @@ const pages = Object.fromEntries(posts.map((post) => [post.id, post]));
 const route = await OGImageRoute({
   param: "slug",
   pages,
-  getImageOptions: (_path, post) => ({
-    title: post.data.title,
-    description: post.data.description,
-    bgGradient: [
-      [253, 252, 251],
-      [238, 238, 238],
-    ],
-    border: { color: [26, 26, 26], width: 8, side: "inline-start" },
-    padding: 80,
-    font: {
-      title: { weight: "Bold", size: 64, color: [17, 17, 17] },
-      description: { size: 32, color: [102, 102, 102], lineHeight: 1.4 },
-    },
-  }),
+  getImageOptions: (_path, post) => {
+    // Tags line shown after description — first tag as a category hint.
+    const firstTag = post.data.tags?.[0];
+    const desc = [
+      post.data.description ?? "",
+      firstTag ? `#${firstTag}` : "",
+    ]
+      .filter(Boolean)
+      .join("  ·  ");
+
+    return {
+      title: post.data.title,
+      description: desc,
+      // Warm dark palette — matches the blog's dark theme tokens.
+      // Background: --pico-background-color dark (#1a1612 → #221c16)
+      bgGradient: [
+        [26, 22, 18],
+        [34, 28, 22],
+      ],
+      // Top accent bar in Pico orange primary (#f56b3d)
+      border: { color: [245, 107, 61], width: 8, side: "block-start" },
+      padding: 72,
+      font: {
+        // --pico-color dark: #ede4d3 (warm cream)
+        title: { weight: "Bold", size: 56, color: [237, 228, 211], lineHeight: 1.2 },
+        // --pico-muted-color dark: #9d917e (warm gray)
+        description: { size: 26, color: [157, 145, 126], lineHeight: 1.5 },
+      },
+    };
+  },
 });
 
 export const getStaticPaths = route.getStaticPaths;

--- a/src/pages/pt/projects.astro
+++ b/src/pages/pt/projects.astro
@@ -1,5 +1,5 @@
 ---
-import PageLayout from "../layouts/PageLayout.astro";
+import PageLayout from "../../layouts/PageLayout.astro";
 
 const USER = "franklinbaldo";
 const token = import.meta.env.GITHUB_TOKEN ?? process.env.GITHUB_TOKEN;
@@ -48,31 +48,31 @@ try {
   console.warn(`[projects] failed to fetch repos: ${error}`);
 }
 
-const fmt = new Intl.DateTimeFormat("en-US", { year: "numeric", month: "short", day: "2-digit" });
+const fmt = new Intl.DateTimeFormat("pt-BR", { year: "numeric", month: "short", day: "2-digit" });
 ---
 
 <PageLayout
-  title="Projects | Franklin Baldo"
-  description="Public repositories, pulled live from GitHub at build time."
-  lang="en"
-  translationHref="/pt/projects/"
+  title="Projetos | Franklin Baldo"
+  description="Repositórios públicos, carregados diretamente do GitHub no momento do build."
+  lang="pt"
+  translationHref="/projects/"
 >
   <hgroup>
-    <h1>Projects</h1>
+    <h1>Projetos</h1>
     <p><small>
-      Public repos from <a href={`https://github.com/${USER}`}>@{USER}</a>,
-      sorted by stars · last fetched at build
+      Repos públicos de <a href={`https://github.com/${USER}`}>@{USER}</a>,
+      ordenados por estrelas · atualizado no build
     </small></p>
   </hgroup>
 
   {error && (
     <p><small>
-      Couldn't load the live list (<code>{error.slice(0, 120)}</code>).
-      Visit <a href={`https://github.com/${USER}?tab=repositories`}>my GitHub</a> directly.
+      Não foi possível carregar a lista (<code>{error.slice(0, 120)}</code>).
+      Visite <a href={`https://github.com/${USER}?tab=repositories`}>meu GitHub</a> diretamente.
     </small></p>
   )}
 
-  {repos.length === 0 && !error && <p>No public repos to show right now.</p>}
+  {repos.length === 0 && !error && <p>Nenhum repositório público disponível no momento.</p>}
 
   {repos.map((repo) => (
     <article>
@@ -86,7 +86,7 @@ const fmt = new Intl.DateTimeFormat("en-US", { year: "numeric", month: "short", 
         <small>
           {repo.language && <><kbd>{repo.language}</kbd> · </>}
           {repo.forks_count > 0 && <>⑂ {repo.forks_count} · </>}
-          updated <time datetime={repo.pushed_at}>{fmt.format(new Date(repo.pushed_at))}</time>
+          atualizado <time datetime={repo.pushed_at}>{fmt.format(new Date(repo.pushed_at))}</time>
           {repo.homepage && <> · <a href={repo.homepage}>↗ site</a></>}
         </small>
       </footer>


### PR DESCRIPTION
## Summary

- **Sitemap hreflang**: `astro.config.mjs` `serialize` adds `xhtml:link rel="alternate"` for all 6 static EN↔PT page pairs (`/`, `/about/`, `/archive/`, `/tags/`, `/search/`, `/projects/`). Each URL gets `en-US`, `pt-BR`, and `x-default`. Without this Google had no sitemap signal linking EN and PT variants.
- **JSON-LD `inLanguage`**: `BlogPosting` now includes `inLanguage: "pt-BR"` or `"en-US"`. `WebSite` schema gets `inLanguage: "en-US"`. Explicit language signal in structured data.
- **`minutesRead` localized**: Uses `t(lang, 'post.minutesRead')` — PT posts show "X min de leitura".
- **`/pt/projects/`**: PT version with `pt-BR` date formatting and PT copy. Header routes PT users to `/pt/projects/` — all 5 nav links now fully bilingual.
- **EN translation `hermes-vs-openclaw`**: `2026-04-04-hermes-agent-vs-openclaw.md` — faithful EN translation of the ~1,400-word operational harness comparison. `translationKey: hermes-vs-openclaw`.
- **OG card redesign**: Dark warm palette matching the blog's dark theme tokens. Orange top accent bar (`#f56b3d`, Pico primary). Warm cream title (`#ede4d3`), warm muted description (`#9d917e`). First tag appended as `#category` hint in description.
- **`og:image` dimensions**: Added `og:image:type`, `og:image:width` (1200), `og:image:height` (630) — Twitter/scrapers know dimensions without fetching the image first.

## OG card: before → after

| | Before | After |
|---|---|---|
| Background | Light gray `#f4ecdc`→`#eee` | Warm dark `#1a1612`→`#221c16` |
| Border | Black left 8px | Orange top 8px (`#f56b3d`) |
| Title color | `#111` | Warm cream `#ede4d3` |
| Description | Gray `#666` | Warm muted `#9d917e` |
| Tag hint | None | `#firsttag` after description |
| Image dimensions | Not in `<head>` | `1200×630` + `image/png` declared |

## Build

**290 pages** (rebased on updated main).

## Test plan

- [ ] `sitemap-0.xml` — all 6 static EN pages have `xhtml:link` with `en-US`, `pt-BR`, `x-default`
- [ ] PT counterparts have correct reverse alternates
- [ ] Any post `<head>` has `og:image:width="1200"`, `og:image:height="630"`, `og:image:type="image/png"`
- [ ] PT post JSON-LD has `"inLanguage":"pt-BR"`
- [ ] `/og/{any-slug}.png` → dark warm card with orange top bar (test with Twitter Card Validator)
- [ ] PT post reading time shows "X min de leitura"
- [ ] `/pt/projects/` → loads, PT dates, LanguageSwitcher to `/projects/`
- [ ] Header on PT page → "Projetos" → `/pt/projects/`
- [ ] Hermes EN/PT: LanguageSwitcher active on both sides

## Routine log

`.routines/2026-05-15-seo-multilingual-projects.md`

https://claude.ai/code/session_01DyxGMaoW6RrTwiYRSsxxzr