### PR TITLE
hronir: staleness boost de git mtime no active sampling

### DIFF
--- a/scripts/hronir/README.md
+++ b/scripts/hronir/README.md
@@ -100,15 +100,16 @@ A ordem da tabela é por `ordinal` descendente. Tie-break alfabético por `key`.
 `init` não sorteia matches no escuro. Para cada par possível de posts elegíveis, calcula:
 
 ```
-score = -|predictWin(a, b) - 0.5| + sigma_a + sigma_b
+score = -|predictWin(a, b) - 0.5| + sigma_a + sigma_b + stale_bonus(a) + stale_bonus(b)
 ```
 
 - `predictWin` próximo de 0.5 → resultado mais incerto → mais informação extraída pela partida (entropia máxima do outcome).
 - `sigma_a + sigma_b` → preferir pares onde a incerteza individual ainda é alta. Posts que já têm muitas partidas (sigma baixo) cedem prioridade.
+- `stale_bonus` → `+3.0` se o post foi editado no git **depois** do match mais recente em que entrou; `0` se nunca foi avaliado ou se está em dia. Detecção binária: qualquer commit que toca o arquivo conta. (Versão refinada por linhas alteradas é uma melhoria futura — por ora corrige typo conta igual a reescrever metade.)
 
-Greedy: ordena pares por score descendente e pega os top-N, garantindo que nenhum post apareça duas vezes no mesmo run.
+Greedy: ordena pares por score descendente, com jitter aleatório para tie-break, e pega os top-N garantindo que nenhum post apareça duas vezes no mesmo run.
 
-**Cold start:** quando todo mundo tem σ=8.33 e μ=25 default, `predictWin` é sempre 0.5 e o termo de incerteza só soma — qualquer par é informativamente equivalente. O greedy nesse regime se comporta praticamente como random. À medida que partidas acumulam, o sampling foca em pares próximos no skill e em posts subexplorados.
+**Cold start:** quando todo mundo tem σ=8.33 e μ=25 default, `predictWin` é sempre 0.5 e o termo de incerteza só soma — qualquer par é informativamente equivalente. O jitter garante que runs sucessivos cobrem subsets diferentes em vez de fixar nos mesmos posts. À medida que partidas acumulam, o sampling foca em pares próximos no skill, posts subexplorados, e posts cuja versão atual divergiu da que foi avaliada.
 
 ### Por que MIN_APPEARANCES ainda importa com OpenSkill
 

--- a/scripts/hronir/lib/commands.js
+++ b/scripts/hronir/lib/commands.js
@@ -1,14 +1,46 @@
 import fs from "node:fs";
 import path from "node:path";
+import { execFileSync } from "node:child_process";
 import { rating, predictWin } from "openskill";
 import { OUT_DIR, listEnglishWithKey, keyForPath, readPost, listPosts } from "./posts.js";
 import { listMatchFiles, readMatch, writeMatch, postKey } from "./matches.js";
 import { computeRatings } from "./ranking.js";
 
 const MIN_APPEARANCES = 3;
+const STALE_BONUS = 3.0;
 const SKILLS_DIR = "scripts/hronir/skills";
 const ARCHIVE_DIR = path.join(OUT_DIR, "archive");
 const EDITS_DIR = path.join(OUT_DIR, "edits");
+
+function gitMtime(filePath) {
+  try {
+    const out = execFileSync("git", ["log", "-1", "--format=%ct", "--", filePath], {
+      stdio: ["ignore", "pipe", "ignore"],
+    }).toString().trim();
+    return out ? Number(out) * 1000 : 0;
+  } catch {
+    return 0;
+  }
+}
+
+function latestMatchTimeByKey() {
+  const out = new Map();
+  for (const f of listMatchFiles()) {
+    const { data } = readMatch(f);
+    const aKey = postKey(data.post_a);
+    const bKey = postKey(data.post_b);
+    const ts = data.run_at instanceof Date
+      ? data.run_at.getTime()
+      : Date.parse(String(data.run_at || data.run_id || "")) || 0;
+    if (!ts) continue;
+    for (const k of [aKey, bKey]) {
+      if (!k) continue;
+      const prev = out.get(k) || 0;
+      if (ts > prev) out.set(k, ts);
+    }
+  }
+  return out;
+}
 
 function utcStamp() {
   const iso = new Date().toISOString();
@@ -37,14 +69,30 @@ export function init() {
   const nMatches = Math.min(20, Math.floor(corpusSize / 2));
 
   // Active sampling: pick pairs that maximize expected information.
-  // Score = -|predictWin - 0.5| + sigma_a + sigma_b
-  //   -|p - 0.5|  →  closer to 50/50 = higher entropy of outcome
-  //   sigma_a/b   →  prefer posts we know less about
+  // Score = -|predictWin - 0.5| + sigma_a + sigma_b + stale_bonus(a) + stale_bonus(b)
+  //   -|p - 0.5|         →  closer to 50/50 = higher entropy of outcome
+  //   sigma_a/b          →  prefer posts we know less about
+  //   stale_bonus        →  +STALE_BONUS if post was git-edited after its last
+  //                         rated match (current ratings may not reflect the
+  //                         new version; re-evaluate). 0 for never-rated posts.
   // Greedy: sort pairs by score DESC, pick top-N s.t. no post repeats within run.
   const ranking = computeRatings();
   const ratingByKey = new Map();
   for (const r of ranking) ratingByKey.set(r.key, { mu: r.mu, sigma: r.sigma });
   const getRating = (key) => ratingByKey.get(key) ?? rating();
+
+  const lastMatchTime = latestMatchTimeByKey();
+  const staleByKey = new Map();
+  for (const c of candidates) {
+    const lastMatch = lastMatchTime.get(c.translationKey) || 0;
+    if (lastMatch === 0) {
+      staleByKey.set(c.translationKey, false);
+      continue;
+    }
+    const mtime = gitMtime(c.path);
+    staleByKey.set(c.translationKey, mtime > lastMatch);
+  }
+  const staleBonus = (key) => (staleByKey.get(key) ? STALE_BONUS : 0);
 
   const pairs = [];
   for (let i = 0; i < candidates.length; i++) {
@@ -54,7 +102,8 @@ export function init() {
       const ra = getRating(a.translationKey);
       const rb = getRating(b.translationKey);
       const [pA] = predictWin([[ra], [rb]]);
-      const score = -Math.abs(pA - 0.5) + ra.sigma + rb.sigma;
+      const score = -Math.abs(pA - 0.5) + ra.sigma + rb.sigma
+        + staleBonus(a.translationKey) + staleBonus(b.translationKey);
       // Random jitter for tie-break: cold start has many identical scores;
       // without this, stable sort + greedy = same posts picked every run.
       pairs.push({ a, b, score, pA, sa: ra.sigma, sb: rb.sigma, jitter: Math.random() });


### PR DESCRIPTION
Quando um post é editado depois do match mais recente em que entrou, suas ratings podem não refletir mais a versão atual. `init` agora aumenta a prioridade desses posts.

## Fórmula atualizada

```
score = -|predictWin - 0.5| + sigma_a + sigma_b + stale_bonus(a) + stale_bonus(b)
```

`stale_bonus` = `+3.0` se `git log -1 --format=%ct -- <path>` > timestamp do match mais recente envolvendo aquela key. `0` caso contrário (incluindo posts nunca avaliados — esses já têm σ=8.33 dominante).

## Detecção binária

Qualquer commit que toca o arquivo conta. Typo fix = reescrita de meio ensaio (mesma prioridade). Documentado no README como limitação conhecida — refinamento por linhas alteradas (`git log --numstat`) fica como melhoria futura, a fazer quando incomodar.

## Smoke

Corpus atual (32): 2 never-rated, 1 stale. Os 3 posts elegíveis ao bônus subiriam pelo termo de stale/sigma na seleção.

## Codex P1 incorporado na branch base

Codex apontou no #134 que ties no score caíam em ordem alfabética. Fix (jitter aleatório no sort) foi empurrado para `hronir/active-sampling` antes desta PR — esta branch herda automaticamente.

## Validação

- `npm run hronir:doctor` → 0 inconsistências.
- `init` não foi executado.

Base: `hronir/active-sampling` (#134). Rebase para `main` quando #134 mesclar.

Não auto-merge.

---
_Generated by [Claude Code](https://claude.ai/code/session_012as5hQdqsq22hRKLnmEeYb)_