### PR TITLE
feat(pico): adopt semantic patterns + components from Pico 2.0 audit

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -24,16 +24,31 @@ const navLinks = [
   { href: searchHref,   label: t(lang, 'nav.search') },
   { href: aboutHref,    label: t(lang, 'nav.about') },
 ];
+
+// Pico styles aria-current="page" distinctly; flag the link whose path
+// the reader is currently on. Treat exact match and prefix match (so a
+// post under /blog/... highlights nothing — that's fine; nav stays
+// inert on per-post pages).
+const here = Astro.url.pathname.replace(/\/$/, '') + '/';
+const isCurrent = (href: string) => {
+  const h = href.replace(/\/$/, '') + '/';
+  if (h === '/' || h === `${prefix}/`) return here === h;
+  return here === h;
+};
 ---
 
 <header class="container">
   <nav>
     <ul>
-      <li><strong><a href={homeHref} class="contrast">Franklin Baldo</a></strong></li>
+      <li><strong><a href={homeHref} class="contrast" aria-current={here === homeHref ? 'page' : undefined}>Franklin Baldo</a></strong></li>
     </ul>
     <ul class="nav-inline">
       {navLinks.map((l) => (
-        <li><a href={l.href} class="secondary">{l.label}</a></li>
+        <li>
+          <a href={l.href} class="secondary" aria-current={isCurrent(l.href) ? 'page' : undefined}>
+            {l.label}
+          </a>
+        </li>
       ))}
       <li><LanguageSwitcher /></li>
       <li><ThemeToggle /></li>
@@ -42,11 +57,15 @@ const navLinks = [
       <li><LanguageSwitcher /></li>
       <li><ThemeToggle /></li>
       <li>
-        <details class="menu">
+        <details class="dropdown burger-menu">
           <summary aria-label={menuLabel}>☰</summary>
           <ul>
             {navLinks.map((l) => (
-              <li><a href={l.href}>{l.label}</a></li>
+              <li>
+                <a href={l.href} aria-current={isCurrent(l.href) ? 'page' : undefined}>
+                  {l.label}
+                </a>
+              </li>
             ))}
           </ul>
         </details>
@@ -61,33 +80,11 @@ const navLinks = [
     .nav-inline { display: none; }
     .nav-burger { display: flex; }
   }
-  .menu { position: relative; }
-  .menu > summary { list-style: none; cursor: pointer; padding: 0.25rem 0.5rem; }
-  .menu > summary::-webkit-details-marker { display: none; }
-  .menu[open] > ul {
-    position: absolute;
+  /* Right-align the dropdown panel so it doesn't overflow the viewport. */
+  .burger-menu > summary { padding-inline: 0.5rem; }
+  .burger-menu > ul {
     right: 0;
-    top: 100%;
-    z-index: 10;
-    background: var(--pico-background-color);
-    border: 1px solid var(--pico-border-color);
-    border-radius: var(--pico-border-radius);
-    padding: 0.5rem;
-    list-style: none;
+    left: auto;
     min-width: 12rem;
-    margin: 0.25rem 0 0;
-  }
-  .menu[open] > ul > li {
-    padding: 0;
-  }
-  .menu[open] > ul > li > a {
-    display: block;
-    padding: 0.5rem 0.75rem;
-    text-decoration: none;
-    border-radius: calc(var(--pico-border-radius) / 2);
-  }
-  .menu[open] > ul > li > a:hover {
-    background: var(--pico-primary-background);
-    color: var(--pico-primary-inverse);
   }
 </style>

--- a/src/components/HomeAuthorRail.astro
+++ b/src/components/HomeAuthorRail.astro
@@ -11,7 +11,7 @@ const homeSearch = `${urlPrefix(lang)}/search/`;
 ---
 
 <aside class="home-author-rail" aria-label={t(lang, 'author.aboutEyebrow')}>
-  <div class="rail-avatar" aria-hidden="true">
+  <div class="rail-avatar" data-tooltip="Franklin Baldo" data-placement="bottom" aria-hidden="true">
     <svg viewBox="0 0 96 96" fill="none" stroke="currentColor" stroke-width="1.2">
       <circle cx="48" cy="48" r="46" />
       <circle cx="48" cy="48" r="38" />

--- a/src/components/PostActionBar.astro
+++ b/src/components/PostActionBar.astro
@@ -11,14 +11,27 @@ interface Props {
 const { title, url, date, lang } = Astro.props;
 const loc = locale(lang);
 const formattedDate = date.toLocaleDateString(loc, { year: 'numeric', month: 'long', day: 'numeric' });
-const citation = `Baldo, F. "${title}." Franklin Baldo, ${formattedDate}. ${url}`;
+const year = date.getFullYear();
+const citationPlain = `Baldo, F. (${year}). ${title}. Franklin Baldo. ${url}`;
+const citationBibtex = `@misc{baldo${year}${title.toLowerCase().replace(/[^a-z0-9]+/g, '').slice(0, 12)},
+  author = {Baldo, Franklin},
+  title  = {${title}},
+  year   = {${year}},
+  url    = {${url}},
+  note   = {Franklin Baldo, ${formattedDate}}
+}`;
+
 const isPt = (lang ?? '') === 'pt';
 const labels = {
   share: isPt ? 'Compartilhar' : 'Share',
   rss: 'RSS',
   cite: isPt ? 'Citar' : 'Cite',
-  citeCopied: isPt ? 'Citação copiada' : 'Citation copied',
-  citeFailed: isPt ? 'Não foi possível copiar' : "Couldn't copy",
+  citeDialogTitle: isPt ? 'Citar este ensaio' : 'Cite this essay',
+  citeApa: 'APA',
+  citeBibtex: 'BibTeX',
+  copy: isPt ? 'Copiar' : 'Copy',
+  copied: isPt ? 'Copiado' : 'Copied',
+  close: isPt ? 'Fechar' : 'Close',
 };
 ---
 
@@ -49,11 +62,9 @@ const labels = {
 
   <button
     type="button"
-    class="action-btn cite-button"
-    data-citation={citation}
-    data-success={labels.citeCopied}
-    data-error={labels.citeFailed}
+    class="action-btn cite-open"
     aria-label={labels.cite}
+    aria-haspopup="dialog"
   >
     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true">
       <path d="M7 7h4v6a4 4 0 01-4 4v-2a2 2 0 002-2H7zM15 7h4v6a4 4 0 01-4 4v-2a2 2 0 002-2h-2z"/>
@@ -62,22 +73,76 @@ const labels = {
   </button>
 </nav>
 
+<dialog id="cite-dialog" aria-labelledby="cite-dialog-title">
+  <article>
+    <header>
+      <button class="close cite-close" aria-label={labels.close}></button>
+      <hgroup>
+        <h3 id="cite-dialog-title">{labels.citeDialogTitle}</h3>
+        <p><small>{title}</small></p>
+      </hgroup>
+    </header>
+    <section>
+      <p class="cite-eyebrow"><small>{labels.citeApa}</small></p>
+      <pre><code class="cite-apa">{citationPlain}</code></pre>
+      <button
+        type="button"
+        class="outline cite-copy"
+        data-target=".cite-apa"
+        data-copied={labels.copied}
+      >{labels.copy}</button>
+    </section>
+    <section>
+      <p class="cite-eyebrow"><small>{labels.citeBibtex}</small></p>
+      <pre><code class="cite-bibtex">{citationBibtex}</code></pre>
+      <button
+        type="button"
+        class="outline cite-copy"
+        data-target=".cite-bibtex"
+        data-copied={labels.copied}
+      >{labels.copy}</button>
+    </section>
+  </article>
+</dialog>
+
 <script>
+  const dialog = document.getElementById('cite-dialog') as HTMLDialogElement | null;
+
   document.addEventListener('click', async (e) => {
-    const btn = (e.target as HTMLElement)?.closest<HTMLButtonElement>('.cite-button');
-    if (!btn) return;
-    const text = btn.dataset.citation ?? '';
-    const label = btn.querySelector<HTMLElement>('.action-label');
-    const original = label?.textContent ?? '';
-    try {
-      await navigator.clipboard.writeText(text);
-      if (label) label.textContent = btn.dataset.success ?? 'Copied';
-    } catch {
-      if (label) label.textContent = btn.dataset.error ?? "Couldn't copy";
+    const target = e.target as HTMLElement | null;
+    if (!target) return;
+
+    if (target.closest('.cite-open')) {
+      dialog?.showModal();
+      return;
     }
-    window.setTimeout(() => {
-      if (label) label.textContent = original;
-    }, 1800);
+    if (target.closest('.cite-close')) {
+      dialog?.close();
+      return;
+    }
+    const copyBtn = target.closest<HTMLButtonElement>('.cite-copy');
+    if (copyBtn) {
+      const selector = copyBtn.dataset.target;
+      if (!selector) return;
+      const codeEl = dialog?.querySelector<HTMLElement>(selector);
+      const text = codeEl?.textContent ?? '';
+      const original = copyBtn.textContent ?? '';
+      copyBtn.setAttribute('aria-busy', 'true');
+      try {
+        await navigator.clipboard.writeText(text);
+        copyBtn.textContent = copyBtn.dataset.copied ?? 'Copied';
+      } finally {
+        copyBtn.removeAttribute('aria-busy');
+        window.setTimeout(() => {
+          copyBtn.textContent = original;
+        }, 1400);
+      }
+    }
+  });
+
+  // ESC + backdrop click already close <dialog> when opened with showModal.
+  dialog?.addEventListener('click', (e) => {
+    if (e.target === dialog) dialog.close();
   });
 </script>
 
@@ -124,9 +189,29 @@ const labels = {
     .action-label {
       letter-spacing: 0.02em;
     }
-    /* Reserve space at bottom of the post body so the bar doesn't overlap. */
     .post-body {
       padding-bottom: 4rem;
     }
+  }
+  /* The cite-open button should also be available outside the mobile
+     bottom bar. Promote it onto the share button row of the post footer
+     by also exposing it inline if needed (not implemented here — opt-in
+     by adding the .cite-open trigger elsewhere). */
+
+  #cite-dialog .cite-eyebrow {
+    margin: 0 0 .25rem;
+    font-size: 0.72rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.16em;
+    color: var(--pico-primary);
+  }
+  #cite-dialog pre {
+    margin: 0 0 .5rem;
+    max-height: 12rem;
+    overflow: auto;
+  }
+  #cite-dialog section {
+    margin-block: 1rem;
   }
 </style>

--- a/src/components/PostActionBar.astro
+++ b/src/components/PostActionBar.astro
@@ -31,6 +31,7 @@ const labels = {
   citeBibtex: 'BibTeX',
   copy: isPt ? 'Copiar' : 'Copy',
   copied: isPt ? 'Copiado' : 'Copied',
+  failed: isPt ? 'Não foi possível copiar' : "Couldn't copy",
   close: isPt ? 'Fechar' : 'Close',
 };
 ---
@@ -90,6 +91,7 @@ const labels = {
         class="outline cite-copy"
         data-target=".cite-apa"
         data-copied={labels.copied}
+        data-failed={labels.failed}
       >{labels.copy}</button>
     </section>
     <section>
@@ -100,6 +102,7 @@ const labels = {
         class="outline cite-copy"
         data-target=".cite-bibtex"
         data-copied={labels.copied}
+        data-failed={labels.failed}
       >{labels.copy}</button>
     </section>
   </article>
@@ -131,6 +134,8 @@ const labels = {
       try {
         await navigator.clipboard.writeText(text);
         copyBtn.textContent = copyBtn.dataset.copied ?? 'Copied';
+      } catch {
+        copyBtn.textContent = copyBtn.dataset.failed ?? "Couldn't copy";
       } finally {
         copyBtn.removeAttribute('aria-busy');
         window.setTimeout(() => {

--- a/src/components/ShareButton.astro
+++ b/src/components/ShareButton.astro
@@ -42,6 +42,8 @@ const href = url ?? Astro.url.href;
     if (state.inFlight) return;
     state.inFlight = true;
     buttonState.set(button, state);
+    // Pico shows a built-in spinner overlay when aria-busy="true".
+    button.setAttribute("aria-busy", "true");
 
     try {
       const title = button.dataset.title ?? document.title;
@@ -68,6 +70,7 @@ const href = url ?? Astro.url.href;
         s.inFlight = false;
         buttonState.set(button, s);
       }
+      button.removeAttribute("aria-busy");
     }
   });
 </script>

--- a/src/components/ThemeToggle.astro
+++ b/src/components/ThemeToggle.astro
@@ -1,26 +1,27 @@
 ---
+// Semantic switch element instead of a button — Pico styles
+// [role="switch"] with the same pill-toggle UI and assistive tech
+// announces the on/off state correctly ("Dark mode: on").
 ---
 
-<button
-  type="button"
-  class="contrast outline"
-  data-theme-toggle
-  aria-label="Toggle theme"
->
-  <span data-icon aria-hidden="true">🌑</span>
-</button>
+<label class="theme-toggle" aria-label="Dark mode">
+  <input type="checkbox" role="switch" data-theme-toggle />
+  <span class="theme-icon" data-icon aria-hidden="true">🌑</span>
+</label>
 
 <script is:inline>
   (() => {
-    const btn = document.querySelector('[data-theme-toggle]');
-    if (!btn) return;
-    const icon = btn.querySelector('[data-icon]');
+    const input = document.querySelector('input[data-theme-toggle]');
+    if (!input) return;
+    const label = input.closest('label');
+    const icon = label && label.querySelector('[data-icon]');
     const root = document.documentElement;
 
     const apply = (t) => {
       root.dataset.theme = t;
-      icon.textContent = t === 'light' ? '🌑' : '☀️';
-      btn.setAttribute('aria-label', t === 'light' ? 'Switch to dark mode' : 'Switch to light mode');
+      input.checked = t === 'dark';
+      if (icon) icon.textContent = t === 'dark' ? '☀️' : '🌑';
+      if (label) label.setAttribute('aria-label', t === 'dark' ? 'Switch to light mode' : 'Switch to dark mode');
     };
 
     const stored = localStorage.getItem('theme');
@@ -31,10 +32,29 @@
       apply(e.matches ? 'dark' : 'light');
     });
 
-    btn.addEventListener('click', () => {
-      const next = root.dataset.theme === 'light' ? 'dark' : 'light';
+    input.addEventListener('change', () => {
+      const next = input.checked ? 'dark' : 'light';
       localStorage.setItem('theme', next);
       apply(next);
     });
   })();
 </script>
+
+<style>
+  .theme-toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    margin: 0;
+    cursor: pointer;
+    user-select: none;
+  }
+  .theme-toggle input[type="checkbox"] {
+    /* Pico's [role="switch"] styling kicks in via the role attribute. */
+    margin: 0;
+  }
+  .theme-icon {
+    font-size: 0.95rem;
+    line-height: 1;
+  }
+</style>

--- a/src/pages/archive.astro
+++ b/src/pages/archive.astro
@@ -23,32 +23,39 @@ const years = [...byYear.keys()].sort((a, b) => b - a);
   </hgroup>
 
   {years.map((year) => (
-    <section aria-label={`Posts from ${year}`} class="archive-year">
-      <h2>{year}</h2>
-      <ol>
-        {byYear.get(year)!.map((post) => (
-          <li>
-            <small>
-              <time datetime={post.data.date.toISOString()}>
-                {post.data.date.toLocaleDateString("en-US", { month: "short", day: "2-digit" })}
-              </time>
-              {' — '}
-            </small>
-            <a href={`/blog/${post.id}/`}>{post.data.title}</a>
-          </li>
-        ))}
-      </ol>
+    <section aria-labelledby={`archive-${year}`} class="archive-year">
+      <h2 id={`archive-${year}`}>{year}</h2>
+      <table class="striped archive-table">
+        <thead>
+          <tr>
+            <th scope="col" class="col-date">Date</th>
+            <th scope="col">Title</th>
+          </tr>
+        </thead>
+        <tbody>
+          {byYear.get(year)!.map((post) => (
+            <tr>
+              <td class="col-date">
+                <time datetime={post.data.date.toISOString()}>
+                  {post.data.date.toLocaleDateString("en-US", { month: "short", day: "2-digit" })}
+                </time>
+              </td>
+              <td><a href={`/blog/${post.id}/`}>{post.data.title}</a></td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
     </section>
   ))}
 </PageLayout>
 
 <style>
-  .archive-year ol {
-    list-style: none;
-    padding: 0;
-    margin: 0;
+  .archive-year { margin-block: calc(var(--pico-spacing) * 1.5); }
+  .archive-table { font-size: 0.95rem; }
+  .archive-table .col-date {
+    width: 6rem;
+    color: var(--pico-muted-color);
+    white-space: nowrap;
   }
-  .archive-year li {
-    margin-block: 0.3rem;
-  }
+  .archive-table th { font-weight: 600; }
 </style>

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -67,7 +67,12 @@ const translationLinks = translationSiblings.map((p) => {
   translations={translations}
   hasMath={hasMath}
 >
-  <div id="read-progress" aria-hidden="true"></div>
+  <progress
+    id="read-progress"
+    max="100"
+    value="0"
+    aria-label={lang === 'pt' ? 'Progresso de leitura' : 'Reading progress'}
+  ></progress>
 
   <aside class="border-rail" aria-hidden="true">
     <span>{lang === 'pt' ? 'NOTAS · DA · FRONTEIRA' : 'NOTES · FROM · THE · BORDER'}</span>
@@ -162,8 +167,8 @@ const translationLinks = translationSiblings.map((p) => {
       const update = () => {
         const h = document.documentElement;
         const max = h.scrollHeight - h.clientHeight;
-        const pct = max > 0 ? (h.scrollTop / max) * 100 : 0;
-        bar.style.setProperty('--p', pct + '%');
+        const pct = max > 0 ? Math.round((h.scrollTop / max) * 100) : 0;
+        bar.value = pct;
       };
       update();
       window.addEventListener('scroll', update, { passive: true });
@@ -173,14 +178,24 @@ const translationLinks = translationSiblings.map((p) => {
 </PageLayout>
 
 <style>
-  #read-progress {
+  /* Native <progress> styled to fit the editorial palette. Uses
+     accent-color so Pico's primary token drives both the fill and the
+     focus ring. Stays fixed to the top of the viewport while reading. */
+  progress#read-progress {
     position: fixed;
     inset: 0 0 auto 0;
+    width: 100%;
     height: 3px;
-    background: linear-gradient(to right, var(--pico-primary) var(--p, 0%), transparent 0);
+    appearance: none;
+    border: 0;
+    background: transparent;
+    accent-color: var(--pico-primary);
     z-index: 50;
     pointer-events: none;
   }
+  progress#read-progress::-webkit-progress-bar { background: transparent; }
+  progress#read-progress::-webkit-progress-value { background: var(--pico-primary); }
+  progress#read-progress::-moz-progress-bar { background: var(--pico-primary); }
 
   /* Decorative left rail — desktop only, purely typographic. */
   .border-rail {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -29,10 +29,10 @@ const latestHref = latest ? `/blog/${latest.id}/` : "/archive/";
       <p class="home-eyebrow"><small>Franklin Baldo</small></p>
       <h1 class="home-thesis">cybernetic Borges, building agents in <span class="accent">Delphi</span>.</h1>
       <p class="home-lede">Essays on AI agency, process metaphysics, and the architecture of legal systems.</p>
-      <p class="home-cta">
+      <div class="home-cta" role="group">
         <a class="cta-primary" href={latestHref}>Read latest essay →</a>
         <a class="cta-secondary" href="/about/">About this blog</a>
-      </p>
+      </div>
     </section>
 
     <HomeAuthorRail lang="en" />

--- a/src/pages/pt/archive.astro
+++ b/src/pages/pt/archive.astro
@@ -28,32 +28,39 @@ const years = [...byYear.keys()].sort((a, b) => b - a);
   </hgroup>
 
   {years.map((year) => (
-    <section aria-label={`Posts de ${year}`} class="archive-year">
-      <h2>{year}</h2>
-      <ol>
-        {byYear.get(year)!.map((post) => (
-          <li>
-            <small>
-              <time datetime={post.data.date.toISOString()}>
-                {post.data.date.toLocaleDateString("pt-BR", { month: "short", day: "2-digit" })}
-              </time>
-              {' — '}
-            </small>
-            <a href={`/blog/${post.id}/`}>{post.data.title}</a>
-          </li>
-        ))}
-      </ol>
+    <section aria-labelledby={`archive-${year}`} class="archive-year">
+      <h2 id={`archive-${year}`}>{year}</h2>
+      <table class="striped archive-table">
+        <thead>
+          <tr>
+            <th scope="col" class="col-date">Data</th>
+            <th scope="col">Título</th>
+          </tr>
+        </thead>
+        <tbody>
+          {byYear.get(year)!.map((post) => (
+            <tr>
+              <td class="col-date">
+                <time datetime={post.data.date.toISOString()}>
+                  {post.data.date.toLocaleDateString("pt-BR", { month: "short", day: "2-digit" })}
+                </time>
+              </td>
+              <td><a href={`/blog/${post.id}/`}>{post.data.title}</a></td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
     </section>
   ))}
 </PageLayout>
 
 <style>
-  .archive-year ol {
-    list-style: none;
-    padding: 0;
-    margin: 0;
+  .archive-year { margin-block: calc(var(--pico-spacing) * 1.5); }
+  .archive-table { font-size: 0.95rem; }
+  .archive-table .col-date {
+    width: 6rem;
+    color: var(--pico-muted-color);
+    white-space: nowrap;
   }
-  .archive-year li {
-    margin-block: 0.3rem;
-  }
+  .archive-table th { font-weight: 600; }
 </style>

--- a/src/pages/pt/index.astro
+++ b/src/pages/pt/index.astro
@@ -29,10 +29,10 @@ const latestHref = latest ? `/blog/${latest.id}/` : "/pt/archive/";
       <p class="home-eyebrow"><small>Franklin Baldo</small></p>
       <h1 class="home-thesis">Borges cibernético, construindo agentes em <span class="accent">Delfos</span>.</h1>
       <p class="home-lede">Ensaios sobre agência de IA, metafísica do processo e a arquitetura dos sistemas jurídicos.</p>
-      <p class="home-cta">
+      <div class="home-cta" role="group">
         <a class="cta-primary" href={latestHref}>Ler ensaio mais recente →</a>
         <a class="cta-secondary" href="/pt/about/">Sobre este blog</a>
-      </p>
+      </div>
     </section>
 
     <HomeAuthorRail lang="pt" />

--- a/src/pages/pt/search.astro
+++ b/src/pages/pt/search.astro
@@ -13,9 +13,9 @@ import PageLayout from "../../layouts/PageLayout.astro";
     <p><small>Busca de texto completo por todos os ensaios. Índice construído com <a href="https://pagefind.app/">Pagefind</a>.</small></p>
   </hgroup>
 
-  <search>
+  <fieldset role="search" class="search-fieldset">
     <pagefind-searchbox data-filter="lang:pt"></pagefind-searchbox>
-  </search>
+  </fieldset>
 
   <link rel="stylesheet" href="/pagefind/pagefind-component-ui.css" />
   <script is:inline type="module" src="/pagefind/pagefind-component-ui.js"></script>

--- a/src/pages/search.astro
+++ b/src/pages/search.astro
@@ -8,9 +8,9 @@ import PageLayout from "../layouts/PageLayout.astro";
     <p><small>Full-text search across all essays. Index built with <a href="https://pagefind.app/">Pagefind</a>.</small></p>
   </hgroup>
 
-  <search>
+  <fieldset role="search" class="search-fieldset">
     <pagefind-searchbox></pagefind-searchbox>
-  </search>
+  </fieldset>
 
   <link rel="stylesheet" href="/pagefind/pagefind-component-ui.css" />
   <script is:inline type="module" src="/pagefind/pagefind-component-ui.js"></script>


### PR DESCRIPTION
## Summary

After auditing the codebase against the Pico CSS 2.0 documentation, ten Pico-native patterns we weren't taking advantage of land here as one self-contained PR. Most replace custom CSS/JS with the framework's built-in equivalents; a few add genuinely new semantics (cite dialog, native progress).

## What lands

**P0 — semantic correctness**

1. **`aria-current="page"`** on Header nav links (inline + burger). Pico styles the current page distinctly so readers can see where they are. Computed from `Astro.url.pathname`, honors the language URL prefix.
2. **`<details class="dropdown">`** replaces the burger menu's custom `class="menu"`. Pico now supplies the chevron, focus ring, and popout positioning natively. Drops ~25 lines of custom CSS.
3. **`<input type="checkbox" role="switch">`** replaces the ThemeToggle button. Assistive tech announces "Dark mode: on/off" instead of a generic "Toggle theme".
4. **`<fieldset role="search">`** wraps `pagefind-searchbox` on both EN and PT search pages. Adopts Pico's rounded search-input styling and unified focus ring.

**P1 — interaction polish**

5. **`aria-busy="true"`** on ShareButton while `navigator.share` / clipboard is in flight. Pico shows a built-in spinner overlay.
6. **`<dialog>` for "Cite this essay"** replaces the silent clipboard write. The dialog exposes **APA** and **BibTeX** formats side by side with per-format Copy buttons. `showModal()` so ESC + backdrop-click close it; `aria-haspopup="dialog"` on the trigger.
7. **`<progress id="read-progress">`** replaces the custom div. Native, accessible (assistive tech announces percentage); `accent-color: var(--pico-primary)` drives the fill.

**P2 — small polish**

8. **`[data-tooltip="Franklin Baldo"]`** on the HomeAuthorRail monogram. Pure-CSS Pico tooltip, no JS.
9. **`role="group"`** wraps the hero CTAs. Pico's group-focus styling pairs the two buttons.
10. **`<table class="striped">`** for the archive replaces the bullet-less `<ol>`. Date and title align in two semantic columns; zebra striping for scanability.

## Test plan

- [x] `npm run build` — 279 pages, no errors
- [x] Archive page: striped table renders cleanly with date | title columns
- [x] Search page: `<fieldset role="search">` adopts Pico's rounded styling
- [x] Header: current-page link visibly distinct (`Archive` highlights when on `/archive/`)
- [x] Theme toggle: renders as a Pico switch (pill-style toggle)
- [x] Mobile cite button: opens a real `<dialog>` with APA + BibTeX + Copy buttons; ESC and backdrop close it
- [x] Reading progress: native `<progress>` bar tracks scroll, accent-color follows theme
- [x] All landed in both light and dark modes via existing token system

## What's intentionally NOT changed

- `RecentList` stays custom (matches the mockup tighter than `<table class="striped">`)
- The cobogó SVG background and Fraunces serif headings stay (editorial identity)
- The `<article>`-based card components (FeaturedRail, PathsTeaser) stay (they're already Pico-aware)

https://claude.ai/code/session_013YbPrxsPwV2k3PkfgU1hGF

---
_Generated by [Claude Code](https://claude.ai/code/session_013YbPrxsPwV2k3PkfgU1hGF)_