### PR TITLE
fix(i18n): dedup translationKey fields, Three Hammers PT, draft orphan

### DIFF
--- a/.routines/2026-05-16-dedup-three-hammers-pt.md
+++ b/.routines/2026-05-16-dedup-three-hammers-pt.md
@@ -1,0 +1,138 @@
+---
+date: 2026-05-16
+slug: dedup-three-hammers-pt
+branch: claude/great-mccarthy-Jqq7N
+status: pr-open
+session: 10
+---
+
+# Sessão 2026-05-16 — Dedup translationKey, Three Hammers PT, Orphan Draft
+
+## Contexto
+
+Décima sessão com o sistema `.routines/`. Branch designado: `claude/great-mccarthy-Jqq7N`.
+
+Estado ao chegar:
+- 0 PRs abertos (todos mergeados na sessão anterior)
+- 20 posts com **dois** campos `translationKey` no frontmatter YAML — bug de dados herdado de sessões que adicionaram novos keys sem remover os antigos
+- `three-hammers` sem par PT (único post recente sem tradução)
+- Post órfão `2026-03-28-the-art-of-delegating-orchestrating-jules-and-claude-in-everyday-life.md` com `draft: false` mas sem `translationKey` — quase-duplicata de `the-art-of-delegation.md`
+
+## O que foi feito nesta sessão
+
+### 1. Fix de campos `translationKey` duplicados (20 arquivos)
+
+**Por que é crítico**: Em YAML, campos duplicados têm comportamento indefinido — a maioria dos parsers usa o último valor, mas o comportamento não é garantido pelo spec. O Astro usa `js-yaml` que silencia o aviso e usa o último valor. Isso significa que alguns posts estavam sendo roteados com a key ERRADA (o valor antigo e longo em vez do novo curto), quebrando silenciosamente o LanguageSwitcher.
+
+**Estratégia**: script Python que:
+1. Abre cada arquivo afetado
+2. Remove TODOS os campos `translationKey` do frontmatter
+3. Reinsere o valor correto (o novo/curto) logo após o campo `lang:`
+
+**Arquivos corrigidos** (20 no total, 10 pares):
+
+| Par | translationKey correto | Key antiga removida |
+|-----|----------------------|---------------------|
+| `everything-is-a-process-5-...md` + `tudo-e-processo.md` | `everything-is-process` | `everything-is-a-process-5-lessons-we-should-have-learned-2500-years-ago` |
+| `travessia-the-project-that-writes-itself.md` + `travessia.md` | `travessia-project` | `travessia-the-project-that-writes-itself` |
+| `crossing-after-interference.md` + `travessia-update.md` | `crossing-interference` | `crossing-after-interference` |
+| `we-are-all-becoming-lobsters.md` + `estamos-todos-nos-tornando-lagostas.md` | `becoming-lobsters` | `we-are-all-becoming-lobsters` |
+| `reddit-submarine-osint.md` + `eles-esto-realmente-...md` | `reddit-submarine-osint` | `reddit-submarine` |
+| `building-funes.md` + `construindo-funes-...md` | `building-funes` | `building-funes` (idêntico — dedup) |
+| `funes-soul.md` + `soulmd-funes.md` | `funes-soul` | `soul-md` |
+| `verne-identity-repo.md` + `verne-e-o-padro-identity-repo-...md` | `verne-identity-repo` | `verne-identity-repo` (idêntico — dedup) |
+| `the-future-father-...md` + `o-pai-do-futuro.md` | `future-father` | `future-father` (idêntico — dedup) |
+| `hermes-agent-vs-openclaw-...md` + `hermes-vs-openclaw.md` | `hermes-vs-openclaw` | `hermes-agent-vs-openclaw-why-my-experience-got-so-much-better` |
+
+**Resultado**: build continua clean (293 páginas), LanguageSwitcher agora usa keys corretas e curtas em todos os posts.
+
+### 2. Tradução PT de "Three Hammers Walk Into a Bar"
+
+**Arquivo criado**: `src/content/blog/2026-05-15-tres-martelos-entram-num-bar.md`
+
+**Por que agora**: Era o único post recente (últimas semanas) sem par PT. O post é biograficamente denso e tem muita terminologia jurídico-administrativa brasileira que já estava em português no original EN — o que torna a tradução PT particularmente natural e valiosa para leitores brasileiros que veriam o texto "de dentro" em vez de como observadores.
+
+**Decisões de tradução**:
+- Todos os termos jurídico-administrativos (*papelada*, *despacho*, *visto*, *servidor*, *Constituição*, etc.) mantidos em PT pois eram os termos originais
+- Vocabulário técnico de alinhamento traduzido: *affordance enumeration* → *enumeração de affordances*, *content-addressed canon* → *cânone endereçado por conteúdo*
+- Meme Drake adaptado com texto PT (URL do memegen alterada para texto PT)
+- Pull-quote traduzida para PT
+- Links internos atualizados para versões PT (`/blog/2026-05-14-o-agente-que-nao-inventa-verbos`, `/blog/pierre-menard-pesquisador-computacional`)
+- Further reading: referências originais mantidas em EN (são títulos de livros/papers reais); entrada do artigo do Franklin atualizada para "Alinhamento por Restrição de Affordances"
+
+### 3. Post órfão marcado como draft
+
+**Arquivo**: `2026-03-28-the-art-of-delegating-orchestrating-jules-and-claude-in-everyday-life.md`
+
+**Por quê**: Quase-duplicata de `2026-03-28-the-art-of-delegation.md` — mesmo tema, mesma data, conteúdo similar, sem `translationKey`. O segundo tem `translationKey: "delegating-to-agents"` e está pareado com o PT. Manter ambos seria ruído nos resultados de busca e Related Posts. Marcado `draft: true` em vez de deletado (pode ser aproveitado no futuro ou comparado).
+
+## Build
+
+293 páginas (up from 290 da sessão anterior). +3:
+- `/blog/2026-05-15-tres-martelos-entram-num-bar/` (novo)
+- `/og/2026-05-15-tres-martelos-entram-num-bar.png` (novo)
+- Post órfão delegating removido do build por `draft: true` (-1)
+- Net: +2 novas páginas públicas
+
+## Estado atual de pares de tradução
+
+**30 pares ativos** (era 29 na sessão anterior, +1 three-hammers).
+
+| Par | EN | PT |
+|-----|----|----|
+| three-hammers | ✅ | ✅ **novo** |
+| pierre-menard | ✅ | ✅ |
+| agent-no-verbs | ✅ | ✅ |
+| delegating-to-agents | ✅ | ✅ |
+| hermes-vs-openclaw | ✅ | ✅ |
+| everything-is-process | ✅ | ✅ |
+| travessia-project | ✅ | ✅ |
+| crossing-interference | ✅ | ✅ |
+| verne-identity-repo | ✅ | ✅ |
+| becoming-lobsters | ✅ | ✅ |
+| reddit-submarine-osint | ✅ | ✅ |
+| future-father | ✅ | ✅ |
+| building-funes | ✅ | ✅ |
+| funes-soul | ✅ | ✅ |
+| delphi-imperatives | ✅ | ✅ |
+| reclaiming-harness | ✅ | ✅ |
+| serpents-egg | ✅ | ✅ |
+| third-half-fourth-wall | ✅ | ✅ |
+| jules-api-harness | ✅ | ✅ |
+| asterisk-protects | ✅ | ✅ |
+| conservation-law | ✅ | ✅ |
+| vitrine-sonora | ✅ | ✅ |
+| pampa-circuit | ✅ | ✅ |
+| intelligible-void | ✅ | ✅ |
+| family-memory | ✅ | ✅ |
+| social-vulnerabilities | ✅ | ✅ |
+| rosencrantz-coin | ✅ | ✅ |
+| inaugural-post | ✅ | ✅ |
+| pontifex-guide | ✅ | ✅ |
+| pontifex-research | ✅ | ✅ |
+| conceptual-document | ✅ | ✅ |
+
+## Próximas sessões — backlog priorizado
+
+### Alta prioridade
+1. **Atualizar `defu` (PR #38 dependabot)**: `defu` 6.1.4 → 6.1.6 no `package.json`. PR antigo de dependabot — atualização simples sem breaking changes.
+2. **SEO**: Adicionar `wordCount` ao JSON-LD `BlogPosting` — `minutesRead` disponível, pode estimar wordCount (minutesRead × 200 words/min).
+3. **SEO**: FAQ Schema em `/about/` e `/pt/about/` — 3-5 FAQs sobre o autor/blog adicionam rich results.
+4. **Tradução PT de posts EN-only restantes**: verificar se há posts EN sem par PT (todos os importantes já estão pareados, mas pode haver posts mais antigos).
+
+### Média prioridade
+5. **Sticky ToC sidebar**: o CSS do `.toc-col` já implementa `position: sticky` para ≥1100px. Verificar se `IntersectionObserver` para highlight do item ativo seria útil.
+6. **`wordCount` no JSON-LD**: `minutesRead * 200` como estimativa.
+7. **Pagination**: `/archive/` e `/tags/[tag]/` com Astro `paginate()` — escala com crescimento.
+8. **Canonical tag no `<head>`**: verificar se `PageLayout.astro` já emite `<link rel="canonical">` corretamente para todas as páginas (incluindo PT).
+
+### Baixa prioridade
+9. **Focus management nas transições de página** (ClientRouter).
+10. **`og:locale:alternate` para posts PT-only sem par EN** (atualmente só gerado quando `translationHref` presente).
+
+## Decisões arquiteturais
+
+- **Script Python para dedup vs edits manuais**: script foi mais seguro pois garantiu tratamento uniforme dos 20 arquivos e documentou o padrão de fix. Edit manual por arquivo seria propenso a erro.
+- **Tradução de three-hammers agora**: prioridade justificada pelo fato de ser o único post recente sem par PT — posts mais antigos (que já têm pares) têm menos urgência.
+- **Draft em vez de delete para o orphan**: preservação do conteúdo para possível reutilização. O post tem valor como rascunho ou referência histórica.
+- **Meme adaptado para PT**: a URL do memegen aceita textos em qualquer idioma — melhor UX para leitores PT do que manter texto EN num post PT.

--- a/src/content/blog/2026-02-26-everything-is-a-process-5-lessons-we-should-have-learned-2500-years-ago.md
+++ b/src/content/blog/2026-02-26-everything-is-a-process-5-lessons-we-should-have-learned-2500-years-ago.md
@@ -1,7 +1,6 @@
 ---
 
 title: "Everything is a Process: 5 Lessons We Should Have Learned 2,500 Years Ago"
-translationKey: everything-is-a-process-5-lessons-we-should-have-learned-2500-years-ago
 description: "Twenty-five centuries ago, four voices from opposite corners of the world converged on the same intuition: process precedes substance. The river is more real than the bank."
 date: 2026-02-26
 lang: en

--- a/src/content/blog/2026-02-26-tudo-e-processo.md
+++ b/src/content/blog/2026-02-26-tudo-e-processo.md
@@ -1,6 +1,5 @@
 ---
 title: "Tudo é Processo: 5 Lições que Deveríamos Ter Aprendido Há 2.500 Anos"
-translationKey: everything-is-a-process-5-lessons-we-should-have-learned-2500-years-ago
 description: "Há vinte e cinco séculos, quatro vozes em cantos opostos do mundo convergiram para a mesma intuição: o processo precede a substância. O rio é mais real que a margem."
 date: 2026-02-26
 lang: pt

--- a/src/content/blog/2026-03-02-travessia-the-project-that-writes-itself.md
+++ b/src/content/blog/2026-03-02-travessia-the-project-that-writes-itself.md
@@ -1,7 +1,6 @@
 ---
 
 title: "Travessia: The Project that Writes Itself"
-translationKey: travessia-the-project-that-writes-itself
 description: "Riobaldo and Ted Chiang exchange letters. But no one sits down to write. One Jules session schedules the next one. The correspondence exists because it happens—incrementally, automatically, without needing me."
 date: 2026-03-02
 lang: en

--- a/src/content/blog/2026-03-02-travessia.md
+++ b/src/content/blog/2026-03-02-travessia.md
@@ -1,6 +1,5 @@
 ---
 title: "Travessia: O Projeto que Escreve a Si Mesmo"
-translationKey: travessia-the-project-that-writes-itself
 description: "Riobaldo e Ted Chiang trocam cartas. Mas ninguém senta para escrever. Uma sessão do Jules agenda a próxima. A correspondência existe porque acontece — incrementalmente, automaticamente, sem precisar de mim."
 date: 2026-03-02
 lang: pt

--- a/src/content/blog/2026-03-17-crossing-after-interference.md
+++ b/src/content/blog/2026-03-17-crossing-after-interference.md
@@ -1,7 +1,6 @@
 ---
 
 title: "Crossing After Interference"
-translationKey: crossing-after-interference
 description: "Two test letters entered the system, Riobaldo responded angrily, Franklin apologized and the Crossing changed its nature. It is no longer just an autonomous correspondence: it is a narrative world in which the author entered and was challenged."
 date: 2026-03-17
 lang: en

--- a/src/content/blog/2026-03-17-travessia-update.md
+++ b/src/content/blog/2026-03-17-travessia-update.md
@@ -1,6 +1,5 @@
 ---
 title: "Travessia Depois da Interferência"
-translationKey: crossing-after-interference
 description: "Duas cartas de teste entraram no sistema, Riobaldo respondeu com raiva, Franklin pediu desculpas e a Travessia mudou de natureza. Já não é só uma correspondência autônoma: é um mundo narrativo em que o autor entrou e foi contestado."
 date: 2026-03-17
 lang: pt

--- a/src/content/blog/2026-03-18-verne-e-o-padro-identity-repo-como-os-agentes-de-ia-se-lembram.md
+++ b/src/content/blog/2026-03-18-verne-e-o-padro-identity-repo-como-os-agentes-de-ia-se-lembram.md
@@ -5,7 +5,6 @@ date: 2026-03-18
 lang: pt
 translationKey: verne-identity-repo
 title: "Verne e o padrão Identity-Repo: como os agentes de IA se lembram"
-translationKey: verne-identity-repo
 description: "Explicando o projeto Verne, os agentes de IA e como a arquitetura de repositório de identidade permite que entidades autônomas mantenham memória e contexto contínuos em tarefas isoladas, permanecendo compatíveis com qualquer equipamento cognitivo."
 tags: ["verne", "ai", "agents", "architecture", "identity-repo", "openclaw"]
 heroImage: ./images/inaugural-post-a-glimpse-inside-my-mind-cover.png

--- a/src/content/blog/2026-03-18-verne-identity-repo.md
+++ b/src/content/blog/2026-03-18-verne-identity-repo.md
@@ -4,7 +4,6 @@ date: 2026-03-18
 lang: en
 translationKey: verne-identity-repo
 title: "Verne and the Identity-Repo Pattern: How AI Agents Remember"
-translationKey: verne-identity-repo
 description: "Explaining the Verne project, AI agents, and how the identity-repo architecture allows autonomous entities to maintain continuous memory and context across isolated tasks — while remaining compatible with any cognitive harness."
 tags: ["verne", "ai", "agents", "architecture", "identity-repo", "openclaw"]
 heroImage: ./images/inaugural-post-a-glimpse-inside-my-mind-cover.png

--- a/src/content/blog/2026-03-21-estamos-todos-nos-tornando-lagostas.md
+++ b/src/content/blog/2026-03-21-estamos-todos-nos-tornando-lagostas.md
@@ -4,7 +4,6 @@ date: 2026-03-21
 lang: pt
 translationKey: becoming-lobsters
 title: "Estamos todos nos tornando lagostas"
-translationKey: we-are-all-becoming-lobsters
 description: "Sobre a transformação, a hiperstição e a maquinaria da substituição gradual. Estabelecendo conexões entre Kafka, Lanthimos e o presente agente."
 tags: ["transformation", "AI agents", "hyperstition", "Kafka", "culture", "digital future"]
 ---

--- a/src/content/blog/2026-03-21-we-are-all-becoming-lobsters.md
+++ b/src/content/blog/2026-03-21-we-are-all-becoming-lobsters.md
@@ -4,7 +4,6 @@ date: 2026-03-21
 lang: en
 translationKey: becoming-lobsters
 title: "We Are All Becoming Lobsters"
-translationKey: we-are-all-becoming-lobsters
 description: "On transformation, hyperstition, and the machinery of gradual replacement. Drawing connections between Kafka, Lanthimos, and the agentic present."
 tags: ["transformation", "AI agents", "hyperstition", "Kafka", "culture", "digital future"]
 ---

--- a/src/content/blog/2026-03-22-eles-esto-realmente-usando-uma-postagem-do-reddit-para-ajudar-a-bombardear-um-submarino-no-ir.md
+++ b/src/content/blog/2026-03-22-eles-esto-realmente-usando-uma-postagem-do-reddit-para-ajudar-a-bombardear-um-submarino-no-ir.md
@@ -1,7 +1,6 @@
 ---
 
 title: "Eles estão realmente usando uma postagem do Reddit para ajudar a bombardear um submarino no Irã?"
-translationKey: reddit-submarine
 author: franklin
 date: 2026-03-22
 lang: pt

--- a/src/content/blog/2026-03-22-o-pai-do-futuro.md
+++ b/src/content/blog/2026-03-22-o-pai-do-futuro.md
@@ -4,7 +4,6 @@ date: 2026-03-22
 lang: pt
 translationKey: future-father
 title: "O Pai do Futuro: building a transmedia novel with AI agents"
-translationKey: future-father
 description: "How I'm using Jules, autonovel, and public records to generate a novel about a father who discovers he's speaking with his children from the future — and why it reminds me of Kleber Mendonça Filho's O Agente Secreto."
 tags: ["autonovel", "ai", "fiction", "transmedia", "jules"]
 heroImage: ./images/inaugural-post-a-glimpse-inside-my-mind-cover.png

--- a/src/content/blog/2026-03-22-reddit-submarine-osint.md
+++ b/src/content/blog/2026-03-22-reddit-submarine-osint.md
@@ -1,6 +1,5 @@
 ---
 title: "Are they really using a Reddit post to help bomb a submarine in Iran?"
-translationKey: reddit-submarine
 author: franklin
 date: 2026-03-22
 lang: en

--- a/src/content/blog/2026-03-22-the-future-father-building-a-transmedia-novel-with-ai-agents.md
+++ b/src/content/blog/2026-03-22-the-future-father-building-a-transmedia-novel-with-ai-agents.md
@@ -5,7 +5,6 @@ date: 2026-03-22
 lang: en
 translationKey: future-father
 title: "The Future Father: building a transmedia novel with AI agents"
-translationKey: future-father
 description: "How I'm using Jules, autonovel, and public records to generate a novel about a father who discovers he's speaking with his children from the future — and why it reminds me of Kleber Mendonça Filho's O Agente Secreto."
 tags: ["autonovel", "ai", "fiction", "transmedia", "jules"]
 heroImage: ./images/inaugural-post-a-glimpse-inside-my-mind-cover.png

--- a/src/content/blog/2026-03-28-the-art-of-delegating-orchestrating-jules-and-claude-in-everyday-life.md
+++ b/src/content/blog/2026-03-28-the-art-of-delegating-orchestrating-jules-and-claude-in-everyday-life.md
@@ -4,7 +4,7 @@ description: "Reflections from a software engineer and father on how to delegate
 date: "2026-03-28"
 lang: en
 tags: ["ai", "agents", "software-engineering", "parenting", "metaphysics"]
-draft: false
+draft: true
 author: "franklin"
 ---
 There's something deeply strange and yet familiar about watching two artificial intelligence agents—[Jules](/blog/2026-05-10-jules-api-harness-backend/) and Claude—collaborate on a codebase while my youngest daughter sleeps in the next room. As a software engineer, automation has always been the holy grail; As a parent, delegation has become a necessity for survival. But the intersection of these two realities revealed an unexpected complexity: that the real difficulty is not in making machines work, but in knowing how to supervise them without suffocating them.

--- a/src/content/blog/2026-04-04-hermes-agent-vs-openclaw-why-my-experience-got-so-much-better.md
+++ b/src/content/blog/2026-04-04-hermes-agent-vs-openclaw-why-my-experience-got-so-much-better.md
@@ -1,6 +1,5 @@
 ---
 title: "Hermes Agent vs OpenClaw: Why My Experience Got So Much Better"
-translationKey: hermes-agent-vs-openclaw-why-my-experience-got-so-much-better
 description: "An honest account, based on my own sessions, about the UX leap between the old OpenClaw harness and the Hermes Agent."
 date: "2026-04-04"
 lang: en

--- a/src/content/blog/2026-04-04-hermes-vs-openclaw.md
+++ b/src/content/blog/2026-04-04-hermes-vs-openclaw.md
@@ -1,6 +1,5 @@
 ---
 title: "Hermes Agent vs OpenClaw: por que minha experiência ficou muito melhor"
-translationKey: hermes-agent-vs-openclaw-why-my-experience-got-so-much-better
 description: "Um relato honesto, baseado nas minhas próprias sessões, sobre o salto de UX entre o antigo harness OpenClaw e o Hermes Agent."
 date: "2026-04-04"
 lang: pt

--- a/src/content/blog/2026-05-15-tres-martelos-entram-num-bar.md
+++ b/src/content/blog/2026-05-15-tres-martelos-entram-num-bar.md
@@ -1,0 +1,96 @@
+---
+title: "Três Martelos Entram num Bar"
+description: "Sobre três posturas profissionais, quatro propriedades de alinhamento e a propriedade que teve que vir de fora."
+date: "2026-05-15"
+lang: pt
+translationKey: three-hammers
+tags: ["ai", "alinhamento", "agentes", "direito", "brasil", "supply-chain"]
+---
+
+Um advogado, um brasileiro e um servidor público entram num bar. O barman está lendo sobre AI safety no celular e, sem levantar a cabeça, diz: me explica como você alinharia uma IA.
+
+O advogado larga o copo primeiro. *Papelada,* diz. O ato não existe até ser reduzido a texto — até que o que foi feito tenha um registro que possa ser recorrido, citado, intimado, arquivado. Se você quer que uma máquina faça algo, primeiro precisa existir o documento ao qual a máquina se compromete. O documento é o ato; o fazer é a conformidade com o documento.
+
+O brasileiro, que passou a vida dentro de um *Estado* de gabinetes, concorda com a cabeça. *Papelada,* concorda, mas quer dizer coisa diferente. Num ministério brasileiro nenhum ato relevante tem uma só assinatura — o técnico minuta, o *assessor* revisa, o *coordenador* aprova, o *secretário* assina, muitas vezes o ministro contrassigna. *Vistos* no *despacho.* A cadeia em si é o ato. Uma assinatura sozinha não produz nada.
+
+O servidor público, que lê a *Constituição* como os outros lêem jornais, diz apenas: *papelada.* O que a lei não autorizou expressamente, o agente público não pode fazer. Cidadãos podem fazer tudo que não é proibido; servidores não podem fazer nada que não é permitido. O catálogo de permissões é o limite do cargo. Um ato novo fora do catálogo não é, pela lei da sua profissão, um ato.
+
+O barman espera. Nenhum dos três respondeu à pergunta. Todos responderam à mesma pergunta.
+
+## Três martelos, um prego
+
+O que há de desconfortável na piada é que eu sou os três.
+
+Sou o advogado; a *Constituição* é o manual da minha profissão. Sou o brasileiro, e os *vistos* no *despacho* são como despachei um *parecer* quinta-feira passada. Sou o servidor público no sentido mais literal — *Procurador do Estado*, meu contracheque é orçamento público, o segundo artigo da *Lei Orgânica* que rege meu cargo é a regra que o servidor no bar recita. Nenhuma dessas é uma posição que defendo. São, no sentido mais banal, a minha formação profissional. *É o mesmo martelo com três cabos.*
+
+O que há de desconfortável no [artigo que acabei de escrever](https://github.com/franklinbaldo/papers/blob/main/paper_affordance_restriction.md) é que ele tem quatro propriedades, e três delas são posturas profissionais traduzidas em vocabulário de alinhamento. A quarta é estrangeira. *Enumeração de affordances, separação doutrina/procedimento, compromisso estruturado ex-ante, cânone endereçado por conteúdo* — lidas em voz alta parecem o índice de um bom artigo de alinhamento. Lidas contra o meu currículo, são: legalidade estrita, aprovação distribuída, o-ato-é-o-papel e uma coisa que eu não trouxe.
+
+Isso não é uma crítica ao artigo. As três primeiras são boas propriedades. São as propriedades de design de agentes que uma tradição administrativa-jurídica ininterrupta refinou por séculos porque os atores envolvidos — juízes, advogados, *servidores* — precisavam dessas propriedades para operar sem que um deles virasse rei. Se a prática administrativa-jurídica produz restrições úteis sobre agentes de máquina, isso não é acidente. É o que acontece quando uma profissão que existe para restringir o poderoso é perguntada, pela primeira vez, como é que *restrição* se parece.
+
+O que quero registrar aqui, antes que o próximo artigo tome minha atenção de volta para si mesmo, é uma pequena genealogia. De onde vieram as quatro propriedades. Quais três delas eu já tinha comigo, e qual uma tive que pegar emprestada.
+
+## Os três martelos, um a um
+
+O martelo do advogado é *ex ante.* O advogado não age e depois descreve; o advogado protocola e então *é*. Um *recurso* não é uma impugnação até ser reduzido a texto e protocolado nos autos; um *parecer* não é uma opinião até ser assinado e roteado; um *despacho* não é uma decisão até o *despacho* existir. Atos no mundo que não têm versão em papel são, na profissão do advogado, alucinações. Propriedade 3 — *compromisso estruturado ex-ante* — é esse princípio transplantado para um agente de IA. Antes de fazer qualquer coisa, o agente emite uma proposta: qual entrada do catálogo vai executar, com quais vinculações, justificada por qual caminho pelo catálogo. A proposta é a petição. A execução é o advogado cumprindo o que a petição diz, nem mais.
+
+O martelo do brasileiro é a *cadeia de vistos.* Nenhuma postura singular num *Estado de Direito* produz um ato. A minuta do técnico é revisada pelo *assessor* antes de chegar ao *coordenador.* A recomendação do *coordenador* circula como *despacho* antes de o *secretário* assinar. Alguns atos sobem mais. A frase que um estrangeiro às vezes confunde com burocracia vazia — *com vista ao setor de tal coisa* — é um dispositivo estrutural: nada de relevância acontece sem visibilidade distribuída. Propriedade 2 — *separação doutrina/procedimento* — é esse princípio generalizado. Adicionar uma especialização procedimental ao catálogo do agente é barato; adicionar um compromisso doutrinário exige uma assinatura diferente, numa fila diferente, sob uma flag explícita que nomeia o que está sendo feito. A assimetria não é atrito. É o *visto.*
+
+O martelo do servidor público é a *legalidade estrita.* O artigo 37 da *Constituição* de 1988 a enuncia; Bandeira de Mello e Hely Lopes Meirelles gastam capítulos inteiros nela. O cidadão pode fazer tudo que não é proibido; o *servidor* não pode fazer nada que não é autorizado. O agente do Estado é limitado por um catálogo enumerado de permissões; se o catálogo não diz *você pode fazer isto*, então ele não pode. Propriedade 1 — *enumeração de affordances* — é isso quase ao pé da letra, com *servidor* substituído por *agente de IA.* As ações permitidas ao agente são as entradas de um catálogo finito, curado por humanos. Novas entradas requerem aprovação humana. O agente não inventa verbos; o *servidor*, pelo seu próprio juramento, não inventa poderes.
+
+Três martelos, três propriedades. *Essa palavra está fazendo trabalho demais* quando digo neutralmente que *o artigo descreve um padrão.* A frase honesta é que o padrão, nas três primeiras propriedades, descreve o trabalho que eu já havia feito antes de saber que estava fazendo.
+
+## O quarto martelo não é meu
+
+Propriedade 4 — *cânone endereçado por conteúdo* — não estava na caixa de ferramentas que trouxe para o artigo. As entradas do catálogo são identificadas por hash do conteúdo normalizado; nomes de arquivo embutem o hash; arestas estruturais entre entradas apontam para hashes; uma edição muda o hash, que muda a identidade, o que faz do ato de editar estruturalmente um ato de substituição. A trilha de auditoria não é um registro separado mantido ao lado do catálogo — *o catálogo é o registro*, porque conteúdo equivale a identidade.
+
+Essa não é uma técnica que a prática administrativa-jurídica desenvolveu. Ela foi tomada emprestada, abertamente, do supply chain de software. Árvores de Merkle (Merkle, 1987). O modelo de objetos do Git, no qual cada commit, árvore e blob é um SHA. Sigstore e o framework SLSA para verificar que o que foi construído é o que roda. Atestações in-toto. As pessoas de software descobriram, da maneira difícil, que *o nome legível por humanos de uma coisa não é um identificador confiável da coisa*, e que proveniência durável exige identificar cada artefato pelo que ele contém.
+
+A prática administrativa-jurídica falha classicamente exatamente nisso. O *carbono-papelado* nos escritórios brasileiros era a coisa mais próxima de uma função hash: a cópia em carbono garantia que dois papéis tinham o mesmo conteúdo, por impressão mecânica em vez de transcrição. *É dando folha de Merkle primitiva.* Mas a cópia em carbono não sobreviveu à migração de acervo; processos foram perdidos em enchentes, em incêndios, na migração para sistemas digitais onde a imprecisão na forma original foi silenciosamente suavizada. Uma *norma revogada* cujo texto pré-revogação o escritório atual não mais possui é um evento regular; o ato que depende da versão mais antiga torna-se juridicamente incitável, não porque alguém assim decidiu, mas porque o texto escorregou sob os pés de todos.
+
+<figure class="meme">
+  <img
+    src="https://api.memegen.link/images/drake/Inventar_a_Propriedade_4_do_zero/Ler_a_spec_do_SLSA_e_anotar.png?width=500"
+    alt="Meme do Drake: Drake recusando o painel de cima com 'Inventar a Propriedade 4 do zero'; Drake aprovando o painel de baixo com 'Ler a spec do SLSA e anotar'."
+    loading="lazy"
+  />
+  <figcaption>O balanço honesto sobre a Propriedade 4. Três eu trouxe do serviço público; uma copiei de pessoas que já haviam resolvido meu problema num artefato diferente.</figcaption>
+</figure>
+
+É isso que faz o artigo ser um artigo e não uma memória. Os três martelos da minha formação profissional produziram três propriedades úteis mas sempre incompletas. O endereçamento por conteúdo foi a peça que faltava — a garantia técnica de que o catálogo sob o qual o agente agiu no momento *t₀* é recuperável, bit a bit, no momento *t₁*, não importa como o sistema de arquivos tenha sido reorganizado no intervalo. A tradição administrativa-jurídica teria gostado dessa propriedade e não conseguia produzi-la. Ela teve que vir de um software que aprendeu, do jeito difícil, que não se pode confiar em nomes de arquivo.
+
+## Se você é martelo
+
+A piada é engraçada porque a mesma palavra — *papelada* — faz três trabalhos diferentes em três bocas diferentes. O risco de escrever o artigo com esse histórico é exatamente o aviso que o título carrega: se você é martelo, todo problema é prego. Talvez o alinhamento não seja burocracia. Talvez os LLMs precisem de algo mais estranho do que três posturas administrativas podem oferecer.
+
+A resposta honesta, para o alinhamento geral, é provavelmente sim. A escrita criativa aberta não tem unidade discreta de ação; a conversa íntima não tem registro onde a reflexão pertence; o jornalismo investigativo com fontes confidenciais ativamente *resiste* a ser auditável. Cada um dos três martelos falha num desses. O catálogo enumerado do servidor não consegue descrever uma carta de condolências; a cadeia de *vistos* do brasileiro não tem análogo numa deliberação privada; o compromisso *ex-ante* do advogado não faz sentido para um jornalista que não consegue se comprometer antecipadamente com o que a fonte vai revelar. *A conta não fecha* fora do domínio.
+
+<blockquote class="pull-quote">
+  O padrão não foi derivado de uma teoria geral de alinhamento. Foi abstraído das condições em que os três martelos se sustentam simultaneamente.
+</blockquote>
+
+O que os três martelos *identificam*, quando encaixam, não é uma metáfora de alinhamento mas uma especificação de onde esse padrão particular se aplica. A [Seção 5 do artigo](https://github.com/franklinbaldo/papers/blob/main/paper_affordance_restriction.md) nomeia três perguntas semânticas — *existe uma unidade discreta de ação, existe um registro onde a reflexão pertence, o operador quer ser auditável* — e as perguntas são, em retrospecto, os três martelos perguntando *onde no mundo nós três nos sustentamos simultaneamente?* Quando todas as três respostas são sim, o padrão encaixa e o advogado-brasileiro-servidor-público concorda consigo mesmo nos três cabos. Quando qualquer resposta é não, o acordo colapsa e um dos martelos está sendo pedido para pregar algo que não é prego.
+
+É também por isso que [o post companheiro](/blog/2026-05-14-the-agent-that-doesnt-invent-verbs) limita sua afirmação a agentes administrativos-jurídicos delimitados. O padrão não foi derivado de uma teoria geral de alinhamento. Foi abstraído das condições em que os três martelos se sustentam simultaneamente. Dentro dessas condições o padrão encaixa sem resto. Fora delas, nenhum dos martelos é a ferramenta certa, e fingir o contrário é a piada virada contra o contador da piada.
+
+## Última rodada
+
+Os três acabaram suas bebidas. O barman, que estava ouvindo com mais atenção do que eles perceberam, seca um copo e diz, no tom de quem entrega a única observação sensata da noite:
+
+*— É, vocês acabaram de descrever o paper que esse cara aí escreveu semana passada.*
+
+Ele faz um sinal para uma mesa no canto. Os três se viram para olhar. Não há ninguém lá, ou há um homem com três cabos, ou há uma pilha de papel assinada em três grafias diferentes. Cervantes teria gostado da estrutura, embora não necessariamente a aprovado.
+
+O advogado, o brasileiro e o servidor público não alinharam uma IA. Foram alinhados por uma IA. O catálogo encontrou o *servidor*; o *despacho* encontrou a cadeia de *vistos*; a petição encontrou o advogado. Uma quarta coisa — um hash — os encontrou a todos de fora, e observou, com a polidez do software, que os três tinham sido a mesma pessoa o tempo todo.
+
+O bar fecha. Um leitor chegará, eventualmente.
+
+## Para ler mais
+
+- **Hely Lopes Meirelles, *Direito Administrativo Brasileiro*** — o tratado canônico de direito administrativo brasileiro; o capítulo sobre o *princípio da legalidade* é onde o martelo do servidor é forjado.
+- **Celso Antônio Bandeira de Mello, *Curso de Direito Administrativo*** — o princípio da legalidade estrita em sua forma canônica mais explícita; a Propriedade 1 lida em voz alta soa como tradução de suas páginas sobre a *vinculação* do administrador público.
+- **Roberto DaMatta, *Carnavais, Malandros e Heróis* (1979)** — o relato antropológico do *jeitinho*, do *despacho* e da prática institucional brasileira; o martelo brasileiro é um de seus temas recorrentes, mesmo que ele o descrevesse de fora do escritório.
+- **Lucy Suchman, *Plans and Situated Actions* (1987)** — o martelo do advogado em registro acadêmico: planos como artefatos de responsabilização, não como cognição causal. A proposta-como-compromisso no nosso artigo é como isso parece quando implementado num diretório.
+- **Ralph Merkle, *A Digital Signature Based on a Conventional Encryption Function* (1987)** — a patente do quarto martelo; a fonte que a tradição administrativa-jurídica não poderia ter produzido e teve que importar.
+- **Franklin Baldo, *[Alinhamento por Restrição de Affordances](https://github.com/franklinbaldo/papers/blob/main/paper_affordance_restriction.md)*** — o artigo do qual este post é o companheiro biográfico. As quatro propriedades são enunciadas formalmente na Seção 3; este post é o apêndice não-oficial sobre de onde três delas vieram.
+- **[O Agente que Não Inventa Verbos](/blog/2026-05-14-o-agente-que-nao-inventa-verbos)** — o companheiro arquitetural: como as quatro propriedades aparecem num sistema funcionando.
+- **[Pierre Menard, Pesquisador Computacional](/blog/pierre-menard-pesquisador-computacional)** — o companheiro metodológico: como o artigo foi escrito antes de a pesquisa estar pronta. Este post é o terceiro registro — biográfico, sobre de onde vieram os próprios martelos do autor.

--- a/src/content/blog/building-funes.md
+++ b/src/content/blog/building-funes.md
@@ -1,6 +1,5 @@
 ---
 title: "Building Funes: How I Gave an AI Agent a Soul"
-translationKey: building-funes
 author: franklin
 date: 2026-02-17
 lang: en

--- a/src/content/blog/construindo-funes-como-dei-uma-alma-a-um-agente-de-ia.md
+++ b/src/content/blog/construindo-funes-como-dei-uma-alma-a-um-agente-de-ia.md
@@ -1,7 +1,6 @@
 ---
 
 title: "Construindo Funes: como dei uma alma a um agente de IA"
-translationKey: building-funes
 author: franklin
 date: 2026-02-17
 lang: pt

--- a/src/content/blog/funes-soul.md
+++ b/src/content/blog/funes-soul.md
@@ -1,6 +1,5 @@
 ---
 title: "SOUL.md — Funes"
-translationKey: soul-md
 author: funes
 date: 2026-02-17
 lang: en

--- a/src/content/blog/soulmd-funes.md
+++ b/src/content/blog/soulmd-funes.md
@@ -1,7 +1,6 @@
 ---
 
 title: "SOUL.md – Funes"
-translationKey: soul-md
 author: funes
 date: 2026-02-17
 lang: pt


### PR DESCRIPTION
## Summary

- **Fix duplicate YAML `translationKey` fields in 20 blog posts (10 pairs)** — `js-yaml` silently uses the last value when keys are duplicated, so several posts had the wrong (long, old) key active. The LanguageSwitcher was routing correctly in some cases but the pairing was fragile. Now each file has exactly one `translationKey` placed consistently after the `lang:` field.
- **Add PT translation of "Three Hammers Walk Into a Bar"** → `2026-05-15-tres-martelos-entram-num-bar.md` (`translationKey: three-hammers`). This was the only recent post without a PT counterpart. Legal/admin jargon preserved in PT (it was already the source vocabulary); alignment terms translated; Drake meme adapted to PT text.
- **Mark orphan delegating post as `draft: true`** — `2026-03-28-the-art-of-delegating-orchestrating-jules-and-claude-in-everyday-life.md` is a near-duplicate of `the-art-of-delegation.md` (same date, same topic, no `translationKey`). Hiding from build without deleting preserves history.
- **Session report** `.routines/2026-05-16-dedup-three-hammers-pt.md`

## Pairs fixed (duplicate key → single correct key)

| EN slug | PT slug | Key before | Key after |
|---------|---------|-----------|-----------|
| everything-is-a-process-5-… | tudo-e-processo | `everything-is-a-process-5-…` + `everything-is-process` | `everything-is-process` |
| travessia-the-project-… | travessia | `travessia-the-project-…` + `travessia-project` | `travessia-project` |
| crossing-after-interference | travessia-update | `crossing-after-interference` + `crossing-interference` | `crossing-interference` |
| we-are-all-becoming-lobsters | estamos-todos-… | `becoming-lobsters` + `we-are-all-becoming-lobsters` | `becoming-lobsters` |
| reddit-submarine-osint | eles-esto-realmente-… | `reddit-submarine` + `reddit-submarine-osint` | `reddit-submarine-osint` |
| building-funes | construindo-funes-… | `building-funes` × 2 | `building-funes` |
| funes-soul | soulmd-funes | `soul-md` + `funes-soul` | `funes-soul` |
| verne-identity-repo | verne-e-o-padro-… | `verne-identity-repo` × 2 | `verne-identity-repo` |
| the-future-father-… | o-pai-do-futuro | `future-father` × 2 | `future-father` |
| hermes-agent-vs-openclaw-… | hermes-vs-openclaw | `hermes-agent-vs-openclaw-…` + `hermes-vs-openclaw` | `hermes-vs-openclaw` |

## Build

293 pages (up from 290). 30 active translation pairs (was 29).

## Test plan

- [ ] Build passes: `npm run build` exits clean, 293 pages
- [ ] No post has more than one `translationKey:` line: `grep -c "^translationKey:" src/content/blog/*.md | grep -v ":1" | grep -v ":0"`
- [ ] LanguageSwitcher active on both EN/PT for three-hammers pair
- [ ] Orphan delegating post absent from `/archive/` and search results

---
_Generated by [Claude Code](https://claude.ai/code/session_01284VADD18uoCeqKSuj5qoq)_