### PR TITLE
Asterisco: Robson reads the asterisk as 'challenge accepted'

### DIFF
--- a/src/content/blog/2026-05-15-quem-o-asterisco-protege.md
+++ b/src/content/blog/2026-05-15-quem-o-asterisco-protege.md
@@ -74,7 +74,7 @@ Dona Maria mora ao lado de um servidor que se aposentou por incapacidade permane
 
 A pergunta vértebra do post inteiro cabe numa só frase: contra qual dos dois a anonimização funciona?
 
-Contra a Dona Maria. Robson nem sabe que ela existe.
+Contra a Dona Maria. Para o Robson, asterisco é *challenge accepted*.
 
 <figure class="meme">
   <img src="https://api.memegen.link/images/drake/publicar_o_CPF_inteiro/publicar_nome_completo_e_CPF_picotado.png?width=500" alt="Meme do Drake: rejeitando 'publicar o CPF inteiro' e aprovando 'publicar nome completo e CPF picotado'"/>

--- a/src/content/blog/2026-05-15-who-the-asterisk-protects.md
+++ b/src/content/blog/2026-05-15-who-the-asterisk-protects.md
@@ -74,7 +74,7 @@ Dona Maria lives next to a civil servant who retired for permanent disability la
 
 The spine question of the whole post fits in one sentence: which of the two does the anonymization work against?
 
-Against Dona Maria. Robson doesn't even know she exists.
+Against Dona Maria. For Robson, an asterisk is *challenge accepted*.
 
 <figure class="meme">
   <img src="https://api.memegen.link/images/drake/publish_the_full_CPF/publish_full_name_and_chopped_CPF.png?width=500" alt="Drake meme: rejecting 'publish the full CPF' and approving 'publish full name and chopped CPF'"/>


### PR DESCRIPTION
## Summary
Update the answer to the post's "pergunta vértebra" so Robson's relationship to the asterisk matches what the post already established about him.

Before:
> Contra a Dona Maria. Robson nem sabe que ela existe.

After:
> Contra a Dona Maria. Para o Robson, asterisco é *challenge accepted*.

Robson sees the asterisks — the post already says so a few paragraphs up ("dez minutos via Google + Portal da Transparência"). He just trivially defeats them. The new line preserves the two-clause rhythm and replaces the misleading "oblivion" reading with the actual one: Robson treats the asterisk as a challenge accepted.

PT + EN.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FfwfEZ6aYcEwRtuu2gftcM)_