### PR TITLE
fix(audit): mermaid, mobile overflow, drop-cap scope, TOC, tags, cite, harness

### DIFF
--- a/src/components/MermaidEnhancer.astro
+++ b/src/components/MermaidEnhancer.astro
@@ -10,19 +10,22 @@
   let initialized = false;
 
   async function render() {
-    const codeBlocks = document.querySelectorAll<HTMLElement>(
-      "article pre > code.language-mermaid",
+    // Astro's default Shiki pipeline emits mermaid blocks as
+    // <pre data-language="mermaid"><code>…</code></pre> — the language tag
+    // lives on the <pre>, not on the <code>. Earlier selector targeted
+    // .language-mermaid on <code> and matched nothing.
+    const preBlocks = document.querySelectorAll<HTMLElement>(
+      "article pre[data-language='mermaid']",
     );
-    if (codeBlocks.length === 0) return;
+    if (preBlocks.length === 0) return;
 
     const targets: HTMLElement[] = [];
-    codeBlocks.forEach((code) => {
-      const pre = code.parentElement;
-      if (!pre || pre.dataset.mermaidProcessed === "true") return;
-      const source = code.textContent ?? "";
+    preBlocks.forEach((pre) => {
+      if (pre.dataset.mermaidProcessed === "true") return;
+      const source = pre.textContent ?? "";
       const container = document.createElement("div");
       container.className = "mermaid";
-      container.textContent = source;
+      container.textContent = source.trim();
       pre.replaceWith(container);
       targets.push(container);
     });

--- a/src/components/PathsTeaser.astro
+++ b/src/components/PathsTeaser.astro
@@ -97,7 +97,9 @@ const ICONS: Record<string, string> = {
   .paths-grid {
     display: grid;
     gap: var(--pico-spacing);
-    grid-template-columns: repeat(auto-fit, minmax(20rem, 1fr));
+    /* min(20rem, 100%) keeps each card from forcing the grid track wider
+       than the viewport at <320px screens — the classic "rfs grid" pattern. */
+    grid-template-columns: repeat(auto-fit, minmax(min(20rem, 100%), 1fr));
   }
   .path-card {
     display: grid;

--- a/src/components/PostActionBar.astro
+++ b/src/components/PostActionBar.astro
@@ -215,6 +215,12 @@ const labels = {
     margin: 0 0 .5rem;
     max-height: 12rem;
     overflow: auto;
+    white-space: pre-wrap;
+    word-break: break-word;
+  }
+  #cite-dialog pre code {
+    white-space: inherit;
+    word-break: inherit;
   }
   #cite-dialog section {
     margin-block: 1rem;

--- a/src/components/TableOfContents.astro
+++ b/src/components/TableOfContents.astro
@@ -14,16 +14,21 @@ interface Props {
 }
 
 const { headings, lang, sidebar = false } = Astro.props;
+// rehype-autolink-headings injects a trailing anchor character into each
+// heading's rendered text content; strip it so the ToC reads "Coherence"
+// instead of "Coherence#".
+const clean = (s: string) => s.replace(/#\s*$/, '').trim();
 const toc = headings.filter(h => h.depth === 2 || h.depth === 3);
 const label = t(lang, 'toc.label');
 
 type Node = { slug: string; text: string; children: Node[] };
 const tree: Node[] = [];
 for (const h of toc) {
+  const text = clean(h.text);
   if (h.depth === 2) {
-    tree.push({ slug: h.slug, text: h.text, children: [] });
+    tree.push({ slug: h.slug, text, children: [] });
   } else if (tree.length > 0) {
-    tree[tree.length - 1].children.push({ slug: h.slug, text: h.text, children: [] });
+    tree[tree.length - 1].children.push({ slug: h.slug, text, children: [] });
   }
 }
 

--- a/src/content/blog/2026-04-29-reclaiming-the-harness.md
+++ b/src/content/blog/2026-04-29-reclaiming-the-harness.md
@@ -22,6 +22,8 @@ translationKey: reclaiming-harness
  by sheer choice of vocabulary for half a decade
 >mfw the shape of the words is the shape of the problem
 >mfw the lexicon has been the call coming from inside the house
+```
+
 This post is about that frame. About why "harness" was always going to bite us. And about a tiny CLI in my repo that, almost by accident, started cashing out a different one.
 ### the waluigi has been calling from inside the lexicon
 Quick recap, in case you missed the meme: the Waluigi effect is the observation that if you tell a model "you are a helpful, harmless, honest assistant," you've just defined the *exact silhouette* of its evil twin in latent space. Push too hard on the Luigi-shaped attractor and the dual mode goes click. [Cleo Nardo named it in 2023](https://www.lesswrong.com/posts/D7PumeYTDPfBTp3i7/the-waluigi-mega-post) and that post has been living in alignment Twitter's head rent free ever since. The discourse never quite recovered.
@@ -147,12 +149,18 @@ REGISTRY: dict[str, type[Backend]] = {
     "gemini-cli":  GeminiCliBackend,
     "claude-code": ClaudeCodeBackend,
 }
+```
+
 Each adapter knows the idiosyncratic nonsense of one specific cognitive engine — how its CLI is invoked, how its `stream-json` parses, where its session files live. The daemon doesn't care. The daemon just knows there's a thing that spawns and emits typed events.
+
+```
 ireneo   (gemini-cli)  ─┐
 aparicio (gemini-cli)  ├──▶ canivete bot daemon ──▶ Backend protocol
 claudio  (claude-code) ─┘                              │
                                                        ├─ gemini_cli  adapter
                                                        └─ claude_code adapter
+```
+
 Look at the picture. **The cognitive engines are different. The harness is the same.** Each adapter is doing exactly the work the triad predicted: translating one specific engine's idiom into the harness's uniform interface. The agent (Ireneo, Aparicio, Claudio — three different SOUL.md files, three different personalities) uses the same harness regardless of what's under the hood. The harness is portable. The agent is portable. The engine is swappable.
 That, right there, is the load-bearing pattern. SOUL.md says who you are. The adapters say which cognitive engine you're currently riding. The daemon is the saddle every rider uses. Swap engines, the rider survives. Swap riders, the saddle survives. Swap saddles, you've started a new project.
 It's giving Unix philosophy. It's giving "do one thing well." It's giving the only kind of architecture that survives the next model release.

--- a/src/pages/pt/tags/index.astro
+++ b/src/pages/pt/tags/index.astro
@@ -23,11 +23,47 @@ const tags = [...counts.entries()].sort((a, b) => b[1] - a[1] || a[0].localeComp
   translations={{ en: "/tags/" }}
 >
   <h1>Etiquetas</h1>
-  <nav aria-label="Todas as etiquetas">
-    <ul>
-      {tags.map(([tag, count]) => (
-        <li><a href={`/pt/tags/${tag}/`}>#{tag}</a> <small>({count})</small></li>
-      ))}
-    </ul>
-  </nav>
+  <p><small>{tags.length} etiquetas · ordenadas por frequência</small></p>
+  <ul class="tag-cloud" aria-label="Todas as etiquetas">
+    {tags.map(([tag, count]) => (
+      <li>
+        <a href={`/pt/tags/${tag}/`}>
+          <span class="tag-name">#{tag}</span>
+          <span class="tag-count">{count}</span>
+        </a>
+      </li>
+    ))}
+  </ul>
 </PageLayout>
+
+<style>
+  .tag-cloud {
+    list-style: none;
+    padding: 0;
+    margin: var(--pico-spacing) 0;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+  }
+  .tag-cloud li { margin: 0; }
+  .tag-cloud a {
+    display: inline-flex;
+    align-items: baseline;
+    gap: 0.35rem;
+    padding: 0.3rem 0.7rem;
+    border: 1px solid var(--pico-muted-border-color);
+    border-radius: 999px;
+    text-decoration: none;
+    background: var(--pico-card-background-color);
+    color: var(--pico-color);
+    font-size: 0.9rem;
+  }
+  .tag-cloud a:hover {
+    border-color: var(--pico-primary);
+    color: var(--pico-primary);
+  }
+  .tag-count {
+    color: var(--pico-muted-color);
+    font-size: 0.78rem;
+  }
+</style>

--- a/src/pages/tags/index.astro
+++ b/src/pages/tags/index.astro
@@ -18,11 +18,47 @@ const tags = [...counts.entries()].sort((a, b) => b[1] - a[1] || a[0].localeComp
 
 <PageLayout title="Tags | Franklin Baldo" description="Browse essays by tag." lang="en" translations={{ pt: "/pt/tags/" }}>
   <h1>Tags</h1>
-  <nav aria-label="All tags">
-    <ul>
-      {tags.map(([tag, count]) => (
-        <li><a href={`/tags/${tag}/`}>#{tag}</a> <small>({count})</small></li>
-      ))}
-    </ul>
-  </nav>
+  <p><small>{tags.length} tags · sorted by frequency</small></p>
+  <ul class="tag-cloud" aria-label="All tags">
+    {tags.map(([tag, count]) => (
+      <li>
+        <a href={`/tags/${tag}/`}>
+          <span class="tag-name">#{tag}</span>
+          <span class="tag-count">{count}</span>
+        </a>
+      </li>
+    ))}
+  </ul>
 </PageLayout>
+
+<style>
+  .tag-cloud {
+    list-style: none;
+    padding: 0;
+    margin: var(--pico-spacing) 0;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+  }
+  .tag-cloud li { margin: 0; }
+  .tag-cloud a {
+    display: inline-flex;
+    align-items: baseline;
+    gap: 0.35rem;
+    padding: 0.3rem 0.7rem;
+    border: 1px solid var(--pico-muted-border-color);
+    border-radius: 999px;
+    text-decoration: none;
+    background: var(--pico-card-background-color);
+    color: var(--pico-color);
+    font-size: 0.9rem;
+  }
+  .tag-cloud a:hover {
+    border-color: var(--pico-primary);
+    color: var(--pico-primary);
+  }
+  .tag-count {
+    color: var(--pico-muted-color);
+    font-size: 0.78rem;
+  }
+</style>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -37,7 +37,10 @@ body::before {
  */
 .post-grid {
   display: grid;
-  grid-template-columns: 1fr;
+  /* minmax(0, 1fr) is critical: the default `1fr` is `minmax(min-content, 1fr)`,
+     so a long pre/img/code block would force the track wider than the viewport
+     and create a page-wide horizontal scroll. */
+  grid-template-columns: minmax(0, 1fr);
 }
 
 .toc-col {
@@ -78,7 +81,7 @@ body::before {
  * direct-child <p> after the header so the cap only appears at the opening
  * of the essay, not inside asides or footnotes.
  */
-.post-body article > p:first-of-type::first-letter {
+.post-body > article > p:first-of-type::first-letter {
   float: left;
   font-family: var(--pico-font-family-serif);
   font-size: 4.2rem;
@@ -89,10 +92,37 @@ body::before {
   margin-top: 0.15rem;
 }
 @media (max-width: 600px) {
-  .post-body article > p:first-of-type::first-letter {
+  .post-body > article > p:first-of-type::first-letter {
     font-size: 3.4rem;
     padding-right: 0.4rem;
   }
+}
+
+/*
+ * Hard guarantee that nothing in the article body forces horizontal scroll:
+ *   - Astro's <Image> emits the intrinsic dimensions on width/height attrs;
+ *     without max-width: 100% the natural 1200px hero blasts past a 390px
+ *     mobile viewport.
+ *   - Shiki's .astro-code <pre> elements have `overflow-x: auto` inline but
+ *     no max-width, so a long line inside still pushes the parent wide.
+ *   - <table> needs the same protection on long rows.
+ */
+.post-body img,
+.post-body svg:not(.path-icon svg):not(.rail-avatar svg):not(.icon),
+.post-body video,
+.post-body iframe {
+  max-width: 100%;
+  height: auto;
+}
+.post-body pre,
+.post-body table,
+.post-body .mermaid {
+  max-width: 100%;
+  overflow-x: auto;
+}
+.post-body pre code {
+  display: inline-block;
+  min-width: 0;
 }
 
 .skip-link {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -125,6 +125,22 @@ body::before {
   min-width: 0;
 }
 
+/*
+ * Universal wrap policy. Long URLs, long inline code snippets like
+ * `package.method_with_a_very_long_name`, and unbreakable identifiers in
+ * headings would otherwise force a paragraph (and its grid track) wider
+ * than the viewport. `overflow-wrap: anywhere` allows the browser to
+ * break inside such tokens only when nothing else fits, which is exactly
+ * what we want for narrow phones without harming normal prose flow.
+ */
+:where(p, li, dd, dt, blockquote, h1, h2, h3, h4, h5, h6, a) {
+  overflow-wrap: anywhere;
+}
+:not(pre) > code {
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
 .skip-link {
   position: absolute;
   left: -9999px;


### PR DESCRIPTION
## Summary

Seven independent fixes from a Playwright-based site audit. All small, all bug fixes, no architectural risk.

## Fixes

1. **Mermaid was broken site-wide** — Astro's Shiki emits `<pre data-language="mermaid">`, not `<pre><code class="language-mermaid">`. The MermaidEnhancer selector never matched. Switched to `pre[data-language='mermaid']`. Verified: serpents-egg renders 1 SVG, asterisco 3, three-imperatives 1 (the "empty rectangle" I noticed earlier was a broken mermaid block).

2. **Page-wide horizontal overflow on mobile blog posts** — `.post-grid` had `grid-template-columns: 1fr`, which is `minmax(min-content, 1fr)` and grew to fit the longest line of code. Jules API post measured **2516px wide on a 390px screen**. Switched to `minmax(0, 1fr)` and hard-capped `.post-body img/pre/table/.mermaid` with `max-width: 100%; overflow-x: auto`. All long-form posts I probed now have `scrollWidth == clientWidth` on mobile.

3. **Drop cap leaked into AuthorBio and RelatedPosts** — selector matched any descendant `<article>`. Tightened to `.post-body > article > p:first-of-type` (direct child only).

4. **TOC entries ended with `#`** — `rehype-autolink-headings` anchor character leaked into Astro's `headings`. Strip a trailing `#` in `TableOfContents.astro`.

5. **Tags index pages laid out horizontally (12000+px wide)** — same Pico `<nav><ul>` flex regression as the archive. Replaced with a wrapping `.tag-cloud` of pill chips with count.

6. **Cite dialog content overflowed on mobile** — added `white-space: pre-wrap; word-break: break-word` to dialog `<pre>` blocks.

7. **Reclaiming the Harness post markdown** — missing closing fence on line 15 made the entire post body render as one giant code block. Added the closing fence and wrapped the ASCII Backend-protocol diagram in its own fence.

## Test plan

- [x] `npm run build` — 288 pages, no errors
- [x] Mermaid: probe confirms SVGs render on serpents-egg, asterisco, three-imperatives
- [x] Mobile overflow: probe confirms `sw == cw` (390 == 390) on 4 long-form posts including Jules API
- [x] Drop cap: visual inspection on Reclaiming the Harness shows no drop caps on related posts
- [x] TOC: visual inspection on serpents-egg confirms entries are clean ("Patrimonialism and its serpent" not "Patrimonialism and its serpent#")
- [x] Tags: `/tags/` renders as a pill cloud
- [x] Cite dialog: APA and BibTeX wrap properly on 390px mobile
- [x] Harness post: prose renders as paragraphs with discrete code blocks, drop cap on first paragraph only

https://claude.ai/code/session_013YbPrxsPwV2k3PkfgU1hGF

---
_Generated by [Claude Code](https://claude.ai/code/session_013YbPrxsPwV2k3PkfgU1hGF)_