### PR TITLE
hronir: 20 matches por run + meta de palavras nas defesas

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "hronir": "node scripts/hronir/index.js",
     "hronir:init": "node scripts/hronir/index.js init",
     "hronir:present": "node scripts/hronir/index.js present",
+    "hronir:resume": "node scripts/hronir/index.js resume",
     "hronir:ranking": "node scripts/hronir/index.js ranking",
     "hronir:worst": "node scripts/hronir/index.js worst",
     "hronir:edit-worst": "node scripts/hronir/index.js edit-worst",

--- a/scripts/hronir/README.md
+++ b/scripts/hronir/README.md
@@ -36,8 +36,9 @@ Todos via npm scripts no raiz:
 
 | Comando | Função |
 |---------|--------|
-| `npm run hronir:init` | Sorteia 10 posts EN, cria 5 match files `winner: TODO` |
-| `npm run hronir:present -- <match.md>` | Imprime os dois posts + instrução pro avaliador |
+| `npm run hronir:init` | Sorteia 40 posts EN, cria 20 match files `winner: TODO` |
+| `npm run hronir:present -- <match.md>` | Imprime os dois posts + instrução pro avaliador (meta de palavras na defesa) |
+| `npm run hronir:resume` | Identifica a rodada mais recente, lista pendentes, aponta próximo |
 | `npm run hronir:ranking` | Score acumulado de todos os matches preenchidos |
 | `npm run hronir:worst` | Imprime translationKey do pior ranqueado (apenas inspeção) |
 | `npm run hronir:edit-worst` | Pior elegível + top 3, defesas, registro auditável em `edits/`, e instrução pra ler as skills antes de editar |
@@ -50,8 +51,14 @@ Cada comando termina com uma linha `NEXT STEP:` apontando o próximo passo, exce
 ## Fluxo
 
 ```
-init → present (×5) → edit-worst → (edição manual do post worst) → archive-post <key>
+init → present (×20) → edit-worst → (edição manual do post worst) → archive-post <key>
 ```
+
+`resume` em qualquer ponto identifica a rodada mais recente e aponta o próximo pendente. Útil para crash recovery ou retomada entre sessões.
+
+## Meta de palavras nas defesas
+
+`present` instrui o avaliador que cada defesa deve ter mínimo 100 palavras (piso de qualidade), meta 200 (alvo natural), mencionar os dois posts pelo nome ou pela key, e explicar concretamente. Não há validação coerciva no `doctor` — é instrução proativa. Defesa muito curta ou genérica perde a função do sistema (`edit-worst` lê e cita essas defesas; pouca substância dá pouco sinal).
 
 `worst` continua disponível para inspeção pontual, mas o fluxo automático termina em `edit-worst` + `archive-post`. A crítica em prosa em `.routines/hronir/critiques/` continua sendo um registro válido, mas não dirige a edição; o que dirige são as **skills versionadas** (próxima seção) e o registro auditável em `.routines/hronir/edits/<key>-<ts>.md`.
 

--- a/scripts/hronir/index.js
+++ b/scripts/hronir/index.js
@@ -1,10 +1,10 @@
 #!/usr/bin/env node
-import { init, present, ranking, worst, editWorst, archivePost, migrate, doctor } from "./lib/commands.js";
+import { init, present, ranking, worst, editWorst, archivePost, resume, migrate, doctor } from "./lib/commands.js";
 
 const [, , cmd, ...args] = process.argv;
 
 function usage() {
-  console.error("Uso: hronir {init|present <match>|ranking|worst|edit-worst|archive-post <key>|migrate [--dry-run]|doctor}");
+  console.error("Uso: hronir {init|present <match>|resume|ranking|worst|edit-worst|archive-post <key>|migrate [--dry-run]|doctor}");
   process.exit(1);
 }
 
@@ -14,6 +14,9 @@ switch (cmd) {
     break;
   case "present":
     present(args[0]);
+    break;
+  case "resume":
+    resume();
     break;
   case "ranking":
     ranking();

--- a/scripts/hronir/lib/commands.js
+++ b/scripts/hronir/lib/commands.js
@@ -35,16 +35,16 @@ export function init() {
   fs.mkdirSync(path.join(OUT_DIR, "critiques"), { recursive: true });
 
   const candidates = listEnglishWithKey();
-  if (candidates.length < 10) {
-    console.error(`Erro: só ${candidates.length} posts EN com translationKey em src/content/blog`);
+  if (candidates.length < 40) {
+    console.error(`Erro: só ${candidates.length} posts EN com translationKey em src/content/blog (mínimo 40)`);
     process.exit(1);
   }
 
-  const sample = shuffle(candidates).slice(0, 10);
+  const sample = shuffle(candidates).slice(0, 40);
   const { runId, runAt } = utcStamp();
   const created = [];
 
-  for (let i = 0; i < 5; i++) {
+  for (let i = 0; i < 20; i++) {
     let a = sample[i * 2];
     let b = sample[i * 2 + 1];
     if (Math.random() < 0.5) [a, b] = [b, a];
@@ -101,7 +101,18 @@ export function present(matchFile) {
   console.log("- model: identificador do modelo executando");
   console.log("- substitua <!-- TODO --> pelo texto da defesa, em português");
 
-  nextStep(`Editar ${matchFile} com a decisão e a defesa. Quando os 5 matches estiverem preenchidos, rode \`npm run hronir:edit-worst\`.`);
+  const stepLines = [
+    "A defesa deve ter:",
+    "- mínimo 100 palavras (piso de qualidade)",
+    "- meta 200 palavras (alvo natural)",
+    "- mencionar os dois posts pelo nome ou pela key",
+    "- explicar concretamente, não no abstrato",
+    "",
+    "Defesa muito curta ou genérica perde a função do sistema.",
+    "",
+    `Editar ${matchFile} com a decisão e a defesa. Quando os 20 matches da rodada estiverem preenchidos, rode \`npm run hronir:edit-worst\`. Para retomar do meio da rodada, \`npm run hronir:resume\`.`,
+  ];
+  nextStep(stepLines.join("\n"));
 }
 
 function aggregate() {
@@ -325,6 +336,56 @@ export function editWorst() {
     `Após editar, rode: npm run hronir:archive-post ${worstRow.key}`,
   ];
   nextStep(stepLines.join("\n"));
+}
+
+export function resume() {
+  const files = listMatchFiles();
+  if (files.length === 0) {
+    console.log("Nenhum match encontrado em .routines/hronir/.");
+    nextStep("rode `npm run hronir:init` para começar uma rodada.");
+    return;
+  }
+
+  const byRun = new Map();
+  for (const f of files) {
+    const { data } = readMatch(f);
+    const runId = String(data.run_id || "");
+    if (!runId) continue;
+    if (!byRun.has(runId)) byRun.set(runId, []);
+    byRun.get(runId).push({ file: f, data });
+  }
+
+  if (byRun.size === 0) {
+    console.log("Nenhum match com run_id encontrado.");
+    nextStep("rode `npm run hronir:init` para começar uma rodada.");
+    return;
+  }
+
+  const latestRunId = [...byRun.keys()].sort().pop();
+  const matches = byRun.get(latestRunId);
+  matches.sort((a, b) => (a.data.match_index || 0) - (b.data.match_index || 0));
+
+  const pending = matches.filter((m) => m.data.winner === "TODO" || !m.data.winner);
+  const total = matches.length;
+
+  console.log(`# Rodada mais recente: ${latestRunId}`);
+  console.log(`# Matches: ${total} total, ${pending.length} pendentes, ${total - pending.length} preenchidos`);
+  console.log("");
+
+  if (pending.length === 0) {
+    console.log("Todos os matches da rodada estão preenchidos.");
+    nextStep("rode `npm run hronir:edit-worst`.");
+    return;
+  }
+
+  console.log("Pendentes:");
+  for (const m of pending) {
+    console.log(`  [${m.data.match_index ?? "?"}] ${m.file}`);
+  }
+  console.log("");
+
+  const first = pending[0].file;
+  nextStep(`rode \`npm run hronir:present -- ${first}\` (próximo pendente).`);
 }
 
 export function archivePost(key) {


### PR DESCRIPTION
Três mudanças no Hrönir. Infra apenas — `init`/`present`/`edit-worst` não foram executados.

## (a) 20 matches por run

`init` sorteia 40 posts EN e cria 20 pares disjuntos. Compromisso entre o piso atual de 5 (pouco sinal por rodada) e um stress test de 50 (pesado).

**Atenção:** corpus EN+translationKey hoje é 32. `init` exige ≥40 e vai falhar com mensagem clara até o corpus crescer. Sem mudança forçada no threshold — quando faltar, falta.

## (b) Subcomando `resume`

Identifica o `run_id` mais recente em `.routines/hronir/` (ignora `archive/` por já não ser varrido pelo agregador), lista pendentes com `winner: TODO`. NEXT STEP aponta o próximo pendente OU `edit-worst` quando tudo preenchido. Crash recovery sem cerimônia.

## (c) Meta de palavras nas defesas

NEXT STEP de `present` agora instrui: mínimo 100 palavras, meta 200, mencionar os dois posts por nome ou key, explicar concretamente. Sem validação no `doctor` — é proativo. Defesa curta/genérica vira citação ruim quando `edit-worst` consome o sinal.

## Validação

- `npm run hronir:doctor` → 0 inconsistências.
- `npm run hronir:resume` rodou corretamente nos dados existentes (rodada `2026-05-18T03-09-26`, 5/5 preenchidos, NEXT STEP corretamente apontou edit-worst).

## Base

Esta PR é baseada em `hronir/skills-volume-archive` (PR #118). Quando #118 mesclar, rebase para `main`.

Não auto-merge.

---
_Generated by [Claude Code](https://claude.ai/code/session_012as5hQdqsq22hRKLnmEeYb)_