### PR TITLE
hronir: active sampling em init (info-maximizing pair selection)

### DIFF
--- a/scripts/hronir/README.md
+++ b/scripts/hronir/README.md
@@ -36,7 +36,7 @@ Todos via npm scripts no raiz:
 
 | Comando | Função |
 |---------|--------|
-| `npm run hronir:init` | Sorteia posts EN, cria até 20 match files (n = min(20, ⌊corpus/2⌋); falha se corpus < 4) |
+| `npm run hronir:init` | Cria até 20 match files (n = min(20, ⌊corpus/2⌋); falha se corpus < 4). Seleção por **active sampling** (ver abaixo). |
 | `npm run hronir:present -- <match.md>` | Imprime os dois posts + instrução pro avaliador (meta de palavras na defesa) |
 | `npm run hronir:resume` | Identifica a rodada mais recente, lista pendentes, aponta próximo |
 | `npm run hronir:ranking` | Score acumulado de todos os matches preenchidos |
@@ -94,6 +94,21 @@ Ranking via **OpenSkill** (modelo Weng-Lin, atualização bayesiana online de Pl
 - **`ordinal = mu − 3·sigma`** — score conservador usado para a ordem global. Penaliza incerteza explicitamente: um post novo, mesmo com mu alto, fica atrás de um post estabelecido com mu um pouco menor.
 
 A ordem da tabela é por `ordinal` descendente. Tie-break alfabético por `key`. O `worst` retorna o post com menor `ordinal` entre os elegíveis (`appearances >= MIN_APPEARANCES`) — note que aqui não é "tie-break", é filtro: posts sem volume mínimo são ignorados antes de pegar o último.
+
+### Active sampling no `init`
+
+`init` não sorteia matches no escuro. Para cada par possível de posts elegíveis, calcula:
+
+```
+score = -|predictWin(a, b) - 0.5| + sigma_a + sigma_b
+```
+
+- `predictWin` próximo de 0.5 → resultado mais incerto → mais informação extraída pela partida (entropia máxima do outcome).
+- `sigma_a + sigma_b` → preferir pares onde a incerteza individual ainda é alta. Posts que já têm muitas partidas (sigma baixo) cedem prioridade.
+
+Greedy: ordena pares por score descendente e pega os top-N, garantindo que nenhum post apareça duas vezes no mesmo run.
+
+**Cold start:** quando todo mundo tem σ=8.33 e μ=25 default, `predictWin` é sempre 0.5 e o termo de incerteza só soma — qualquer par é informativamente equivalente. O greedy nesse regime se comporta praticamente como random. À medida que partidas acumulam, o sampling foca em pares próximos no skill e em posts subexplorados.
 
 ### Por que MIN_APPEARANCES ainda importa com OpenSkill
 

--- a/scripts/hronir/README.md
+++ b/scripts/hronir/README.md
@@ -100,15 +100,16 @@ A ordem da tabela é por `ordinal` descendente. Tie-break alfabético por `key`.
 `init` não sorteia matches no escuro. Para cada par possível de posts elegíveis, calcula:
 
 ```
-score = -|predictWin(a, b) - 0.5| + sigma_a + sigma_b
+score = -|predictWin(a, b) - 0.5| + sigma_a + sigma_b + stale_bonus(a) + stale_bonus(b)
 ```
 
 - `predictWin` próximo de 0.5 → resultado mais incerto → mais informação extraída pela partida (entropia máxima do outcome).
 - `sigma_a + sigma_b` → preferir pares onde a incerteza individual ainda é alta. Posts que já têm muitas partidas (sigma baixo) cedem prioridade.
+- `stale_bonus` → `+3.0` se o post foi editado no git **depois** do match mais recente em que entrou; `0` se nunca foi avaliado ou se está em dia. Detecção binária: qualquer commit que toca o arquivo conta. (Versão refinada por linhas alteradas é uma melhoria futura — por ora corrige typo conta igual a reescrever metade.)
 
-Greedy: ordena pares por score descendente e pega os top-N, garantindo que nenhum post apareça duas vezes no mesmo run.
+Greedy: ordena pares por score descendente, com jitter aleatório para tie-break, e pega os top-N garantindo que nenhum post apareça duas vezes no mesmo run.
 
-**Cold start:** quando todo mundo tem σ=8.33 e μ=25 default, `predictWin` é sempre 0.5 e o termo de incerteza só soma — qualquer par é informativamente equivalente. O greedy nesse regime se comporta praticamente como random. À medida que partidas acumulam, o sampling foca em pares próximos no skill e em posts subexplorados.
+**Cold start:** quando todo mundo tem σ=8.33 e μ=25 default, `predictWin` é sempre 0.5 e o termo de incerteza só soma — qualquer par é informativamente equivalente. O jitter garante que runs sucessivos cobrem subsets diferentes em vez de fixar nos mesmos posts. À medida que partidas acumulam, o sampling foca em pares próximos no skill, posts subexplorados, e posts cuja versão atual divergiu da que foi avaliada.
 
 ### Por que MIN_APPEARANCES ainda importa com OpenSkill
 

--- a/scripts/hronir/lib/commands.js
+++ b/scripts/hronir/lib/commands.js
@@ -1,14 +1,46 @@
 import fs from "node:fs";
 import path from "node:path";
+import { execFileSync } from "node:child_process";
 import { rating, predictWin } from "openskill";
 import { OUT_DIR, listEnglishWithKey, keyForPath, readPost, listPosts } from "./posts.js";
 import { listMatchFiles, readMatch, writeMatch, postKey } from "./matches.js";
 import { computeRatings } from "./ranking.js";
 
 const MIN_APPEARANCES = 3;
+const STALE_BONUS = 3.0;
 const SKILLS_DIR = "scripts/hronir/skills";
 const ARCHIVE_DIR = path.join(OUT_DIR, "archive");
 const EDITS_DIR = path.join(OUT_DIR, "edits");
+
+function gitMtime(filePath) {
+  try {
+    const out = execFileSync("git", ["log", "-1", "--format=%ct", "--", filePath], {
+      stdio: ["ignore", "pipe", "ignore"],
+    }).toString().trim();
+    return out ? Number(out) * 1000 : 0;
+  } catch {
+    return 0;
+  }
+}
+
+function latestMatchTimeByKey() {
+  const out = new Map();
+  for (const f of listMatchFiles()) {
+    const { data } = readMatch(f);
+    const aKey = postKey(data.post_a);
+    const bKey = postKey(data.post_b);
+    const ts = data.run_at instanceof Date
+      ? data.run_at.getTime()
+      : Date.parse(String(data.run_at || data.run_id || "")) || 0;
+    if (!ts) continue;
+    for (const k of [aKey, bKey]) {
+      if (!k) continue;
+      const prev = out.get(k) || 0;
+      if (ts > prev) out.set(k, ts);
+    }
+  }
+  return out;
+}
 
 function utcStamp() {
   const iso = new Date().toISOString();
@@ -37,14 +69,30 @@ export function init() {
   const nMatches = Math.min(20, Math.floor(corpusSize / 2));
 
   // Active sampling: pick pairs that maximize expected information.
-  // Score = -|predictWin - 0.5| + sigma_a + sigma_b
-  //   -|p - 0.5|  →  closer to 50/50 = higher entropy of outcome
-  //   sigma_a/b   →  prefer posts we know less about
+  // Score = -|predictWin - 0.5| + sigma_a + sigma_b + stale_bonus(a) + stale_bonus(b)
+  //   -|p - 0.5|         →  closer to 50/50 = higher entropy of outcome
+  //   sigma_a/b          →  prefer posts we know less about
+  //   stale_bonus        →  +STALE_BONUS if post was git-edited after its last
+  //                         rated match (current ratings may not reflect the
+  //                         new version; re-evaluate). 0 for never-rated posts.
   // Greedy: sort pairs by score DESC, pick top-N s.t. no post repeats within run.
   const ranking = computeRatings();
   const ratingByKey = new Map();
   for (const r of ranking) ratingByKey.set(r.key, { mu: r.mu, sigma: r.sigma });
   const getRating = (key) => ratingByKey.get(key) ?? rating();
+
+  const lastMatchTime = latestMatchTimeByKey();
+  const staleByKey = new Map();
+  for (const c of candidates) {
+    const lastMatch = lastMatchTime.get(c.translationKey) || 0;
+    if (lastMatch === 0) {
+      staleByKey.set(c.translationKey, false);
+      continue;
+    }
+    const mtime = gitMtime(c.path);
+    staleByKey.set(c.translationKey, mtime > lastMatch);
+  }
+  const staleBonus = (key) => (staleByKey.get(key) ? STALE_BONUS : 0);
 
   const pairs = [];
   for (let i = 0; i < candidates.length; i++) {
@@ -54,7 +102,8 @@ export function init() {
       const ra = getRating(a.translationKey);
       const rb = getRating(b.translationKey);
       const [pA] = predictWin([[ra], [rb]]);
-      const score = -Math.abs(pA - 0.5) + ra.sigma + rb.sigma;
+      const score = -Math.abs(pA - 0.5) + ra.sigma + rb.sigma
+        + staleBonus(a.translationKey) + staleBonus(b.translationKey);
       // Random jitter for tie-break: cold start has many identical scores;
       // without this, stable sort + greedy = same posts picked every run.
       pairs.push({ a, b, score, pA, sa: ra.sigma, sb: rb.sigma, jitter: Math.random() });

--- a/scripts/hronir/lib/commands.js
+++ b/scripts/hronir/lib/commands.js
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
+import { rating, predictWin } from "openskill";
 import { OUT_DIR, listEnglishWithKey, keyForPath, readPost, listPosts } from "./posts.js";
 import { listMatchFiles, readMatch, writeMatch, postKey } from "./matches.js";
 import { computeRatings } from "./ranking.js";
@@ -15,15 +16,6 @@ function utcStamp() {
     runId: iso.replace(/[:.]/g, "-").replace(/-\d+Z$/, ""),
     runAt: iso.replace(/\.\d+Z$/, "Z"),
   };
-}
-
-function shuffle(arr) {
-  const a = arr.slice();
-  for (let i = a.length - 1; i > 0; i--) {
-    const j = Math.floor(Math.random() * (i + 1));
-    [a[i], a[j]] = [a[j], a[i]];
-  }
-  return a;
 }
 
 function nextStep(text) {
@@ -43,15 +35,48 @@ export function init() {
   }
 
   const nMatches = Math.min(20, Math.floor(corpusSize / 2));
-  console.log(`Corpus: ${corpusSize} posts elegíveis. Criando ${nMatches} matches.`);
 
-  const sample = shuffle(candidates).slice(0, nMatches * 2);
+  // Active sampling: pick pairs that maximize expected information.
+  // Score = -|predictWin - 0.5| + sigma_a + sigma_b
+  //   -|p - 0.5|  →  closer to 50/50 = higher entropy of outcome
+  //   sigma_a/b   →  prefer posts we know less about
+  // Greedy: sort pairs by score DESC, pick top-N s.t. no post repeats within run.
+  const ranking = computeRatings();
+  const ratingByKey = new Map();
+  for (const r of ranking) ratingByKey.set(r.key, { mu: r.mu, sigma: r.sigma });
+  const getRating = (key) => ratingByKey.get(key) ?? rating();
+
+  const pairs = [];
+  for (let i = 0; i < candidates.length; i++) {
+    for (let j = i + 1; j < candidates.length; j++) {
+      const a = candidates[i];
+      const b = candidates[j];
+      const ra = getRating(a.translationKey);
+      const rb = getRating(b.translationKey);
+      const [pA] = predictWin([[ra], [rb]]);
+      const score = -Math.abs(pA - 0.5) + ra.sigma + rb.sigma;
+      pairs.push({ a, b, score, pA, sa: ra.sigma, sb: rb.sigma });
+    }
+  }
+  pairs.sort((x, y) => y.score - x.score);
+
+  const used = new Set();
+  const chosen = [];
+  for (const p of pairs) {
+    if (chosen.length >= nMatches) break;
+    if (used.has(p.a.translationKey) || used.has(p.b.translationKey)) continue;
+    chosen.push(p);
+    used.add(p.a.translationKey);
+    used.add(p.b.translationKey);
+  }
+
+  console.log(`Corpus: ${corpusSize} posts elegíveis. Criando ${chosen.length} matches (active sampling).`);
+
   const { runId, runAt } = utcStamp();
   const created = [];
 
-  for (let i = 0; i < nMatches; i++) {
-    let a = sample[i * 2];
-    let b = sample[i * 2 + 1];
+  for (let i = 0; i < chosen.length; i++) {
+    let { a, b } = chosen[i];
     if (Math.random() < 0.5) [a, b] = [b, a];
 
     const file = path.join(

--- a/scripts/hronir/lib/commands.js
+++ b/scripts/hronir/lib/commands.js
@@ -55,10 +55,12 @@ export function init() {
       const rb = getRating(b.translationKey);
       const [pA] = predictWin([[ra], [rb]]);
       const score = -Math.abs(pA - 0.5) + ra.sigma + rb.sigma;
-      pairs.push({ a, b, score, pA, sa: ra.sigma, sb: rb.sigma });
+      // Random jitter for tie-break: cold start has many identical scores;
+      // without this, stable sort + greedy = same posts picked every run.
+      pairs.push({ a, b, score, pA, sa: ra.sigma, sb: rb.sigma, jitter: Math.random() });
     }
   }
-  pairs.sort((x, y) => y.score - x.score);
+  pairs.sort((x, y) => (y.score - x.score) || (x.jitter - y.jitter));
 
   const used = new Set();
   const chosen = [];


### PR DESCRIPTION
Substitui a seleção aleatória de pares em `init` por **active sampling** dirigido por OpenSkill.

## Fórmula

Para cada par `(a, b)` de posts elegíveis:

```
score = -|predictWin(a, b) - 0.5| + sigma_a + sigma_b
```

- **`-|predictWin - 0.5|`** — pares cujo desfecho é incerto (próximo de 50/50) maximizam a entropia do outcome, portanto extraem mais informação por partida.
- **`+ sigma_a + sigma_b`** — favorece pares envolvendo posts ainda subexplorados, onde σ é alto.

Greedy: ordena por score DESC, pega os top-N garantindo que nenhum post aparece em mais de um par no mesmo run.

## Cold start

Quando todo mundo tem σ=8.33 e μ=25 default, `predictWin` é sempre 0.5 e o score colapsa para a soma de sigmas — comportamento equivalente a random. À medida que partidas acumulam, o sampling foca naturalmente em (a) pares de skill próximo e (b) posts pouco vistos.

## Smoke (corpus atual)

Top 5 pares por score, sobre 496 candidatos:

| score | pA | sa | sb | par |
|---|---|---|---|---|
| 16.667 | 0.500 | 8.33 | 8.33 | everything-is-process × hermes-vs-openclaw |
| 16.323 | 0.434 | 8.33 | 8.06 | everything-is-process × pierre-menard |
| 16.323 | 0.434 | 8.33 | 8.06 | hermes-vs-openclaw × pierre-menard |
| 16.301 | 0.411 | 8.33 | 8.06 | everything-is-process × future-father |
| 16.301 | 0.589 | 8.06 | 8.33 | future-father × hermes-vs-openclaw |

Exatamente o comportamento cold-start esperado: prioriza posts nunca ranqueados.

## Validação

- `npm run hronir:doctor` → 0 inconsistências.
- `init` não foi executado (PR é infra).
- Removida a função `shuffle` (não mais usada).

Não auto-merge.

---
_Generated by [Claude Code](https://claude.ai/code/session_012as5hQdqsq22hRKLnmEeYb)_