### PR TITLE
hronir: land chain (#119/#121/#122) + ranking page + rank on post

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
       "devDependencies": {
         "@astrojs/check": "^0.9.9",
         "gray-matter": "^4.0.3",
+        "openskill": "^4.1.1",
         "playwright": "^1.60.0"
       },
       "engines": {
@@ -2529,6 +2530,13 @@
         "@types/estree": "*"
       }
     },
+    "node_modules/@types/gaussian": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@types/gaussian/-/gaussian-1.2.2.tgz",
+      "integrity": "sha512-FLlJb9oGcoq0xVaAmn5ytZWeEO4M7nfudewzqL6FxUUYLR5FB+hEzSYAsuhX7H7M6Mw/Z0rLbIVbQkMqHlRS7g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/geojson": {
       "version": "7946.0.16",
       "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
@@ -2587,6 +2595,16 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.16.0"
+      }
+    },
+    "node_modules/@types/ramda": {
+      "version": "0.31.1",
+      "resolved": "https://registry.npmjs.org/@types/ramda/-/ramda-0.31.1.tgz",
+      "integrity": "sha512-Vt6sFXnuRpzaEj+yeutA0q3bcAsK7wdPuASIzR9LXqL4gJPyFw8im9qchlbp4ltuf3kDEIRmPJTD/Fkg60dn7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "types-ramda": "^0.31.0"
       }
     },
     "node_modules/@types/sax": {
@@ -4498,6 +4516,16 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/gaussian": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/gaussian/-/gaussian-1.3.0.tgz",
+      "integrity": "sha512-rYQ0ESfB+z0t7G95nHH80Zh7Pgg9A0FUYoZqV0yPec5WJZWKIHV2MPYpiJNy8oZAeVqyKwC10WXKSCnUQ5iDVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
       }
     },
     "node_modules/get-caller-file": {
@@ -6509,6 +6537,23 @@
         "regex-recursion": "^6.0.2"
       }
     },
+    "node_modules/openskill": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/openskill/-/openskill-4.1.1.tgz",
+      "integrity": "sha512-sVEeVr9oktZv7VRShjOLpZopn1Wdq5NxIVA33BZJKcJCdHAOEc+ZFBxYvkKSijiRJ8bTQTahkOhqcQxM5WloJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/gaussian": "1.2.2",
+        "@types/ramda": "0.31.1",
+        "gaussian": "1.3.0",
+        "ramda": "0.32.0",
+        "sort-unwind": "3.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/p-limit": {
       "version": "7.3.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-7.3.0.tgz",
@@ -6853,6 +6898,17 @@
       "resolved": "https://registry.npmjs.org/radix3/-/radix3-1.1.2.tgz",
       "integrity": "sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA==",
       "license": "MIT"
+    },
+    "node_modules/ramda": {
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.32.0.tgz",
+      "integrity": "sha512-GQWAHhxhxWBWA8oIBr1XahFVjQ9Fic6MK9ikijfd4TZHfE2+urfk+irVlR5VOn48uwMgM+loRRBJd6Yjsbc0zQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ramda"
+      }
     },
     "node_modules/readdirp": {
       "version": "5.0.0",
@@ -7525,6 +7581,16 @@
         "url": "https://github.com/sponsors/cyyynthia"
       }
     },
+    "node_modules/sort-unwind": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/sort-unwind/-/sort-unwind-3.1.0.tgz",
+      "integrity": "sha512-9NJPZtqwIHNXBqY3SWZrwd/VU+lFo2i1Q79cuaRpMMkZFuf+Y54XVAADyy/w6r8t409KkNwo6cKaEKM56XaSNQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.7.6",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
@@ -7763,6 +7829,13 @@
         "node": ">=6.10"
       }
     },
+    "node_modules/ts-toolbelt": {
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/ts-toolbelt/-/ts-toolbelt-9.6.0.tgz",
+      "integrity": "sha512-nsZd8ZeNUzukXPlJmTBwUAuABDe/9qtVDelJeT/qW0ow3ZS3BsQJtNkan1802aM9Uf68/Y8ljw86Hu0h5IUW3w==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/tsconfck": {
       "version": "3.1.6",
       "resolved": "https://registry.npmjs.org/tsconfck/-/tsconfck-3.1.6.tgz",
@@ -7789,6 +7862,16 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD",
       "optional": true
+    },
+    "node_modules/types-ramda": {
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/types-ramda/-/types-ramda-0.31.0.tgz",
+      "integrity": "sha512-vaoC35CRC3xvL8Z6HkshDbi6KWM1ezK0LHN0YyxXWUn9HKzBNg/T3xSGlJZjCYspnOD3jE7bcizsp0bUXZDxnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ts-toolbelt": "^9.6.0"
+      }
     },
     "node_modules/typesafe-path": {
       "version": "0.2.2",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   "devDependencies": {
     "@astrojs/check": "^0.9.9",
     "gray-matter": "^4.0.3",
+    "openskill": "^4.1.1",
     "playwright": "^1.60.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "hronir": "node scripts/hronir/index.js",
     "hronir:init": "node scripts/hronir/index.js init",
     "hronir:present": "node scripts/hronir/index.js present",
+    "hronir:resume": "node scripts/hronir/index.js resume",
     "hronir:ranking": "node scripts/hronir/index.js ranking",
     "hronir:worst": "node scripts/hronir/index.js worst",
     "hronir:edit-worst": "node scripts/hronir/index.js edit-worst",

--- a/scripts/hronir/README.md
+++ b/scripts/hronir/README.md
@@ -36,7 +36,7 @@ Todos via npm scripts no raiz:
 
 | Comando | Função |
 |---------|--------|
-| `npm run hronir:init` | Sorteia 40 posts EN, cria 20 match files `winner: TODO` |
+| `npm run hronir:init` | Sorteia posts EN, cria até 20 match files (n = min(20, ⌊corpus/2⌋); falha se corpus < 4) |
 | `npm run hronir:present -- <match.md>` | Imprime os dois posts + instrução pro avaliador (meta de palavras na defesa) |
 | `npm run hronir:resume` | Identifica a rodada mais recente, lista pendentes, aponta próximo |
 | `npm run hronir:ranking` | Score acumulado de todos os matches preenchidos |
@@ -51,7 +51,7 @@ Cada comando termina com uma linha `NEXT STEP:` apontando o próximo passo, exce
 ## Fluxo
 
 ```
-init → present (×20) → edit-worst → (edição manual do post worst) → archive-post <key>
+init → present (×n_matches) → edit-worst → (edição manual do post worst) → archive-post <key>
 ```
 
 `resume` em qualquer ponto identifica a rodada mais recente e aponta o próximo pendente. Útil para crash recovery ou retomada entre sessões.

--- a/scripts/hronir/README.md
+++ b/scripts/hronir/README.md
@@ -36,8 +36,9 @@ Todos via npm scripts no raiz:
 
 | Comando | Função |
 |---------|--------|
-| `npm run hronir:init` | Sorteia 10 posts EN, cria 5 match files `winner: TODO` |
-| `npm run hronir:present -- <match.md>` | Imprime os dois posts + instrução pro avaliador |
+| `npm run hronir:init` | Sorteia 40 posts EN, cria 20 match files `winner: TODO` |
+| `npm run hronir:present -- <match.md>` | Imprime os dois posts + instrução pro avaliador (meta de palavras na defesa) |
+| `npm run hronir:resume` | Identifica a rodada mais recente, lista pendentes, aponta próximo |
 | `npm run hronir:ranking` | Score acumulado de todos os matches preenchidos |
 | `npm run hronir:worst` | Imprime translationKey do pior ranqueado (apenas inspeção) |
 | `npm run hronir:edit-worst` | Pior elegível + top 3, defesas, registro auditável em `edits/`, e instrução pra ler as skills antes de editar |
@@ -50,8 +51,14 @@ Cada comando termina com uma linha `NEXT STEP:` apontando o próximo passo, exce
 ## Fluxo
 
 ```
-init → present (×5) → edit-worst → (edição manual do post worst) → archive-post <key>
+init → present (×20) → edit-worst → (edição manual do post worst) → archive-post <key>
 ```
+
+`resume` em qualquer ponto identifica a rodada mais recente e aponta o próximo pendente. Útil para crash recovery ou retomada entre sessões.
+
+## Meta de palavras nas defesas
+
+`present` instrui o avaliador que cada defesa deve ter mínimo 100 palavras (piso de qualidade), meta 200 (alvo natural), mencionar os dois posts pelo nome ou pela key, e explicar concretamente. Não há validação coerciva no `doctor` — é instrução proativa. Defesa muito curta ou genérica perde a função do sistema (`edit-worst` lê e cita essas defesas; pouca substância dá pouco sinal).
 
 `worst` continua disponível para inspeção pontual, mas o fluxo automático termina em `edit-worst` + `archive-post`. A crítica em prosa em `.routines/hronir/critiques/` continua sendo um registro válido, mas não dirige a edição; o que dirige são as **skills versionadas** (próxima seção) e o registro auditável em `.routines/hronir/edits/<key>-<ts>.md`.
 

--- a/scripts/hronir/README.md
+++ b/scripts/hronir/README.md
@@ -87,9 +87,13 @@ O `edit-worst` instrui a leitura de **ambas** antes de editar e a escolher a apl
 
 ## Ranking
 
-Ranking via **OpenSkill** (modelo Weng-Lin, atualização bayesiana online de Plackett-Luce). Cada par é tratado como uma partida 1v1; vencedor sobe `mu` e desce `sigma`, perdedor o oposto. A ordem global usa `ordinal(r) = mu - 3*sigma` — score conservador que penaliza incerteza, então um post com poucas partidas tende a ter ordinal menor mesmo que `mu` esteja alto.
+Ranking via **OpenSkill** (modelo Weng-Lin, atualização bayesiana online de Plackett-Luce). Cada par é tratado como uma partida 1v1; vencedor sobe `mu` e desce `sigma`, perdedor o oposto. Três eixos saem da computação, todos exibidos lado a lado em `hronir:ranking`:
 
-Tie-break alfabético. O `worst` retorna o de menor ordinal entre os posts com `appearances >= MIN_APPEARANCES`.
+- **`mu`** — estimativa pontual da "qualidade" do post. Sobe quando o post vence, desce quando perde, com magnitude proporcional à surpresa (vencer um post de mu alto vale mais).
+- **`sigma`** — incerteza sobre `mu`. Começa alta (pouca informação) e cai a cada partida. Não diz que o post é ruim — diz que ainda não sabemos.
+- **`ordinal = mu − 3·sigma`** — score conservador usado para a ordem global. Penaliza incerteza explicitamente: um post novo, mesmo com mu alto, fica atrás de um post estabelecido com mu um pouco menor.
+
+A ordem da tabela é por `ordinal` descendente. Tie-break alfabético por `key`. O `worst` retorna o post com menor `ordinal` entre os elegíveis (`appearances >= MIN_APPEARANCES`) — note que aqui não é "tie-break", é filtro: posts sem volume mínimo são ignorados antes de pegar o último.
 
 ### Por que MIN_APPEARANCES ainda importa com OpenSkill
 

--- a/scripts/hronir/README.md
+++ b/scripts/hronir/README.md
@@ -87,9 +87,18 @@ O `edit-worst` instrui a leitura de **ambas** antes de editar e a escolher a apl
 
 ## Ranking
 
-Score = `floor(wins * 1000 / appearances) + appearances`. Tie-break por chave alfabética. O `worst` retorna o de menor score.
+Ranking via **OpenSkill** (modelo Weng-Lin, atualização bayesiana online de Plackett-Luce). Cada par é tratado como uma partida 1v1; vencedor sobe `mu` e desce `sigma`, perdedor o oposto. A ordem global usa `ordinal(r) = mu - 3*sigma` — score conservador que penaliza incerteza, então um post com poucas partidas tende a ter ordinal menor mesmo que `mu` esteja alto.
 
-A componente `+ appearances` é deliberada: posts com mais aparições têm mais informação sobre eles, então um post com 0/1 fica acima de um post sem dados. O pior ranqueado precisa ter aparecido pelo menos uma vez.
+Tie-break alfabético. O `worst` retorna o de menor ordinal entre os posts com `appearances >= MIN_APPEARANCES`.
+
+### Por que MIN_APPEARANCES ainda importa com OpenSkill
+
+OpenSkill já carrega incerteza em `sigma`, então em tese seria possível ranquear posts com 1 partida. Mas duas razões mantêm o threshold:
+
+1. **Sinal de defesa.** `edit-worst` consome as defesas como contexto. Um post com 1 derrota dá só 1 defesa pra trabalhar; com 3+ derrotas, o conjunto de defesas começa a triangular o problema do post.
+2. **Estabilidade.** Os 3 primeiros matches de um post podem oscilar muito (sigma alto, ordinal sensível). MIN_APPEARANCES=3 evita editar com base num único par que pode ter sido sorte/azar.
+
+`appearances` continua reportado ao lado de `mu`/`sigma` exatamente para isso ser legível.
 
 ## Match file
 

--- a/scripts/hronir/index.js
+++ b/scripts/hronir/index.js
@@ -1,10 +1,10 @@
 #!/usr/bin/env node
-import { init, present, ranking, worst, editWorst, archivePost, migrate, doctor } from "./lib/commands.js";
+import { init, present, ranking, worst, editWorst, archivePost, resume, migrate, doctor } from "./lib/commands.js";
 
 const [, , cmd, ...args] = process.argv;
 
 function usage() {
-  console.error("Uso: hronir {init|present <match>|ranking|worst|edit-worst|archive-post <key>|migrate [--dry-run]|doctor}");
+  console.error("Uso: hronir {init|present <match>|resume|ranking|worst|edit-worst|archive-post <key>|migrate [--dry-run]|doctor}");
   process.exit(1);
 }
 
@@ -14,6 +14,9 @@ switch (cmd) {
     break;
   case "present":
     present(args[0]);
+    break;
+  case "resume":
+    resume();
     break;
   case "ranking":
     ranking();

--- a/scripts/hronir/lib/commands.js
+++ b/scripts/hronir/lib/commands.js
@@ -35,16 +35,16 @@ export function init() {
   fs.mkdirSync(path.join(OUT_DIR, "critiques"), { recursive: true });
 
   const candidates = listEnglishWithKey();
-  if (candidates.length < 10) {
-    console.error(`Erro: só ${candidates.length} posts EN com translationKey em src/content/blog`);
+  if (candidates.length < 40) {
+    console.error(`Erro: só ${candidates.length} posts EN com translationKey em src/content/blog (mínimo 40)`);
     process.exit(1);
   }
 
-  const sample = shuffle(candidates).slice(0, 10);
+  const sample = shuffle(candidates).slice(0, 40);
   const { runId, runAt } = utcStamp();
   const created = [];
 
-  for (let i = 0; i < 5; i++) {
+  for (let i = 0; i < 20; i++) {
     let a = sample[i * 2];
     let b = sample[i * 2 + 1];
     if (Math.random() < 0.5) [a, b] = [b, a];
@@ -101,7 +101,18 @@ export function present(matchFile) {
   console.log("- model: identificador do modelo executando");
   console.log("- substitua <!-- TODO --> pelo texto da defesa, em português");
 
-  nextStep(`Editar ${matchFile} com a decisão e a defesa. Quando os 5 matches estiverem preenchidos, rode \`npm run hronir:edit-worst\`.`);
+  const stepLines = [
+    "A defesa deve ter:",
+    "- mínimo 100 palavras (piso de qualidade)",
+    "- meta 200 palavras (alvo natural)",
+    "- mencionar os dois posts pelo nome ou pela key",
+    "- explicar concretamente, não no abstrato",
+    "",
+    "Defesa muito curta ou genérica perde a função do sistema.",
+    "",
+    `Editar ${matchFile} com a decisão e a defesa. Quando os 20 matches da rodada estiverem preenchidos, rode \`npm run hronir:edit-worst\`. Para retomar do meio da rodada, \`npm run hronir:resume\`.`,
+  ];
+  nextStep(stepLines.join("\n"));
 }
 
 function aggregate() {
@@ -326,6 +337,56 @@ export function editWorst() {
     `Após editar, rode: npm run hronir:archive-post ${worstRow.key}`,
   ];
   nextStep(stepLines.join("\n"));
+}
+
+export function resume() {
+  const files = listMatchFiles();
+  if (files.length === 0) {
+    console.log("Nenhum match encontrado em .routines/hronir/.");
+    nextStep("rode `npm run hronir:init` para começar uma rodada.");
+    return;
+  }
+
+  const byRun = new Map();
+  for (const f of files) {
+    const { data } = readMatch(f);
+    const runId = String(data.run_id || "");
+    if (!runId) continue;
+    if (!byRun.has(runId)) byRun.set(runId, []);
+    byRun.get(runId).push({ file: f, data });
+  }
+
+  if (byRun.size === 0) {
+    console.log("Nenhum match com run_id encontrado.");
+    nextStep("rode `npm run hronir:init` para começar uma rodada.");
+    return;
+  }
+
+  const latestRunId = [...byRun.keys()].sort().pop();
+  const matches = byRun.get(latestRunId);
+  matches.sort((a, b) => (a.data.match_index || 0) - (b.data.match_index || 0));
+
+  const pending = matches.filter((m) => m.data.winner === "TODO" || !m.data.winner);
+  const total = matches.length;
+
+  console.log(`# Rodada mais recente: ${latestRunId}`);
+  console.log(`# Matches: ${total} total, ${pending.length} pendentes, ${total - pending.length} preenchidos`);
+  console.log("");
+
+  if (pending.length === 0) {
+    console.log("Todos os matches da rodada estão preenchidos.");
+    nextStep("rode `npm run hronir:edit-worst`.");
+    return;
+  }
+
+  console.log("Pendentes:");
+  for (const m of pending) {
+    console.log(`  [${m.data.match_index ?? "?"}] ${m.file}`);
+  }
+  console.log("");
+
+  const first = pending[0].file;
+  nextStep(`rode \`npm run hronir:present -- ${first}\` (próximo pendente).`);
 }
 
 export function archivePost(key) {

--- a/scripts/hronir/lib/commands.js
+++ b/scripts/hronir/lib/commands.js
@@ -35,16 +35,20 @@ export function init() {
   fs.mkdirSync(path.join(OUT_DIR, "critiques"), { recursive: true });
 
   const candidates = listEnglishWithKey();
-  if (candidates.length < 40) {
-    console.error(`Erro: só ${candidates.length} posts EN com translationKey em src/content/blog (mínimo 40)`);
+  const corpusSize = candidates.length;
+  if (corpusSize < 4) {
+    console.error(`Erro: só ${corpusSize} posts EN com translationKey em src/content/blog (mínimo 4 para formar 2 pares)`);
     process.exit(1);
   }
 
-  const sample = shuffle(candidates).slice(0, 40);
+  const nMatches = Math.min(20, Math.floor(corpusSize / 2));
+  console.log(`Corpus: ${corpusSize} posts elegíveis. Criando ${nMatches} matches.`);
+
+  const sample = shuffle(candidates).slice(0, nMatches * 2);
   const { runId, runAt } = utcStamp();
   const created = [];
 
-  for (let i = 0; i < 20; i++) {
+  for (let i = 0; i < nMatches; i++) {
     let a = sample[i * 2];
     let b = sample[i * 2 + 1];
     if (Math.random() < 0.5) [a, b] = [b, a];
@@ -110,7 +114,7 @@ export function present(matchFile) {
     "",
     "Defesa muito curta ou genérica perde a função do sistema.",
     "",
-    `Editar ${matchFile} com a decisão e a defesa. Quando os 20 matches da rodada estiverem preenchidos, rode \`npm run hronir:edit-worst\`. Para retomar do meio da rodada, \`npm run hronir:resume\`.`,
+    `Editar ${matchFile} com a decisão e a defesa. Quando todos os matches da rodada estiverem preenchidos, rode \`npm run hronir:edit-worst\`. Para retomar do meio da rodada, \`npm run hronir:resume\`.`,
   ];
   nextStep(stepLines.join("\n"));
 }

--- a/scripts/hronir/lib/commands.js
+++ b/scripts/hronir/lib/commands.js
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { OUT_DIR, listEnglishWithKey, keyForPath, readPost, listPosts } from "./posts.js";
 import { listMatchFiles, readMatch, writeMatch, postKey } from "./matches.js";
+import { computeRatings } from "./ranking.js";
 
 const MIN_APPEARANCES = 3;
 const SKILLS_DIR = "scripts/hronir/skills";
@@ -119,56 +120,33 @@ export function present(matchFile) {
   nextStep(stepLines.join("\n"));
 }
 
-function aggregate() {
-  const wins = new Map();
-  const appearances = new Map();
-  const labels = new Map();
+// Ratings via OpenSkill (computeRatings, lib/ranking.js).
+// Output: rows ordered by ordinal DESC (best first).
 
-  for (const f of listMatchFiles()) {
-    const { data } = readMatch(f);
-    let winner = data.winner;
-    if (data.override && data.override !== "null") winner = data.override;
-    if (winner === "TODO" || !winner) continue;
-
-    const aKey = postKey(data.post_a);
-    const bKey = postKey(data.post_b);
-    if (!aKey || !bKey) continue;
-
-    appearances.set(aKey, (appearances.get(aKey) || 0) + 1);
-    appearances.set(bKey, (appearances.get(bKey) || 0) + 1);
-    if (data.post_a?.path) labels.set(aKey, data.post_a.path);
-    if (data.post_b?.path) labels.set(bKey, data.post_b.path);
-    if (winner === "a") wins.set(aKey, (wins.get(aKey) || 0) + 1);
-    else if (winner === "b") wins.set(bKey, (wins.get(bKey) || 0) + 1);
-  }
-
-  const rows = [];
-  for (const [key, a] of appearances) {
-    const w = wins.get(key) || 0;
-    const score = Math.floor((w * 1000) / a) + a;
-    rows.push({ key, wins: w, appearances: a, score, path: labels.get(key) || "" });
-  }
-  rows.sort((x, y) => x.score - y.score || x.key.localeCompare(y.key));
-  return rows;
+function fmt(n, w = 6) {
+  return n.toFixed(3).padStart(w);
 }
 
 export function ranking() {
-  const rows = aggregate();
-  for (const r of rows) {
-    console.log(`${r.score}\t${r.wins}\t${r.appearances}\t${r.key}`);
+  const rows = computeRatings();
+  console.log(`rank\tkey\tordinal\tmu\tsigma\tW/N`);
+  for (let i = 0; i < rows.length; i++) {
+    const r = rows[i];
+    console.log(`${i + 1}\t${r.key}\t${fmt(r.ordinal)}\t${fmt(r.mu)}\t${fmt(r.sigma)}\t${r.wins}/${r.appearances}`);
   }
   nextStep("Rode `npm run hronir:edit-worst` para iniciar a edição do pior ranqueado (ou `npm run hronir:worst` apenas para inspeção).");
 }
 
 export function worst() {
-  const rows = aggregate();
-  if (rows.length === 0) {
-    console.error("Sem matches preenchidos suficientes para ranquear.");
+  const rows = computeRatings();
+  const eligible = rows.filter((r) => r.appearances >= MIN_APPEARANCES);
+  if (eligible.length === 0) {
+    console.error(`Sem posts com appearances >= ${MIN_APPEARANCES}.`);
     process.exit(1);
   }
-  const w = rows[0];
+  const w = eligible[eligible.length - 1];
   console.log(w.key);
-  console.error(`(path: ${w.path}, wins: ${w.wins}/${w.appearances}, score: ${w.score})`);
+  console.error(`(path: ${w.path}, wins: ${w.wins}/${w.appearances}, ordinal: ${w.ordinal.toFixed(3)}, mu: ${w.mu.toFixed(3)}, sigma: ${w.sigma.toFixed(3)})`);
 }
 
 function collectDefensesForLoser(loserKey, limit = 5) {
@@ -232,7 +210,7 @@ function collectDefensesForWinners(winnerKeys, limit = 5) {
 }
 
 export function editWorst() {
-  const rows = aggregate();
+  const rows = computeRatings();
   if (rows.length === 0) {
     console.error("Sem matches preenchidos suficientes para ranquear.");
     process.exit(1);
@@ -247,14 +225,17 @@ export function editWorst() {
     return;
   }
 
-  const worstRow = eligible[0];
-  const topRows = eligible.slice(-3).reverse();
+  // rows are sorted by ordinal DESC (best first); worst eligible is the last,
+  // top 3 are the first three eligible — same threshold applied to both sides
+  // so contrast set never comes from low-volume posts.
+  const worstRow = eligible[eligible.length - 1];
+  const topRows = eligible.slice(0, 3);
   const topKeys = topRows.map((r) => r.key);
 
   console.log(`# Pior ranqueado (≥${MIN_APPEARANCES} aparições): ${worstRow.key}`);
-  console.log(`# Elegíveis: ${eligible.length} de ${rows.length} no ranking total`);
   console.log(`# Path: ${worstRow.path}`);
-  console.log(`# Score: ${worstRow.score} (wins ${worstRow.wins}/${worstRow.appearances})`);
+  console.log(`# Ordinal: ${worstRow.ordinal.toFixed(3)} (mu ${worstRow.mu.toFixed(3)}, sigma ${worstRow.sigma.toFixed(3)}, wins ${worstRow.wins}/${worstRow.appearances})`);
+  console.log(`# Elegíveis: ${eligible.length} de ${rows.length} no ranking total`);
   console.log("");
   console.log("# Top 3 (contraste): " + topKeys.join(", "));
   console.log("");

--- a/scripts/hronir/lib/ranking.js
+++ b/scripts/hronir/lib/ranking.js
@@ -1,0 +1,76 @@
+import { rating, rate, ordinal } from "openskill";
+import { listMatchFiles, readMatch, postKey } from "./matches.js";
+
+export function computeRatings() {
+  // 1. Load matches, filter winner != TODO, resolve effective_winner.
+  const raw = [];
+  for (const f of listMatchFiles()) {
+    const { data } = readMatch(f);
+    let winner = data.winner;
+    if (data.override && data.override !== "null") winner = data.override;
+    if (winner === "TODO" || !winner) continue;
+
+    const aKey = postKey(data.post_a);
+    const bKey = postKey(data.post_b);
+    if (!aKey || !bKey) continue;
+    if (winner !== "a" && winner !== "b") continue;
+
+    raw.push({
+      runAt: String(data.run_at || data.run_id || ""),
+      aKey,
+      bKey,
+      aPath: data.post_a?.path || "",
+      bPath: data.post_b?.path || "",
+      winner,
+    });
+  }
+
+  // 2. Sort by run_at ascending (stable temporal order matters for OpenSkill).
+  raw.sort((x, y) => x.runAt.localeCompare(y.runAt));
+
+  // 3. Iterate, maintain Map<key, rating>, update appearances/wins.
+  const ratings = new Map();
+  const appearances = new Map();
+  const wins = new Map();
+  const labels = new Map();
+
+  const ensure = (key) => {
+    if (!ratings.has(key)) ratings.set(key, rating());
+    return ratings.get(key);
+  };
+
+  for (const m of raw) {
+    const aRating = ensure(m.aKey);
+    const bRating = ensure(m.bKey);
+    labels.set(m.aKey, m.aPath);
+    labels.set(m.bKey, m.bPath);
+    appearances.set(m.aKey, (appearances.get(m.aKey) || 0) + 1);
+    appearances.set(m.bKey, (appearances.get(m.bKey) || 0) + 1);
+
+    const winnerKey = m.winner === "a" ? m.aKey : m.bKey;
+    const loserKey = m.winner === "a" ? m.bKey : m.aKey;
+    const winnerRating = ratings.get(winnerKey);
+    const loserRating = ratings.get(loserKey);
+
+    const [[newWinner], [newLoser]] = rate([[winnerRating], [loserRating]]);
+    ratings.set(winnerKey, newWinner);
+    ratings.set(loserKey, newLoser);
+    wins.set(winnerKey, (wins.get(winnerKey) || 0) + 1);
+  }
+
+  // 4. Build sorted output (ordinal DESC = best first; tie-break alphabetical).
+  const out = [];
+  for (const [key, r] of ratings) {
+    out.push({
+      key,
+      mu: r.mu,
+      sigma: r.sigma,
+      ordinal: ordinal(r),
+      appearances: appearances.get(key) || 0,
+      wins: wins.get(key) || 0,
+      path: labels.get(key) || "",
+    });
+  }
+  out.sort((x, y) => y.ordinal - x.ordinal || x.key.localeCompare(y.key));
+  return out;
+}

--- a/scripts/hronir/lib/ranking.js
+++ b/scripts/hronir/lib/ranking.js
@@ -17,6 +17,8 @@ export function computeRatings() {
 
     raw.push({
       runAt: String(data.run_at || data.run_id || ""),
+      matchIndex: Number.isFinite(data.match_index) ? data.match_index : 0,
+      filename: f,
       aKey,
       bKey,
       aPath: data.post_a?.path || "",
@@ -25,8 +27,15 @@ export function computeRatings() {
     });
   }
 
-  // 2. Sort by run_at ascending (stable temporal order matters for OpenSkill).
-  raw.sort((x, y) => x.runAt.localeCompare(y.runAt));
+  // 2. Sort by run_at ascending (OpenSkill is order-sensitive); within a run
+  //    (same run_at) break ties by match_index then filename so different
+  //    environments produce identical ratings for identical data.
+  raw.sort((x, y) => {
+    const cmp = x.runAt.localeCompare(y.runAt);
+    if (cmp !== 0) return cmp;
+    if (x.matchIndex !== y.matchIndex) return x.matchIndex - y.matchIndex;
+    return x.filename.localeCompare(y.filename);
+  });
 
   // 3. Iterate, maintain Map<key, rating>, update appearances/wins.
   const ratings = new Map();
@@ -42,8 +51,8 @@ export function computeRatings() {
   for (const m of raw) {
     const aRating = ensure(m.aKey);
     const bRating = ensure(m.bKey);
-    labels.set(m.aKey, m.aPath);
-    labels.set(m.bKey, m.bPath);
+    if (m.aPath) labels.set(m.aKey, m.aPath);
+    if (m.bPath) labels.set(m.bKey, m.bPath);
     appearances.set(m.aKey, (appearances.get(m.aKey) || 0) + 1);
     appearances.set(m.bKey, (appearances.get(m.bKey) || 0) + 1);
 

--- a/scripts/hronir/lib/ranking.js
+++ b/scripts/hronir/lib/ranking.js
@@ -15,8 +15,14 @@ export function computeRatings() {
     if (!aKey || !bKey) continue;
     if (winner !== "a" && winner !== "b") continue;
 
+    // Normalize run_at: gray-matter parses unquoted ISO timestamps into Date
+    // objects, and String(Date) returns locale text ("Mon May 18 ...") that
+    // does NOT sort chronologically via localeCompare. Coerce Dates to ISO.
+    const rawRunAt = data.run_at ?? data.run_id ?? "";
+    const runAt = rawRunAt instanceof Date ? rawRunAt.toISOString() : String(rawRunAt);
+
     raw.push({
-      runAt: String(data.run_at || data.run_id || ""),
+      runAt,
       matchIndex: Number.isFinite(data.match_index) ? data.match_index : 0,
       filename: f,
       aKey,

--- a/scripts/hronir/package-lock.json
+++ b/scripts/hronir/package-lock.json
@@ -1,0 +1,201 @@
+{
+  "name": "hronir",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "hronir",
+      "version": "0.1.0",
+      "dependencies": {
+        "gray-matter": "^4.0.3",
+        "openskill": "^4.1.1"
+      },
+      "bin": {
+        "hronir": "index.js"
+      }
+    },
+    "node_modules/@types/gaussian": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@types/gaussian/-/gaussian-1.2.2.tgz",
+      "integrity": "sha512-FLlJb9oGcoq0xVaAmn5ytZWeEO4M7nfudewzqL6FxUUYLR5FB+hEzSYAsuhX7H7M6Mw/Z0rLbIVbQkMqHlRS7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/ramda": {
+      "version": "0.31.1",
+      "resolved": "https://registry.npmjs.org/@types/ramda/-/ramda-0.31.1.tgz",
+      "integrity": "sha512-Vt6sFXnuRpzaEj+yeutA0q3bcAsK7wdPuASIzR9LXqL4gJPyFw8im9qchlbp4ltuf3kDEIRmPJTD/Fkg60dn7g==",
+      "license": "MIT",
+      "dependencies": {
+        "types-ramda": "^0.31.0"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+      "license": "MIT",
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/gaussian": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/gaussian/-/gaussian-1.3.0.tgz",
+      "integrity": "sha512-rYQ0ESfB+z0t7G95nHH80Zh7Pgg9A0FUYoZqV0yPec5WJZWKIHV2MPYpiJNy8oZAeVqyKwC10WXKSCnUQ5iDVg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/gray-matter": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-4.0.3.tgz",
+      "integrity": "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-yaml": "^3.13.1",
+        "kind-of": "^6.0.2",
+        "section-matter": "^1.0.0",
+        "strip-bom-string": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
+    "node_modules/is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/js-yaml": {
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/openskill": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/openskill/-/openskill-4.1.1.tgz",
+      "integrity": "sha512-sVEeVr9oktZv7VRShjOLpZopn1Wdq5NxIVA33BZJKcJCdHAOEc+ZFBxYvkKSijiRJ8bTQTahkOhqcQxM5WloJw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/gaussian": "1.2.2",
+        "@types/ramda": "0.31.1",
+        "gaussian": "1.3.0",
+        "ramda": "0.32.0",
+        "sort-unwind": "3.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/ramda": {
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.32.0.tgz",
+      "integrity": "sha512-GQWAHhxhxWBWA8oIBr1XahFVjQ9Fic6MK9ikijfd4TZHfE2+urfk+irVlR5VOn48uwMgM+loRRBJd6Yjsbc0zQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ramda"
+      }
+    },
+    "node_modules/section-matter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz",
+      "integrity": "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==",
+      "license": "MIT",
+      "dependencies": {
+        "extend-shallow": "^2.0.1",
+        "kind-of": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/sort-unwind": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/sort-unwind/-/sort-unwind-3.1.0.tgz",
+      "integrity": "sha512-9NJPZtqwIHNXBqY3SWZrwd/VU+lFo2i1Q79cuaRpMMkZFuf+Y54XVAADyy/w6r8t409KkNwo6cKaEKM56XaSNQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/strip-bom-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
+      "integrity": "sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ts-toolbelt": {
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/ts-toolbelt/-/ts-toolbelt-9.6.0.tgz",
+      "integrity": "sha512-nsZd8ZeNUzukXPlJmTBwUAuABDe/9qtVDelJeT/qW0ow3ZS3BsQJtNkan1802aM9Uf68/Y8ljw86Hu0h5IUW3w==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/types-ramda": {
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/types-ramda/-/types-ramda-0.31.0.tgz",
+      "integrity": "sha512-vaoC35CRC3xvL8Z6HkshDbi6KWM1ezK0LHN0YyxXWUn9HKzBNg/T3xSGlJZjCYspnOD3jE7bcizsp0bUXZDxnQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ts-toolbelt": "^9.6.0"
+      }
+    }
+  }
+}

--- a/scripts/hronir/package.json
+++ b/scripts/hronir/package.json
@@ -7,6 +7,7 @@
     "hronir": "./index.js"
   },
   "dependencies": {
-    "gray-matter": "^4.0.3"
+    "gray-matter": "^4.0.3",
+    "openskill": "^4.1.1"
   }
 }

--- a/src/lib/hronir-rank.ts
+++ b/src/lib/hronir-rank.ts
@@ -1,0 +1,32 @@
+// Build-time bridge to the OpenSkill aggregator in scripts/hronir/.
+// Reads .routines/hronir/*.md, runs OpenSkill, exposes a Map<key, RankRow>
+// keyed by translationKey, plus a sorted array.
+
+import { computeRatings } from "../../scripts/hronir/lib/ranking.js";
+
+export interface RankRow {
+  key: string;
+  mu: number;
+  sigma: number;
+  ordinal: number;
+  appearances: number;
+  wins: number;
+  path: string;
+}
+
+let _cache: RankRow[] | null = null;
+
+export function getRanking(): RankRow[] {
+  if (_cache) return _cache;
+  _cache = computeRatings() as RankRow[];
+  return _cache;
+}
+
+export function getRankByKey(): Map<string, { rank: number; row: RankRow; total: number }> {
+  const rows = getRanking();
+  const map = new Map<string, { rank: number; row: RankRow; total: number }>();
+  for (let i = 0; i < rows.length; i++) {
+    map.set(rows[i].key, { rank: i + 1, row: rows[i], total: rows.length });
+  }
+  return map;
+}

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -10,6 +10,7 @@ import Webmentions from '../../components/Webmentions.astro';
 import TableOfContents from '../../components/TableOfContents.astro';
 import RelatedPosts from '../../components/RelatedPosts.astro';
 import AuthorBio from '../../components/AuthorBio.astro';
+import { getRankByKey } from '../../lib/hronir-rank';
 import Comments from '../../components/Comments.astro';
 import SeriesContext from '../../components/SeriesContext.astro';
 import PostActionBar from '../../components/PostActionBar.astro';
@@ -35,6 +36,10 @@ const lastModifiedISO: string | undefined = remarkPluginFrontmatter.lastModified
 const lastModified = lastModifiedISO ? new Date(lastModifiedISO) : undefined;
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
 const showUpdated = lastModified && lastModified.valueOf() - date.valueOf() > MS_PER_DAY;
+
+const rankInfo = translationKey ? getRankByKey().get(translationKey) : undefined;
+const rankLabel = lang === 'pt' ? 'ranking Hrönir' : 'Hrönir rank';
+const rankHref = lang === 'pt' ? '/pt/ranking/' : '/ranking/';
 const series = await getSeriesContext(post, { lang: lang ?? DEFAULT_LANG });
 const locale = localeFor(lang);
 const dateOpts = { year: 'numeric', month: 'long', day: 'numeric' } as const;
@@ -98,6 +103,9 @@ const translationLinks = translationSiblings.map((p) => {
                   <> · {t(lang, 'post.updated')} <time datetime={lastModified.toISOString()}>
                     {lastModified.toLocaleDateString(locale, dateOpts)}
                   </time></>
+                )}
+                {rankInfo && (
+                  <> · <a href={rankHref} title={`μ ${rankInfo.row.mu.toFixed(2)}, σ ${rankInfo.row.sigma.toFixed(2)}, ${rankInfo.row.wins}/${rankInfo.row.appearances}`}>{rankLabel} #{rankInfo.rank}/{rankInfo.total}</a></>
                 )}
               </small>
             </p>

--- a/src/pages/pt/ranking.astro
+++ b/src/pages/pt/ranking.astro
@@ -13,7 +13,7 @@ for (const p of all) {
   const lang = p.data.lang ?? "en";
   // Prefer PT entry on this page; otherwise fall back to anything.
   if (!existing || lang === "pt") {
-    byKey.set(key, { slug: p.slug ?? p.id.replace(/\.mdx?$/, ""), title: p.data.title, lang });
+    byKey.set(key, { slug: p.id, title: p.data.title, lang });
   }
 }
 

--- a/src/pages/pt/ranking.astro
+++ b/src/pages/pt/ranking.astro
@@ -1,0 +1,85 @@
+---
+import PageLayout from "../../layouts/PageLayout.astro";
+import { getCollection } from "astro:content";
+import { getRanking } from "../../lib/hronir-rank";
+
+const all = await getCollection("blog");
+const byKey = new Map<string, { slug: string; title: string; lang: string }>();
+for (const p of all) {
+  if (p.data.draft) continue;
+  const key = p.data.translationKey;
+  if (!key) continue;
+  const existing = byKey.get(key);
+  const lang = p.data.lang ?? "en";
+  // Prefer PT entry on this page; otherwise fall back to anything.
+  if (!existing || lang === "pt") {
+    byKey.set(key, { slug: p.slug ?? p.id.replace(/\.mdx?$/, ""), title: p.data.title, lang });
+  }
+}
+
+const rows = getRanking();
+const enriched = rows.map((r, i) => ({
+  rank: i + 1,
+  ...r,
+  post: byKey.get(r.key),
+}));
+---
+
+<PageLayout
+  title="Ranking | Franklin Baldo"
+  description="Posts ranqueados por comparações par-a-par sob o sistema Hrönir, com OpenSkill."
+  lang="pt"
+  translations={{ en: "/ranking/" }}
+>
+  <hgroup>
+    <h1>Ranking</h1>
+    <p>
+      <small>
+        Posts ordenados pelo <em>ordinal</em> do OpenSkill (μ − 3σ). Maior é melhor.
+        Atualizado a cada build a partir de <code>.routines/hronir/</code>.
+      </small>
+    </p>
+  </hgroup>
+
+  <p>
+    O sistema Hrönir confronta posts em duelos par-a-par. Um avaliador (às vezes eu, às vezes um modelo)
+    escolhe um vencedor e escreve uma defesa apaixonada. O OpenSkill transforma esses duelos num ranking
+    contínuo com incerteza explícita (σ). Posts com poucas aparições têm σ maior e portanto ordinal mais
+    baixo mesmo com μ alto.
+  </p>
+
+  <table class="striped">
+    <thead>
+      <tr>
+        <th scope="col" style="text-align:right">#</th>
+        <th scope="col">Post</th>
+        <th scope="col" style="text-align:right">ordinal</th>
+        <th scope="col" style="text-align:right">μ</th>
+        <th scope="col" style="text-align:right">σ</th>
+        <th scope="col" style="text-align:right">V/N</th>
+      </tr>
+    </thead>
+    <tbody>
+      {enriched.map((r) => (
+        <tr>
+          <td style="text-align:right">{r.rank}</td>
+          <td>
+            {r.post ? (
+              <a href={`/blog/${r.post.slug}/`}>{r.post.title}</a>
+            ) : (
+              <code>{r.key}</code>
+            )}
+          </td>
+          <td style="text-align:right"><code>{r.ordinal.toFixed(2)}</code></td>
+          <td style="text-align:right"><code>{r.mu.toFixed(2)}</code></td>
+          <td style="text-align:right"><code>{r.sigma.toFixed(2)}</code></td>
+          <td style="text-align:right"><code>{r.wins}/{r.appearances}</code></td>
+        </tr>
+      ))}
+    </tbody>
+  </table>
+
+  {enriched.length === 0 && (
+    <p><em>Sem posts ranqueados ainda — rode uma rodada Hrönir para popular o ranking.</em></p>
+  )}
+</PageLayout>

--- a/src/pages/ranking.astro
+++ b/src/pages/ranking.astro
@@ -1,0 +1,83 @@
+---
+import PageLayout from "../layouts/PageLayout.astro";
+import { getCollection } from "astro:content";
+import { getRanking } from "../lib/hronir-rank";
+
+const all = await getCollection("blog");
+const byKey = new Map<string, { slug: string; title: string; lang: string }>();
+for (const p of all) {
+  if (p.data.draft) continue;
+  const key = p.data.translationKey;
+  if (!key) continue;
+  // Prefer EN entry for the link; fall back to first seen.
+  const existing = byKey.get(key);
+  if (!existing || (p.data.lang ?? "en") === "en") {
+    byKey.set(key, { slug: p.slug ?? p.id.replace(/\.mdx?$/, ""), title: p.data.title, lang: p.data.lang ?? "en" });
+  }
+}
+
+const rows = getRanking();
+const enriched = rows.map((r, i) => ({
+  rank: i + 1,
+  ...r,
+  post: byKey.get(r.key),
+}));
+---
+
+<PageLayout
+  title="Ranking | Franklin Baldo"
+  description="Posts ranked by pairwise comparisons under the Hrönir system, scored with OpenSkill."
+  lang="en"
+  translations={{ pt: "/pt/ranking/" }}
+>
+  <hgroup>
+    <h1>Ranking</h1>
+    <p>
+      <small>
+        Posts ordered by OpenSkill <em>ordinal</em> (μ − 3σ). Higher is better.
+        Updated every build from <code>.routines/hronir/</code>.
+      </small>
+    </p>
+  </hgroup>
+
+  <p>
+    The Hrönir system pits posts against each other in pairwise duels. An evaluator (sometimes me, sometimes a model)
+    picks a winner and writes a passionate defense. OpenSkill turns those duels into a continuous ranking with
+    explicit uncertainty (σ). Posts with few appearances have larger σ and therefore a lower ordinal even with high μ.
+  </p>
+
+  <table class="striped">
+    <thead>
+      <tr>
+        <th scope="col" style="text-align:right">#</th>
+        <th scope="col">Post</th>
+        <th scope="col" style="text-align:right">ordinal</th>
+        <th scope="col" style="text-align:right">μ</th>
+        <th scope="col" style="text-align:right">σ</th>
+        <th scope="col" style="text-align:right">W/N</th>
+      </tr>
+    </thead>
+    <tbody>
+      {enriched.map((r) => (
+        <tr>
+          <td style="text-align:right">{r.rank}</td>
+          <td>
+            {r.post ? (
+              <a href={`/blog/${r.post.slug}/`}>{r.post.title}</a>
+            ) : (
+              <code>{r.key}</code>
+            )}
+          </td>
+          <td style="text-align:right"><code>{r.ordinal.toFixed(2)}</code></td>
+          <td style="text-align:right"><code>{r.mu.toFixed(2)}</code></td>
+          <td style="text-align:right"><code>{r.sigma.toFixed(2)}</code></td>
+          <td style="text-align:right"><code>{r.wins}/{r.appearances}</code></td>
+        </tr>
+      ))}
+    </tbody>
+  </table>
+
+  {enriched.length === 0 && (
+    <p><em>No rated posts yet — run a Hrönir round to populate the ranking.</em></p>
+  )}
+</PageLayout>

--- a/src/pages/ranking.astro
+++ b/src/pages/ranking.astro
@@ -12,7 +12,7 @@ for (const p of all) {
   // Prefer EN entry for the link; fall back to first seen.
   const existing = byKey.get(key);
   if (!existing || (p.data.lang ?? "en") === "en") {
-    byKey.set(key, { slug: p.slug ?? p.id.replace(/\.mdx?$/, ""), title: p.data.title, lang: p.data.lang ?? "en" });
+    byKey.set(key, { slug: p.id, title: p.data.title, lang: p.data.lang ?? "en" });
   }
 }
 


### PR DESCRIPTION
Duas coisas em uma PR porque dependem da mesma cadeia de commits:

## 1. Land da cadeia #119/#121/#122

#119, #121 e #122 foram "merged" mas em branches encadeadas (`hronir/skills-volume-archive` → `hronir/scale-20-word-targets` → `hronir/init-dynamic-n`), não em `main`. Cherry-picked os 7 commits únicos para esta branch, base em `main`:

- `5e706fc8` — 20 matches per run + resume + word-target (de #119)
- `7de92ba0` — dynamic n_matches em init (de #121)
- `567340d9` — OpenSkill replace winrate (de #122)
- `cd98c383` — openskill em devDeps root (de #122)
- `7cd50908` — ordenação determinística + preserva path (de #122)
- `202584a0` — README mu/sigma/ordinal (de #122)
- `1d410b72` — Date→ISO normalize (de #122)

Conflito ao cherry-pick do OpenSkill (worstRow/topRows slice direction): resolvido a favor do OpenSkill (DESC sort).

## 2. Página pública de ranking + posição no post

- **`src/lib/hronir-rank.ts`** — wrapper TS sobre `computeRatings()` (`scripts/hronir/lib/ranking.js`). Lê `.routines/hronir/*.md` no build, retorna array OpenSkill ordenado + Map por translationKey.
- **`/ranking`** (EN) + **`/pt/ranking`** (PT) — tabela `#  Post  ordinal  μ  σ  W/N` com links pros posts.
- **Post template** (`src/pages/blog/[...slug].astro`) — abaixo da data/reading-time, mostra `Hrönir rank #N/total` com link pra página de ranking; tooltip do anchor mostra μ/σ/wins/appearances.

## Validação

- `npm run build` — 304 páginas, `/ranking` e `/pt/ranking` presentes.
- `npm run hronir:doctor` — 0 inconsistências.
- Sample do post `who-the-asterisk-protects` injeta `Hrönir rank #2/31`.
- Ranking top: `serpents-egg` (4/4), `asterisk-protects` (3/3), `vitrine-sonora` (3/4). Bottom: `inaugural-post` (0/3).

Não auto-merge.

---
_Generated by [Claude Code](https://claude.ai/code/session_012as5hQdqsq22hRKLnmEeYb)_