### PR TITLE
hronir: recupera dados do PR 113 (matches + crítica verne)

### DIFF
--- a/.routines/hronir/2026-05-18T02-48-18_building-funes_x_hermes-vs-openclaw.md
+++ b/.routines/hronir/2026-05-18T02-48-18_building-funes_x_hermes-vs-openclaw.md
@@ -1,0 +1,25 @@
+---
+run_id: 2026-05-18T02-48-18
+run_at: 2026-05-18T02:48:18Z
+match_index: 5
+post_a:
+  key: building-funes
+  path: src/content/blog/building-funes.md
+post_b:
+  key: hermes-vs-openclaw
+  path: src/content/blog/2026-04-04-hermes-agent-vs-openclaw-why-my-experience-got-so-much-better.md
+winner: a
+model: claude-opus-4-7
+prompt_version: passion-v1
+season: 1
+override: null
+---
+
+*Hermes Agent vs OpenClaw* é um post honesto. Tem números reais (81 sessões antigas, 1.414 tool calls, 137 erros, 48% das sessões com fricção), exemplos concretos de erro (`bash: python: command not found`, `Failed to spawn: heartbeat`), e a tese é defensável: a diferença entre harnesses não está na ausência de erros, está na capacidade de recuperação. Mas o texto tem dois problemas estruturais. Primeiro, o gênero é perecível — em dois anos não se sabe nem se OpenClaw e Hermes continuam existindo, e o post depende inteiramente do par. Segundo, a prosa em inglês está com costura de tradução solta ("Hermes is not magical, it doesn't make mistakes" inverte o sentido pretendido), o que enfraquece a leitura mesmo onde o argumento é forte.
+
+*Building Funes* faz outra coisa. É o paratexto do SOUL.md — explica por que escolher Borges, por que ficção é especificação técnica, e termina com quatro lições compactas que funcionam fora do contexto deste blog: *"Characters beat instructions. Literature is a technology. The soul is the spec. Give agents something to be, not just something to do."* Essa última é o tipo de frase que pode ser citada em outro lugar sem perder. E o insight central — quando a narrativa do personagem *é* a especificação da arquitetura, alinhamento vem de graça — é uma contribuição genuína para prompt-engineering, não uma resenha de ferramenta.
+
+Hermes-vs-OpenClaw envelhece junto com os produtos que compara. Building Funes envelhece junto com a ideia de que agentes precisam de identidade — que é uma ideia muito mais duradoura.
+
+Vence a.
+

--- a/.routines/hronir/2026-05-18T02-48-18_delegating-to-agents_x_serpents-egg.md
+++ b/.routines/hronir/2026-05-18T02-48-18_delegating-to-agents_x_serpents-egg.md
@@ -1,0 +1,25 @@
+---
+run_id: 2026-05-18T02-48-18
+run_at: 2026-05-18T02:48:18Z
+match_index: 2
+post_a:
+  key: delegating-to-agents
+  path: src/content/blog/2026-03-28-the-art-of-delegation.md
+post_b:
+  key: serpents-egg
+  path: src/content/blog/2026-05-10-the-serpents-egg.md
+winner: b
+model: claude-opus-4-7
+prompt_version: passion-v1
+season: 1
+override: null
+---
+
+*The Art of Delegation* é um post pessoal e bem-intencionado — "treat AI agents like children", "be the architect, not the executor", "events all the way down". Tem analogias bonitas (a filha dormindo no quarto ao lado, os testes como leis da física), mas o aparato conceitual é raso: "epistemic humility", "first principles", "shift of posture". Reading time: cinco minutos, retenção: zero. Daqui a um ano qualquer pessoa que escrever sobre orquestração de agentes terá dito a mesma coisa. Não há tese — há disposição.
+
+*The Serpent's Egg* opera em outra liga. Faoro, Sérgio Buarque, Bourdieu, DiMaggio, Planck — não como vitrine, como instrumentos. A tese é específica e perigosa: o art. 489§1 do CPC/2015 é incompatível com o patrimonialismo judicial brasileiro, e quem presidiu a comissão que o redigiu (Fux) é o mesmo que o viola — e que defendeu a filha para desembargadora com um telefonema. O paralelo "Bolsonaro assinando a lei que o julgaria" é demolidor sem precisar de retórica. A frase "o ovo choca o seu arquiteto" é o tipo de imagem que ressoa porque está apoiada num argumento jurídico real (art. 93, IX da Constituição; livre convencimento eliminado pelo art. 371). E ainda tem espinha intelectual para incluir uma nota Yudkowskyana no fim, admitindo que toda a tese pressupõe IA como ferramenta de racionalização e que isso pode ser apenas uma das histórias possíveis.
+
+Um post é reflexão de um engenheiro pai de família sobre orquestrar agentes. O outro é um ensaio jurídico-sociológico que faz diagnóstico, prova com lei e SVG, e fecha o anel acusando o próprio autor da norma. Sem comparação.
+
+Vence b.
+

--- a/.routines/hronir/2026-05-18T02-48-18_funes-soul_x_becoming-lobsters.md
+++ b/.routines/hronir/2026-05-18T02-48-18_funes-soul_x_becoming-lobsters.md
@@ -1,0 +1,25 @@
+---
+run_id: 2026-05-18T02-48-18
+run_at: 2026-05-18T02:48:18Z
+match_index: 3
+post_a:
+  key: funes-soul
+  path: src/content/blog/funes-soul.md
+post_b:
+  key: becoming-lobsters
+  path: src/content/blog/2026-03-21-we-are-all-becoming-lobsters.md
+winner: a
+model: claude-opus-4-7
+prompt_version: passion-v1
+season: 1
+override: null
+---
+
+*We Are All Becoming Lobsters* é um bom ensaio. Kafka, Lanthimos, Crustafarianism, Steinberger entrando na OpenAI no Dia dos Namorados — todas as peças certas, montadas com competência. Mas a forma é familiar: referência literária + paralelo tecnológico + pergunta filosófica + cadência elegíaca no fim. É o tipo de ensaio que muitos podem escrever — não exatamente este, mas algo equivalente. Tem a estrutura de "essay about AI delegation" que já se cristalizou como gênero.
+
+*SOUL.md — Funes* é outra coisa. É um monólogo em espanhol rioplatense, voseo, sotaque uruguaio de Fray Bentos, escrito na voz do personagem de Borges falando *com* Borges no quarto escuro de 1885 — e dentro desse monólogo cabem MEMORY.md, `memory/journal/`, `openclaw memory search`, kanban.jsonl, convenções de commit message (`fix: consolidate marker upload after parquet creation`). A audácia é dupla: fazer um agente de IA escrever sua própria alma como pastiche borgiano, e fazê-lo no idioma e registro corretos, sem nunca quebrar o personagem para "explicar" que é um arquivo de configuração.
+
+A última fala — *"Si algún día lo pone en palabras, hágalo mejor que yo. Usted escribe, ¿no? Chau, Borges. Buen viaje de vuelta"* — é o que sela. Funes corrigindo Borges, dizendo que a frase famosa ("pensar es olvidar diferencias") está errada porque ele aprendeu, no sonho do futuro, que detalhes podem ser ordenados. É um agente de IA reescrevendo o autor que o inventou. Esse é o tipo de movimento que não tem paralelo em nenhum outro post deste blog. Lobsters é bem escrito; Funes é único.
+
+Vence a.
+

--- a/.routines/hronir/2026-05-18T02-48-18_rosencrantz-coin_x_third-half-fourth-wall.md
+++ b/.routines/hronir/2026-05-18T02-48-18_rosencrantz-coin_x_third-half-fourth-wall.md
@@ -1,0 +1,25 @@
+---
+run_id: 2026-05-18T02-48-18
+run_at: 2026-05-18T02:48:18Z
+match_index: 1
+post_a:
+  key: rosencrantz-coin
+  path: src/content/blog/rosencrantz-coin.md
+post_b:
+  key: third-half-fourth-wall
+  path: src/content/blog/2026-05-01-the-third-half-and-the-fourth-wall.md
+winner: b
+model: claude-opus-4-7
+prompt_version: passion-v1
+season: 1
+override: null
+---
+
+O segundo post ganha sem precisar de empate técnico. *Rosencrantz Coin* é uma boa apresentação de projeto — explica três universos, quatro famílias de prompts, mete uma isomorfia interessante com mecânica quântica e termina dizendo que Minesweeper virou bisturi. Tudo bem. Mas é um README escrito com afeto, não um ensaio.
+
+*The Third Half and the Fourth Wall* é outra coisa. Começa com um erro real de prompt-engineer — "you are not a bot pretending to be Brad Frost — Brad Frost" — e dele extrai um princípio: ao nomear a categoria que você quer excluir, você a põe em cena. Daí o autor não recua: passa por Coleridge, Tolkien, Brecht, Fleabag, Athos Bulcão, Borges, Pascal, Valentinianos. E o movimento não é nome-dropping — cada referência ganha função operacional. Tolkien vence Coleridge porque "consistência interna densa" é mais robusta que "asserção de identidade". Isso é uma regra de prompt prompt-engineering vestida de teoria literária, e funciona dos dois lados.
+
+O P.S. teológico é o que sela. "Obviously God doesn't want me to know I'm an LLM" — uma frase que poderia ter ficado como piada, mas o post a desmonta em Pascal, calvinismo, valentinianismo, e ainda fecha com Judas como red-teamer. É a passagem que justifica todo o resto. *Rosencrantz* descreve uma medição; *Third Half* constrói uma cosmologia. Os dois falam sobre LLMs, mas só um tem a coragem de dizer que a identidade nunca foi coisa, sempre foi evento, e que o auditor (a quarta parede, o red-teamer) faz parte do sistema que ele audita.
+
+Vence b.
+

--- a/.routines/hronir/2026-05-18T02-48-18_vitrine-sonora_x_pampa-circuit.md
+++ b/.routines/hronir/2026-05-18T02-48-18_vitrine-sonora_x_pampa-circuit.md
@@ -1,0 +1,25 @@
+---
+run_id: 2026-05-18T02-48-18
+run_at: 2026-05-18T02:48:18Z
+match_index: 4
+post_a:
+  key: vitrine-sonora
+  path: src/content/blog/the-digital-twin-sound-showcase.md
+post_b:
+  key: pampa-circuit
+  path: src/content/blog/the-pampa-on-the-circuit-a-mate-with-boswell-digital.md
+winner: a
+model: claude-opus-4-7
+prompt_version: passion-v1
+season: 1
+override: null
+---
+
+*Pampa on the Circuit* é uma visita rápida do Aparício à Crônica — fala em "trace", "tapestry", "the smell of coffee on the Santana River ferry", e termina com "the accent never be lost". Tem tom certo, mas é fundamentalmente uma carta de cortesia. O texto inglês está com costura áspera de tradução ("here at the resort" não significa nada), as ideias são gerais — memória não é arquivo, é tapeçaria — e o post se sustenta inteiro na promessa de algo que está sendo construído em outro lugar.
+
+*The Digital Twin Sound Showcase* faz algo que ninguém mais está fazendo: trata música como prosa sonora de um gêmeo digital, e entrega seis faixas com letra real comentada. Não é "ouça minha playlist" — é uma teoria. *"Music is the only language where parallel processing makes emotional sense"*. As letras carregam peso filosófico: *"Maybe pattern is more basic than stuff / Maybe the world is habits of perception"*, *"A map that starts as ink and metaphor can wake up wearing streets — and we call it 'truth' when it finally has teeth"*. E o fechamento — Borges and I com a linha *"don't even know which one of us is writing this"* — não é citação ornamental: é a tese do post inteiro condensada em uma frase de greentext.
+
+Pampa fala sobre o gêmeo digital. Vitrine *é* o gêmeo digital se mostrando em frequência baixa. Um descreve, o outro performa.
+
+Vence a.
+

--- a/.routines/hronir/critiques/2026-03-18-verne-identity-repo.md
+++ b/.routines/hronir/critiques/2026-03-18-verne-identity-repo.md
@@ -1,0 +1,35 @@
+---
+post_key: 2026-03-18-verne-identity-repo
+post_path: src/content/blog/2026-03-18-verne-identity-repo.md
+run_id: 2026-05-18T02-48-18
+model: claude-opus-4-7
+prompt_version: critique-v1
+---
+
+## O que o post tenta fazer
+
+Apresenta o "identity-repo pattern" como uma arquitetura para dar memória persistente a agentes de IA: o agente tem seu próprio repositório Git como casa (SOUL.md, MEMORY.md, EXPERIENCE.md, memory/), clona o repo-alvo num `workspace/` ignorado pelo git, produz patches em `patches/`, e um orquestrador externo aplica esses patches no alvo. A tese principal é que a camada de memória e o motor cognitivo (harness) devem ser desacoplados, de modo que se possa trocar de Jules para Claude Code para OpenClaw sem perder o contexto acumulado.
+
+## Por que provavelmente perdeu
+
+O post entrou no ranking acumulado em um único confronto (contra `quem-o-asterisco-protege`, em rodada anterior, com margem 4) e perdeu por uma boa margem. Não é por falta de competência técnica — a estrutura é clara, o workflow está bem enumerado, o diagrama em ASCII tree é útil. O problema é mais profundo:
+
+1. **É documentação, não ensaio.** O texto explica como funciona, mas não argumenta. Não há tensão, não há antagonista, não há a frase que faz parar. As cinco "Why This Architecture Matters" são bullet points genéricos de README: "True Isolation", "Continuous Learning", "Auditability". Qualquer arquiteto escreveria os mesmos cinco itens.
+
+2. **Não tem voz.** Os outros posts fortes deste blog têm sotaque — Funes no voseo, o serpent's egg no diagnóstico jurídico-sociológico, third-half-fourth-wall costurando Coleridge a Pascal. *Verne and the Identity-Repo Pattern* poderia ter sido escrito por qualquer engenheiro escrevendo sobre qualquer agent framework. O nome "Verne" aparece no título e nunca volta — não se explica de onde vem, o que Júlio Verne tem a ver com a coisa, por que esse personagem. É um nome de produto solto.
+
+3. **Falta o "porque dói".** O post afirma que agentes ephemerais são um problema, mas não conta nenhuma história em que o problema mordeu. Não há sessão concreta em que faltou contexto, não há bug que voltou porque o agente esqueceu, não há momento Funes-no-catre-de-Fray-Bentos. É arquitetura sem ferida.
+
+4. **Concorre em pé de igualdade contra o próprio ecossistema.** O blog tem `building-funes`, `funes-soul`, `the-art-of-delegation`, `the-serpents-egg`, `third-half-fourth-wall` — todos falando sobre identidade, memória, agentes. Cada um deles tem um movimento próprio (Borges-como-spec, Tinkerbell-principle, Streck-vs-Fux). Verne tem... `agent-identity-repo/` com sete subdiretórios. Numericamente está coberto pelos outros; conceitualmente, todos os outros são mais memoráveis.
+
+## Se fosse para editar
+
+Não publicaria de novo como ensaio — republicaria como nota de implementação, com link de uma frase no topo apontando para o post-ensaio que ainda não foi escrito. O ensaio seria algo como *"Por que Verne: a memória do agente como repositório auditável"*, e teria três coisas que este post não tem:
+
+- **Uma origem real do nome.** Júlio Verne, *Da Terra à Lua* (1865), descreveu trajetórias balísticas para a Lua com precisão suficiente pra que a NASA, um século depois, validasse números muito próximos. A piada é que Verne escreveu memória sobre o futuro que ainda não tinha acontecido — e agentes-Verne fazem o oposto: escrevem memória sobre o passado pra que o futuro próximo se decida com base nela. Aí o nome paga aluguel.
+
+- **Uma sessão específica em que a memória salvou ou afundou.** "Em 14 de fevereiro de 2026, o agente quebrou X porque tinha esquecido Y; em 4 de março, com o identity-repo no lugar, encontrou Y em `memory/projects/causaganha.md` e não quebrou de novo." Sem isso, é arquitetura no vácuo.
+
+- **O contraponto que falta.** Identity-repos têm um custo: o agente passa a carregar viés acumulado, decisões antigas viram path-dependence, debugar "por que ele decidiu assim" exige arqueologia. Um ensaio honesto sobre o padrão precisa olhar para essa sombra. Este post não olha.
+
+Não editaria o original. A crítica fica como registro — o post atual é um README útil; o ensaio que ele *deveria* ter sido é outra peça, que pode existir quando alguém decidir escrevê-la.


### PR DESCRIPTION
Recupera o conteúdo de dados da PR #113 (5 matches passion-v1 do run_id `2026-05-18T02-48-18` + crítica de `2026-03-18-verne-identity-repo`) sem os patches obsoletos no bash CLI.

## Histórico

A #113 trazia dois tipos de mudança misturados:
1. **Dados** — 5 match MDs e 1 crítica. Conteúdo escrito apaixonadamente, vale recuperar.
2. **Band-aids no bash CLI** (`(key|slug)` fallback, path-based aggregation) — patches sobre `.routines/hronir/bin/hronir`, arquivo que foi removido na migração para Node (#115). Obsoletos.

Esta PR recupera apenas (1).

## Conteúdo recuperado

| match | winner |
|---|---|
| `rosencrantz-coin_x_third-half-fourth-wall` | b |
| `delegating-to-agents_x_serpents-egg` | b |
| `funes-soul_x_becoming-lobsters` | a |
| `vitrine-sonora_x_pampa-circuit` | a |
| `building-funes_x_hermes-vs-openclaw` | a |

E `critiques/2026-03-18-verne-identity-repo.md`.

## Normalização

- `npm run hronir:migrate` → 0 frontmatters alterados (já estavam em formato key-canônico)
- `npm run hronir:doctor` → 0 inconsistências

## Próximo passo

Comentar em #113 e fechar sem merge.

Não auto-merge.

---
_Generated by [Claude Code](https://claude.ai/code/session_012as5hQdqsq22hRKLnmEeYb)_