### PR TITLE
feat(seo+i18n): sitemap hreflang for blog posts, RSS split EN/PT, archive badges

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,28 @@
+name: Check
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci
+
+      - name: Astro type check
+        run: npx astro check
+
+      - name: Build
+        run: npm run build
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.routines/2026-05-17-sitemap-hreflang-rss-split-archive-badges.md
+++ b/.routines/2026-05-17-sitemap-hreflang-rss-split-archive-badges.md
@@ -1,0 +1,118 @@
+---
+date: 2026-05-17
+slug: sitemap-hreflang-rss-split-archive-badges
+branch: claude/great-mccarthy-kdWBD
+status: pr-open
+session: 11
+---
+
+# Sessão 2026-05-17 — Sitemap hreflang para posts, RSS split EN/PT, badges no arquivo
+
+## Contexto
+
+Décima-primeira sessão com o sistema `.routines/`. Branch designado: `claude/great-mccarthy-kdWBD`.
+
+Estado ao chegar:
+- PR #103 aberto (feat(seo): PT 404, FAQ schema, wordCount JSON-LD, x-default hreflang) — CI verde, `mergeable_state: clean`
+- PR #102 aberto (Optimize profile visuals) — Kilo Code Review FAILED (2 bugs de build: `---` indentado e key `author.moreAbout` inexistente)
+- 31 pares de tradução conectados via `translationKey`
+- Sitemap com hreflang para apenas 6 páginas estáticas (sem cobertura de posts de blog)
+- Feed RSS incluindo posts EN + PT misturados com `<language>en-us</language>`
+
+## Ações realizadas
+
+### PRs revisados
+- **PR #103** mergeado (squash) — todos os checks passando ✅
+- **PR #102** mantido aberto — Kilo Code Review falhou; bugs de build confirmados pelo PR #103
+
+### 1. Sitemap hreflang para todos os pares de posts de blog
+
+**Problema**: O sitemap tinha hreflang apenas para 6 páginas estáticas. Os 31 pares de posts EN↔PT (62 URLs de blog) não tinham hreflang no sitemap — sinal de idioma incompleto para crawlers.
+
+**Solução**:
+- `scripts/generate-translation-pairs.mjs` — script novo que lê o frontmatter de todos os `.md` em `src/content/blog/`, agrupa por `translationKey`, e emite `src/generated/blog-translation-pairs.json` (mapa bidirecional `{ "/blog/slug/": { en, pt } }`)
+- `package.json` — `prebuild` e `predev` agora executam o script antes do build
+- `astro.config.mjs` — importa o JSON gerado e usa no `serialize()` do sitemap para adicionar hreflang `en-US`, `pt-BR` e `x-default` para cada URL de post que tem par
+
+**Resultado**: sitemap passou de 6 para **74 triplets de hreflang** (6 estáticos + 31 pares × 2 URLs cada).
+
+| Antes | Depois |
+|-------|--------|
+| 6 URLs com hreflang | 74 URLs com hreflang |
+| Posts sem sinal de idioma no sitemap | Todos os 62 posts pareados têm `en-US`, `pt-BR`, `x-default` |
+
+### 2. RSS split EN/PT
+
+**Problema**: `rss.xml` incluía todos os posts (EN + PT) com `<language>en-us</language>` — dado incorreto que confundia agregadores e leitores.
+
+**Mudanças**:
+
+| Arquivo | Mudança |
+|---------|---------|
+| `src/pages/rss.xml.js` | Adicionado filtro `.filter(lang === 'en')` |
+| `src/pages/pt/rss.xml.js` | **Novo** — feed PT-only, `<language>pt-br</language>`, título "Franklin Baldo (Português)" |
+| `src/layouts/PageLayout.astro` | `<link rel="alternate" type="application/rss+xml">` agora aponta para `/pt/rss.xml` em páginas PT e `/rss.xml` em páginas EN; título do link também localizado |
+| `src/components/Footer.astro` | Recebe `lang` prop; link "RSS" no rodapé aponta para o feed correto por idioma |
+| `src/pages/pt/about.astro` | Link RSS atualizado para `/pt/rss.xml` |
+
+**Fluxo correto agora**:
+- Usuário EN visita `/` → RSS autodiscovery aponta para `/rss.xml` (EN only, `en-us`)
+- Usuário PT visita `/pt/` → RSS autodiscovery aponta para `/pt/rss.xml` (PT only, `pt-br`)
+- Rodapé mostra o link RSS correto por idioma
+
+### 3. `<meta name="author">` em todas as páginas
+
+**Arquivo**: `src/layouts/PageLayout.astro`
+
+Adicionado `<meta name="author" content="Franklin Baldo" />` logo após `<meta name="description">`. Sinal de atribuição de conteúdo para motores de busca e ferramentas de análise de byline.
+
+### 4. Badges de tradução no arquivo
+
+**Problema**: O arquivo (`/archive/` e `/pt/archive/`) mostrava apenas data + título. Não havia indicação de quais posts tinham versão no outro idioma.
+
+**Mudança**: Adicionada coluna "PT" (no arquivo EN) e "EN" (no arquivo PT) com um badge colorido quando a tradução existe. O badge usa `color-mix()` com a cor primária do Pico para seguir o tema (light/dark automaticamente).
+
+| Arquivo | Mudança |
+|---------|---------|
+| `src/pages/archive.astro` | Nova coluna PT; set de `translationKey` PT para lookup O(1); badge estilizado |
+| `src/pages/pt/archive.astro` | Nova coluna EN; set de `translationKey` EN para lookup O(1); badge estilizado |
+
+**UX**: Leitor EN que vê um post com badge PT sabe que pode recomendar para falantes de PT. Leitor PT vê quais posts têm versão EN.
+
+## Build
+
+294 páginas — sem erros. Feed RSS PT gerado em `/pt/rss.xml`.
+
+## Estado atual após esta sessão
+
+- Sitemap: 74 triplets hreflang (era 6) ✅
+- RSS EN: `/rss.xml` — EN-only, `<language>en-us</language>` ✅
+- RSS PT: `/pt/rss.xml` — PT-only, `<language>pt-br</language>` ✅ (novo)
+- `<meta name="author">` em todas as páginas ✅
+- Archive EN: badge PT em posts pareados ✅
+- Archive PT: badge EN em posts pareados ✅
+- PR #102: ainda aberto (bugs de build não corrigidos)
+
+## Próximas sessões — backlog priorizado
+
+### Alta prioridade
+1. **PR #102 fix**: O PR tem 2 bugs: `---` frontmatter indentado em `PageLayout.astro` e `author.moreAbout` (key inexistente, deveria ser `author.aboutMore`). Vale corrigir esses bugs e mergear o PR, pois a funcionalidade (pixel art de perfil + "Read latest essay" chronológico) é válida.
+2. **Dedup: `defu` atualização**: PR #38 do dependabot — `defu` 6.1.4 → 6.1.6. Simples atualização no `package.json`.
+
+### Média prioridade
+3. **Tags /tags/[tag]/ exibindo mix EN+PT**: A página de tags mostra posts EN e PT juntos. Deveria filtrar por idioma (igual ao archive) ou ao menos mostrar o badge de idioma.
+4. **Pagination**: `/archive/` e `/pt/archive/` — crescimento linear. Astro `paginate()` antes de ter >100 posts.
+5. **TOC IntersectionObserver**: Highlight ativo do item TOC conforme scroll. O CSS do `.toc-col` já tem `sticky`, falta o JS observer.
+6. **`og:image:width` + `og:image:height`** no PageLayout — melhora preview em LinkedIn/Slack. As OG images têm dimensões fixas (1200×630).
+
+### Baixa prioridade
+7. **Tags page: filtro por idioma** — `/tags/` e `/pt/tags/` provavelmente não filtram por idioma (mostram todas as tags de todos os posts). Verificar e corrigir.
+8. **`article:author` meta tag** para LinkedIn — complementa o `<meta name="author">`.
+9. **Focus management** nas transições de página (ClientRouter).
+
+## Decisões arquiteturais
+
+- **Prebuild script para pares**: alternativa seria resolver os pares diretamente no `astro.config.mjs` via importação estática do JSON (gerado uma vez e commitado). Escolhemos regenerar em cada build via script para manter o JSON sempre sincronizado com os posts — zero risco de dessincronia se alguém adicionar um post sem rodar o script manualmente.
+- **RSS split vs RSS único com `<language>` por item**: RSS 2.0 não suporta `<language>` por item (apenas por canal). Um feed unificado seria sempre rotulado com um único idioma. Split por canal é a solução correta e o que grandes blogs multilíngues fazem.
+- **Badge simples vs link para tradução no arquivo**: optamos pelo badge sem link (só indica disponibilidade). Link direto para a tradução seria útil mas complica o layout; o LanguageSwitcher no post já oferece navegação cross-language.
+- **`color-mix()` para badges**: garante que o badge segue o tema (dark/light) sem CSS duplicado. Suportado em todos os browsers modernos e compatível com Pico.css v2.

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,8 +1,9 @@
 // @ts-check
 import { defineConfig } from 'astro/config';
 import { readFileSync } from 'node:fs';
+import { DEFAULT_LANG, LANG_META } from './src/lib/languages.mjs';
 
-/** @type {Record<string, { en: string; pt: string }>} */
+/** @type {Record<string, Record<string, string>>} */
 let blogPairs = {};
 try {
   blogPairs = JSON.parse(readFileSync('./src/generated/blog-translation-pairs.json', 'utf-8'));
@@ -29,6 +30,17 @@ export default defineConfig({
     sitemap({
       serialize(item) {
         const base = 'https://franklinbaldo.github.io';
+
+        // Build hreflang links from a { [langCode]: absoluteUrl } map.
+        /** @param {Record<string, string>} langUrls */
+        const makeLinks = (langUrls) => [
+          ...Object.entries(langUrls).map(([code, url]) => ({
+            lang: LANG_META[code]?.locale ?? code,
+            url,
+          })),
+          { lang: 'x-default', url: langUrls[DEFAULT_LANG] ?? Object.values(langUrls)[0] },
+        ];
+
         const staticPairs = {
           [base + '/']: base + '/pt/',
           [base + '/about/']: base + '/pt/about/',
@@ -40,28 +52,19 @@ export default defineConfig({
         const ptToEn = Object.fromEntries(
           Object.entries(staticPairs).map(([en, pt]) => [pt, en])
         );
+
         if (staticPairs[item.url]) {
-          item.links = [
-            { lang: 'en-US', url: item.url },
-            { lang: 'pt-BR', url: staticPairs[item.url] },
-            { lang: 'x-default', url: item.url },
-          ];
+          item.links = makeLinks({ en: item.url, pt: staticPairs[item.url] });
         } else if (ptToEn[item.url]) {
-          item.links = [
-            { lang: 'en-US', url: ptToEn[item.url] },
-            { lang: 'pt-BR', url: item.url },
-            { lang: 'x-default', url: ptToEn[item.url] },
-          ];
+          item.links = makeLinks({ en: ptToEn[item.url], pt: item.url });
         } else {
           // Blog post pairs — look up pre-generated bidirectional map.
           const path = item.url.replace(base, '');
           const pair = blogPairs[path];
           if (pair) {
-            item.links = [
-              { lang: 'en-US', url: base + pair.en },
-              { lang: 'pt-BR', url: base + pair.pt },
-              { lang: 'x-default', url: base + pair.en },
-            ];
+            item.links = makeLinks(
+              Object.fromEntries(Object.entries(pair).map(([code, p]) => [code, base + p]))
+            );
           }
         }
         return item;
@@ -81,6 +84,7 @@ export default defineConfig({
           name: 'greentext',
           scopeName: 'source.greentext',
           patterns: [],
+          repository: {},
         },
       ],
       transformers: [
@@ -89,7 +93,11 @@ export default defineConfig({
           line(node, line) {
             if (this.options.lang !== 'greentext') return;
             const text = node.children
-              .map((c) => (c.type === 'element' ? c.children?.[0]?.value ?? '' : ''))
+              .map((c) => {
+                if (c.type !== 'element') return '';
+                const child = c.children?.[0];
+                return child?.type === 'text' ? child.value : '';
+              })
               .join('');
             if (/^\s*>/.test(text)) {
               node.properties.class = `${node.properties.class ?? ''} gt-quote`.trim();

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,5 +1,14 @@
 // @ts-check
 import { defineConfig } from 'astro/config';
+import { readFileSync } from 'node:fs';
+
+/** @type {Record<string, { en: string; pt: string }>} */
+let blogPairs = {};
+try {
+  blogPairs = JSON.parse(readFileSync('./src/generated/blog-translation-pairs.json', 'utf-8'));
+} catch {
+  // File not yet generated — sitemap will emit blog posts without hreflang.
+}
 
 import mdx from '@astrojs/mdx';
 import sitemap from '@astrojs/sitemap';
@@ -43,6 +52,17 @@ export default defineConfig({
             { lang: 'pt-BR', url: item.url },
             { lang: 'x-default', url: ptToEn[item.url] },
           ];
+        } else {
+          // Blog post pairs — look up pre-generated bidirectional map.
+          const path = item.url.replace(base, '');
+          const pair = blogPairs[path];
+          if (pair) {
+            item.links = [
+              { lang: 'en-US', url: base + pair.en },
+              { lang: 'pt-BR', url: base + pair.pt },
+              { lang: 'x-default', url: base + pair.en },
+            ];
+          }
         }
         return item;
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "typescript": "^5.9.3"
       },
       "devDependencies": {
+        "@astrojs/check": "^0.9.9",
         "playwright": "^1.60.0"
       },
       "engines": {
@@ -48,6 +49,55 @@
         "url": "https://github.com/sponsors/antfu"
       }
     },
+    "node_modules/@astrojs/check": {
+      "version": "0.9.9",
+      "resolved": "https://registry.npmjs.org/@astrojs/check/-/check-0.9.9.tgz",
+      "integrity": "sha512-A5UW8uIuErLWEoRQvzgXpO1gTjUFtK8r7nU2Z7GewAMxUb7bPvpk11qaKKgxqXlHJWlAvaaxy+Xg28A6bmQ1Tg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@astrojs/language-server": "^2.16.7",
+        "chokidar": "^4.0.3",
+        "kleur": "^4.1.5",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "astro-check": "bin/astro-check.js"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0 || ^6.0.0"
+      }
+    },
+    "node_modules/@astrojs/check/node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@astrojs/check/node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@astrojs/compiler": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-4.0.0.tgz",
@@ -62,6 +112,55 @@
       "dependencies": {
         "picomatch": "^4.0.4"
       }
+    },
+    "node_modules/@astrojs/language-server": {
+      "version": "2.16.8",
+      "resolved": "https://registry.npmjs.org/@astrojs/language-server/-/language-server-2.16.8.tgz",
+      "integrity": "sha512-yg1pZF6hs9FaKr2fgXMOGbW7pDLgFexFjuhWilPAc8VybTU+WSnbfbhYaUL1exm6dAK4sM3aKXGcfVwss+HXbg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@astrojs/compiler": "^2.13.1",
+        "@astrojs/yaml2ts": "^0.2.3",
+        "@jridgewell/sourcemap-codec": "^1.5.5",
+        "@volar/kit": "~2.4.28",
+        "@volar/language-core": "~2.4.28",
+        "@volar/language-server": "~2.4.28",
+        "@volar/language-service": "~2.4.28",
+        "muggle-string": "^0.4.1",
+        "tinyglobby": "^0.2.16",
+        "volar-service-css": "0.0.70",
+        "volar-service-emmet": "0.0.70",
+        "volar-service-html": "0.0.70",
+        "volar-service-prettier": "0.0.70",
+        "volar-service-typescript": "0.0.70",
+        "volar-service-typescript-twoslash-queries": "0.0.70",
+        "volar-service-yaml": "0.0.70",
+        "vscode-html-languageservice": "^5.6.2",
+        "vscode-uri": "^3.1.0"
+      },
+      "bin": {
+        "astro-ls": "bin/nodeServer.js"
+      },
+      "peerDependencies": {
+        "prettier": "^3.0.0",
+        "prettier-plugin-astro": ">=0.11.0"
+      },
+      "peerDependenciesMeta": {
+        "prettier": {
+          "optional": true
+        },
+        "prettier-plugin-astro": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@astrojs/language-server/node_modules/@astrojs/compiler": {
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-2.13.1.tgz",
+      "integrity": "sha512-f3FN83d2G/v32ipNClRKgYv30onQlMZX1vCeZMjPsMMPl1mDpmbl0+N5BYo4S/ofzqJyS5hvwacEo0CCVDn/Qg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@astrojs/markdown-remark": {
       "version": "7.1.1",
@@ -168,6 +267,16 @@
       },
       "engines": {
         "node": "18.20.8 || ^20.3.0 || >=22.0.0"
+      }
+    },
+    "node_modules/@astrojs/yaml2ts": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@astrojs/yaml2ts/-/yaml2ts-0.2.3.tgz",
+      "integrity": "sha512-PJzRmgQzUxI2uwpdX2lXSHtP4G8ocp24/t+bZyf5Fy0SZLSF9f9KXZoMlFM/XCGue+B0nH/2IZ7FpBYQATBsCg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yaml": "^2.8.2"
       }
     },
     "node_modules/@babel/helper-string-parser": {
@@ -298,6 +407,68 @@
       "engines": {
         "node": ">= 20.12.0"
       }
+    },
+    "node_modules/@emmetio/abbreviation": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@emmetio/abbreviation/-/abbreviation-2.3.3.tgz",
+      "integrity": "sha512-mgv58UrU3rh4YgbE/TzgLQwJ3pFsHHhCLqY20aJq+9comytTXUDNGG/SMtSeMJdkpxgXSXunBGLD8Boka3JyVA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@emmetio/scanner": "^1.0.4"
+      }
+    },
+    "node_modules/@emmetio/css-abbreviation": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@emmetio/css-abbreviation/-/css-abbreviation-2.1.8.tgz",
+      "integrity": "sha512-s9yjhJ6saOO/uk1V74eifykk2CBYi01STTK3WlXWGOepyKa23ymJ053+DNQjpFcy1ingpaO7AxCcwLvHFY9tuw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@emmetio/scanner": "^1.0.4"
+      }
+    },
+    "node_modules/@emmetio/css-parser": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@emmetio/css-parser/-/css-parser-0.4.1.tgz",
+      "integrity": "sha512-2bC6m0MV/voF4CTZiAbG5MWKbq5EBmDPKu9Sb7s7nVcEzNQlrZP6mFFFlIaISM8X6514H9shWMme1fCm8cWAfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@emmetio/stream-reader": "^2.2.0",
+        "@emmetio/stream-reader-utils": "^0.1.0"
+      }
+    },
+    "node_modules/@emmetio/html-matcher": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@emmetio/html-matcher/-/html-matcher-1.3.0.tgz",
+      "integrity": "sha512-NTbsvppE5eVyBMuyGfVu2CRrLvo7J4YHb6t9sBFLyY03WYhXET37qA4zOYUjBWFCRHO7pS1B9khERtY0f5JXPQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@emmetio/scanner": "^1.0.0"
+      }
+    },
+    "node_modules/@emmetio/scanner": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@emmetio/scanner/-/scanner-1.0.4.tgz",
+      "integrity": "sha512-IqRuJtQff7YHHBk4G8YZ45uB9BaAGcwQeVzgj/zj8/UdOhtQpEIupUhSk8dys6spFIWVZVeK20CzGEnqR5SbqA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@emmetio/stream-reader": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@emmetio/stream-reader/-/stream-reader-2.2.0.tgz",
+      "integrity": "sha512-fXVXEyFA5Yv3M3n8sUGT7+fvecGrZP4k6FnWWMSZVQf69kAq0LLpaBQLGcPR30m3zMmKYhECP4k/ZkzvhEW5kw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@emmetio/stream-reader-utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@emmetio/stream-reader-utils/-/stream-reader-utils-0.1.0.tgz",
+      "integrity": "sha512-ZsZ2I9Vzso3Ho/pjZFsmmZ++FWeEd/txqybHTm4OgaZzdS8V9V/YYWQwg5TC38Z7uLWUV1vavpLLbjJtKubR1A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@emnapi/runtime": {
       "version": "1.10.0",
@@ -2455,6 +2626,104 @@
         "d3-transition": "^3.0.1"
       }
     },
+    "node_modules/@volar/kit": {
+      "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@volar/kit/-/kit-2.4.28.tgz",
+      "integrity": "sha512-cKX4vK9dtZvDRaAzeoUdaAJEew6IdxHNCRrdp5Kvcl6zZOqb6jTOfk3kXkIkG3T7oTFXguEMt5+9ptyqYR84Pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/language-service": "2.4.28",
+        "@volar/typescript": "2.4.28",
+        "typesafe-path": "^0.2.2",
+        "vscode-languageserver-textdocument": "^1.0.11",
+        "vscode-uri": "^3.0.8"
+      },
+      "peerDependencies": {
+        "typescript": "*"
+      }
+    },
+    "node_modules/@volar/language-core": {
+      "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-2.4.28.tgz",
+      "integrity": "sha512-w4qhIJ8ZSitgLAkVay6AbcnC7gP3glYM3fYwKV3srj8m494E3xtrCv6E+bWviiK/8hs6e6t1ij1s2Endql7vzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/source-map": "2.4.28"
+      }
+    },
+    "node_modules/@volar/language-server": {
+      "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@volar/language-server/-/language-server-2.4.28.tgz",
+      "integrity": "sha512-NqcLnE5gERKuS4PUFwlhMxf6vqYo7hXtbMFbViXcbVkbZ905AIVWhnSo0ZNBC2V127H1/2zP7RvVOVnyITFfBw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/language-core": "2.4.28",
+        "@volar/language-service": "2.4.28",
+        "@volar/typescript": "2.4.28",
+        "path-browserify": "^1.0.1",
+        "request-light": "^0.7.0",
+        "vscode-languageserver": "^9.0.1",
+        "vscode-languageserver-protocol": "^3.17.5",
+        "vscode-languageserver-textdocument": "^1.0.11",
+        "vscode-uri": "^3.0.8"
+      }
+    },
+    "node_modules/@volar/language-service": {
+      "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@volar/language-service/-/language-service-2.4.28.tgz",
+      "integrity": "sha512-Rh/wYCZJrI5vCwMk9xyw/Z+MsWxlJY1rmMZPsxUoJKfzIRjS/NF1NmnuEcrMbEVGja00aVpCsInJfixQTMdvLw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/language-core": "2.4.28",
+        "vscode-languageserver-protocol": "^3.17.5",
+        "vscode-languageserver-textdocument": "^1.0.11",
+        "vscode-uri": "^3.0.8"
+      }
+    },
+    "node_modules/@volar/source-map": {
+      "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-2.4.28.tgz",
+      "integrity": "sha512-yX2BDBqJkRXfKw8my8VarTyjv48QwxdJtvRgUpNE5erCsgEUdI2DsLbpa+rOQVAJYshY99szEcRDmyHbF10ggQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@volar/typescript": {
+      "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-2.4.28.tgz",
+      "integrity": "sha512-Ja6yvWrbis2QtN4ClAKreeUZPVYMARDYZl9LMEv1iQ1QdepB6wn0jTRxA9MftYmYa4DQ4k/DaSZpFPUfxl8giw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/language-core": "2.4.28",
+        "path-browserify": "^1.0.1",
+        "vscode-uri": "^3.0.8"
+      }
+    },
+    "node_modules/@vscode/emmet-helper": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@vscode/emmet-helper/-/emmet-helper-2.11.0.tgz",
+      "integrity": "sha512-QLxjQR3imPZPQltfbWRnHU6JecWTF1QSWhx3GAKQpslx7y3Dp6sIIXhKjiUJ/BR9FX8PVthjr9PD6pNwOJfAzw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emmet": "^2.4.3",
+        "jsonc-parser": "^2.3.0",
+        "vscode-languageserver-textdocument": "^1.0.1",
+        "vscode-languageserver-types": "^3.15.1",
+        "vscode-uri": "^3.0.8"
+      }
+    },
+    "node_modules/@vscode/l10n": {
+      "version": "0.0.18",
+      "resolved": "https://registry.npmjs.org/@vscode/l10n/-/l10n-0.0.18.tgz",
+      "integrity": "sha512-KYSIHVmslkaCDyw013pphY+d7x1qV8IZupYfeIfzNA+nsaWHbn5uPuQRvdRFsa9zFzGeudPuoGoZ1Op4jrJXIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@zxing/library": {
       "version": "0.21.3",
       "resolved": "https://registry.npmjs.org/@zxing/library/-/library-0.21.3.tgz",
@@ -2496,6 +2765,64 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-draft-04": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
+      "integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "ajv": "^8.5.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/anymatch": {
@@ -2791,6 +3118,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/clsx": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
@@ -2808,6 +3150,19 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
       }
     },
     "node_modules/color-name": {
@@ -3705,6 +4060,30 @@
         "node": ">=4"
       }
     },
+    "node_modules/emmet": {
+      "version": "2.4.11",
+      "resolved": "https://registry.npmjs.org/emmet/-/emmet-2.4.11.tgz",
+      "integrity": "sha512-23QPJB3moh/U9sT4rQzGgeyyGIrcM+GH5uVYg2C6wZIxAIJq7Ng3QLT79tl8FUwDXhyq9SusfknOrofAKqvgyQ==",
+      "dev": true,
+      "license": "MIT",
+      "workspaces": [
+        "./packages/scanner",
+        "./packages/abbreviation",
+        "./packages/css-abbreviation",
+        "./"
+      ],
+      "dependencies": {
+        "@emmetio/abbreviation": "^2.3.3",
+        "@emmetio/css-abbreviation": "^2.1.8"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/emoji-regex-xs": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/emoji-regex-xs/-/emoji-regex-xs-2.0.1.tgz",
@@ -3803,6 +4182,16 @@
         "@esbuild/win32-arm64": "0.27.7",
         "@esbuild/win32-ia32": "0.27.7",
         "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/escape-html": {
@@ -3932,6 +4321,13 @@
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "license": "MIT"
     },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fast-string-truncated-width": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz",
@@ -3946,6 +4342,23 @@
       "dependencies": {
         "fast-string-truncated-width": "^3.0.2"
       }
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fast-wrap-ansi": {
       "version": "0.2.0",
@@ -4057,6 +4470,16 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
       }
     },
     "node_modules/github-slugger": {
@@ -4496,6 +4919,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-hexadecimal": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
@@ -4578,6 +5011,20 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsonc-parser": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-2.3.1.tgz",
+      "integrity": "sha512-H8jvkz1O50L3dMZCsLqiuB2tA7muqbSg1AtGEkN0leAqGjsUzDJir3Zwr02BhqdcITPg3ei3mZ+HjMocAknhhg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/katex": {
       "version": "0.16.45",
       "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.45.tgz",
@@ -4607,6 +5054,16 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/khroma/-/khroma-2.1.0.tgz",
       "integrity": "sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw=="
+    },
+    "node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/langium": {
       "version": "4.2.3",
@@ -5840,6 +6297,13 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
+    "node_modules/muggle-string": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/muggle-string/-/muggle-string-0.4.1.tgz",
+      "integrity": "sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/nanoid": {
       "version": "3.3.12",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
@@ -6095,6 +6559,13 @@
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
+    "node_modules/path-browserify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/path-data-parser": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/path-data-parser/-/path-data-parser-0.1.0.tgz",
@@ -6253,6 +6724,22 @@
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "license": "MIT"
+    },
+    "node_modules/prettier": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
     },
     "node_modules/prismjs": {
       "version": "1.30.0",
@@ -6630,6 +7117,33 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/request-light": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/request-light/-/request-light-0.7.0.tgz",
+      "integrity": "sha512-lMbBMrDoxgsyO+yB3sDcrDuX85yYt7sS8BfQd11jtbW/z5ZWgLZRcEGLsLoYw7I0WSUGQBs8CC8ScIxkTX1+6Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/retext": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/retext/-/retext-9.0.0.tgz",
@@ -6943,6 +7457,21 @@
       "integrity": "sha512-TlnjJ1C0QrmxRNrON00JvaFFlNh5TTG00APw23j74ET7gkQpTASi6/L2fuiav8pzK715HXtUeClpBTw2NPSn6w==",
       "license": "MIT"
     },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/string.prototype.codepointat": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/string.prototype.codepointat/-/string.prototype.codepointat-0.2.1.tgz",
@@ -6961,6 +7490,19 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/strnum": {
@@ -7129,6 +7671,13 @@
       "license": "0BSD",
       "optional": true
     },
+    "node_modules/typesafe-path": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/typesafe-path/-/typesafe-path-0.2.2.tgz",
+      "integrity": "sha512-OJabfkAg1WLZSqJAJ0Z6Sdt3utnbzr/jh+NAHoyWHJe8CMSy79Gm085094M9nvTPy22KzTVn5Zq5mbapCI/hPA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -7140,6 +7689,16 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/typescript-auto-import-cache": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/typescript-auto-import-cache/-/typescript-auto-import-cache-0.3.6.tgz",
+      "integrity": "sha512-RpuHXrknHdVdK7wv/8ug3Fr0WNsNi5l5aB8MYYuXhq2UH5lnEB1htJ1smhtD5VeCsGr2p8mUDtd83LCQDFVgjQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.8"
       }
     },
     "node_modules/ufo": {
@@ -7586,6 +8145,199 @@
         }
       }
     },
+    "node_modules/volar-service-css": {
+      "version": "0.0.70",
+      "resolved": "https://registry.npmjs.org/volar-service-css/-/volar-service-css-0.0.70.tgz",
+      "integrity": "sha512-K1qyOvBpE3rzdAv3e4/6Rv5yizrYPy5R/ne3IWCAzLBuMO4qBMV3kSqWzj6KUVe6S0AnN6wxF7cRkiaKfYMYJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "vscode-css-languageservice": "^6.3.0",
+        "vscode-languageserver-textdocument": "^1.0.11",
+        "vscode-uri": "^3.0.8"
+      },
+      "peerDependencies": {
+        "@volar/language-service": "~2.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@volar/language-service": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/volar-service-emmet": {
+      "version": "0.0.70",
+      "resolved": "https://registry.npmjs.org/volar-service-emmet/-/volar-service-emmet-0.0.70.tgz",
+      "integrity": "sha512-xi5bC4m/VyE3zy/n2CXspKeDZs3qA41tHLTw275/7dNWM/RqE2z3BnDICQybHIVp/6G1iOQj5c1qXMgQC08TNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@emmetio/css-parser": "^0.4.1",
+        "@emmetio/html-matcher": "^1.3.0",
+        "@vscode/emmet-helper": "^2.9.3",
+        "vscode-uri": "^3.0.8"
+      },
+      "peerDependencies": {
+        "@volar/language-service": "~2.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@volar/language-service": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/volar-service-html": {
+      "version": "0.0.70",
+      "resolved": "https://registry.npmjs.org/volar-service-html/-/volar-service-html-0.0.70.tgz",
+      "integrity": "sha512-eR6vCgMdmYAo4n+gcT7DSyBQbwB8S3HZZvSagTf0sxNaD4WppMCFfpqWnkrlGStPKMZvMiejRRVmqsX9dYcTvQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "vscode-html-languageservice": "^5.3.0",
+        "vscode-languageserver-textdocument": "^1.0.11",
+        "vscode-uri": "^3.0.8"
+      },
+      "peerDependencies": {
+        "@volar/language-service": "~2.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@volar/language-service": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/volar-service-prettier": {
+      "version": "0.0.70",
+      "resolved": "https://registry.npmjs.org/volar-service-prettier/-/volar-service-prettier-0.0.70.tgz",
+      "integrity": "sha512-Z6BCFSpGVCd8BPAsZ785Kce1BGlWd5ODqmqZGVuB14MJvrR4+CYz6cDy4F+igmE1gMifqfvMhdgT8Aud4M5ngg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "vscode-uri": "^3.0.8"
+      },
+      "peerDependencies": {
+        "@volar/language-service": "~2.4.0",
+        "prettier": "^2.2 || ^3.0"
+      },
+      "peerDependenciesMeta": {
+        "@volar/language-service": {
+          "optional": true
+        },
+        "prettier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/volar-service-typescript": {
+      "version": "0.0.70",
+      "resolved": "https://registry.npmjs.org/volar-service-typescript/-/volar-service-typescript-0.0.70.tgz",
+      "integrity": "sha512-l46Bx4cokkUedTd74ojO5H/zqHZJ8SUuyZ0IB8JN4jfRqUM3bQFBHoOwlZCyZmOeO0A3RQNkMnFclxO4c++gsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-browserify": "^1.0.1",
+        "semver": "^7.6.2",
+        "typescript-auto-import-cache": "^0.3.5",
+        "vscode-languageserver-textdocument": "^1.0.11",
+        "vscode-nls": "^5.2.0",
+        "vscode-uri": "^3.0.8"
+      },
+      "peerDependencies": {
+        "@volar/language-service": "~2.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@volar/language-service": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/volar-service-typescript-twoslash-queries": {
+      "version": "0.0.70",
+      "resolved": "https://registry.npmjs.org/volar-service-typescript-twoslash-queries/-/volar-service-typescript-twoslash-queries-0.0.70.tgz",
+      "integrity": "sha512-IdD13Z9N2Bu8EM6CM0fDV1E69olEYGHDU25X51YXmq8Y0CmJ2LNj6gOiBJgpS5JGUqFzECVhMNBW7R0sPdRTMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "vscode-uri": "^3.0.8"
+      },
+      "peerDependencies": {
+        "@volar/language-service": "~2.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@volar/language-service": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/volar-service-yaml": {
+      "version": "0.0.70",
+      "resolved": "https://registry.npmjs.org/volar-service-yaml/-/volar-service-yaml-0.0.70.tgz",
+      "integrity": "sha512-0c8bXDBeoATF9F6iPIlOuYTuZAC4c+yi0siQo920u7eiBJk8oQmUmg9cDUbR4+Gl++bvGP4plj3fErbJuPqdcQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "vscode-uri": "^3.0.8",
+        "yaml-language-server": "~1.20.0"
+      },
+      "peerDependencies": {
+        "@volar/language-service": "~2.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@volar/language-service": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vscode-css-languageservice": {
+      "version": "6.3.10",
+      "resolved": "https://registry.npmjs.org/vscode-css-languageservice/-/vscode-css-languageservice-6.3.10.tgz",
+      "integrity": "sha512-eq5N9Er3fC4vA9zd9EFhyBG90wtCCuXgRSpAndaOgXMh1Wgep5lBgRIeDgjZBW9pa+332yC9+49cZMW8jcL3MA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vscode/l10n": "^0.0.18",
+        "vscode-languageserver-textdocument": "^1.0.12",
+        "vscode-languageserver-types": "3.17.5",
+        "vscode-uri": "^3.1.0"
+      }
+    },
+    "node_modules/vscode-html-languageservice": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/vscode-html-languageservice/-/vscode-html-languageservice-5.6.2.tgz",
+      "integrity": "sha512-ulCrSnFnfQ16YzvwnYUgEbUEl/ZG7u2eV27YhvLObSHKkb8fw1Z9cgsnUwjTEeDIdJDoTDTDpxuhQwoenoLNMg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vscode/l10n": "^0.0.18",
+        "vscode-languageserver-textdocument": "^1.0.12",
+        "vscode-languageserver-types": "^3.17.5",
+        "vscode-uri": "^3.1.0"
+      }
+    },
+    "node_modules/vscode-json-languageservice": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/vscode-json-languageservice/-/vscode-json-languageservice-4.1.8.tgz",
+      "integrity": "sha512-0vSpg6Xd9hfV+eZAaYN63xVVMOTmJ4GgHxXnkLCh+9RsQBkWKIghzLhW2B9ebfG+LQQg8uLtsQ2aUKjTgE+QOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jsonc-parser": "^3.0.0",
+        "vscode-languageserver-textdocument": "^1.0.1",
+        "vscode-languageserver-types": "^3.16.0",
+        "vscode-nls": "^5.0.0",
+        "vscode-uri": "^3.0.2"
+      },
+      "engines": {
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/vscode-json-languageservice/node_modules/jsonc-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+      "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/vscode-jsonrpc": {
       "version": "8.2.0",
       "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
@@ -7629,6 +8381,13 @@
       "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
       "license": "MIT"
     },
+    "node_modules/vscode-nls": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-nls/-/vscode-nls-5.2.0.tgz",
+      "integrity": "sha512-RAaHx7B14ZU04EU31pT+rKz2/zSl7xMsfIZuo8pd+KZO6PXtQmpevpq3vxvWNcrGbdmhM/rr5Uw5Mz+NBfhVng==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/vscode-uri": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
@@ -7654,11 +8413,117 @@
         "node": ">=4"
       }
     },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/xxhash-wasm": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/xxhash-wasm/-/xxhash-wasm-1.1.0.tgz",
       "integrity": "sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA==",
       "license": "MIT"
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "devOptional": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/yaml-language-server": {
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/yaml-language-server/-/yaml-language-server-1.20.0.tgz",
+      "integrity": "sha512-qhjK/bzSRZ6HtTvgeFvjNPJGWdZ0+x5NREV/9XZWFjIGezew2b4r5JPy66IfOhd5OA7KeFwk1JfmEbnTvev0cA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vscode/l10n": "^0.0.18",
+        "ajv": "^8.17.1",
+        "ajv-draft-04": "^1.0.0",
+        "prettier": "^3.5.0",
+        "request-light": "^0.5.7",
+        "vscode-json-languageservice": "4.1.8",
+        "vscode-languageserver": "^9.0.0",
+        "vscode-languageserver-textdocument": "^1.0.1",
+        "vscode-languageserver-types": "^3.16.0",
+        "vscode-uri": "^3.0.2",
+        "yaml": "2.7.1"
+      },
+      "bin": {
+        "yaml-language-server": "bin/yaml-language-server"
+      }
+    },
+    "node_modules/yaml-language-server/node_modules/request-light": {
+      "version": "0.5.8",
+      "resolved": "https://registry.npmjs.org/request-light/-/request-light-0.5.8.tgz",
+      "integrity": "sha512-3Zjgh+8b5fhRJBQZoy+zbVKpAQGLyka0MPgW3zruTF4dFFJ8Fqcfu9YsAvi/rvdcaTeWG3MkbZv4WKxAn/84Lg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/yaml-language-server/node_modules/yaml": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.1.tgz",
+      "integrity": "sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/yargs-parser": {
       "version": "22.0.0",
@@ -7667,6 +8532,16 @@
       "license": "ISC",
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/yargs/node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "typescript": "^5.9.3"
   },
   "devDependencies": {
+    "@astrojs/check": "^0.9.9",
     "playwright": "^1.60.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
     "node": ">=22.12.0"
   },
   "scripts": {
-    "prebuild": "node scripts/copy-katex.mjs",
-    "predev": "node scripts/copy-katex.mjs",
+    "prebuild": "node scripts/copy-katex.mjs && node scripts/generate-translation-pairs.mjs",
+    "predev": "node scripts/copy-katex.mjs && node scripts/generate-translation-pairs.mjs",
     "dev": "astro dev",
     "build": "astro build && pagefind --site dist",
     "preview": "astro preview",

--- a/scripts/generate-translation-pairs.mjs
+++ b/scripts/generate-translation-pairs.mjs
@@ -21,7 +21,7 @@ for (const file of files) {
   const fm = match[1];
 
   const get = (key) => {
-    const m = fm.match(new RegExp(`^${key}:\\s*(.+)$`, 'm'));
+    const m = fm.match(new RegExp(`^${key}:\\s*([^\r\n]+)$`, 'm'));
     return m ? m[1].trim() : undefined;
   };
 

--- a/scripts/generate-translation-pairs.mjs
+++ b/scripts/generate-translation-pairs.mjs
@@ -1,10 +1,11 @@
 // Scans src/content/blog/*.md frontmatter and emits
 // src/generated/blog-translation-pairs.json — a bidirectional map
-// { "/blog/en-slug/": { en: "/blog/en-slug/", pt: "/blog/pt-slug/" }, ... }
+// { "/blog/slug/": { en: "/blog/en-slug/", pt: "/blog/pt-slug/" } }
 // Used by astro.config.mjs to inject hreflang links into the sitemap.
 import { readFileSync, readdirSync, writeFileSync, mkdirSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { DEFAULT_LANG, LANG_META } from '../src/lib/languages.mjs';
 
 const __dir = dirname(fileURLToPath(import.meta.url));
 const blogDir = join(__dir, '../src/content/blog');
@@ -30,31 +31,31 @@ for (const file of files) {
   const key = get('translationKey');
   if (!key) continue;
 
-  const lang = get('lang') ?? 'en';
+  const lang = get('lang') ?? DEFAULT_LANG;
   const id = file.replace(/\.md$/, '');
   posts.push({ id, lang, key });
 }
 
-// Group by translationKey
+// Group by translationKey → { [lang]: "/blog/slug/" }
 const grouped = {};
 for (const p of posts) {
   if (!grouped[p.key]) grouped[p.key] = {};
   grouped[p.key][p.lang] = `/blog/${p.id}/`;
 }
 
-// Build bidirectional lookup: each URL maps to { en, pt } pair
+// Build bidirectional lookup: each URL maps to the full { [lang]: url } pair.
+// Emit only groups where at least two languages are present.
 const pairs = {};
-for (const langs of Object.values(grouped)) {
-  const en = langs['en'];
-  const pt = langs['pt'];
-  if (en && pt) {
-    pairs[en] = { en, pt };
-    pairs[pt] = { en, pt };
+for (const langUrls of Object.values(grouped)) {
+  const langs = Object.keys(langUrls);
+  if (langs.length < 2) continue;
+  for (const lang of langs) {
+    pairs[langUrls[lang]] = langUrls;
   }
 }
 
 mkdirSync(outDir, { recursive: true });
 writeFileSync(outFile, JSON.stringify(pairs, null, 2) + '\n');
 
-const count = Object.keys(pairs).length / 2;
-console.log(`✔ blog-translation-pairs.json: ${count} pairs`);
+const count = new Set(Object.values(pairs)).size;
+console.log(`✔ blog-translation-pairs.json: ${count} pairs across ${Object.keys(LANG_META).join(', ')}`);

--- a/scripts/generate-translation-pairs.mjs
+++ b/scripts/generate-translation-pairs.mjs
@@ -1,0 +1,60 @@
+// Scans src/content/blog/*.md frontmatter and emits
+// src/generated/blog-translation-pairs.json — a bidirectional map
+// { "/blog/en-slug/": { en: "/blog/en-slug/", pt: "/blog/pt-slug/" }, ... }
+// Used by astro.config.mjs to inject hreflang links into the sitemap.
+import { readFileSync, readdirSync, writeFileSync, mkdirSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dir = dirname(fileURLToPath(import.meta.url));
+const blogDir = join(__dir, '../src/content/blog');
+const outDir = join(__dir, '../src/generated');
+const outFile = join(outDir, 'blog-translation-pairs.json');
+
+const files = readdirSync(blogDir).filter((f) => f.endsWith('.md'));
+
+const posts = [];
+for (const file of files) {
+  const raw = readFileSync(join(blogDir, file), 'utf-8');
+  const match = raw.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (!match) continue;
+  const fm = match[1];
+
+  const get = (key) => {
+    const m = fm.match(new RegExp(`^${key}:\\s*(.+)$`, 'm'));
+    return m ? m[1].trim() : undefined;
+  };
+
+  if (get('draft') === 'true') continue;
+
+  const key = get('translationKey');
+  if (!key) continue;
+
+  const lang = get('lang') ?? 'en';
+  const id = file.replace(/\.md$/, '');
+  posts.push({ id, lang, key });
+}
+
+// Group by translationKey
+const grouped = {};
+for (const p of posts) {
+  if (!grouped[p.key]) grouped[p.key] = {};
+  grouped[p.key][p.lang] = `/blog/${p.id}/`;
+}
+
+// Build bidirectional lookup: each URL maps to { en, pt } pair
+const pairs = {};
+for (const langs of Object.values(grouped)) {
+  const en = langs['en'];
+  const pt = langs['pt'];
+  if (en && pt) {
+    pairs[en] = { en, pt };
+    pairs[pt] = { en, pt };
+  }
+}
+
+mkdirSync(outDir, { recursive: true });
+writeFileSync(outFile, JSON.stringify(pairs, null, 2) + '\n');
+
+const count = Object.keys(pairs).length / 2;
+console.log(`✔ blog-translation-pairs.json: ${count} pairs`);

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,5 +1,10 @@
 ---
+interface Props {
+  lang?: string;
+}
+const { lang = 'en' } = Astro.props;
 const year = new Date().getFullYear();
+const rssHref = lang === 'pt' ? '/pt/rss.xml' : '/rss.xml';
 ---
 
 <footer class="container">
@@ -9,7 +14,7 @@ const year = new Date().getFullYear();
       <li><small>© {year} Franklin Baldo</small></li>
     </ul>
     <ul>
-      <li><small><a href="/rss.xml">RSS</a></small></li>
+      <li><small><a href={rssHref}>RSS</a></small></li>
       <li><small><a href="https://github.com/franklinbaldo" rel="me">GitHub</a></small></li>
     </ul>
   </nav>

--- a/src/generated/blog-translation-pairs.json
+++ b/src/generated/blog-translation-pairs.json
@@ -1,0 +1,250 @@
+{
+  "/blog/2026-02-26-everything-is-a-process-5-lessons-we-should-have-learned-2500-years-ago/": {
+    "en": "/blog/2026-02-26-everything-is-a-process-5-lessons-we-should-have-learned-2500-years-ago/",
+    "pt": "/blog/2026-02-26-tudo-e-processo/"
+  },
+  "/blog/2026-02-26-tudo-e-processo/": {
+    "en": "/blog/2026-02-26-everything-is-a-process-5-lessons-we-should-have-learned-2500-years-ago/",
+    "pt": "/blog/2026-02-26-tudo-e-processo/"
+  },
+  "/blog/2026-03-02-travessia-the-project-that-writes-itself/": {
+    "en": "/blog/2026-03-02-travessia-the-project-that-writes-itself/",
+    "pt": "/blog/2026-03-02-travessia/"
+  },
+  "/blog/2026-03-02-travessia/": {
+    "en": "/blog/2026-03-02-travessia-the-project-that-writes-itself/",
+    "pt": "/blog/2026-03-02-travessia/"
+  },
+  "/blog/2026-03-17-crossing-after-interference/": {
+    "en": "/blog/2026-03-17-crossing-after-interference/",
+    "pt": "/blog/2026-03-17-travessia-update/"
+  },
+  "/blog/2026-03-17-travessia-update/": {
+    "en": "/blog/2026-03-17-crossing-after-interference/",
+    "pt": "/blog/2026-03-17-travessia-update/"
+  },
+  "/blog/2026-03-18-verne-identity-repo/": {
+    "en": "/blog/2026-03-18-verne-identity-repo/",
+    "pt": "/blog/2026-03-18-verne-e-o-padro-identity-repo-como-os-agentes-de-ia-se-lembram/"
+  },
+  "/blog/2026-03-18-verne-e-o-padro-identity-repo-como-os-agentes-de-ia-se-lembram/": {
+    "en": "/blog/2026-03-18-verne-identity-repo/",
+    "pt": "/blog/2026-03-18-verne-e-o-padro-identity-repo-como-os-agentes-de-ia-se-lembram/"
+  },
+  "/blog/2026-03-21-we-are-all-becoming-lobsters/": {
+    "en": "/blog/2026-03-21-we-are-all-becoming-lobsters/",
+    "pt": "/blog/2026-03-21-estamos-todos-nos-tornando-lagostas/"
+  },
+  "/blog/2026-03-21-estamos-todos-nos-tornando-lagostas/": {
+    "en": "/blog/2026-03-21-we-are-all-becoming-lobsters/",
+    "pt": "/blog/2026-03-21-estamos-todos-nos-tornando-lagostas/"
+  },
+  "/blog/2026-03-22-reddit-submarine-osint/": {
+    "en": "/blog/2026-03-22-reddit-submarine-osint/",
+    "pt": "/blog/2026-03-22-eles-esto-realmente-usando-uma-postagem-do-reddit-para-ajudar-a-bombardear-um-submarino-no-ir/"
+  },
+  "/blog/2026-03-22-eles-esto-realmente-usando-uma-postagem-do-reddit-para-ajudar-a-bombardear-um-submarino-no-ir/": {
+    "en": "/blog/2026-03-22-reddit-submarine-osint/",
+    "pt": "/blog/2026-03-22-eles-esto-realmente-usando-uma-postagem-do-reddit-para-ajudar-a-bombardear-um-submarino-no-ir/"
+  },
+  "/blog/2026-03-22-the-future-father-building-a-transmedia-novel-with-ai-agents/": {
+    "en": "/blog/2026-03-22-the-future-father-building-a-transmedia-novel-with-ai-agents/",
+    "pt": "/blog/2026-03-22-o-pai-do-futuro/"
+  },
+  "/blog/2026-03-22-o-pai-do-futuro/": {
+    "en": "/blog/2026-03-22-the-future-father-building-a-transmedia-novel-with-ai-agents/",
+    "pt": "/blog/2026-03-22-o-pai-do-futuro/"
+  },
+  "/blog/2026-03-28-the-art-of-delegation/": {
+    "en": "/blog/2026-03-28-the-art-of-delegation/",
+    "pt": "/blog/2026-03-28-delegando-para-agentes/"
+  },
+  "/blog/2026-03-28-delegando-para-agentes/": {
+    "en": "/blog/2026-03-28-the-art-of-delegation/",
+    "pt": "/blog/2026-03-28-delegando-para-agentes/"
+  },
+  "/blog/2026-04-04-hermes-agent-vs-openclaw-why-my-experience-got-so-much-better/": {
+    "en": "/blog/2026-04-04-hermes-agent-vs-openclaw-why-my-experience-got-so-much-better/",
+    "pt": "/blog/2026-04-04-hermes-vs-openclaw/"
+  },
+  "/blog/2026-04-04-hermes-vs-openclaw/": {
+    "en": "/blog/2026-04-04-hermes-agent-vs-openclaw-why-my-experience-got-so-much-better/",
+    "pt": "/blog/2026-04-04-hermes-vs-openclaw/"
+  },
+  "/blog/2026-04-29-reclaiming-the-harness/": {
+    "en": "/blog/2026-04-29-reclaiming-the-harness/",
+    "pt": "/blog/2026-04-29-recuperando-o-harness/"
+  },
+  "/blog/2026-04-29-recuperando-o-harness/": {
+    "en": "/blog/2026-04-29-reclaiming-the-harness/",
+    "pt": "/blog/2026-04-29-recuperando-o-harness/"
+  },
+  "/blog/2026-05-01-the-third-half-and-the-fourth-wall/": {
+    "en": "/blog/2026-05-01-the-third-half-and-the-fourth-wall/",
+    "pt": "/blog/2026-05-01-a-terceira-metade-e-a-quarta-parede/"
+  },
+  "/blog/2026-05-01-a-terceira-metade-e-a-quarta-parede/": {
+    "en": "/blog/2026-05-01-the-third-half-and-the-fourth-wall/",
+    "pt": "/blog/2026-05-01-a-terceira-metade-e-a-quarta-parede/"
+  },
+  "/blog/2026-05-04-the-three-imperatives-at-delphi/": {
+    "en": "/blog/2026-05-04-the-three-imperatives-at-delphi/",
+    "pt": "/blog/os-tres-imperativos-em-delfos/"
+  },
+  "/blog/os-tres-imperativos-em-delfos/": {
+    "en": "/blog/2026-05-04-the-three-imperatives-at-delphi/",
+    "pt": "/blog/os-tres-imperativos-em-delfos/"
+  },
+  "/blog/2026-05-10-jules-api-harness-backend/": {
+    "en": "/blog/2026-05-10-jules-api-harness-backend/",
+    "pt": "/blog/2026-05-10-a-api-do-jules-como-backend-do-harness/"
+  },
+  "/blog/2026-05-10-a-api-do-jules-como-backend-do-harness/": {
+    "en": "/blog/2026-05-10-jules-api-harness-backend/",
+    "pt": "/blog/2026-05-10-a-api-do-jules-como-backend-do-harness/"
+  },
+  "/blog/2026-05-10-the-serpents-egg/": {
+    "en": "/blog/2026-05-10-the-serpents-egg/",
+    "pt": "/blog/o-ovo-de-serpente/"
+  },
+  "/blog/o-ovo-de-serpente/": {
+    "en": "/blog/2026-05-10-the-serpents-egg/",
+    "pt": "/blog/o-ovo-de-serpente/"
+  },
+  "/blog/2026-05-14-the-agent-that-doesnt-invent-verbs/": {
+    "en": "/blog/2026-05-14-the-agent-that-doesnt-invent-verbs/",
+    "pt": "/blog/2026-05-14-o-agente-que-nao-inventa-verbos/"
+  },
+  "/blog/2026-05-14-o-agente-que-nao-inventa-verbos/": {
+    "en": "/blog/2026-05-14-the-agent-that-doesnt-invent-verbs/",
+    "pt": "/blog/2026-05-14-o-agente-que-nao-inventa-verbos/"
+  },
+  "/blog/2026-05-14-pierre-menard-computational-researcher/": {
+    "en": "/blog/2026-05-14-pierre-menard-computational-researcher/",
+    "pt": "/blog/pierre-menard-pesquisador-computacional/"
+  },
+  "/blog/pierre-menard-pesquisador-computacional/": {
+    "en": "/blog/2026-05-14-pierre-menard-computational-researcher/",
+    "pt": "/blog/pierre-menard-pesquisador-computacional/"
+  },
+  "/blog/2026-05-15-who-the-asterisk-protects/": {
+    "en": "/blog/2026-05-15-who-the-asterisk-protects/",
+    "pt": "/blog/2026-05-15-quem-o-asterisco-protege/"
+  },
+  "/blog/2026-05-15-quem-o-asterisco-protege/": {
+    "en": "/blog/2026-05-15-who-the-asterisk-protects/",
+    "pt": "/blog/2026-05-15-quem-o-asterisco-protege/"
+  },
+  "/blog/2026-05-15-three-hammers-walk-into-a-bar/": {
+    "en": "/blog/2026-05-15-three-hammers-walk-into-a-bar/",
+    "pt": "/blog/2026-05-15-tres-martelos-entram-num-bar/"
+  },
+  "/blog/2026-05-15-tres-martelos-entram-num-bar/": {
+    "en": "/blog/2026-05-15-three-hammers-walk-into-a-bar/",
+    "pt": "/blog/2026-05-15-tres-martelos-entram-num-bar/"
+  },
+  "/blog/will-ai-discover-new-conservation-law-before-2050/": {
+    "en": "/blog/will-ai-discover-new-conservation-law-before-2050/",
+    "pt": "/blog/a-ia-descobrir-uma-nova-lei-de-conservao-antes-de-2050/"
+  },
+  "/blog/a-ia-descobrir-uma-nova-lei-de-conservao-antes-de-2050/": {
+    "en": "/blog/will-ai-discover-new-conservation-law-before-2050/",
+    "pt": "/blog/a-ia-descobrir-uma-nova-lei-de-conservao-antes-de-2050/"
+  },
+  "/blog/the-digital-twin-sound-showcase/": {
+    "en": "/blog/the-digital-twin-sound-showcase/",
+    "pt": "/blog/a-vitrine-sonora-do-gemeo-digital/"
+  },
+  "/blog/a-vitrine-sonora-do-gemeo-digital/": {
+    "en": "/blog/the-digital-twin-sound-showcase/",
+    "pt": "/blog/a-vitrine-sonora-do-gemeo-digital/"
+  },
+  "/blog/building-funes/": {
+    "en": "/blog/building-funes/",
+    "pt": "/blog/construindo-funes-como-dei-uma-alma-a-um-agente-de-ia/"
+  },
+  "/blog/construindo-funes-como-dei-uma-alma-a-um-agente-de-ia/": {
+    "en": "/blog/building-funes/",
+    "pt": "/blog/construindo-funes-como-dei-uma-alma-a-um-agente-de-ia/"
+  },
+  "/blog/conceptual-document-the-chronicle-of-franklin-baldo/": {
+    "en": "/blog/conceptual-document-the-chronicle-of-franklin-baldo/",
+    "pt": "/blog/documento-conceitual-a-cronica-de-franklin-baldo/"
+  },
+  "/blog/documento-conceitual-a-cronica-de-franklin-baldo/": {
+    "en": "/blog/conceptual-document-the-chronicle-of-franklin-baldo/",
+    "pt": "/blog/documento-conceitual-a-cronica-de-franklin-baldo/"
+  },
+  "/blog/funes-soul/": {
+    "en": "/blog/funes-soul/",
+    "pt": "/blog/soulmd-funes/"
+  },
+  "/blog/soulmd-funes/": {
+    "en": "/blog/funes-soul/",
+    "pt": "/blog/soulmd-funes/"
+  },
+  "/blog/pontifex-architecture-implementation-guide/": {
+    "en": "/blog/pontifex-architecture-implementation-guide/",
+    "pt": "/blog/guia-de-implementao-da-arquitetura-pontifex/"
+  },
+  "/blog/guia-de-implementao-da-arquitetura-pontifex/": {
+    "en": "/blog/pontifex-architecture-implementation-guide/",
+    "pt": "/blog/guia-de-implementao-da-arquitetura-pontifex/"
+  },
+  "/blog/inaugural-post-a-glimpse-inside-my-mind/": {
+    "en": "/blog/inaugural-post-a-glimpse-inside-my-mind/",
+    "pt": "/blog/postagem-inaugural-um-vislumbre-da-minha-mente/"
+  },
+  "/blog/postagem-inaugural-um-vislumbre-da-minha-mente/": {
+    "en": "/blog/inaugural-post-a-glimpse-inside-my-mind/",
+    "pt": "/blog/postagem-inaugural-um-vislumbre-da-minha-mente/"
+  },
+  "/blog/rosencrantz-coin/": {
+    "en": "/blog/rosencrantz-coin/",
+    "pt": "/blog/moeda-rosencrantz-testando-se-os-llms-respeitam-a-probabilidade/"
+  },
+  "/blog/moeda-rosencrantz-testando-se-os-llms-respeitam-a-probabilidade/": {
+    "en": "/blog/rosencrantz-coin/",
+    "pt": "/blog/moeda-rosencrantz-testando-se-os-llms-respeitam-a-probabilidade/"
+  },
+  "/blog/the-pampa-on-the-circuit-a-mate-with-boswell-digital/": {
+    "en": "/blog/the-pampa-on-the-circuit-a-mate-with-boswell-digital/",
+    "pt": "/blog/o-pampa-no-circuito-um-mate-com-o-boswell-digital/"
+  },
+  "/blog/o-pampa-no-circuito-um-mate-com-o-boswell-digital/": {
+    "en": "/blog/the-pampa-on-the-circuit-a-mate-with-boswell-digital/",
+    "pt": "/blog/o-pampa-no-circuito-um-mate-com-o-boswell-digital/"
+  },
+  "/blog/the-intelligible-void-hassabis-and-events/": {
+    "en": "/blog/the-intelligible-void-hassabis-and-events/",
+    "pt": "/blog/o-vazio-inteligvel-sobre-hassabis-silcio-e-eventos-at-o-fim/"
+  },
+  "/blog/o-vazio-inteligvel-sobre-hassabis-silcio-e-eventos-at-o-fim/": {
+    "en": "/blog/the-intelligible-void-hassabis-and-events/",
+    "pt": "/blog/o-vazio-inteligvel-sobre-hassabis-silcio-e-eventos-at-o-fim/"
+  },
+  "/blog/what-i-learned-orchestrating-ai-agents-to-preserve-family-memory/": {
+    "en": "/blog/what-i-learned-orchestrating-ai-agents-to-preserve-family-memory/",
+    "pt": "/blog/orquestrando-agentes-memoria-familiar/"
+  },
+  "/blog/orquestrando-agentes-memoria-familiar/": {
+    "en": "/blog/what-i-learned-orchestrating-ai-agents-to-preserve-family-memory/",
+    "pt": "/blog/orquestrando-agentes-memoria-familiar/"
+  },
+  "/blog/patents-for-social-vulnerabilities/": {
+    "en": "/blog/patents-for-social-vulnerabilities/",
+    "pt": "/blog/patentes-para-vulnerabilidades-sociais-uma-proposta-modesta-para-transformar-criminosos-em-consultores/"
+  },
+  "/blog/patentes-para-vulnerabilidades-sociais-uma-proposta-modesta-para-transformar-criminosos-em-consultores/": {
+    "en": "/blog/patents-for-social-vulnerabilities/",
+    "pt": "/blog/patentes-para-vulnerabilidades-sociais-uma-proposta-modesta-para-transformar-criminosos-em-consultores/"
+  },
+  "/blog/pontifex-novel-architecture-semantic-probing/": {
+    "en": "/blog/pontifex-novel-architecture-semantic-probing/",
+    "pt": "/blog/pontifex-uma-nova-arquitetura-para-investigao-semntica/"
+  },
+  "/blog/pontifex-uma-nova-arquitetura-para-investigao-semntica/": {
+    "en": "/blog/pontifex-novel-architecture-semantic-probing/",
+    "pt": "/blog/pontifex-uma-nova-arquitetura-para-investigao-semntica/"
+  }
+}

--- a/src/generated/blog-translation-pairs.json
+++ b/src/generated/blog-translation-pairs.json
@@ -23,45 +23,45 @@
     "en": "/blog/2026-03-17-crossing-after-interference/",
     "pt": "/blog/2026-03-17-travessia-update/"
   },
-  "/blog/2026-03-18-verne-identity-repo/": {
-    "en": "/blog/2026-03-18-verne-identity-repo/",
-    "pt": "/blog/2026-03-18-verne-e-o-padro-identity-repo-como-os-agentes-de-ia-se-lembram/"
-  },
   "/blog/2026-03-18-verne-e-o-padro-identity-repo-como-os-agentes-de-ia-se-lembram/": {
-    "en": "/blog/2026-03-18-verne-identity-repo/",
-    "pt": "/blog/2026-03-18-verne-e-o-padro-identity-repo-como-os-agentes-de-ia-se-lembram/"
+    "pt": "/blog/2026-03-18-verne-e-o-padro-identity-repo-como-os-agentes-de-ia-se-lembram/",
+    "en": "/blog/2026-03-18-verne-identity-repo/"
   },
-  "/blog/2026-03-21-we-are-all-becoming-lobsters/": {
-    "en": "/blog/2026-03-21-we-are-all-becoming-lobsters/",
-    "pt": "/blog/2026-03-21-estamos-todos-nos-tornando-lagostas/"
+  "/blog/2026-03-18-verne-identity-repo/": {
+    "pt": "/blog/2026-03-18-verne-e-o-padro-identity-repo-como-os-agentes-de-ia-se-lembram/",
+    "en": "/blog/2026-03-18-verne-identity-repo/"
   },
   "/blog/2026-03-21-estamos-todos-nos-tornando-lagostas/": {
-    "en": "/blog/2026-03-21-we-are-all-becoming-lobsters/",
-    "pt": "/blog/2026-03-21-estamos-todos-nos-tornando-lagostas/"
+    "pt": "/blog/2026-03-21-estamos-todos-nos-tornando-lagostas/",
+    "en": "/blog/2026-03-21-we-are-all-becoming-lobsters/"
   },
-  "/blog/2026-03-22-reddit-submarine-osint/": {
-    "en": "/blog/2026-03-22-reddit-submarine-osint/",
-    "pt": "/blog/2026-03-22-eles-esto-realmente-usando-uma-postagem-do-reddit-para-ajudar-a-bombardear-um-submarino-no-ir/"
+  "/blog/2026-03-21-we-are-all-becoming-lobsters/": {
+    "pt": "/blog/2026-03-21-estamos-todos-nos-tornando-lagostas/",
+    "en": "/blog/2026-03-21-we-are-all-becoming-lobsters/"
   },
   "/blog/2026-03-22-eles-esto-realmente-usando-uma-postagem-do-reddit-para-ajudar-a-bombardear-um-submarino-no-ir/": {
-    "en": "/blog/2026-03-22-reddit-submarine-osint/",
-    "pt": "/blog/2026-03-22-eles-esto-realmente-usando-uma-postagem-do-reddit-para-ajudar-a-bombardear-um-submarino-no-ir/"
+    "pt": "/blog/2026-03-22-eles-esto-realmente-usando-uma-postagem-do-reddit-para-ajudar-a-bombardear-um-submarino-no-ir/",
+    "en": "/blog/2026-03-22-reddit-submarine-osint/"
   },
-  "/blog/2026-03-22-the-future-father-building-a-transmedia-novel-with-ai-agents/": {
-    "en": "/blog/2026-03-22-the-future-father-building-a-transmedia-novel-with-ai-agents/",
-    "pt": "/blog/2026-03-22-o-pai-do-futuro/"
+  "/blog/2026-03-22-reddit-submarine-osint/": {
+    "pt": "/blog/2026-03-22-eles-esto-realmente-usando-uma-postagem-do-reddit-para-ajudar-a-bombardear-um-submarino-no-ir/",
+    "en": "/blog/2026-03-22-reddit-submarine-osint/"
   },
   "/blog/2026-03-22-o-pai-do-futuro/": {
-    "en": "/blog/2026-03-22-the-future-father-building-a-transmedia-novel-with-ai-agents/",
-    "pt": "/blog/2026-03-22-o-pai-do-futuro/"
+    "pt": "/blog/2026-03-22-o-pai-do-futuro/",
+    "en": "/blog/2026-03-22-the-future-father-building-a-transmedia-novel-with-ai-agents/"
   },
-  "/blog/2026-03-28-the-art-of-delegation/": {
-    "en": "/blog/2026-03-28-the-art-of-delegation/",
-    "pt": "/blog/2026-03-28-delegando-para-agentes/"
+  "/blog/2026-03-22-the-future-father-building-a-transmedia-novel-with-ai-agents/": {
+    "pt": "/blog/2026-03-22-o-pai-do-futuro/",
+    "en": "/blog/2026-03-22-the-future-father-building-a-transmedia-novel-with-ai-agents/"
   },
   "/blog/2026-03-28-delegando-para-agentes/": {
-    "en": "/blog/2026-03-28-the-art-of-delegation/",
-    "pt": "/blog/2026-03-28-delegando-para-agentes/"
+    "pt": "/blog/2026-03-28-delegando-para-agentes/",
+    "en": "/blog/2026-03-28-the-art-of-delegation/"
+  },
+  "/blog/2026-03-28-the-art-of-delegation/": {
+    "pt": "/blog/2026-03-28-delegando-para-agentes/",
+    "en": "/blog/2026-03-28-the-art-of-delegation/"
   },
   "/blog/2026-04-04-hermes-agent-vs-openclaw-why-my-experience-got-so-much-better/": {
     "en": "/blog/2026-04-04-hermes-agent-vs-openclaw-why-my-experience-got-so-much-better/",
@@ -79,13 +79,13 @@
     "en": "/blog/2026-04-29-reclaiming-the-harness/",
     "pt": "/blog/2026-04-29-recuperando-o-harness/"
   },
-  "/blog/2026-05-01-the-third-half-and-the-fourth-wall/": {
-    "en": "/blog/2026-05-01-the-third-half-and-the-fourth-wall/",
-    "pt": "/blog/2026-05-01-a-terceira-metade-e-a-quarta-parede/"
-  },
   "/blog/2026-05-01-a-terceira-metade-e-a-quarta-parede/": {
-    "en": "/blog/2026-05-01-the-third-half-and-the-fourth-wall/",
-    "pt": "/blog/2026-05-01-a-terceira-metade-e-a-quarta-parede/"
+    "pt": "/blog/2026-05-01-a-terceira-metade-e-a-quarta-parede/",
+    "en": "/blog/2026-05-01-the-third-half-and-the-fourth-wall/"
+  },
+  "/blog/2026-05-01-the-third-half-and-the-fourth-wall/": {
+    "pt": "/blog/2026-05-01-a-terceira-metade-e-a-quarta-parede/",
+    "en": "/blog/2026-05-01-the-third-half-and-the-fourth-wall/"
   },
   "/blog/2026-05-04-the-three-imperatives-at-delphi/": {
     "en": "/blog/2026-05-04-the-three-imperatives-at-delphi/",
@@ -95,13 +95,13 @@
     "en": "/blog/2026-05-04-the-three-imperatives-at-delphi/",
     "pt": "/blog/os-tres-imperativos-em-delfos/"
   },
-  "/blog/2026-05-10-jules-api-harness-backend/": {
-    "en": "/blog/2026-05-10-jules-api-harness-backend/",
-    "pt": "/blog/2026-05-10-a-api-do-jules-como-backend-do-harness/"
-  },
   "/blog/2026-05-10-a-api-do-jules-como-backend-do-harness/": {
-    "en": "/blog/2026-05-10-jules-api-harness-backend/",
-    "pt": "/blog/2026-05-10-a-api-do-jules-como-backend-do-harness/"
+    "pt": "/blog/2026-05-10-a-api-do-jules-como-backend-do-harness/",
+    "en": "/blog/2026-05-10-jules-api-harness-backend/"
+  },
+  "/blog/2026-05-10-jules-api-harness-backend/": {
+    "pt": "/blog/2026-05-10-a-api-do-jules-como-backend-do-harness/",
+    "en": "/blog/2026-05-10-jules-api-harness-backend/"
   },
   "/blog/2026-05-10-the-serpents-egg/": {
     "en": "/blog/2026-05-10-the-serpents-egg/",
@@ -111,13 +111,13 @@
     "en": "/blog/2026-05-10-the-serpents-egg/",
     "pt": "/blog/o-ovo-de-serpente/"
   },
-  "/blog/2026-05-14-the-agent-that-doesnt-invent-verbs/": {
-    "en": "/blog/2026-05-14-the-agent-that-doesnt-invent-verbs/",
-    "pt": "/blog/2026-05-14-o-agente-que-nao-inventa-verbos/"
-  },
   "/blog/2026-05-14-o-agente-que-nao-inventa-verbos/": {
-    "en": "/blog/2026-05-14-the-agent-that-doesnt-invent-verbs/",
-    "pt": "/blog/2026-05-14-o-agente-que-nao-inventa-verbos/"
+    "pt": "/blog/2026-05-14-o-agente-que-nao-inventa-verbos/",
+    "en": "/blog/2026-05-14-the-agent-that-doesnt-invent-verbs/"
+  },
+  "/blog/2026-05-14-the-agent-that-doesnt-invent-verbs/": {
+    "pt": "/blog/2026-05-14-o-agente-que-nao-inventa-verbos/",
+    "en": "/blog/2026-05-14-the-agent-that-doesnt-invent-verbs/"
   },
   "/blog/2026-05-14-pierre-menard-computational-researcher/": {
     "en": "/blog/2026-05-14-pierre-menard-computational-researcher/",
@@ -127,13 +127,13 @@
     "en": "/blog/2026-05-14-pierre-menard-computational-researcher/",
     "pt": "/blog/pierre-menard-pesquisador-computacional/"
   },
-  "/blog/2026-05-15-who-the-asterisk-protects/": {
-    "en": "/blog/2026-05-15-who-the-asterisk-protects/",
-    "pt": "/blog/2026-05-15-quem-o-asterisco-protege/"
-  },
   "/blog/2026-05-15-quem-o-asterisco-protege/": {
-    "en": "/blog/2026-05-15-who-the-asterisk-protects/",
-    "pt": "/blog/2026-05-15-quem-o-asterisco-protege/"
+    "pt": "/blog/2026-05-15-quem-o-asterisco-protege/",
+    "en": "/blog/2026-05-15-who-the-asterisk-protects/"
+  },
+  "/blog/2026-05-15-who-the-asterisk-protects/": {
+    "pt": "/blog/2026-05-15-quem-o-asterisco-protege/",
+    "en": "/blog/2026-05-15-who-the-asterisk-protects/"
   },
   "/blog/2026-05-15-three-hammers-walk-into-a-bar/": {
     "en": "/blog/2026-05-15-three-hammers-walk-into-a-bar/",
@@ -143,21 +143,21 @@
     "en": "/blog/2026-05-15-three-hammers-walk-into-a-bar/",
     "pt": "/blog/2026-05-15-tres-martelos-entram-num-bar/"
   },
-  "/blog/will-ai-discover-new-conservation-law-before-2050/": {
-    "en": "/blog/will-ai-discover-new-conservation-law-before-2050/",
-    "pt": "/blog/a-ia-descobrir-uma-nova-lei-de-conservao-antes-de-2050/"
-  },
   "/blog/a-ia-descobrir-uma-nova-lei-de-conservao-antes-de-2050/": {
-    "en": "/blog/will-ai-discover-new-conservation-law-before-2050/",
-    "pt": "/blog/a-ia-descobrir-uma-nova-lei-de-conservao-antes-de-2050/"
+    "pt": "/blog/a-ia-descobrir-uma-nova-lei-de-conservao-antes-de-2050/",
+    "en": "/blog/will-ai-discover-new-conservation-law-before-2050/"
   },
-  "/blog/the-digital-twin-sound-showcase/": {
-    "en": "/blog/the-digital-twin-sound-showcase/",
-    "pt": "/blog/a-vitrine-sonora-do-gemeo-digital/"
+  "/blog/will-ai-discover-new-conservation-law-before-2050/": {
+    "pt": "/blog/a-ia-descobrir-uma-nova-lei-de-conservao-antes-de-2050/",
+    "en": "/blog/will-ai-discover-new-conservation-law-before-2050/"
   },
   "/blog/a-vitrine-sonora-do-gemeo-digital/": {
-    "en": "/blog/the-digital-twin-sound-showcase/",
-    "pt": "/blog/a-vitrine-sonora-do-gemeo-digital/"
+    "pt": "/blog/a-vitrine-sonora-do-gemeo-digital/",
+    "en": "/blog/the-digital-twin-sound-showcase/"
+  },
+  "/blog/the-digital-twin-sound-showcase/": {
+    "pt": "/blog/a-vitrine-sonora-do-gemeo-digital/",
+    "en": "/blog/the-digital-twin-sound-showcase/"
   },
   "/blog/building-funes/": {
     "en": "/blog/building-funes/",
@@ -183,13 +183,13 @@
     "en": "/blog/funes-soul/",
     "pt": "/blog/soulmd-funes/"
   },
-  "/blog/pontifex-architecture-implementation-guide/": {
-    "en": "/blog/pontifex-architecture-implementation-guide/",
-    "pt": "/blog/guia-de-implementao-da-arquitetura-pontifex/"
-  },
   "/blog/guia-de-implementao-da-arquitetura-pontifex/": {
-    "en": "/blog/pontifex-architecture-implementation-guide/",
-    "pt": "/blog/guia-de-implementao-da-arquitetura-pontifex/"
+    "pt": "/blog/guia-de-implementao-da-arquitetura-pontifex/",
+    "en": "/blog/pontifex-architecture-implementation-guide/"
+  },
+  "/blog/pontifex-architecture-implementation-guide/": {
+    "pt": "/blog/guia-de-implementao-da-arquitetura-pontifex/",
+    "en": "/blog/pontifex-architecture-implementation-guide/"
   },
   "/blog/inaugural-post-a-glimpse-inside-my-mind/": {
     "en": "/blog/inaugural-post-a-glimpse-inside-my-mind/",
@@ -199,45 +199,45 @@
     "en": "/blog/inaugural-post-a-glimpse-inside-my-mind/",
     "pt": "/blog/postagem-inaugural-um-vislumbre-da-minha-mente/"
   },
-  "/blog/rosencrantz-coin/": {
-    "en": "/blog/rosencrantz-coin/",
-    "pt": "/blog/moeda-rosencrantz-testando-se-os-llms-respeitam-a-probabilidade/"
-  },
   "/blog/moeda-rosencrantz-testando-se-os-llms-respeitam-a-probabilidade/": {
-    "en": "/blog/rosencrantz-coin/",
-    "pt": "/blog/moeda-rosencrantz-testando-se-os-llms-respeitam-a-probabilidade/"
+    "pt": "/blog/moeda-rosencrantz-testando-se-os-llms-respeitam-a-probabilidade/",
+    "en": "/blog/rosencrantz-coin/"
   },
-  "/blog/the-pampa-on-the-circuit-a-mate-with-boswell-digital/": {
-    "en": "/blog/the-pampa-on-the-circuit-a-mate-with-boswell-digital/",
-    "pt": "/blog/o-pampa-no-circuito-um-mate-com-o-boswell-digital/"
+  "/blog/rosencrantz-coin/": {
+    "pt": "/blog/moeda-rosencrantz-testando-se-os-llms-respeitam-a-probabilidade/",
+    "en": "/blog/rosencrantz-coin/"
   },
   "/blog/o-pampa-no-circuito-um-mate-com-o-boswell-digital/": {
-    "en": "/blog/the-pampa-on-the-circuit-a-mate-with-boswell-digital/",
-    "pt": "/blog/o-pampa-no-circuito-um-mate-com-o-boswell-digital/"
+    "pt": "/blog/o-pampa-no-circuito-um-mate-com-o-boswell-digital/",
+    "en": "/blog/the-pampa-on-the-circuit-a-mate-with-boswell-digital/"
   },
-  "/blog/the-intelligible-void-hassabis-and-events/": {
-    "en": "/blog/the-intelligible-void-hassabis-and-events/",
-    "pt": "/blog/o-vazio-inteligvel-sobre-hassabis-silcio-e-eventos-at-o-fim/"
+  "/blog/the-pampa-on-the-circuit-a-mate-with-boswell-digital/": {
+    "pt": "/blog/o-pampa-no-circuito-um-mate-com-o-boswell-digital/",
+    "en": "/blog/the-pampa-on-the-circuit-a-mate-with-boswell-digital/"
   },
   "/blog/o-vazio-inteligvel-sobre-hassabis-silcio-e-eventos-at-o-fim/": {
-    "en": "/blog/the-intelligible-void-hassabis-and-events/",
-    "pt": "/blog/o-vazio-inteligvel-sobre-hassabis-silcio-e-eventos-at-o-fim/"
+    "pt": "/blog/o-vazio-inteligvel-sobre-hassabis-silcio-e-eventos-at-o-fim/",
+    "en": "/blog/the-intelligible-void-hassabis-and-events/"
   },
-  "/blog/what-i-learned-orchestrating-ai-agents-to-preserve-family-memory/": {
-    "en": "/blog/what-i-learned-orchestrating-ai-agents-to-preserve-family-memory/",
-    "pt": "/blog/orquestrando-agentes-memoria-familiar/"
+  "/blog/the-intelligible-void-hassabis-and-events/": {
+    "pt": "/blog/o-vazio-inteligvel-sobre-hassabis-silcio-e-eventos-at-o-fim/",
+    "en": "/blog/the-intelligible-void-hassabis-and-events/"
   },
   "/blog/orquestrando-agentes-memoria-familiar/": {
-    "en": "/blog/what-i-learned-orchestrating-ai-agents-to-preserve-family-memory/",
-    "pt": "/blog/orquestrando-agentes-memoria-familiar/"
+    "pt": "/blog/orquestrando-agentes-memoria-familiar/",
+    "en": "/blog/what-i-learned-orchestrating-ai-agents-to-preserve-family-memory/"
   },
-  "/blog/patents-for-social-vulnerabilities/": {
-    "en": "/blog/patents-for-social-vulnerabilities/",
-    "pt": "/blog/patentes-para-vulnerabilidades-sociais-uma-proposta-modesta-para-transformar-criminosos-em-consultores/"
+  "/blog/what-i-learned-orchestrating-ai-agents-to-preserve-family-memory/": {
+    "pt": "/blog/orquestrando-agentes-memoria-familiar/",
+    "en": "/blog/what-i-learned-orchestrating-ai-agents-to-preserve-family-memory/"
   },
   "/blog/patentes-para-vulnerabilidades-sociais-uma-proposta-modesta-para-transformar-criminosos-em-consultores/": {
-    "en": "/blog/patents-for-social-vulnerabilities/",
-    "pt": "/blog/patentes-para-vulnerabilidades-sociais-uma-proposta-modesta-para-transformar-criminosos-em-consultores/"
+    "pt": "/blog/patentes-para-vulnerabilidades-sociais-uma-proposta-modesta-para-transformar-criminosos-em-consultores/",
+    "en": "/blog/patents-for-social-vulnerabilities/"
+  },
+  "/blog/patents-for-social-vulnerabilities/": {
+    "pt": "/blog/patentes-para-vulnerabilidades-sociais-uma-proposta-modesta-para-transformar-criminosos-em-consultores/",
+    "en": "/blog/patents-for-social-vulnerabilities/"
   },
   "/blog/pontifex-novel-architecture-semantic-probing/": {
     "en": "/blog/pontifex-novel-architecture-semantic-probing/",

--- a/src/layouts/PageLayout.astro
+++ b/src/layouts/PageLayout.astro
@@ -44,7 +44,7 @@ const canonical = new URL(Astro.url.pathname, Astro.site);
 const DEFAULT_OG_IMAGE = lang === "pt" ? "/og/home-pt.png" : "/og/home.png";
 const ogImageRaw = image ?? DEFAULT_OG_IMAGE;
 const ogImage = Astro.site ? new URL(ogImageRaw, Astro.site).href : ogImageRaw;
-const rssUrl = new URL("rss.xml", Astro.site);
+const rssUrl = new URL(lang === 'pt' ? "pt/rss.xml" : "rss.xml", Astro.site);
 
 const SOCIAL_PROFILES = [
   "https://github.com/franklinbaldo",
@@ -117,6 +117,7 @@ const personLd = {
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>{documentTitle}</title>
     <meta name="description" content={description} />
+    <meta name="author" content="Franklin Baldo" />
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png" />
     <link rel="icon" type="image/png" sizes="192x192" href="/favicon-192.png" />
     <link rel="icon" href="/favicon.ico" sizes="any" />
@@ -124,7 +125,7 @@ const personLd = {
     <meta name="theme-color" content="#1f1f1f" media="(prefers-color-scheme: dark)" />
     <meta name="theme-color" content="#fdfdfd" media="(prefers-color-scheme: light)" />
     <link rel="canonical" href={canonical.href} />
-    <link rel="alternate" type="application/rss+xml" title="Franklin Baldo" href={rssUrl} />
+    <link rel="alternate" type="application/rss+xml" title={lang === 'pt' ? 'Franklin Baldo (Português)' : 'Franklin Baldo'} href={rssUrl} />
     <link rel="sitemap" href="/sitemap-index.xml" />
     {hasMath && <link rel="stylesheet" href="/katex/katex.min.css" />}
 
@@ -190,7 +191,7 @@ const personLd = {
       <slot />
     </main>
 
-    <Footer />
+    <Footer lang={lang} />
 
     <style is:global>
       .heading-anchor {

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -1,5 +1,7 @@
+import { DEFAULT_LANG as _DEFAULT_LANG, LANG_META } from './languages.mjs';
+
+export { DEFAULT_LANG } from './languages.mjs';
 export type Lang = 'en' | 'pt';
-export const DEFAULT_LANG: Lang = 'en';
 
 const UI_KEYS = [
   'nav.home',
@@ -48,29 +50,16 @@ const UI_KEYS = [
 
 export type UIKey = (typeof UI_KEYS)[number];
 
-/**
- * Strings describing another language from the current language's perspective.
- * `LANGUAGES.en.targets.pt.invitation` is what an EN reader sees inviting
- * them to switch to PT ("Ler em Português"). Adding a third language means
- * adding its target entry to every existing language config (and a new
- * config block).
- */
 export interface TargetLangCopy {
-  /** Short label shown on a compact button, e.g. "PT". */
   shortLabel: string;
-  /** Full invitation, typically written in the target language. */
   invitation: string;
-  /** Shown when no translation exists in this target language. */
   noTranslation: string;
 }
 
 export interface LangConfig {
   code: string;
-  /** BCP-47 locale tag for Intl APIs. */
   locale: string;
-  /** URL prefix for in-site links; empty string for the default language. */
   urlPrefix: string;
-  /** Lowercase prefixes of `navigator.language` that resolve to this code. */
   navMatch: string[];
   ui: Record<UIKey, string>;
   targets: Record<string, TargetLangCopy>;
@@ -79,9 +68,7 @@ export interface LangConfig {
 export const LANGUAGES: Record<string, LangConfig> = {
   en: {
     code: 'en',
-    locale: 'en-US',
-    urlPrefix: '',
-    navMatch: ['en'],
+    ...LANG_META.en,
     ui: {
       'nav.home': 'Home',
       'nav.archive': 'Archive',
@@ -136,9 +123,7 @@ export const LANGUAGES: Record<string, LangConfig> = {
   },
   pt: {
     code: 'pt',
-    locale: 'pt-BR',
-    urlPrefix: '/pt',
-    navMatch: ['pt'],
+    ...LANG_META.pt,
     ui: {
       'nav.home': 'Início',
       'nav.archive': 'Arquivo',
@@ -194,19 +179,14 @@ export const LANGUAGES: Record<string, LangConfig> = {
 };
 
 function configFor(lang: string | undefined): LangConfig {
-  return LANGUAGES[lang ?? DEFAULT_LANG] ?? LANGUAGES[DEFAULT_LANG];
+  return LANGUAGES[lang ?? _DEFAULT_LANG] ?? LANGUAGES[_DEFAULT_LANG];
 }
 
-/** Translate a UI key with default-language fallback. */
 export function t(lang: string | undefined, key: UIKey): string {
   const cfg = configFor(lang);
-  return cfg.ui[key] ?? LANGUAGES[DEFAULT_LANG].ui[key];
+  return cfg.ui[key] ?? LANGUAGES[_DEFAULT_LANG].ui[key];
 }
 
-/**
- * Look up the copy describing `targetLang` from `currentLang`'s perspective.
- * Falls back to a code-only label when the pairing is undefined.
- */
 export function targetCopy(
   currentLang: string | undefined,
   targetLang: string,
@@ -221,16 +201,12 @@ export function targetCopy(
   );
 }
 
-/**
- * Generic per-language lookup for caller-provided dictionaries (e.g. reading
- * path titles). Falls back to the default-language entry, then to any entry.
- */
 export function pick<T>(
   lang: string | undefined,
   dict: Record<string, T>,
 ): T {
-  const key = lang ?? DEFAULT_LANG;
-  return dict[key] ?? dict[DEFAULT_LANG] ?? (Object.values(dict)[0] as T);
+  const key = lang ?? _DEFAULT_LANG;
+  return dict[key] ?? dict[_DEFAULT_LANG] ?? (Object.values(dict)[0] as T);
 }
 
 export function locale(lang: string | undefined): string {
@@ -246,12 +222,12 @@ export function supportedLangs(): string[] {
 }
 
 export function detectLang(): string {
-  if (typeof window === 'undefined') return DEFAULT_LANG;
+  if (typeof window === 'undefined') return _DEFAULT_LANG;
   const stored = localStorage.getItem('lang');
   if (stored && LANGUAGES[stored]) return stored;
   const navLang = navigator.language.toLowerCase();
   for (const cfg of Object.values(LANGUAGES)) {
     if (cfg.navMatch.some((m) => navLang.startsWith(m))) return cfg.code;
   }
-  return DEFAULT_LANG;
+  return _DEFAULT_LANG;
 }

--- a/src/lib/languages.mjs
+++ b/src/lib/languages.mjs
@@ -1,0 +1,25 @@
+/**
+ * Language registry — plain ES module so both i18n.ts (via import) and
+ * Node scripts (generate-translation-pairs.mjs, astro.config.mjs) can
+ * import without a TypeScript compiler step.
+ *
+ * UI strings live in i18n.ts only; this file carries only the structural
+ * metadata that scripts need: locale tag, URL prefix, and navMatch prefixes.
+ */
+
+/** @type {string} */
+export const DEFAULT_LANG = 'en';
+
+/**
+ * @typedef {{ locale: string; urlPrefix: string; navMatch: string[] }} LangMeta
+ * @type {Record<string, LangMeta>}
+ */
+export const LANG_META = {
+  en: { locale: 'en-US', urlPrefix: '',    navMatch: ['en'] },
+  pt: { locale: 'pt-BR', urlPrefix: '/pt', navMatch: ['pt'] },
+};
+
+/** @returns {string[]} */
+export function supportedLangs() {
+  return Object.keys(LANG_META);
+}

--- a/src/pages/archive.astro
+++ b/src/pages/archive.astro
@@ -2,7 +2,16 @@
 import { getCollection } from "astro:content";
 import PageLayout from "../layouts/PageLayout.astro";
 
-const posts = (await getCollection("blog"))
+const all = await getCollection("blog");
+
+// Build set of translationKeys present in PT so we can mark paired EN posts
+const ptKeys = new Set(
+  all
+    .filter((p) => !p.data.draft && p.data.lang === 'pt' && p.data.translationKey)
+    .map((p) => p.data.translationKey!)
+);
+
+const posts = all
   .filter((p) => !p.data.draft)
   .filter((p) => (p.data.lang ?? 'en') === 'en')
   .sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf());
@@ -30,19 +39,26 @@ const years = [...byYear.keys()].sort((a, b) => b - a);
           <tr>
             <th scope="col" class="col-date">Date</th>
             <th scope="col">Title</th>
+            <th scope="col" class="col-pt" aria-label="Portuguese version available">PT</th>
           </tr>
         </thead>
         <tbody>
-          {byYear.get(year)!.map((post) => (
-            <tr>
-              <td class="col-date">
-                <time datetime={post.data.date.toISOString()}>
-                  {post.data.date.toLocaleDateString("en-US", { month: "short", day: "2-digit" })}
-                </time>
-              </td>
-              <td><a href={`/blog/${post.id}/`}>{post.data.title}</a></td>
-            </tr>
-          ))}
+          {byYear.get(year)!.map((post) => {
+            const hasPt = !!(post.data.translationKey && ptKeys.has(post.data.translationKey));
+            return (
+              <tr>
+                <td class="col-date">
+                  <time datetime={post.data.date.toISOString()}>
+                    {post.data.date.toLocaleDateString("en-US", { month: "short", day: "2-digit" })}
+                  </time>
+                </td>
+                <td><a href={`/blog/${post.id}/`}>{post.data.title}</a></td>
+                <td class="col-pt">
+                  {hasPt && <span class="pt-badge" aria-label="Portuguese version available" title="Portuguese version available">PT</span>}
+                </td>
+              </tr>
+            );
+          })}
         </tbody>
       </table>
     </section>
@@ -58,4 +74,20 @@ const years = [...byYear.keys()].sort((a, b) => b - a);
     white-space: nowrap;
   }
   .archive-table th { font-weight: 600; }
+  .col-pt {
+    width: 2.5rem;
+    text-align: center;
+  }
+  .pt-badge {
+    display: inline-block;
+    font-size: 0.68rem;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    padding: 0.1em 0.35em;
+    border-radius: 3px;
+    background: color-mix(in srgb, var(--pico-primary) 15%, transparent);
+    color: var(--pico-primary);
+    border: 1px solid color-mix(in srgb, var(--pico-primary) 35%, transparent);
+    vertical-align: middle;
+  }
 </style>

--- a/src/pages/og/[...slug].png.ts
+++ b/src/pages/og/[...slug].png.ts
@@ -36,7 +36,7 @@ export const GET: APIRoute = async ({ props }) => {
     path: props.path as string,
     qrPng: qrPng ?? undefined,
   });
-  return new Response(png, {
+  return new Response(new Uint8Array(png), {
     headers: {
       "Content-Type": "image/png",
       "Cache-Control": "public, max-age=31536000, immutable",

--- a/src/pages/og/home-pt.png.ts
+++ b/src/pages/og/home-pt.png.ts
@@ -14,7 +14,7 @@ export const GET: APIRoute = async () => {
     path: "/pt/",
     qrPng: qrPng ?? undefined,
   });
-  return new Response(png, {
+  return new Response(new Uint8Array(png), {
     headers: {
       "Content-Type": "image/png",
       "Cache-Control": "public, max-age=31536000, immutable",

--- a/src/pages/og/home.png.ts
+++ b/src/pages/og/home.png.ts
@@ -14,7 +14,7 @@ export const GET: APIRoute = async () => {
     path: "/",
     qrPng: qrPng ?? undefined,
   });
-  return new Response(png, {
+  return new Response(new Uint8Array(png), {
     headers: {
       "Content-Type": "image/png",
       "Cache-Control": "public, max-age=31536000, immutable",

--- a/src/pages/paths/[slug].astro
+++ b/src/pages/paths/[slug].astro
@@ -13,7 +13,7 @@ export async function getStaticPaths() {
 const { path } = Astro.props;
 const posts = await getPathPosts(path.slug, 'en');
 const ptHasPosts = (await getPathPosts(path.slug, 'pt')).length > 0;
-const translations = ptHasPosts ? { pt: `/pt/paths/${path.slug}/` } : {};
+const translations: Record<string, string> = ptHasPosts ? { pt: `/pt/paths/${path.slug}/` } : {};
 ---
 
 <PageLayout

--- a/src/pages/pt/about.astro
+++ b/src/pages/pt/about.astro
@@ -79,7 +79,7 @@ const faqLd = {
     <ul>
       <li>GitHub — <a href="https://github.com/franklinbaldo" rel="me">github.com/franklinbaldo</a></li>
       <li>Twitter / X — <a href="https://twitter.com/franklinbaldo" rel="me">twitter.com/franklinbaldo</a></li>
-      <li>RSS — <a href="/rss.xml">/rss.xml</a></li>
+      <li>RSS — <a href="/pt/rss.xml">/pt/rss.xml</a></li>
     </ul>
 
     <h2>Colofão</h2>

--- a/src/pages/pt/archive.astro
+++ b/src/pages/pt/archive.astro
@@ -2,7 +2,16 @@
 import { getCollection } from "astro:content";
 import PageLayout from "../../layouts/PageLayout.astro";
 
-const posts = (await getCollection("blog"))
+const all = await getCollection("blog");
+
+// Build set of translationKeys present in EN so we can mark paired PT posts
+const enKeys = new Set(
+  all
+    .filter((p) => !p.data.draft && (p.data.lang ?? 'en') === 'en' && p.data.translationKey)
+    .map((p) => p.data.translationKey!)
+);
+
+const posts = all
   .filter((p) => !p.data.draft)
   .filter((p) => p.data.lang === 'pt')
   .sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf());
@@ -35,19 +44,26 @@ const years = [...byYear.keys()].sort((a, b) => b - a);
           <tr>
             <th scope="col" class="col-date">Data</th>
             <th scope="col">Título</th>
+            <th scope="col" class="col-en" aria-label="Versão em inglês disponível">EN</th>
           </tr>
         </thead>
         <tbody>
-          {byYear.get(year)!.map((post) => (
-            <tr>
-              <td class="col-date">
-                <time datetime={post.data.date.toISOString()}>
-                  {post.data.date.toLocaleDateString("pt-BR", { month: "short", day: "2-digit" })}
-                </time>
-              </td>
-              <td><a href={`/blog/${post.id}/`}>{post.data.title}</a></td>
-            </tr>
-          ))}
+          {byYear.get(year)!.map((post) => {
+            const hasEn = !!(post.data.translationKey && enKeys.has(post.data.translationKey));
+            return (
+              <tr>
+                <td class="col-date">
+                  <time datetime={post.data.date.toISOString()}>
+                    {post.data.date.toLocaleDateString("pt-BR", { month: "short", day: "2-digit" })}
+                  </time>
+                </td>
+                <td><a href={`/blog/${post.id}/`}>{post.data.title}</a></td>
+                <td class="col-en">
+                  {hasEn && <span class="en-badge" aria-label="Versão em inglês disponível" title="Versão em inglês disponível">EN</span>}
+                </td>
+              </tr>
+            );
+          })}
         </tbody>
       </table>
     </section>
@@ -63,4 +79,20 @@ const years = [...byYear.keys()].sort((a, b) => b - a);
     white-space: nowrap;
   }
   .archive-table th { font-weight: 600; }
+  .col-en {
+    width: 2.5rem;
+    text-align: center;
+  }
+  .en-badge {
+    display: inline-block;
+    font-size: 0.68rem;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    padding: 0.1em 0.35em;
+    border-radius: 3px;
+    background: color-mix(in srgb, var(--pico-primary) 15%, transparent);
+    color: var(--pico-primary);
+    border: 1px solid color-mix(in srgb, var(--pico-primary) 35%, transparent);
+    vertical-align: middle;
+  }
 </style>

--- a/src/pages/pt/archive.astro
+++ b/src/pages/pt/archive.astro
@@ -13,7 +13,7 @@ const enKeys = new Set(
 
 const posts = all
   .filter((p) => !p.data.draft)
-  .filter((p) => p.data.lang === 'pt')
+  .filter((p) => (p.data.lang ?? 'en') === 'pt')
   .sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf());
 
 const byYear = new Map<number, typeof posts>();

--- a/src/pages/pt/paths/[slug].astro
+++ b/src/pages/pt/paths/[slug].astro
@@ -13,7 +13,7 @@ export async function getStaticPaths() {
 const { path } = Astro.props;
 const posts = await getPathPosts(path.slug, 'pt');
 const enHasPosts = (await getPathPosts(path.slug, 'en')).length > 0;
-const translations = enHasPosts ? { en: `/paths/${path.slug}/` } : {};
+const translations: Record<string, string> = enHasPosts ? { en: `/paths/${path.slug}/` } : {};
 ---
 
 <PageLayout

--- a/src/pages/pt/rss.xml.js
+++ b/src/pages/pt/rss.xml.js
@@ -4,13 +4,13 @@ import { getCollection } from 'astro:content';
 export async function GET(context) {
   const posts = (await getCollection('blog'))
     .filter((post) => !post.data.draft)
-    .filter((post) => (post.data.lang ?? 'en') === 'en')
+    .filter((post) => post.data.lang === 'pt')
     .sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf());
 
   return rss({
-    title: 'Franklin Baldo',
+    title: 'Franklin Baldo (Português)',
     description:
-      "Lawyer and State Attorney. Exploring the intersections of process metaphysics, AI agency, and the architecture of legal systems.",
+      'Advogado e Procurador do Estado. Explorando as interseções entre metafísica do processo, agentes de IA e a arquitetura dos sistemas jurídicos.',
     site: context.site,
     items: posts.map((post) => ({
       title: post.data.title,
@@ -19,6 +19,6 @@ export async function GET(context) {
       link: `/blog/${post.id}/`,
       categories: post.data.tags ?? [],
     })),
-    customData: '<language>en-us</language>',
+    customData: '<language>pt-br</language>',
   });
 }

--- a/src/pages/pt/rss.xml.js
+++ b/src/pages/pt/rss.xml.js
@@ -4,7 +4,7 @@ import { getCollection } from 'astro:content';
 export async function GET(context) {
   const posts = (await getCollection('blog'))
     .filter((post) => !post.data.draft)
-    .filter((post) => post.data.lang === 'pt')
+    .filter((post) => (post.data.lang ?? 'en') === 'pt')
     .sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf());
 
   return rss({


### PR DESCRIPTION
## Summary

- **Sitemap hreflang for all 31 blog post pairs**: new `scripts/generate-translation-pairs.mjs` prebuild script scans frontmatter, emits `src/generated/blog-translation-pairs.json`, and `astro.config.mjs` uses it in `sitemap.serialize()` — sitemap went from 6 → **74 hreflang triplets** covering all EN↔PT post pairs
- **RSS split EN/PT**: `rss.xml` is now EN-only (`<language>en-us</language>`); new `/pt/rss.xml` is PT-only (`<language>pt-br</language>`); `PageLayout` and `Footer` wire autodiscovery and the footer RSS link to the correct feed per language
- **`<meta name="author">`**: added to every page via `PageLayout.astro`
- **Archive translation badges**: both `/archive/` and `/pt/archive/` now show a styled PT/EN badge on rows where a translation exists — readers can see at a glance which posts are available in the other language

## What was merged this session

- **PR #103** (feat(seo): PT 404, FAQ schema, wordCount JSON-LD, x-default hreflang) — CI green, merged ✅

## Why PR #102 was not merged

PR #102 (Optimize profile visuals) still has a failing Kilo Code Review. Two build-breaking bugs remain unfixed: indented `---` delimiter in `PageLayout.astro` and call to non-existent i18n key `author.moreAbout` (correct key is `author.aboutMore`).

## Test plan

- [ ] Build passes: `npm run build` → 294 pages, no errors ✅
- [ ] `dist/sitemap-0.xml` contains `hreflang="pt-BR"` entries for blog posts (not just static pages)
- [ ] `dist/rss.xml` contains only EN posts; `dist/pt/rss.xml` contains only PT posts
- [ ] `/archive/` shows PT badges on rows with translations; `/pt/archive/` shows EN badges
- [ ] Footer RSS link on PT pages points to `/pt/rss.xml`; on EN pages to `/rss.xml`
- [ ] All pages have `<meta name="author" content="Franklin Baldo">` in `<head>`

https://claude.ai/code/session_015gjUavRTUNdsrc6mxZ3jSG

---
_Generated by [Claude Code](https://claude.ai/code/session_015gjUavRTUNdsrc6mxZ3jSG)_