### PR TITLE
Fix mermaid syntax in asterisco post

### DIFF
--- a/src/content/blog/2026-05-15-quem-o-asterisco-protege.md
+++ b/src/content/blog/2026-05-15-quem-o-asterisco-protege.md
@@ -56,11 +56,11 @@ Não foi sempre assim. Em algum momento entre 2018 e 2022, todo mundo no serviç
 
 ```mermaid
 flowchart LR
-    A["Ato no DOE-TCE<br/>nome completo<br/>CPF parcial"] --> B[Portal da Transparência]
-    A --> C[Diário Oficial pesquisável]
-    B --> D[matrícula, cargo, lotação]
+    A["Ato no DOE-TCE<br/>nome completo<br/>CPF parcial"] --> B["Portal da Transparência"]
+    A --> C["Diário Oficial pesquisável"]
+    B --> D["matrícula, cargo, lotação"]
     C --> E["publicações anteriores<br/>(CPF inteiro)"]
-    D --> F[identificação unívoca]
+    D --> F["identificação unívoca"]
     E --> F
 ```
 
@@ -87,10 +87,10 @@ O teto técnico do adversário não-estatal e não-Big-Tech brasileiro tem nome,
 
 ```mermaid
 flowchart LR
-    M["Dona Maria"] -.barrada nos asteriscos.-> X["—"]
-    R["Robson"] -->|10 minutos| ID["identificação<br/>unívoca"]
-    R -.+ teimosia<br/>+ dump Serasa.-> H["hacker de<br/>Araraquara"]
-    H -->|15 segundos| ID
+    M["Dona Maria"] -. "barrada nos asteriscos" .-> X["—"]
+    R["Robson"] -->|"10 minutos"| ID["identificação<br/>unívoca"]
+    R -. "+ teimosia<br/>+ dump Serasa" .-> H["hacker de<br/>Araraquara"]
+    H -->|"15 segundos"| ID
 ```
 
 ## A garrafa pet em cima do padrão

--- a/src/content/blog/2026-05-15-who-the-asterisk-protects.md
+++ b/src/content/blog/2026-05-15-who-the-asterisk-protects.md
@@ -56,11 +56,11 @@ It wasn't always this way. Sometime between 2018 and 2022, everyone in the Brazi
 
 ```mermaid
 flowchart LR
-    A["Act in the Court Gazette<br/>full name<br/>partial CPF"] --> B[Transparency Portal]
-    A --> C[Searchable Official Gazette]
-    B --> D[registration, position, posting]
+    A["Act in the Court Gazette<br/>full name<br/>partial CPF"] --> B["Transparency Portal"]
+    A --> C["Searchable Official Gazette"]
+    B --> D["registration, position, posting"]
     C --> E["older publications<br/>(full CPF)"]
-    D --> F[unique identification]
+    D --> F["unique identification"]
     E --> F
 ```
 
@@ -87,10 +87,10 @@ The technical ceiling of the non-state, non-Big-Tech Brazilian adversary has a n
 
 ```mermaid
 flowchart LR
-    M["Dona Maria"] -.stopped by asterisks.-> X["—"]
-    R["Robson"] -->|10 minutes| ID["unique<br/>identification"]
-    R -.+ stubbornness<br/>+ Serasa dump.-> H["hacker from<br/>Araraquara"]
-    H -->|15 seconds| ID
+    M["Dona Maria"] -. "stopped by asterisks" .-> X["—"]
+    R["Robson"] -->|"10 minutes"| ID["unique<br/>identification"]
+    R -. "+ stubbornness<br/>+ Serasa dump" .-> H["hacker from<br/>Araraquara"]
+    H -->|"15 seconds"| ID
 ```
 
 ## The PET bottle on top of the meter


### PR DESCRIPTION
## Summary
The mermaid diagrams in the "asterisco" post weren't rendering. Two parser issues:

1. **Diagram 1**: unquoted node labels with commas (`D[matrícula, cargo, lotação]`) — mermaid splits on the comma.
2. **Diagram 2**: dotted-edge labels with spaces, `+` and `<br/>` written as `-.label.->` — that form only accepts simple identifiers. Switched to the quoted form `-. "label" .->`.

Also quoted the `|10 minutos|` / `|15 seconds|` edge labels for consistency. Applied in PT and EN.

## Test plan
- [ ] Diagrams render after deploy on both `/blog/2026-05-15-quem-o-asterisco-protege` and the EN counterpart.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FfwfEZ6aYcEwRtuu2gftcM)_