### PR TITLE
hronir: CLI

### DIFF
--- a/.routines/hronir/bin/hronir
+++ b/.routines/hronir/bin/hronir
@@ -3,41 +3,29 @@ set -e
 
 POSTS_DIR="src/content/blog"
 OUT_DIR=".routines/hronir"
-mkdir -p "$OUT_DIR"
+mkdir -p "$OUT_DIR" "$OUT_DIR/critiques"
 
-extract_key() {
-  awk '
+extract_field() {
+  local field="$1" file="$2"
+  awk -v f="$field" '
     /^---[[:space:]]*$/ { n++; next }
-    n==1 && /^translationKey:/ {
-      sub(/^translationKey:[[:space:]]*/, "")
-      gsub(/["'"'"']/, "")
+    n==1 && $0 ~ "^"f":" {
+      sub("^"f":[[:space:]]*", "")
+      gsub(/["'\'']/, "")
       print
       exit
     }
-  ' "$1"
-}
-
-extract_lang() {
-  awk '
-    /^---[[:space:]]*$/ { n++; next }
-    n==1 && /^lang:/ {
-      sub(/^lang:[[:space:]]*/, "")
-      gsub(/["'"'"']/, "")
-      print
-      exit
-    }
-  ' "$1"
+  ' "$file"
 }
 
 case "$1" in
   init)
     mapfile -t ALL_EN < <(
       find "$POSTS_DIR" -type f \( -name "*.md" -o -name "*.mdx" \) | while read -r f; do
-        lang=$(extract_lang "$f")
-        if [ -z "$lang" ] || [ "$lang" = "en" ]; then
-          if [ -n "$(extract_key "$f")" ]; then
-            echo "$f"
-          fi
+        lang=$(extract_field lang "$f")
+        key=$(extract_field translationKey "$f")
+        if { [ -z "$lang" ] || [ "$lang" = "en" ]; } && [ -n "$key" ]; then
+          echo "$f"
         fi
       done | sort
     )
@@ -55,8 +43,8 @@ case "$1" in
     for i in 0 1 2 3 4; do
       A_PATH="${SAMPLE[$((i*2))]}"
       B_PATH="${SAMPLE[$((i*2+1))]}"
-      A_KEY=$(extract_key "$A_PATH")
-      B_KEY=$(extract_key "$B_PATH")
+      A_KEY=$(extract_field translationKey "$A_PATH")
+      B_KEY=$(extract_field translationKey "$B_PATH")
 
       if (( RANDOM % 2 )); then
         K1=$A_KEY; K2=$B_KEY; P1=$A_PATH; P2=$B_PATH
@@ -93,7 +81,7 @@ EOF
   present)
     match_file="$2"
     if [ -z "$match_file" ] || [ ! -f "$match_file" ]; then
-      echo "Uso: hronir present <caminho-do-match.md>" >&2
+      echo "Uso: hronir present <match.md>" >&2
       exit 1
     fi
 
@@ -117,13 +105,43 @@ Escolha um. Defenda apaixonadamente a escolha.
 
 Edite $match_file:
 - winner: a (primeiro) ou b (segundo)
-- model: o identificador do modelo que está executando
-- substitua o <!-- TODO --> pelo texto da defesa, em português
+- model: identificador do modelo executando
+- substitua <!-- TODO --> pelo texto da defesa, em português
 EOF
     ;;
 
+  ranking)
+    declare -A WINS APPEARANCES
+    for f in "$OUT_DIR"/*_x_*.md; do
+      [ -f "$f" ] || continue
+      winner=$(extract_field winner "$f")
+      override=$(extract_field override "$f")
+      [ "$override" != "null" ] && [ -n "$override" ] && winner="$override"
+      [ "$winner" = "TODO" ] && continue
+      a_key=$(awk '/^post_a:/{f=1; next} f && /key:/{sub(/.*key:[[:space:]]*/,""); print; exit}' "$f")
+      b_key=$(awk '/^post_b:/{f=1; next} f && /key:/{sub(/.*key:[[:space:]]*/,""); print; exit}' "$f")
+      APPEARANCES[$a_key]=$((${APPEARANCES[$a_key]:-0}+1))
+      APPEARANCES[$b_key]=$((${APPEARANCES[$b_key]:-0}+1))
+      if [ "$winner" = "a" ]; then
+        WINS[$a_key]=$((${WINS[$a_key]:-0}+1))
+      elif [ "$winner" = "b" ]; then
+        WINS[$b_key]=$((${WINS[$b_key]:-0}+1))
+      fi
+    done
+    for key in "${!APPEARANCES[@]}"; do
+      w=${WINS[$key]:-0}
+      a=${APPEARANCES[$key]}
+      score=$(( w * 1000 / a + a ))
+      printf "%d\t%d\t%d\t%s\n" "$score" "$w" "$a" "$key"
+    done | sort -n
+    ;;
+
+  worst)
+    "$0" ranking | head -1 | awk -F'\t' '{print $4}'
+    ;;
+
   *)
-    echo "Uso: hronir {init|present <match-file>}" >&2
+    echo "Uso: hronir {init|present <match>|ranking|worst}" >&2
     exit 1
     ;;
 esac


### PR DESCRIPTION
Adiciona subcomandos `ranking` e `worst` à CLI `hronir`, além de manter `init` e `present`. `ranking` agrega vencedores/aparições entre todos os matches preenchidos; `worst` retorna a translationKey do pior ranqueado para alimentar a etapa de crítica.

---
_Generated by [Claude Code](https://claude.ai/code/session_012as5hQdqsq22hRKLnmEeYb)_