### PR TITLE
home: minimal hero, posts first; fix theme flash; share FAB

### DIFF
--- a/src/components/PostActionBar.astro
+++ b/src/components/PostActionBar.astro
@@ -53,6 +53,14 @@ const shareLabel = isPt ? 'Compartilhar' : 'Share';
     width: 20px;
     height: 20px;
   }
+  /* BackToTop pill lives at bottom-right ≥600px; stack the FAB above it
+     in the 600–800px range so they don't compete for the same tap area. */
+  @media (min-width: 600px) and (max-width: 800px) {
+    .share-fab {
+      bottom: 4.25rem;
+      right: 1.5rem;
+    }
+  }
   @media (min-width: 801px) {
     .share-fab {
       display: none;

--- a/src/components/PostActionBar.astro
+++ b/src/components/PostActionBar.astro
@@ -1,6 +1,4 @@
 ---
-import { t, locale } from '../lib/i18n';
-
 interface Props {
   title: string;
   url: string;
@@ -8,221 +6,56 @@ interface Props {
   lang?: string;
 }
 
-const { title, url, date, lang } = Astro.props;
-const loc = locale(lang);
-const formattedDate = date.toLocaleDateString(loc, { year: 'numeric', month: 'long', day: 'numeric' });
-const year = date.getFullYear();
-const citationPlain = `Baldo, F. (${year}). ${title}. Franklin Baldo. ${url}`;
-const citationBibtex = `@misc{baldo${year}${title.toLowerCase().replace(/[^a-z0-9]+/g, '').slice(0, 12)},
-  author = {Baldo, Franklin},
-  title  = {${title}},
-  year   = {${year}},
-  url    = {${url}},
-  note   = {Franklin Baldo, ${formattedDate}}
-}`;
-
+const { title, url, lang } = Astro.props;
 const isPt = (lang ?? '') === 'pt';
-const labels = {
-  share: isPt ? 'Compartilhar' : 'Share',
-  rss: 'RSS',
-  cite: isPt ? 'Citar' : 'Cite',
-  citeDialogTitle: isPt ? 'Citar este ensaio' : 'Cite this essay',
-  citeApa: 'APA',
-  citeBibtex: 'BibTeX',
-  copy: isPt ? 'Copiar' : 'Copy',
-  copied: isPt ? 'Copiado' : 'Copied',
-  failed: isPt ? 'Não foi possível copiar' : "Couldn't copy",
-  close: isPt ? 'Fechar' : 'Close',
-};
+const shareLabel = isPt ? 'Compartilhar' : 'Share';
 ---
 
-<nav class="post-action-bar" aria-label={isPt ? 'Ações do post' : 'Post actions'}>
-  <button
-    type="button"
-    class="action-btn share-button"
-    data-title={title}
-    data-url={url}
-    aria-label={labels.share}
-  >
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true">
-      <path d="M4 12v7a1 1 0 001 1h14a1 1 0 001-1v-7"/>
-      <path d="M16 6l-4-4-4 4"/>
-      <line x1="12" y1="2" x2="12" y2="15"/>
-    </svg>
-    <span class="action-label">{labels.share}</span>
-  </button>
-
-  <a class="action-btn" href="/rss.xml" aria-label="RSS feed">
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true">
-      <path d="M4 11a9 9 0 019 9"/>
-      <path d="M4 4a16 16 0 0116 16"/>
-      <circle cx="5" cy="19" r="1.5" fill="currentColor"/>
-    </svg>
-    <span class="action-label">{labels.rss}</span>
-  </a>
-
-  <button
-    type="button"
-    class="action-btn cite-open"
-    aria-label={labels.cite}
-    aria-haspopup="dialog"
-  >
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true">
-      <path d="M7 7h4v6a4 4 0 01-4 4v-2a2 2 0 002-2H7zM15 7h4v6a4 4 0 01-4 4v-2a2 2 0 002-2h-2z"/>
-    </svg>
-    <span class="action-label">{labels.cite}</span>
-  </button>
-</nav>
-
-<dialog id="cite-dialog" aria-labelledby="cite-dialog-title">
-  <article>
-    <header>
-      <button class="close cite-close" aria-label={labels.close}></button>
-      <hgroup>
-        <h3 id="cite-dialog-title">{labels.citeDialogTitle}</h3>
-        <p><small>{title}</small></p>
-      </hgroup>
-    </header>
-    <section>
-      <p class="cite-eyebrow"><small>{labels.citeApa}</small></p>
-      <pre><code class="cite-apa">{citationPlain}</code></pre>
-      <button
-        type="button"
-        class="outline cite-copy"
-        data-target=".cite-apa"
-        data-copied={labels.copied}
-        data-failed={labels.failed}
-      >{labels.copy}</button>
-    </section>
-    <section>
-      <p class="cite-eyebrow"><small>{labels.citeBibtex}</small></p>
-      <pre><code class="cite-bibtex">{citationBibtex}</code></pre>
-      <button
-        type="button"
-        class="outline cite-copy"
-        data-target=".cite-bibtex"
-        data-copied={labels.copied}
-        data-failed={labels.failed}
-      >{labels.copy}</button>
-    </section>
-  </article>
-</dialog>
-
-<script>
-  const dialog = document.getElementById('cite-dialog') as HTMLDialogElement | null;
-
-  document.addEventListener('click', async (e) => {
-    const target = e.target as HTMLElement | null;
-    if (!target) return;
-
-    if (target.closest('.cite-open')) {
-      dialog?.showModal();
-      return;
-    }
-    if (target.closest('.cite-close')) {
-      dialog?.close();
-      return;
-    }
-    const copyBtn = target.closest<HTMLButtonElement>('.cite-copy');
-    if (copyBtn) {
-      const selector = copyBtn.dataset.target;
-      if (!selector) return;
-      const codeEl = dialog?.querySelector<HTMLElement>(selector);
-      const text = codeEl?.textContent ?? '';
-      const original = copyBtn.textContent ?? '';
-      copyBtn.setAttribute('aria-busy', 'true');
-      try {
-        await navigator.clipboard.writeText(text);
-        copyBtn.textContent = copyBtn.dataset.copied ?? 'Copied';
-      } catch {
-        copyBtn.textContent = copyBtn.dataset.failed ?? "Couldn't copy";
-      } finally {
-        copyBtn.removeAttribute('aria-busy');
-        window.setTimeout(() => {
-          copyBtn.textContent = original;
-        }, 1400);
-      }
-    }
-  });
-
-  // ESC + backdrop click already close <dialog> when opened with showModal.
-  dialog?.addEventListener('click', (e) => {
-    if (e.target === dialog) dialog.close();
-  });
-</script>
+<button
+  type="button"
+  class="share-fab share-button"
+  data-title={title}
+  data-url={url}
+  aria-label={shareLabel}
+  title={shareLabel}
+>
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true">
+    <path d="M4 12v7a1 1 0 001 1h14a1 1 0 001-1v-7"/>
+    <path d="M16 6l-4-4-4 4"/>
+    <line x1="12" y1="2" x2="12" y2="15"/>
+  </svg>
+</button>
 
 <style>
-  .post-action-bar {
-    display: none;
-  }
-  @media (max-width: 800px) {
-    .post-action-bar {
-      display: grid;
-      grid-template-columns: repeat(3, 1fr);
-      position: fixed;
-      left: 0;
-      right: 0;
-      bottom: 0;
-      z-index: 40;
-      border-top: 1px solid var(--pico-muted-border-color);
-      background: var(--pico-card-background-color);
-      padding: 0.5rem 0;
-      backdrop-filter: blur(6px);
-    }
-    .action-btn {
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-      justify-content: center;
-      gap: 0.15rem;
-      padding: 0.4rem 0.25rem;
-      border: 0;
-      background: transparent;
-      color: var(--pico-color);
-      text-decoration: none;
-      font-size: 0.75rem;
-      cursor: pointer;
-    }
-    .action-btn svg {
-      width: 22px;
-      height: 22px;
-      color: var(--pico-primary);
-    }
-    .action-btn:hover {
-      color: var(--pico-primary);
-    }
-    .action-label {
-      letter-spacing: 0.02em;
-    }
-    .post-body {
-      padding-bottom: 4rem;
-    }
-  }
-  /* The cite-open button should also be available outside the mobile
-     bottom bar. Promote it onto the share button row of the post footer
-     by also exposing it inline if needed (not implemented here — opt-in
-     by adding the .cite-open trigger elsewhere). */
-
-  #cite-dialog .cite-eyebrow {
-    margin: 0 0 .25rem;
-    font-size: 0.72rem;
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 0.16em;
+  .share-fab {
+    position: fixed;
+    right: 1rem;
+    bottom: 1rem;
+    z-index: 40;
+    width: 44px;
+    height: 44px;
+    padding: 0;
+    border-radius: 999px;
+    border: 1px solid var(--pico-muted-border-color);
+    background: var(--pico-card-background-color);
     color: var(--pico-primary);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
   }
-  #cite-dialog pre {
-    margin: 0 0 .5rem;
-    max-height: 12rem;
-    overflow: auto;
-    white-space: pre-wrap;
-    word-break: break-word;
+  .share-fab:hover {
+    color: var(--pico-primary-hover, var(--pico-primary));
+    border-color: var(--pico-primary);
   }
-  #cite-dialog pre code {
-    white-space: inherit;
-    word-break: inherit;
+  .share-fab svg {
+    width: 20px;
+    height: 20px;
   }
-  #cite-dialog section {
-    margin-block: 1rem;
+  @media (min-width: 801px) {
+    .share-fab {
+      display: none;
+    }
   }
 </style>

--- a/src/generated/blog-translation-pairs.json
+++ b/src/generated/blog-translation-pairs.json
@@ -143,6 +143,14 @@
     "en": "/blog/2026-05-15-three-hammers-walk-into-a-bar/",
     "pt": "/blog/2026-05-15-tres-martelos-entram-num-bar/"
   },
+  "/blog/2026-05-17-duas-perguntas-em-voz-alta/": {
+    "pt": "/blog/2026-05-17-duas-perguntas-em-voz-alta/",
+    "en": "/blog/2026-05-17-two-questions-out-loud/"
+  },
+  "/blog/2026-05-17-two-questions-out-loud/": {
+    "pt": "/blog/2026-05-17-duas-perguntas-em-voz-alta/",
+    "en": "/blog/2026-05-17-two-questions-out-loud/"
+  },
   "/blog/a-ia-descobrir-uma-nova-lei-de-conservao-antes-de-2050/": {
     "pt": "/blog/a-ia-descobrir-uma-nova-lei-de-conservao-antes-de-2050/",
     "en": "/blog/will-ai-discover-new-conservation-law-before-2050/"

--- a/src/layouts/PageLayout.astro
+++ b/src/layouts/PageLayout.astro
@@ -178,6 +178,18 @@ const personLd = {
         (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
       document.documentElement.setAttribute('data-theme', theme);
     </script>
+    <script is:inline>
+      // Preserve the current theme across Astro view transitions: the
+      // server-rendered <html> in the incoming document has no data-theme,
+      // so without this the page would flash to the OS default before the
+      // bootstrap script in the new <head> reapplies localStorage.
+      document.addEventListener('astro:before-swap', (event) => {
+        const current = document.documentElement.getAttribute('data-theme');
+        if (current) {
+          event.newDocument.documentElement.setAttribute('data-theme', current);
+        }
+      });
+    </script>
     <script is:inline define:vars={{ translations, pageLang: lang }}>
       window.__pageLang = pageLang;
       window.__translations = translations || {};

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -2,142 +2,53 @@
 import { getCollection } from "astro:content";
 import PageLayout from "../layouts/PageLayout.astro";
 import RecentList from "../components/RecentList.astro";
-import FeaturedRail from "../components/FeaturedRail.astro";
 import PathsTeaser from "../components/PathsTeaser.astro";
-import HomeAuthorRail from "../components/HomeAuthorRail.astro";
 
 const all = (await getCollection("blog"))
   .filter((post) => !post.data.draft)
   .filter((post) => (post.data.lang ?? 'en') === 'en')
   .sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf());
 
-const featured = all.filter((p) => p.data.featured);
-const featuredIds = new Set(featured.map((p) => p.id));
-const recent = all.filter((p) => !featuredIds.has(p.id)).slice(0, 8);
-const latest = featured[0] ?? all[0];
-const latestHref = latest ? `/blog/${latest.id}/` : "/archive/";
+const recent = all.slice(0, 12);
 ---
 
 <PageLayout
   title="Home"
-  description="Lawyer and State Attorney. Exploring the intersections of process metaphysics, AI agency, and the architecture of legal systems."
+  description="Franklin Baldo — notes on AI, law, and systems."
   lang="en"
   translations={{ pt: "/pt/" }}
 >
-  <div class="home-top">
-    <section class="home-hero" aria-label="Introduction">
-      <p class="home-eyebrow"><small>Franklin Baldo</small></p>
-      <h1 class="home-thesis">cybernetic Borges, building agents in <span class="accent">Delphi</span>.</h1>
-      <p class="home-lede">Essays on AI agency, process metaphysics, and the architecture of legal systems.</p>
-      <div class="home-cta" role="group">
-        <a class="cta-primary" href={latestHref}>Read latest essay →</a>
-        <a class="cta-secondary" href="/about/">About this blog</a>
-      </div>
-    </section>
+  <section class="home-hero" aria-label="Introduction">
+    <h1 class="home-title">Franklin Baldo</h1>
+    <p class="home-tagline">Notes on AI, law, and systems.</p>
+  </section>
 
-    <HomeAuthorRail lang="en" />
-  </div>
-
-  <FeaturedRail posts={featured} lang="en" />
-
-  <PathsTeaser lang="en" />
-
-  <section class="home-recent" aria-label="Recent essays">
-    <p class="section-eyebrow"><small>Recent essays</small></p>
-    <h2 class="section-heading">Recent essays</h2>
+  <section class="home-recent" aria-label="Recent posts">
     <RecentList posts={recent} lang="en" />
     <p class="home-archive-link">
       <small><a href="/archive/">View the full archive →</a></small>
     </p>
   </section>
+
+  <PathsTeaser lang="en" />
 </PageLayout>
 
 <style>
-  .home-top {
-    margin-block: calc(var(--pico-spacing) * 1.5) calc(var(--pico-spacing) * 2.5);
-    display: grid;
-    grid-template-columns: 1fr;
-    gap: calc(var(--pico-spacing) * 2);
-  }
-  @media (min-width: 1100px) {
-    .home-top {
-      grid-template-columns: minmax(0, 1fr) 18rem;
-      gap: calc(var(--pico-spacing) * 3);
-      align-items: start;
-    }
-  }
   .home-hero {
-    max-width: 38rem;
+    margin-block: calc(var(--pico-spacing) * 1.25) calc(var(--pico-spacing) * 1.5);
   }
-  .home-eyebrow {
+  .home-title {
+    font-size: clamp(1.75rem, 4vw, 2.5rem);
     margin: 0 0 .25rem;
-    font-size: 0.78rem;
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 0.14em;
-    color: var(--pico-primary);
+    letter-spacing: -0.01em;
   }
-  .home-thesis {
-    font-size: clamp(2.25rem, 5.5vw, 4rem);
-    line-height: 1.02;
-    letter-spacing: -0.02em;
-    margin: 0 0 .75rem;
-  }
-  .home-thesis .accent {
-    color: var(--pico-primary);
-  }
-  .home-lede {
-    font-size: 1.15rem;
+  .home-tagline {
     color: var(--pico-muted-color);
-    max-width: 55ch;
-    margin: 0 0 1.25rem;
-  }
-  .home-cta {
-    display: flex;
-    gap: 1rem;
-    flex-wrap: wrap;
     margin: 0;
-  }
-  .cta-primary {
-    display: inline-block;
-    padding: 0.65rem 1.1rem;
-    background: var(--pico-primary);
-    color: var(--pico-primary-inverse, #fff);
-    text-decoration: none;
-    border-radius: var(--pico-border-radius);
-    font-weight: 600;
-  }
-  .cta-primary:hover {
-    background: var(--pico-primary-hover, var(--pico-primary));
-    opacity: 0.92;
-  }
-  .cta-secondary {
-    display: inline-block;
-    padding: 0.65rem 1.1rem;
-    border: 1px solid var(--pico-border-color);
-    color: var(--pico-color);
-    text-decoration: none;
-    border-radius: var(--pico-border-radius);
-  }
-  .cta-secondary:hover {
-    border-color: var(--pico-primary);
-    color: var(--pico-primary);
+    font-size: 1rem;
   }
   .home-recent {
-    margin-block: calc(var(--pico-spacing) * 2);
-  }
-  .section-eyebrow {
-    margin: 0 0 .25rem;
-    font-size: 0.78rem;
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 0.14em;
-    color: var(--pico-primary);
-  }
-  .section-heading {
-    margin: 0 0 var(--pico-spacing);
-    font-size: clamp(1.5rem, 3vw, 2rem);
-    line-height: 1.15;
+    margin-block: calc(var(--pico-spacing) * 1.5) calc(var(--pico-spacing) * 2);
   }
   .home-archive-link {
     margin-top: var(--pico-spacing);

--- a/src/pages/pt/index.astro
+++ b/src/pages/pt/index.astro
@@ -2,142 +2,53 @@
 import { getCollection } from "astro:content";
 import PageLayout from "../../layouts/PageLayout.astro";
 import RecentList from "../../components/RecentList.astro";
-import FeaturedRail from "../../components/FeaturedRail.astro";
 import PathsTeaser from "../../components/PathsTeaser.astro";
-import HomeAuthorRail from "../../components/HomeAuthorRail.astro";
 
 const all = (await getCollection("blog"))
   .filter((post) => !post.data.draft)
   .filter((post) => post.data.lang === 'pt')
   .sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf());
 
-const featured = all.filter((p) => p.data.featured);
-const featuredIds = new Set(featured.map((p) => p.id));
-const recent = all.filter((p) => !featuredIds.has(p.id)).slice(0, 8);
-const latest = featured[0] ?? all[0];
-const latestHref = latest ? `/blog/${latest.id}/` : "/pt/archive/";
+const recent = all.slice(0, 12);
 ---
 
 <PageLayout
   title="Início"
-  description="Advogado e Procurador do Estado. Explorando as interseções entre metafísica do processo, agentes de IA e a arquitetura dos sistemas jurídicos."
+  description="Franklin Baldo — notas sobre IA, direito e sistemas."
   lang="pt"
   translations={{ en: "/" }}
 >
-  <div class="home-top">
-    <section class="home-hero" aria-label="Introdução">
-      <p class="home-eyebrow"><small>Franklin Baldo</small></p>
-      <h1 class="home-thesis">Borges cibernético, construindo agentes em <span class="accent">Delfos</span>.</h1>
-      <p class="home-lede">Ensaios sobre agência de IA, metafísica do processo e a arquitetura dos sistemas jurídicos.</p>
-      <div class="home-cta" role="group">
-        <a class="cta-primary" href={latestHref}>Ler ensaio mais recente →</a>
-        <a class="cta-secondary" href="/pt/about/">Sobre este blog</a>
-      </div>
-    </section>
+  <section class="home-hero" aria-label="Introdução">
+    <h1 class="home-title">Franklin Baldo</h1>
+    <p class="home-tagline">Notas sobre IA, direito e sistemas.</p>
+  </section>
 
-    <HomeAuthorRail lang="pt" />
-  </div>
-
-  <FeaturedRail posts={featured} lang="pt" />
-
-  <PathsTeaser lang="pt" />
-
-  <section class="home-recent" aria-label="Ensaios recentes">
-    <p class="section-eyebrow"><small>Ensaios recentes</small></p>
-    <h2 class="section-heading">Ensaios recentes</h2>
+  <section class="home-recent" aria-label="Posts recentes">
     <RecentList posts={recent} lang="pt" />
     <p class="home-archive-link">
       <small><a href="/pt/archive/">Ver o arquivo completo →</a></small>
     </p>
   </section>
+
+  <PathsTeaser lang="pt" />
 </PageLayout>
 
 <style>
-  .home-top {
-    margin-block: calc(var(--pico-spacing) * 1.5) calc(var(--pico-spacing) * 2.5);
-    display: grid;
-    grid-template-columns: 1fr;
-    gap: calc(var(--pico-spacing) * 2);
-  }
-  @media (min-width: 1100px) {
-    .home-top {
-      grid-template-columns: minmax(0, 1fr) 18rem;
-      gap: calc(var(--pico-spacing) * 3);
-      align-items: start;
-    }
-  }
   .home-hero {
-    max-width: 38rem;
+    margin-block: calc(var(--pico-spacing) * 1.25) calc(var(--pico-spacing) * 1.5);
   }
-  .home-eyebrow {
+  .home-title {
+    font-size: clamp(1.75rem, 4vw, 2.5rem);
     margin: 0 0 .25rem;
-    font-size: 0.78rem;
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 0.14em;
-    color: var(--pico-primary);
+    letter-spacing: -0.01em;
   }
-  .home-thesis {
-    font-size: clamp(2.25rem, 5.5vw, 4rem);
-    line-height: 1.02;
-    letter-spacing: -0.02em;
-    margin: 0 0 .75rem;
-  }
-  .home-thesis .accent {
-    color: var(--pico-primary);
-  }
-  .home-lede {
-    font-size: 1.15rem;
+  .home-tagline {
     color: var(--pico-muted-color);
-    max-width: 55ch;
-    margin: 0 0 1.25rem;
-  }
-  .home-cta {
-    display: flex;
-    gap: 1rem;
-    flex-wrap: wrap;
     margin: 0;
-  }
-  .cta-primary {
-    display: inline-block;
-    padding: 0.65rem 1.1rem;
-    background: var(--pico-primary);
-    color: var(--pico-primary-inverse, #fff);
-    text-decoration: none;
-    border-radius: var(--pico-border-radius);
-    font-weight: 600;
-  }
-  .cta-primary:hover {
-    background: var(--pico-primary-hover, var(--pico-primary));
-    opacity: 0.92;
-  }
-  .cta-secondary {
-    display: inline-block;
-    padding: 0.65rem 1.1rem;
-    border: 1px solid var(--pico-border-color);
-    color: var(--pico-color);
-    text-decoration: none;
-    border-radius: var(--pico-border-radius);
-  }
-  .cta-secondary:hover {
-    border-color: var(--pico-primary);
-    color: var(--pico-primary);
+    font-size: 1rem;
   }
   .home-recent {
-    margin-block: calc(var(--pico-spacing) * 2);
-  }
-  .section-eyebrow {
-    margin: 0 0 .25rem;
-    font-size: 0.78rem;
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 0.14em;
-    color: var(--pico-primary);
-  }
-  .section-heading {
-    margin: 0 0 var(--pico-spacing);
-    font-size: clamp(1.5rem, 3vw, 2rem);
-    line-height: 1.15;
+    margin-block: calc(var(--pico-spacing) * 1.5) calc(var(--pico-spacing) * 2);
   }
   .home-archive-link {
     margin-top: var(--pico-spacing);


### PR DESCRIPTION
## Summary

- **Dark mode consistency**: preserves `data-theme` across Astro view transitions via an `astro:before-swap` handler — navigating from a dark home to a post no longer flashes to the OS default before the new head's bootstrap reapplies.
- **Home redesign**: drops the "cybernetic Borges / process metaphysics" hero, the FeaturedRail, and the HomeAuthorRail. The home now opens with a one-line hero (name + tagline) and the recent posts list immediately below. Same treatment on `/pt/`.
- **Featured curation removed**: posts in the home list are now strictly most-recent. No more `featured` filtering (the frontmatter field is still tolerated; it's just unused on the home).
- **Mobile post actions**: replaces the bottom RSS/Cite/Share bar with a small floating Share button (FAB) in the bottom-right. The existing `ShareButton` click handler picks it up (same `share-button` class).

## Test plan

- [ ] Home (EN + PT) shows posts at the top, no "Borges" / "Delphi" / "process metaphysics" copy.
- [ ] Toggle dark mode on the home, click into a post — theme stays dark (no flash).
- [ ] On mobile width (≤800px), a single round Share button appears bottom-right on post pages; RSS and Cite are gone from the post UI.
- [ ] On desktop, the FAB is hidden (the existing inline Share button in the post footer still works).
- [ ] `npm run build` succeeds (302 pages).

---
_Generated by [Claude Code](https://claude.ai/code/session_01KcqhjPqW15TCfTGXLpBDLF)_