### PR TITLE
hronir: substitui agregador winrate por OpenSkill

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
       "devDependencies": {
         "@astrojs/check": "^0.9.9",
         "gray-matter": "^4.0.3",
+        "openskill": "^4.1.1",
         "playwright": "^1.60.0"
       },
       "engines": {
@@ -2529,6 +2530,13 @@
         "@types/estree": "*"
       }
     },
+    "node_modules/@types/gaussian": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@types/gaussian/-/gaussian-1.2.2.tgz",
+      "integrity": "sha512-FLlJb9oGcoq0xVaAmn5ytZWeEO4M7nfudewzqL6FxUUYLR5FB+hEzSYAsuhX7H7M6Mw/Z0rLbIVbQkMqHlRS7g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/geojson": {
       "version": "7946.0.16",
       "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
@@ -2587,6 +2595,16 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.16.0"
+      }
+    },
+    "node_modules/@types/ramda": {
+      "version": "0.31.1",
+      "resolved": "https://registry.npmjs.org/@types/ramda/-/ramda-0.31.1.tgz",
+      "integrity": "sha512-Vt6sFXnuRpzaEj+yeutA0q3bcAsK7wdPuASIzR9LXqL4gJPyFw8im9qchlbp4ltuf3kDEIRmPJTD/Fkg60dn7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "types-ramda": "^0.31.0"
       }
     },
     "node_modules/@types/sax": {
@@ -4498,6 +4516,16 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/gaussian": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/gaussian/-/gaussian-1.3.0.tgz",
+      "integrity": "sha512-rYQ0ESfB+z0t7G95nHH80Zh7Pgg9A0FUYoZqV0yPec5WJZWKIHV2MPYpiJNy8oZAeVqyKwC10WXKSCnUQ5iDVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
       }
     },
     "node_modules/get-caller-file": {
@@ -6509,6 +6537,23 @@
         "regex-recursion": "^6.0.2"
       }
     },
+    "node_modules/openskill": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/openskill/-/openskill-4.1.1.tgz",
+      "integrity": "sha512-sVEeVr9oktZv7VRShjOLpZopn1Wdq5NxIVA33BZJKcJCdHAOEc+ZFBxYvkKSijiRJ8bTQTahkOhqcQxM5WloJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/gaussian": "1.2.2",
+        "@types/ramda": "0.31.1",
+        "gaussian": "1.3.0",
+        "ramda": "0.32.0",
+        "sort-unwind": "3.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/p-limit": {
       "version": "7.3.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-7.3.0.tgz",
@@ -6853,6 +6898,17 @@
       "resolved": "https://registry.npmjs.org/radix3/-/radix3-1.1.2.tgz",
       "integrity": "sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA==",
       "license": "MIT"
+    },
+    "node_modules/ramda": {
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.32.0.tgz",
+      "integrity": "sha512-GQWAHhxhxWBWA8oIBr1XahFVjQ9Fic6MK9ikijfd4TZHfE2+urfk+irVlR5VOn48uwMgM+loRRBJd6Yjsbc0zQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ramda"
+      }
     },
     "node_modules/readdirp": {
       "version": "5.0.0",
@@ -7525,6 +7581,16 @@
         "url": "https://github.com/sponsors/cyyynthia"
       }
     },
+    "node_modules/sort-unwind": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/sort-unwind/-/sort-unwind-3.1.0.tgz",
+      "integrity": "sha512-9NJPZtqwIHNXBqY3SWZrwd/VU+lFo2i1Q79cuaRpMMkZFuf+Y54XVAADyy/w6r8t409KkNwo6cKaEKM56XaSNQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.7.6",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
@@ -7763,6 +7829,13 @@
         "node": ">=6.10"
       }
     },
+    "node_modules/ts-toolbelt": {
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/ts-toolbelt/-/ts-toolbelt-9.6.0.tgz",
+      "integrity": "sha512-nsZd8ZeNUzukXPlJmTBwUAuABDe/9qtVDelJeT/qW0ow3ZS3BsQJtNkan1802aM9Uf68/Y8ljw86Hu0h5IUW3w==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/tsconfck": {
       "version": "3.1.6",
       "resolved": "https://registry.npmjs.org/tsconfck/-/tsconfck-3.1.6.tgz",
@@ -7789,6 +7862,16 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD",
       "optional": true
+    },
+    "node_modules/types-ramda": {
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/types-ramda/-/types-ramda-0.31.0.tgz",
+      "integrity": "sha512-vaoC35CRC3xvL8Z6HkshDbi6KWM1ezK0LHN0YyxXWUn9HKzBNg/T3xSGlJZjCYspnOD3jE7bcizsp0bUXZDxnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ts-toolbelt": "^9.6.0"
+      }
     },
     "node_modules/typesafe-path": {
       "version": "0.2.2",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   "devDependencies": {
     "@astrojs/check": "^0.9.9",
     "gray-matter": "^4.0.3",
+    "openskill": "^4.1.1",
     "playwright": "^1.60.0"
   }
 }

--- a/scripts/hronir/README.md
+++ b/scripts/hronir/README.md
@@ -87,9 +87,13 @@ O `edit-worst` instrui a leitura de **ambas** antes de editar e a escolher a apl
 
 ## Ranking
 
-Ranking via **OpenSkill** (modelo Weng-Lin, atualização bayesiana online de Plackett-Luce). Cada par é tratado como uma partida 1v1; vencedor sobe `mu` e desce `sigma`, perdedor o oposto. A ordem global usa `ordinal(r) = mu - 3*sigma` — score conservador que penaliza incerteza, então um post com poucas partidas tende a ter ordinal menor mesmo que `mu` esteja alto.
+Ranking via **OpenSkill** (modelo Weng-Lin, atualização bayesiana online de Plackett-Luce). Cada par é tratado como uma partida 1v1; vencedor sobe `mu` e desce `sigma`, perdedor o oposto. Três eixos saem da computação, todos exibidos lado a lado em `hronir:ranking`:
 
-Tie-break alfabético. O `worst` retorna o de menor ordinal entre os posts com `appearances >= MIN_APPEARANCES`.
+- **`mu`** — estimativa pontual da "qualidade" do post. Sobe quando o post vence, desce quando perde, com magnitude proporcional à surpresa (vencer um post de mu alto vale mais).
+- **`sigma`** — incerteza sobre `mu`. Começa alta (pouca informação) e cai a cada partida. Não diz que o post é ruim — diz que ainda não sabemos.
+- **`ordinal = mu − 3·sigma`** — score conservador usado para a ordem global. Penaliza incerteza explicitamente: um post novo, mesmo com mu alto, fica atrás de um post estabelecido com mu um pouco menor.
+
+A ordem da tabela é por `ordinal` descendente. Tie-break alfabético por `key`. O `worst` retorna o post com menor `ordinal` entre os elegíveis (`appearances >= MIN_APPEARANCES`) — note que aqui não é "tie-break", é filtro: posts sem volume mínimo são ignorados antes de pegar o último.
 
 ### Por que MIN_APPEARANCES ainda importa com OpenSkill
 

--- a/scripts/hronir/README.md
+++ b/scripts/hronir/README.md
@@ -87,9 +87,18 @@ O `edit-worst` instrui a leitura de **ambas** antes de editar e a escolher a apl
 
 ## Ranking
 
-Score = `floor(wins * 1000 / appearances) + appearances`. Tie-break por chave alfabética. O `worst` retorna o de menor score.
+Ranking via **OpenSkill** (modelo Weng-Lin, atualização bayesiana online de Plackett-Luce). Cada par é tratado como uma partida 1v1; vencedor sobe `mu` e desce `sigma`, perdedor o oposto. A ordem global usa `ordinal(r) = mu - 3*sigma` — score conservador que penaliza incerteza, então um post com poucas partidas tende a ter ordinal menor mesmo que `mu` esteja alto.
 
-A componente `+ appearances` é deliberada: posts com mais aparições têm mais informação sobre eles, então um post com 0/1 fica acima de um post sem dados. O pior ranqueado precisa ter aparecido pelo menos uma vez.
+Tie-break alfabético. O `worst` retorna o de menor ordinal entre os posts com `appearances >= MIN_APPEARANCES`.
+
+### Por que MIN_APPEARANCES ainda importa com OpenSkill
+
+OpenSkill já carrega incerteza em `sigma`, então em tese seria possível ranquear posts com 1 partida. Mas duas razões mantêm o threshold:
+
+1. **Sinal de defesa.** `edit-worst` consome as defesas como contexto. Um post com 1 derrota dá só 1 defesa pra trabalhar; com 3+ derrotas, o conjunto de defesas começa a triangular o problema do post.
+2. **Estabilidade.** Os 3 primeiros matches de um post podem oscilar muito (sigma alto, ordinal sensível). MIN_APPEARANCES=3 evita editar com base num único par que pode ter sido sorte/azar.
+
+`appearances` continua reportado ao lado de `mu`/`sigma` exatamente para isso ser legível.
 
 ## Match file
 

--- a/scripts/hronir/lib/commands.js
+++ b/scripts/hronir/lib/commands.js
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { OUT_DIR, listEnglishWithKey, keyForPath, readPost, listPosts } from "./posts.js";
 import { listMatchFiles, readMatch, writeMatch, postKey } from "./matches.js";
+import { computeRatings } from "./ranking.js";
 
 const MIN_APPEARANCES = 3;
 const SKILLS_DIR = "scripts/hronir/skills";
@@ -119,56 +120,33 @@ export function present(matchFile) {
   nextStep(stepLines.join("\n"));
 }
 
-function aggregate() {
-  const wins = new Map();
-  const appearances = new Map();
-  const labels = new Map();
+// Ratings via OpenSkill (computeRatings, lib/ranking.js).
+// Output: rows ordered by ordinal DESC (best first).
 
-  for (const f of listMatchFiles()) {
-    const { data } = readMatch(f);
-    let winner = data.winner;
-    if (data.override && data.override !== "null") winner = data.override;
-    if (winner === "TODO" || !winner) continue;
-
-    const aKey = postKey(data.post_a);
-    const bKey = postKey(data.post_b);
-    if (!aKey || !bKey) continue;
-
-    appearances.set(aKey, (appearances.get(aKey) || 0) + 1);
-    appearances.set(bKey, (appearances.get(bKey) || 0) + 1);
-    if (data.post_a?.path) labels.set(aKey, data.post_a.path);
-    if (data.post_b?.path) labels.set(bKey, data.post_b.path);
-    if (winner === "a") wins.set(aKey, (wins.get(aKey) || 0) + 1);
-    else if (winner === "b") wins.set(bKey, (wins.get(bKey) || 0) + 1);
-  }
-
-  const rows = [];
-  for (const [key, a] of appearances) {
-    const w = wins.get(key) || 0;
-    const score = Math.floor((w * 1000) / a) + a;
-    rows.push({ key, wins: w, appearances: a, score, path: labels.get(key) || "" });
-  }
-  rows.sort((x, y) => x.score - y.score || x.key.localeCompare(y.key));
-  return rows;
+function fmt(n, w = 6) {
+  return n.toFixed(3).padStart(w);
 }
 
 export function ranking() {
-  const rows = aggregate();
-  for (const r of rows) {
-    console.log(`${r.score}\t${r.wins}\t${r.appearances}\t${r.key}`);
+  const rows = computeRatings();
+  console.log(`rank\tkey\tordinal\tmu\tsigma\tW/N`);
+  for (let i = 0; i < rows.length; i++) {
+    const r = rows[i];
+    console.log(`${i + 1}\t${r.key}\t${fmt(r.ordinal)}\t${fmt(r.mu)}\t${fmt(r.sigma)}\t${r.wins}/${r.appearances}`);
   }
   nextStep("Rode `npm run hronir:edit-worst` para iniciar a edição do pior ranqueado (ou `npm run hronir:worst` apenas para inspeção).");
 }
 
 export function worst() {
-  const rows = aggregate();
-  if (rows.length === 0) {
-    console.error("Sem matches preenchidos suficientes para ranquear.");
+  const rows = computeRatings();
+  const eligible = rows.filter((r) => r.appearances >= MIN_APPEARANCES);
+  if (eligible.length === 0) {
+    console.error(`Sem posts com appearances >= ${MIN_APPEARANCES}.`);
     process.exit(1);
   }
-  const w = rows[0];
+  const w = eligible[eligible.length - 1];
   console.log(w.key);
-  console.error(`(path: ${w.path}, wins: ${w.wins}/${w.appearances}, score: ${w.score})`);
+  console.error(`(path: ${w.path}, wins: ${w.wins}/${w.appearances}, ordinal: ${w.ordinal.toFixed(3)}, mu: ${w.mu.toFixed(3)}, sigma: ${w.sigma.toFixed(3)})`);
 }
 
 function collectDefensesForLoser(loserKey, limit = 5) {
@@ -232,7 +210,7 @@ function collectDefensesForWinners(winnerKeys, limit = 5) {
 }
 
 export function editWorst() {
-  const rows = aggregate();
+  const rows = computeRatings();
   if (rows.length === 0) {
     console.error("Sem matches preenchidos suficientes para ranquear.");
     process.exit(1);
@@ -247,13 +225,17 @@ export function editWorst() {
     return;
   }
 
-  const worstRow = eligible[0];
-  const topRows = rows.slice(-3).reverse();
+  // rows are sorted by ordinal DESC (best first); worst eligible is the last,
+  // top 3 are the first three eligible — same threshold applied to both sides
+  // so contrast set never comes from low-volume posts.
+  const worstRow = eligible[eligible.length - 1];
+  const topRows = eligible.slice(0, 3);
   const topKeys = topRows.map((r) => r.key);
 
   console.log(`# Pior ranqueado (≥${MIN_APPEARANCES} aparições): ${worstRow.key}`);
   console.log(`# Path: ${worstRow.path}`);
-  console.log(`# Score: ${worstRow.score} (wins ${worstRow.wins}/${worstRow.appearances})`);
+  console.log(`# Ordinal: ${worstRow.ordinal.toFixed(3)} (mu ${worstRow.mu.toFixed(3)}, sigma ${worstRow.sigma.toFixed(3)}, wins ${worstRow.wins}/${worstRow.appearances})`);
+  console.log(`# Elegíveis: ${eligible.length} de ${rows.length} no ranking total`);
   console.log("");
   console.log("# Top 3 (contraste): " + topKeys.join(", "));
   console.log("");

--- a/scripts/hronir/lib/ranking.js
+++ b/scripts/hronir/lib/ranking.js
@@ -1,0 +1,76 @@
+import { rating, rate, ordinal } from "openskill";
+import { listMatchFiles, readMatch, postKey } from "./matches.js";
+
+export function computeRatings() {
+  // 1. Load matches, filter winner != TODO, resolve effective_winner.
+  const raw = [];
+  for (const f of listMatchFiles()) {
+    const { data } = readMatch(f);
+    let winner = data.winner;
+    if (data.override && data.override !== "null") winner = data.override;
+    if (winner === "TODO" || !winner) continue;
+
+    const aKey = postKey(data.post_a);
+    const bKey = postKey(data.post_b);
+    if (!aKey || !bKey) continue;
+    if (winner !== "a" && winner !== "b") continue;
+
+    raw.push({
+      runAt: String(data.run_at || data.run_id || ""),
+      aKey,
+      bKey,
+      aPath: data.post_a?.path || "",
+      bPath: data.post_b?.path || "",
+      winner,
+    });
+  }
+
+  // 2. Sort by run_at ascending (stable temporal order matters for OpenSkill).
+  raw.sort((x, y) => x.runAt.localeCompare(y.runAt));
+
+  // 3. Iterate, maintain Map<key, rating>, update appearances/wins.
+  const ratings = new Map();
+  const appearances = new Map();
+  const wins = new Map();
+  const labels = new Map();
+
+  const ensure = (key) => {
+    if (!ratings.has(key)) ratings.set(key, rating());
+    return ratings.get(key);
+  };
+
+  for (const m of raw) {
+    const aRating = ensure(m.aKey);
+    const bRating = ensure(m.bKey);
+    labels.set(m.aKey, m.aPath);
+    labels.set(m.bKey, m.bPath);
+    appearances.set(m.aKey, (appearances.get(m.aKey) || 0) + 1);
+    appearances.set(m.bKey, (appearances.get(m.bKey) || 0) + 1);
+
+    const winnerKey = m.winner === "a" ? m.aKey : m.bKey;
+    const loserKey = m.winner === "a" ? m.bKey : m.aKey;
+    const winnerRating = ratings.get(winnerKey);
+    const loserRating = ratings.get(loserKey);
+
+    const [[newWinner], [newLoser]] = rate([[winnerRating], [loserRating]]);
+    ratings.set(winnerKey, newWinner);
+    ratings.set(loserKey, newLoser);
+    wins.set(winnerKey, (wins.get(winnerKey) || 0) + 1);
+  }
+
+  // 4. Build sorted output (ordinal DESC = best first; tie-break alphabetical).
+  const out = [];
+  for (const [key, r] of ratings) {
+    out.push({
+      key,
+      mu: r.mu,
+      sigma: r.sigma,
+      ordinal: ordinal(r),
+      appearances: appearances.get(key) || 0,
+      wins: wins.get(key) || 0,
+      path: labels.get(key) || "",
+    });
+  }
+  out.sort((x, y) => y.ordinal - x.ordinal || x.key.localeCompare(y.key));
+  return out;
+}

--- a/scripts/hronir/lib/ranking.js
+++ b/scripts/hronir/lib/ranking.js
@@ -17,6 +17,8 @@ export function computeRatings() {
 
     raw.push({
       runAt: String(data.run_at || data.run_id || ""),
+      matchIndex: Number.isFinite(data.match_index) ? data.match_index : 0,
+      filename: f,
       aKey,
       bKey,
       aPath: data.post_a?.path || "",
@@ -25,8 +27,15 @@ export function computeRatings() {
     });
   }
 
-  // 2. Sort by run_at ascending (stable temporal order matters for OpenSkill).
-  raw.sort((x, y) => x.runAt.localeCompare(y.runAt));
+  // 2. Sort by run_at ascending (OpenSkill is order-sensitive); within a run
+  //    (same run_at) break ties by match_index then filename so different
+  //    environments produce identical ratings for identical data.
+  raw.sort((x, y) => {
+    const cmp = x.runAt.localeCompare(y.runAt);
+    if (cmp !== 0) return cmp;
+    if (x.matchIndex !== y.matchIndex) return x.matchIndex - y.matchIndex;
+    return x.filename.localeCompare(y.filename);
+  });
 
   // 3. Iterate, maintain Map<key, rating>, update appearances/wins.
   const ratings = new Map();
@@ -42,8 +51,8 @@ export function computeRatings() {
   for (const m of raw) {
     const aRating = ensure(m.aKey);
     const bRating = ensure(m.bKey);
-    labels.set(m.aKey, m.aPath);
-    labels.set(m.bKey, m.bPath);
+    if (m.aPath) labels.set(m.aKey, m.aPath);
+    if (m.bPath) labels.set(m.bKey, m.bPath);
     appearances.set(m.aKey, (appearances.get(m.aKey) || 0) + 1);
     appearances.set(m.bKey, (appearances.get(m.bKey) || 0) + 1);
 

--- a/scripts/hronir/lib/ranking.js
+++ b/scripts/hronir/lib/ranking.js
@@ -15,8 +15,14 @@ export function computeRatings() {
     if (!aKey || !bKey) continue;
     if (winner !== "a" && winner !== "b") continue;
 
+    // Normalize run_at: gray-matter parses unquoted ISO timestamps into Date
+    // objects, and String(Date) returns locale text ("Mon May 18 ...") that
+    // does NOT sort chronologically via localeCompare. Coerce Dates to ISO.
+    const rawRunAt = data.run_at ?? data.run_id ?? "";
+    const runAt = rawRunAt instanceof Date ? rawRunAt.toISOString() : String(rawRunAt);
+
     raw.push({
-      runAt: String(data.run_at || data.run_id || ""),
+      runAt,
       matchIndex: Number.isFinite(data.match_index) ? data.match_index : 0,
       filename: f,
       aKey,

--- a/scripts/hronir/package-lock.json
+++ b/scripts/hronir/package-lock.json
@@ -1,0 +1,201 @@
+{
+  "name": "hronir",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "hronir",
+      "version": "0.1.0",
+      "dependencies": {
+        "gray-matter": "^4.0.3",
+        "openskill": "^4.1.1"
+      },
+      "bin": {
+        "hronir": "index.js"
+      }
+    },
+    "node_modules/@types/gaussian": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@types/gaussian/-/gaussian-1.2.2.tgz",
+      "integrity": "sha512-FLlJb9oGcoq0xVaAmn5ytZWeEO4M7nfudewzqL6FxUUYLR5FB+hEzSYAsuhX7H7M6Mw/Z0rLbIVbQkMqHlRS7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/ramda": {
+      "version": "0.31.1",
+      "resolved": "https://registry.npmjs.org/@types/ramda/-/ramda-0.31.1.tgz",
+      "integrity": "sha512-Vt6sFXnuRpzaEj+yeutA0q3bcAsK7wdPuASIzR9LXqL4gJPyFw8im9qchlbp4ltuf3kDEIRmPJTD/Fkg60dn7g==",
+      "license": "MIT",
+      "dependencies": {
+        "types-ramda": "^0.31.0"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+      "license": "MIT",
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/gaussian": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/gaussian/-/gaussian-1.3.0.tgz",
+      "integrity": "sha512-rYQ0ESfB+z0t7G95nHH80Zh7Pgg9A0FUYoZqV0yPec5WJZWKIHV2MPYpiJNy8oZAeVqyKwC10WXKSCnUQ5iDVg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/gray-matter": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-4.0.3.tgz",
+      "integrity": "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-yaml": "^3.13.1",
+        "kind-of": "^6.0.2",
+        "section-matter": "^1.0.0",
+        "strip-bom-string": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
+    "node_modules/is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/js-yaml": {
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/openskill": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/openskill/-/openskill-4.1.1.tgz",
+      "integrity": "sha512-sVEeVr9oktZv7VRShjOLpZopn1Wdq5NxIVA33BZJKcJCdHAOEc+ZFBxYvkKSijiRJ8bTQTahkOhqcQxM5WloJw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/gaussian": "1.2.2",
+        "@types/ramda": "0.31.1",
+        "gaussian": "1.3.0",
+        "ramda": "0.32.0",
+        "sort-unwind": "3.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/ramda": {
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.32.0.tgz",
+      "integrity": "sha512-GQWAHhxhxWBWA8oIBr1XahFVjQ9Fic6MK9ikijfd4TZHfE2+urfk+irVlR5VOn48uwMgM+loRRBJd6Yjsbc0zQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ramda"
+      }
+    },
+    "node_modules/section-matter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz",
+      "integrity": "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==",
+      "license": "MIT",
+      "dependencies": {
+        "extend-shallow": "^2.0.1",
+        "kind-of": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/sort-unwind": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/sort-unwind/-/sort-unwind-3.1.0.tgz",
+      "integrity": "sha512-9NJPZtqwIHNXBqY3SWZrwd/VU+lFo2i1Q79cuaRpMMkZFuf+Y54XVAADyy/w6r8t409KkNwo6cKaEKM56XaSNQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/strip-bom-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
+      "integrity": "sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ts-toolbelt": {
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/ts-toolbelt/-/ts-toolbelt-9.6.0.tgz",
+      "integrity": "sha512-nsZd8ZeNUzukXPlJmTBwUAuABDe/9qtVDelJeT/qW0ow3ZS3BsQJtNkan1802aM9Uf68/Y8ljw86Hu0h5IUW3w==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/types-ramda": {
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/types-ramda/-/types-ramda-0.31.0.tgz",
+      "integrity": "sha512-vaoC35CRC3xvL8Z6HkshDbi6KWM1ezK0LHN0YyxXWUn9HKzBNg/T3xSGlJZjCYspnOD3jE7bcizsp0bUXZDxnQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ts-toolbelt": "^9.6.0"
+      }
+    }
+  }
+}

--- a/scripts/hronir/package.json
+++ b/scripts/hronir/package.json
@@ -7,6 +7,7 @@
     "hronir": "./index.js"
   },
   "dependencies": {
-    "gray-matter": "^4.0.3"
+    "gray-matter": "^4.0.3",
+    "openskill": "^4.1.1"
   }
 }


### PR DESCRIPTION
Substitui o agregador winrate (`floor(wins*1000/appearances) + appearances`) por **OpenSkill** (Weng-Lin, Plackett-Luce online).

## Mudanças

- **`scripts/hronir/lib/ranking.js`** novo: `computeRatings()` carrega matches preenchidos, ordena por `run_at` ascendente, inicializa `rating()` por chave no primeiro contato, chama `rate([[winner], [loser]])` por match. Saída: array ordenado por `ordinal(r) = mu - 3·sigma` descendente.
- **`scripts/hronir/lib/commands.js`** : `ranking`/`worst`/`edit-worst` agora consomem `computeRatings()`. `aggregate()` removido.
  - `ranking` imprime tabela `rank / key / ordinal / mu / sigma / W/N`.
  - `worst` retorna o último elegível (menor ordinal entre `appearances ≥ MIN_APPEARANCES`).
  - `edit-worst` pega worst de `eligible[length-1]` e top 3 de `eligible[0..3]` — mesmo threshold dos dois lados (correção que já tinha sido aplicada em #118).
- **`scripts/hronir/package.json`** + raiz: `openskill@^4.1.1`. Adicionei também na raiz (`devDependencies`) seguindo o padrão de `gray-matter`, senão `npm ci` em CI não resolveria o módulo quando `hronir:doctor` rodar.
- **README**: explica o modelo OpenSkill, o ordinal conservador, e por que `MIN_APPEARANCES` permanece útil mesmo com `sigma` carregando incerteza (sinal de defesa + estabilidade nos primeiros matches).

## Validação local

- `npm run hronir:doctor` → 0 inconsistências.
- `npm run hronir:ranking` produziu tabela de 26 posts sobre 30 matches. Top: `third-half-fourth-wall`, `serpents-egg`, `asterisk-protects`. Bottom: `inaugural-post` (0/3 — único elegível pelo threshold), `verne-identity-repo` (0/2), `pontifex-guide` (0/2).
- Top e bottom batem com a intuição da metodologia anterior, mas agora com gradiente contínuo e incerteza explícita.

## Base

Esta PR baseia em `hronir/init-dynamic-n` (#121). Quando #119 → #121 mesclarem, rebase para `main`.

Não auto-merge.

---
_Generated by [Claude Code](https://claude.ai/code/session_012as5hQdqsq22hRKLnmEeYb)_