### PR TITLE
hronir: edit-worst subcommand

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "hronir:present": "node scripts/hronir/index.js present",
     "hronir:ranking": "node scripts/hronir/index.js ranking",
     "hronir:worst": "node scripts/hronir/index.js worst",
+    "hronir:edit-worst": "node scripts/hronir/index.js edit-worst",
     "hronir:migrate": "node scripts/hronir/index.js migrate",
     "hronir:doctor": "node scripts/hronir/index.js doctor"
   },

--- a/scripts/hronir/README.md
+++ b/scripts/hronir/README.md
@@ -29,11 +29,20 @@ Todos via npm scripts no raiz:
 | `npm run hronir:init` | Sorteia 10 posts EN, cria 5 match files `winner: TODO` |
 | `npm run hronir:present -- <match.md>` | Imprime os dois posts + instrução pro avaliador |
 | `npm run hronir:ranking` | Score acumulado de todos os matches preenchidos |
-| `npm run hronir:worst` | Imprime translationKey do pior ranqueado |
+| `npm run hronir:worst` | Imprime translationKey do pior ranqueado (apenas inspeção) |
+| `npm run hronir:edit-worst` | Imprime worst + top 3, defesas em que worst perdeu (5 mais recentes) e defesas dos top 3 (5 mais recentes), e instrui edição do post |
 | `npm run hronir:migrate` | Normaliza matches legados (slug → key, renomeia arquivos) |
 | `npm run hronir:doctor` | Verifica inconsistências (keys, paths, duplicatas) |
 
 Cada comando termina com uma linha `NEXT STEP:` apontando o próximo passo, exceto quando o fluxo termina.
+
+## Fluxo
+
+```
+init → present (×5) → edit-worst → (edição manual do post worst)
+```
+
+`worst` continua disponível para inspeção pontual, mas o fluxo automático termina em `edit-worst`: o sinal extraído da rodada não é só "este é o pior", e sim "aqui está o pior, aqui estão as defesas em que ele perdeu, aqui estão as defesas dos melhores — edite reduzindo o gap". A crítica em prosa (em `.routines/hronir/critiques/`) continua sendo um registro válido, mas não é mais o terminal do pipeline.
 
 ## Ranking
 

--- a/scripts/hronir/README.md
+++ b/scripts/hronir/README.md
@@ -2,6 +2,16 @@
 
 Sistema de avaliação par-a-par de posts do blog. Cada rodada sorteia 10 posts EN com `translationKey`, monta 5 partidas, e um avaliador (humano ou modelo) escolhe um vencedor por partida defendendo apaixonadamente. O ranking acumulado identifica o post que mais perde, e esse post recebe uma crítica registrada.
 
+> **Este CLI é não-interativo por design** (rodado por Claude Code).
+> Não use `readline`, `inquirer`, `prompts`, leitura de `process.stdin`,
+> nem confirmações em tela do tipo `[y/N]`. Toda saída vai direto pro
+> stdout via `console.log`, sem paginação. O default de qualquer ação
+> destrutiva ou que sobrescreve é "prossiga sem perguntar". Se algum
+> subcomando futuro precisar de confirmação destrutiva (ex: `reset`),
+> implemente com flag explícita `--yes`, não com prompt interativo.
+>
+> Comandos não devem mudar de comportamento baseado em `process.stdout.isTTY`.
+
 ## Identidade canônica
 
 `translationKey` (do frontmatter do post) é a identidade. Versões em idiomas diferentes do mesmo ensaio compartilham a mesma `translationKey` e portanto consolidam wins/appearances no ranking. Match files referenciam posts por `key` (= translationKey) e `path` (= caminho do .md).

--- a/scripts/hronir/index.js
+++ b/scripts/hronir/index.js
@@ -1,10 +1,10 @@
 #!/usr/bin/env node
-import { init, present, ranking, worst, migrate, doctor } from "./lib/commands.js";
+import { init, present, ranking, worst, editWorst, migrate, doctor } from "./lib/commands.js";
 
 const [, , cmd, ...args] = process.argv;
 
 function usage() {
-  console.error("Uso: hronir {init|present <match>|ranking|worst|migrate [--dry-run]|doctor}");
+  console.error("Uso: hronir {init|present <match>|ranking|worst|edit-worst|migrate [--dry-run]|doctor}");
   process.exit(1);
 }
 
@@ -20,6 +20,9 @@ switch (cmd) {
     break;
   case "worst":
     worst();
+    break;
+  case "edit-worst":
+    editWorst();
     break;
   case "migrate":
     migrate({ dryRun: args.includes("--dry-run") });

--- a/scripts/hronir/lib/commands.js
+++ b/scripts/hronir/lib/commands.js
@@ -96,7 +96,7 @@ export function present(matchFile) {
   console.log("- model: identificador do modelo executando");
   console.log("- substitua <!-- TODO --> pelo texto da defesa, em português");
 
-  nextStep(`Editar ${matchFile} com a decisão e a defesa. Quando os 5 matches estiverem preenchidos, rode \`npm run hronir:worst\`.`);
+  nextStep(`Editar ${matchFile} com a decisão e a defesa. Quando os 5 matches estiverem preenchidos, rode \`npm run hronir:edit-worst\`.`);
 }
 
 function aggregate() {
@@ -137,7 +137,7 @@ export function ranking() {
   for (const r of rows) {
     console.log(`${r.score}\t${r.wins}\t${r.appearances}\t${r.key}`);
   }
-  nextStep("Rode `npm run hronir:worst` para identificar o pior ranqueado e iniciar a etapa de crítica.");
+  nextStep("Rode `npm run hronir:edit-worst` para iniciar a edição do pior ranqueado (ou `npm run hronir:worst` apenas para inspeção).");
 }
 
 export function worst() {
@@ -149,7 +149,125 @@ export function worst() {
   const w = rows[0];
   console.log(w.key);
   console.error(`(path: ${w.path}, wins: ${w.wins}/${w.appearances}, score: ${w.score})`);
-  nextStep(`Leia ${w.path} completo e escreva crítica em .routines/hronir/critiques/${w.key}.md (template em scripts/hronir/README.md).`);
+}
+
+function collectDefensesForLoser(loserKey, limit = 5) {
+  const out = [];
+  for (const f of listMatchFiles()) {
+    const { data, content } = readMatch(f);
+    let winner = data.winner;
+    if (data.override && data.override !== "null") winner = data.override;
+    if (winner === "TODO" || !winner) continue;
+
+    const aKey = postKey(data.post_a);
+    const bKey = postKey(data.post_b);
+    const loserSide = winner === "a" ? "b" : "a";
+    const loserSideKey = loserSide === "a" ? aKey : bKey;
+    const winnerSideKey = winner === "a" ? aKey : bKey;
+    if (loserSideKey !== loserKey) continue;
+
+    const body = (content || "").replace(/^\s*<!--\s*TODO\s*-->\s*$/m, "").trim();
+    if (!body) continue;
+    out.push({
+      file: path.basename(f),
+      runId: data.run_id || "",
+      runAt: data.run_at || "",
+      winner: winnerSideKey,
+      loser: loserSideKey,
+      body,
+    });
+  }
+  out.sort((a, b) => String(b.runAt || b.runId).localeCompare(String(a.runAt || a.runId)));
+  return out.slice(0, limit);
+}
+
+function collectDefensesForWinners(winnerKeys, limit = 5) {
+  const set = new Set(winnerKeys);
+  const out = [];
+  for (const f of listMatchFiles()) {
+    const { data, content } = readMatch(f);
+    let winner = data.winner;
+    if (data.override && data.override !== "null") winner = data.override;
+    if (winner === "TODO" || !winner) continue;
+
+    const aKey = postKey(data.post_a);
+    const bKey = postKey(data.post_b);
+    const winnerSideKey = winner === "a" ? aKey : bKey;
+    const loserSideKey = winner === "a" ? bKey : aKey;
+    if (!set.has(winnerSideKey)) continue;
+
+    const body = (content || "").replace(/^\s*<!--\s*TODO\s*-->\s*$/m, "").trim();
+    if (!body) continue;
+    out.push({
+      file: path.basename(f),
+      runId: data.run_id || "",
+      runAt: data.run_at || "",
+      winner: winnerSideKey,
+      loser: loserSideKey,
+      body,
+    });
+  }
+  out.sort((a, b) => String(b.runAt || b.runId).localeCompare(String(a.runAt || a.runId)));
+  return out.slice(0, limit);
+}
+
+export function editWorst() {
+  const rows = aggregate();
+  if (rows.length === 0) {
+    console.error("Sem matches preenchidos suficientes para ranquear.");
+    process.exit(1);
+  }
+  const worstRow = rows[0];
+  const topRows = rows.slice(-3).reverse();
+  const topKeys = topRows.map((r) => r.key);
+
+  console.log(`# Pior ranqueado: ${worstRow.key}`);
+  console.log(`# Path: ${worstRow.path}`);
+  console.log(`# Score: ${worstRow.score} (wins ${worstRow.wins}/${worstRow.appearances})`);
+  console.log("");
+  console.log("# Top 3 (contraste): " + topKeys.join(", "));
+  console.log("");
+  console.log("=== CONTEÚDO DO POST WORST ===");
+  console.log("");
+
+  if (worstRow.path && fs.existsSync(worstRow.path)) {
+    console.log(fs.readFileSync(worstRow.path, "utf8"));
+  } else {
+    console.log(`(arquivo não encontrado: ${worstRow.path})`);
+  }
+
+  console.log("");
+  console.log("=== DEFESAS EM QUE ESTE POST PERDEU ===");
+  console.log("");
+  const losses = collectDefensesForLoser(worstRow.key, 5);
+  if (losses.length === 0) {
+    console.log("(nenhuma defesa textual encontrada em derrotas)");
+  } else {
+    for (const d of losses) {
+      console.log(`--- ${d.file}`);
+      console.log(`(venceu: ${d.winner})`);
+      console.log("");
+      console.log(d.body);
+      console.log("");
+    }
+  }
+
+  console.log("=== DEFESAS DE POSTS QUE VENCERAM (top 3) ===");
+  console.log("");
+  const wins = collectDefensesForWinners(topKeys, 5);
+  if (wins.length === 0) {
+    console.log("(nenhuma defesa textual encontrada para o top 3)");
+  } else {
+    for (const d of wins) {
+      console.log(`--- ${d.file}`);
+      console.log(`(vencedor: ${d.winner}, contra: ${d.loser})`);
+      console.log("");
+      console.log(d.body);
+      console.log("");
+    }
+  }
+
+  nextStep(`edite o post em ${worstRow.path} para diminuir o gap observado entre ele e os melhores, mantendo o espírito do post. Expanda, corte ou reescreva conforme necessário. Não há método prescrito — o resultado é o que importa.`);
 }
 
 function buildPathToKeyIndex() {


### PR DESCRIPTION
Adiciona o subcomando `edit-worst` e ajusta o pipeline para terminar nele.

## Motivação

`worst` apenas identifica o pior ranqueado. O sinal que importa para edição não é só "este é o pior" — é "este é o pior, aqui estão as defesas em que ele perdeu, aqui estão as defesas dos melhores, ajuste o gap". A crítica em prosa (em `.routines/hronir/critiques/`) continua sendo um registro válido, mas não dirige a edição; `edit-worst` dirige.

## O que `edit-worst` faz

1. Roda o ranking, pega o bottom 1 (worst) e o top 3 (best).
2. Coleta até 5 defesas mais recentes em que o worst foi loser.
3. Coleta até 5 defesas mais recentes em que algum do top 3 foi winner.
4. Imprime, em ordem:
   - Path do post worst, score, top 3 para contraste
   - Conteúdo completo do post worst
   - Bloco `DEFESAS EM QUE ESTE POST PERDEU`
   - Bloco `DEFESAS DE POSTS QUE VENCERAM`
5. `NEXT STEP:` edite o post em `<path>` para diminuir o gap observado entre ele e os melhores, mantendo o espírito do post. Expanda, corte ou reescreva conforme necessário. Não há método prescrito — o resultado é o que importa.

## Outras mudanças

- `present` no último match: NEXT STEP agora aponta para `npm run hronir:edit-worst` em vez de `npm run hronir:worst`.
- `ranking` NEXT STEP: menciona `edit-worst` como a próxima ação; `worst` fica para inspeção pontual.
- `worst` perdeu seu próprio NEXT STEP (não é mais terminal do fluxo).
- README documenta o novo fluxo: `init → present ×5 → edit-worst → (edição manual do post)`.
- npm script `hronir:edit-worst` no `package.json` raiz.

## Validação

- `npm run hronir:edit-worst` rodou sem erros, coletou 5 defesas de derrota + 5 defesas dos vencedores top-3 nos dados existentes.
- `npm run hronir:doctor` — 0 inconsistências.
- `init` não foi rodado (PR é infra apenas).

## Nota sobre base

Esta PR é baseada em `hronir/node-migration` (#115), que ainda não foi mesclada. Quando #115 mesclar, esta PR pode ser rebasada para `main`.

Não auto-merge.

---
_Generated by [Claude Code](https://claude.ai/code/session_012as5hQdqsq22hRKLnmEeYb)_