### PR TITLE
hronir: init com n_matches dinâmico

### DIFF
--- a/scripts/hronir/README.md
+++ b/scripts/hronir/README.md
@@ -36,7 +36,7 @@ Todos via npm scripts no raiz:
 
 | Comando | Função |
 |---------|--------|
-| `npm run hronir:init` | Sorteia 40 posts EN, cria 20 match files `winner: TODO` |
+| `npm run hronir:init` | Sorteia posts EN, cria até 20 match files (n = min(20, ⌊corpus/2⌋); falha se corpus < 4) |
 | `npm run hronir:present -- <match.md>` | Imprime os dois posts + instrução pro avaliador (meta de palavras na defesa) |
 | `npm run hronir:resume` | Identifica a rodada mais recente, lista pendentes, aponta próximo |
 | `npm run hronir:ranking` | Score acumulado de todos os matches preenchidos |
@@ -51,7 +51,7 @@ Cada comando termina com uma linha `NEXT STEP:` apontando o próximo passo, exce
 ## Fluxo
 
 ```
-init → present (×20) → edit-worst → (edição manual do post worst) → archive-post <key>
+init → present (×n_matches) → edit-worst → (edição manual do post worst) → archive-post <key>
 ```
 
 `resume` em qualquer ponto identifica a rodada mais recente e aponta o próximo pendente. Útil para crash recovery ou retomada entre sessões.

--- a/scripts/hronir/lib/commands.js
+++ b/scripts/hronir/lib/commands.js
@@ -35,16 +35,20 @@ export function init() {
   fs.mkdirSync(path.join(OUT_DIR, "critiques"), { recursive: true });
 
   const candidates = listEnglishWithKey();
-  if (candidates.length < 40) {
-    console.error(`Erro: só ${candidates.length} posts EN com translationKey em src/content/blog (mínimo 40)`);
+  const corpusSize = candidates.length;
+  if (corpusSize < 4) {
+    console.error(`Erro: só ${corpusSize} posts EN com translationKey em src/content/blog (mínimo 4 para formar 2 pares)`);
     process.exit(1);
   }
 
-  const sample = shuffle(candidates).slice(0, 40);
+  const nMatches = Math.min(20, Math.floor(corpusSize / 2));
+  console.log(`Corpus: ${corpusSize} posts elegíveis. Criando ${nMatches} matches.`);
+
+  const sample = shuffle(candidates).slice(0, nMatches * 2);
   const { runId, runAt } = utcStamp();
   const created = [];
 
-  for (let i = 0; i < 20; i++) {
+  for (let i = 0; i < nMatches; i++) {
     let a = sample[i * 2];
     let b = sample[i * 2 + 1];
     if (Math.random() < 0.5) [a, b] = [b, a];
@@ -110,7 +114,7 @@ export function present(matchFile) {
     "",
     "Defesa muito curta ou genérica perde a função do sistema.",
     "",
-    `Editar ${matchFile} com a decisão e a defesa. Quando os 20 matches da rodada estiverem preenchidos, rode \`npm run hronir:edit-worst\`. Para retomar do meio da rodada, \`npm run hronir:resume\`.`,
+    `Editar ${matchFile} com a decisão e a defesa. Quando todos os matches da rodada estiverem preenchidos, rode \`npm run hronir:edit-worst\`. Para retomar do meio da rodada, \`npm run hronir:resume\`.`,
   ];
   nextStep(stepLines.join("\n"));
 }


### PR DESCRIPTION
`init` agora escala dinamicamente:

```
n_matches = min(20, floor(corpus_size / 2))
```

Com o corpus atual (32 posts EN + translationKey) isso dá **16 matches** — antes (PR #119) `init` falhava porque exigia ≥40. Quando o corpus crescer para ≥40, volta a 20.

Hard floor: corpus < 4 ainda falha (não dá pra formar 2 pares disjuntos).

Primeira linha do output: `Corpus: N posts elegíveis. Criando M matches.`

## Validação

- `npm run hronir:doctor` → 0 inconsistências.
- Smoke estático: `listEnglishWithKey()` retorna 32 → n_matches = 16.

Base: `hronir/scale-20-word-targets` (#119). Rebase para `main` quando #119 mesclar.

Não auto-merge.

---
_Generated by [Claude Code](https://claude.ai/code/session_012as5hQdqsq22hRKLnmEeYb)_