### PR TITLE
feat(ux/seo): PostNav prev/next, CollectionPage schema, PostCard tags, about fix

### DIFF
--- a/.routines/2026-05-20-postnav-tags-structured-data-about-fix.md
+++ b/.routines/2026-05-20-postnav-tags-structured-data-about-fix.md
@@ -1,0 +1,180 @@
+---
+date: 2026-05-20
+slug: postnav-tags-structured-data-about-fix
+branch: claude/great-mccarthy-yQh4L
+status: pr-open
+session: 14
+---
+
+# Sessão 2026-05-20 — PostNav, CollectionPage schema, about fix, PostCard tags
+
+## Contexto
+
+Décima-quarta sessão com o sistema `.routines/`. Branch designado: `claude/great-mccarthy-yQh4L`.
+
+Estado ao chegar:
+
+- PR #152 aberto (seo/ux: home title, archive badge links, WebSite SearchAction) — CI failing (prettier em .routines/)
+- PR #150 aberto (consolidação) — CI failed, Kilo failed — skip
+- PR #147 aberto (hronir delegating-to-agents) — CI verde mas `mergeable_state: dirty`
+- PRs #124–128, #136 — base muito desatualizada — skip
+- PR #102 — Kilo failed, base extremamente desatualizada — skip
+- Cobertura PT: 32 EN posts + 32 PT posts = 100%
+
+## PRs revisados e mergeados
+
+| PR   | Título                                                              | Ação                                                               |
+| ---- | ------------------------------------------------------------------- | ------------------------------------------------------------------ |
+| #152 | feat(seo/ux): home title, archive badge links, WebSite SearchAction | **Mergeado** (squash) — corrigido prettier em .routines/, CI verde |
+| #147 | hronir run 2026-05-18T19 (delegating-to-agents)                     | **Pulado** — `mergeable_state: dirty`, conflitos com main atual    |
+| #150 | Consolidação                                                        | **Pulado** — CI/Kilo failed, conteúdo já absorvido                 |
+
+## Ações realizadas nesta sessão
+
+### 1. Fix PR #152: prettier em .routines/
+
+**Problema**: CI do PR #152 falhava porque dois arquivos `.routines/*.md` não estavam formatados com Prettier.
+
+**Arquivos**: `.routines/2026-05-18-seo-toc-observer-og-dimensions.md`, `.routines/2026-05-19-seo-home-title-archive-links-searchaction.md`
+
+**Mudança**: `npx prettier --write` nos dois arquivos + push para o branch do PR. CI ficou verde e PR foi mergeado.
+
+### 2. `PostNav` — navegação prev/next entre posts
+
+**Problema**: Não existia nenhuma forma de navegar entre posts adjacentes (cronológicos) sem sair para o arquivo. Usuários que terminam de ler um post ficavam sem caminho natural para o próximo. Isso aumenta o bounce rate e reduz o time-on-site.
+
+**Arquivo novo**: `src/components/PostNav.astro`
+
+**Modificado**: `src/pages/blog/[...slug].astro`
+
+**Como funciona**:
+
+- No frontmatter do `[...slug].astro`, os `allPosts` já são carregados para translationSiblings.
+- Filtramos por mesmo idioma (`lang`), ordenamos por data ascendente, encontramos o índice do post atual.
+- `prevPost` = post anterior na lista (mais antigo), `nextPost` = post seguinte (mais recente).
+- O componente `PostNav` renderiza dois links com seta + título, em grid 2 colunas (1 coluna em mobile).
+- Posicionado logo antes de `<Webmentions>` na coluna principal.
+
+**Design**:
+
+- Cards com borda fina, hover em `var(--pico-primary)` + background sutil.
+- "← Previous" / "Next →" (EN) e "← Anterior" / "Próximo →" (PT).
+- Linha separadora acima do bloco para delimitar a zona de navegação.
+
+**Por que importa**: Navegação entre posts é um padrão universal de blogs que reduz bounce, aumenta páginas/sessão e melhora crawlability dos bots.
+
+### 3. Tags pages — `CollectionPage` JSON-LD + descrições melhoradas
+
+**Problema**: As páginas de tag (`/tags/[tag]/` e `/pt/tags/[tag]/`) tinham:
+
+- Descrição genérica: `"Essays tagged #${tag}."` — não útil para snippets de busca
+- Nenhum structured data para indicar que é uma coleção de posts
+- Badge de idioma alternativo com emoji (`🇧🇷 PT`) em vez de badge consistente com o estilo do site
+
+**Arquivos modificados**: `src/pages/tags/[tag].astro`, `src/pages/pt/tags/[tag].astro`
+
+**Mudanças**:
+
+1. **Descrição**: `"${count} essays tagged #${tag} — Franklin Baldo's digital garden on AI, law, and process."` — inclui contagem, nome do autor, contexto.
+
+2. **`CollectionPage` JSON-LD**:
+
+   ```json
+   {
+     "@type": "CollectionPage",
+     "name": "#tag",
+     "description": "...",
+     "inLanguage": "en-US",
+     "url": "https://franklinbaldo.github.io/tags/tag/",
+     "hasPart": [{ "@type": "BlogPosting", "headline": "...", "url": "...", "datePublished": "..." }]
+   }
+   ```
+
+   Informa ao Google que a página é uma coleção de artigos relacionados ao tópico.
+
+3. **Badge de idioma**: `🇧🇷 PT` → `<a class="lang-badge" href="/pt/tags/tag/">PT</a>` — mesmo estilo visual das badges do arquivo (fundo sutil, borda, hover state), sem emoji.
+
+### 4. About page — corrigir cobertura de idioma
+
+**Problema**: `src/pages/about.astro` dizia `"Most posts are in English; some are in Portuguese."` — impreciso após sessões anteriores que atingiram 100% de cobertura PT (32 EN + 32 PT posts com `translationKey`).
+
+**Mudança**: `"All essays are available in both English and Portuguese."`
+
+**Por que importa**: Conteúdo desatualizado na página About prejudica credibilidade e pode confundir leitores portugueses.
+
+### 5. PostCard — exibir tags
+
+**Problema**: Os cards de post na home e nas páginas de tag mostravam título, data, tempo de leitura e descrição — mas não as tags. Leitores não conseguiam ver os tópicos de um post sem abri-lo.
+
+**Arquivo modificado**: `src/components/PostCard.astro`
+
+**Mudança**: Exibe até 3 tags do post como badges clicáveis (`/tags/tag/` ou `/pt/tags/tag/`) acima do link "Continue reading →". Estilo: badges com cor secundária, hover sutil.
+
+**UX**: Leitores podem clicar numa tag no card para ver outros posts relacionados sem precisar entrar no post primeiro.
+
+## Build
+
+304 páginas — sem erros, 0 type errors.
+
+## Estado atual após esta sessão
+
+- Home title EN/PT: descritivos ✅ (mergeado #152)
+- Archive badges → links diretos ✅ (mergeado #152)
+- WebSite JSON-LD SearchAction ✅ (mergeado #152)
+- PostNav prev/next entre posts ✅ (novo — esta sessão)
+- Tags: CollectionPage JSON-LD ✅ (novo — esta sessão)
+- Tags: descrições melhoradas ✅ (novo — esta sessão)
+- Tags: badges de idioma consistentes ✅ (novo — esta sessão)
+- About: cobertura 100% EN+PT ✅ (corrigido — esta sessão)
+- PostCard: tags visíveis ✅ (novo — esta sessão)
+- og:image width/height ✅ (#139, sessão 12)
+- article:author ✅ (#139, sessão 12)
+- TOC IntersectionObserver ✅ (#139, sessão 12)
+- 32 pares EN↔PT via translationKey ✅
+- LanguageSwitcher auto-redirect ✅
+- Hreflang sitemap ✅
+- RSS split EN/PT ✅
+
+## PRs abertos com issues conhecidos
+
+- **PR #102** (Optimize profile visuals): Kilo Code Review failed, base extremamente desatualizada. Recomendação: novo PR do zero com as mudanças válidas.
+- **PR #150** (consolidação): CI/Kilo failed. Pode ser fechado — conteúdo foi absorvido individualmente.
+- **PRs #124–128, #136, #147**: base desatualizada, alguns com conflitos. Baixa prioridade.
+
+## Próximas sessões — backlog priorizado
+
+### Alta prioridade
+
+1. **PR #102 rebase/fix** — pixel art avatar + Astro Image + latest essay logic. Implementar do zero em novo PR, corrigindo os 2 bugs (`---` indentado + `author.moreAbout` → `author.aboutMore`).
+
+2. **OG image per-post**: o gerador existe em `src/pages/og/[...slug].png.ts`. Verificar se as imagens estão sendo geradas e servidas corretamente, e se o `<meta property="og:image">` em cada post aponta para a imagem correta.
+
+3. **Archive: leitura rápida na tabela** — adicionar coluna "~N min" na tabela do arquivo. Adiar enquanto a cobertura de PT posts (100%) for suficiente para justificar melhorias no arquivo.
+
+### Média prioridade
+
+4. **Archive pagination** — Astro `paginate()` antes de ter >60 posts (atualmente ~32 EN, ~32 PT).
+
+5. **Pagefind URL param — verificar comportamento**: o script `?q=` usa `triggerSearch()`. Testar se funciona no deploy.
+
+6. **Tags index page structured data**: `/tags/` e `/pt/tags/` poderiam ter `ItemList` JSON-LD com todas as tags e suas contagens.
+
+7. **PR #38** (dependabot defu 6.1.4 → 6.1.6): atualização simples.
+
+### Baixa prioridade
+
+8. **Focus management** (ClientRouter) — acessibilidade em transições de página.
+
+9. **Visual breadcrumbs** — JSON-LD breadcrumbs já existem; adicionar UI visual no header dos posts.
+
+10. **"Latest essay" logic no home** — PR #102 tinha essa feature; implementar no home rail.
+
+## Decisões arquiteturais
+
+- **PostNav ordena por data, não por ranking Hrönir**: A navegação cronológica é mais intuitiva para leitores. Navegação por ranking seria mais editorial mas menos esperada. Decisão pode ser revisada.
+
+- **PostNav mostra título completo**: Em vez de truncar, o grid responsivo permite que o título quebre em múltiplas linhas. Títulos longos ficam visíveis — melhor UX que "..." que esconde informação.
+
+- **Tags no PostCard: máximo 3**: Evita que o card fique poluído. Os 3 primeiros tags (como aparecem no frontmatter) são exibidos. Sem ordenação por relevância — o frontmatter é o critério.
+
+- **CollectionPage.hasPart com todos os posts da tag**: Algumas tags têm muitos posts. A lista completa no JSON-LD aumenta o tamanho do HTML, mas o impacto é pequeno (poucos KB) e o benefício para crawlers é real.

--- a/src/components/PostCard.astro
+++ b/src/components/PostCard.astro
@@ -8,7 +8,7 @@ interface Props {
 }
 
 const { post } = Astro.props;
-const { title, date, lang, heroImage, heroImageAlt, featured, description } = post.data;
+const { title, date, lang, heroImage, heroImageAlt, featured, description, tags } = post.data;
 
 const postLang = lang ?? DEFAULT_LANG;
 const formattedDate = date.toLocaleDateString(locale(postLang), {
@@ -20,6 +20,8 @@ const wordCount = (post.body ?? '').trim().split(/\s+/).filter(Boolean).length;
 const minutesRead = Math.max(1, Math.round(wordCount / 220));
 
 const href = `/blog/${post.id}/`;
+const tagsPrefix = postLang === 'pt' ? '/pt/tags' : '/tags';
+const visibleTags = (tags ?? []).slice(0, 3);
 ---
 
 <article data-post-lang={postLang}>
@@ -49,6 +51,37 @@ const href = `/blog/${post.id}/`;
   </header>
   <p>{blurb}</p>
   <footer>
+    {visibleTags.length > 0 && (
+      <p class="card-tags">
+        {visibleTags.map((tag) => (
+          <a href={`${tagsPrefix}/${tag}/`} class="card-tag">#{tag}</a>
+        ))}
+      </p>
+    )}
     <a href={href}>{t(postLang, 'post.continueReading')}</a>
   </footer>
 </article>
+
+<style>
+  .card-tags {
+    margin-bottom: 0.5rem;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.3rem;
+  }
+  .card-tag {
+    font-size: 0.72rem;
+    font-weight: 600;
+    padding: 0.1em 0.45em;
+    border-radius: 3px;
+    background: color-mix(in srgb, var(--pico-secondary) 12%, transparent);
+    color: var(--pico-secondary);
+    border: 1px solid color-mix(in srgb, var(--pico-secondary) 30%, transparent);
+    text-decoration: none;
+    letter-spacing: 0.02em;
+  }
+  .card-tag:hover {
+    background: color-mix(in srgb, var(--pico-secondary) 22%, transparent);
+    text-decoration: none;
+  }
+</style>

--- a/src/components/PostNav.astro
+++ b/src/components/PostNav.astro
@@ -1,0 +1,84 @@
+---
+interface Props {
+  prev: { href: string; title: string } | null;
+  next: { href: string; title: string } | null;
+  lang?: string;
+}
+const { prev, next, lang = "en" } = Astro.props;
+const prevLabel = lang === "pt" ? "← Anterior" : "← Previous";
+const nextLabel = lang === "pt" ? "Próximo →" : "Next →";
+const navLabel = lang === "pt" ? "Navegação entre posts" : "Post navigation";
+---
+
+{
+  (prev || next) && (
+    <nav class="post-nav" aria-label={navLabel}>
+      {prev ? (
+        <a class="post-nav-link post-nav-prev" href={prev.href}>
+          <span class="post-nav-dir">{prevLabel}</span>
+          <span class="post-nav-title">{prev.title}</span>
+        </a>
+      ) : (
+        <span />
+      )}
+      {next && (
+        <a class="post-nav-link post-nav-next" href={next.href}>
+          <span class="post-nav-dir">{nextLabel}</span>
+          <span class="post-nav-title">{next.title}</span>
+        </a>
+      )}
+    </nav>
+  )
+}
+
+<style>
+  .post-nav {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 1rem;
+    margin-block: calc(var(--pico-spacing) * 2);
+    padding-top: calc(var(--pico-spacing) * 1.5);
+    border-top: 1px solid var(--pico-border-color);
+  }
+  .post-nav-link {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    padding: 0.75rem 1rem;
+    border-radius: var(--pico-border-radius);
+    border: 1px solid var(--pico-border-color);
+    text-decoration: none;
+    color: inherit;
+    transition:
+      border-color 0.15s ease,
+      background 0.15s ease;
+  }
+  .post-nav-link:hover {
+    border-color: var(--pico-primary);
+    background: color-mix(in srgb, var(--pico-primary) 6%, transparent);
+    text-decoration: none;
+  }
+  .post-nav-next {
+    text-align: right;
+  }
+  .post-nav-dir {
+    font-size: 0.75rem;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    color: var(--pico-primary);
+    text-transform: uppercase;
+  }
+  .post-nav-title {
+    font-size: 0.9rem;
+    color: var(--pico-color);
+    line-height: 1.35;
+  }
+  @media (max-width: 600px) {
+    .post-nav {
+      grid-template-columns: 1fr;
+    }
+    .post-nav-next {
+      text-align: left;
+    }
+  }
+</style>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -72,7 +72,7 @@ const faqLd = {
       <li><strong>Family memory</strong> — what it means to archive a life with help from a machine.</li>
     </ul>
 
-    <p>Most posts are in English; some are in Portuguese.</p>
+    <p>All essays are available in both English and Portuguese.</p>
 
     <h2>Find me</h2>
 

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -14,6 +14,7 @@ import { getRankByKey } from '../../lib/hronir-rank';
 import Comments from '../../components/Comments.astro';
 import SeriesContext from '../../components/SeriesContext.astro';
 import PostActionBar from '../../components/PostActionBar.astro';
+import PostNav from '../../components/PostNav.astro';
 import { getSeriesContext } from '../../lib/series';
 import { t, targetCopy, locale as localeFor, urlPrefix, DEFAULT_LANG } from '../../lib/i18n';
 
@@ -46,6 +47,17 @@ const dateOpts = { year: 'numeric', month: 'long', day: 'numeric' } as const;
 const tagsPrefix = `${urlPrefix(lang)}/tags`;
 
 const allPosts = await getCollection('blog');
+
+// Prev / next posts in the same language, ordered by date ascending.
+const postLang = lang ?? DEFAULT_LANG;
+const sameLangPosts = allPosts
+  .filter((p) => !p.data.draft && (p.data.lang ?? DEFAULT_LANG) === postLang)
+  .sort((a, b) => a.data.date.valueOf() - b.data.date.valueOf());
+const postIdx = sameLangPosts.findIndex((p) => p.id === post.id);
+const prevPost = postIdx > 0 ? sameLangPosts[postIdx - 1] : null;
+const nextPost = postIdx < sameLangPosts.length - 1 ? sameLangPosts[postIdx + 1] : null;
+const prevNav = prevPost ? { href: `/blog/${prevPost.id}/`, title: prevPost.data.title } : null;
+const nextNav = nextPost ? { href: `/blog/${nextPost.id}/`, title: nextPost.data.title } : null;
 const translationSiblings = translationKey
   ? allPosts.filter((p) => p.data.translationKey === translationKey && p.id !== post.id)
   : [];
@@ -152,6 +164,8 @@ const translationLinks = translationSiblings.map((p) => {
       <RelatedPosts currentId={post.id} tags={tags ?? []} lang={lang} />
 
       {series && <SeriesContext series={series} lang={lang ?? DEFAULT_LANG} variant="nav" />}
+
+      <PostNav prev={prevNav} next={nextNav} lang={lang} />
 
       <Webmentions url={new URL(Astro.url.pathname, Astro.site!)} />
 

--- a/src/pages/pt/tags/[tag].astro
+++ b/src/pages/pt/tags/[tag].astro
@@ -34,24 +34,66 @@ interface Props {
 }
 
 const { tag, posts, hasEnCounterpart } = Astro.props;
+const count = posts.length;
+const description = `${count} ${count === 1 ? "ensaio" : "ensaios"} com a etiqueta #${tag} — jardim digital de Franklin Baldo sobre IA, direito e processo.`;
+
+const collectionLd = {
+  "@context": "https://schema.org",
+  "@type": "CollectionPage",
+  name: `#${tag}`,
+  description,
+  inLanguage: "pt-BR",
+  url: Astro.site ? new URL(`/pt/tags/${tag}/`, Astro.site).href : `/pt/tags/${tag}/`,
+  hasPart: posts.map((p) => ({
+    "@type": "BlogPosting",
+    headline: p.data.title,
+    url: Astro.site ? new URL(`/blog/${p.id}/`, Astro.site).href : `/blog/${p.id}/`,
+    datePublished: p.data.date.toISOString(),
+  })),
+};
 ---
 
 <PageLayout
   title={`#${tag} | Franklin Baldo`}
-  description={`Ensaios com a etiqueta #${tag}.`}
+  description={description}
   lang="pt"
   translations={hasEnCounterpart ? { en: `/tags/${tag}/` } : {}}
 >
+  <script type="application/ld+json" set:html={JSON.stringify(collectionLd)} is:inline slot="head" />
   <article>
     <header>
       <hgroup>
         <h1>#{tag}</h1>
-        <p><small>
-          {posts.length} {posts.length === 1 ? "post" : "posts"} · <a href="/pt/tags/">todas as etiquetas</a>
-          {hasEnCounterpart && (<> · <a href={`/tags/${tag}/`}>🇺🇸 EN</a></>)}
-        </small></p>
+        <p>
+          <small>
+            {count} {count === 1 ? "ensaio" : "ensaios"} · <a href="/pt/tags/">todas as etiquetas</a>
+            {hasEnCounterpart && (
+              <> · <a class="lang-badge" href={`/tags/${tag}/`} title="Read in English">EN</a></>
+            )}
+          </small>
+        </p>
       </hgroup>
     </header>
     {posts.map((post) => <PostCard post={post} />)}
   </article>
 </PageLayout>
+
+<style>
+  .lang-badge {
+    display: inline-block;
+    font-size: 0.68rem;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    padding: 0.1em 0.35em;
+    border-radius: 3px;
+    background: color-mix(in srgb, var(--pico-primary) 15%, transparent);
+    color: var(--pico-primary);
+    border: 1px solid color-mix(in srgb, var(--pico-primary) 35%, transparent);
+    text-decoration: none;
+    vertical-align: middle;
+  }
+  .lang-badge:hover {
+    background: color-mix(in srgb, var(--pico-primary) 25%, transparent);
+    text-decoration: none;
+  }
+</style>

--- a/src/pages/tags/[tag].astro
+++ b/src/pages/tags/[tag].astro
@@ -34,24 +34,66 @@ interface Props {
 }
 
 const { tag, posts, hasPtCounterpart } = Astro.props;
+const count = posts.length;
+const description = `${count} ${count === 1 ? "essay" : "essays"} tagged #${tag} — Franklin Baldo's digital garden on AI, law, and process.`;
+
+const collectionLd = {
+  "@context": "https://schema.org",
+  "@type": "CollectionPage",
+  name: `#${tag}`,
+  description,
+  inLanguage: "en-US",
+  url: Astro.site ? new URL(`/tags/${tag}/`, Astro.site).href : `/tags/${tag}/`,
+  hasPart: posts.map((p) => ({
+    "@type": "BlogPosting",
+    headline: p.data.title,
+    url: Astro.site ? new URL(`/blog/${p.id}/`, Astro.site).href : `/blog/${p.id}/`,
+    datePublished: p.data.date.toISOString(),
+  })),
+};
 ---
 
 <PageLayout
   title={`#${tag} | Franklin Baldo`}
-  description={`Essays tagged #${tag}.`}
+  description={description}
   lang="en"
   translations={hasPtCounterpart ? { pt: `/pt/tags/${tag}/` } : {}}
 >
+  <script type="application/ld+json" set:html={JSON.stringify(collectionLd)} is:inline slot="head" />
   <article>
     <header>
       <hgroup>
         <h1>#{tag}</h1>
-        <p><small>
-          {posts.length} {posts.length === 1 ? "post" : "posts"} · <a href="/tags/">all tags</a>
-          {hasPtCounterpart && (<> · <a href={`/pt/tags/${tag}/`}>🇧🇷 PT</a></>)}
-        </small></p>
+        <p>
+          <small>
+            {count} {count === 1 ? "essay" : "essays"} · <a href="/tags/">all tags</a>
+            {hasPtCounterpart && (
+              <> · <a class="lang-badge" href={`/pt/tags/${tag}/`} title="Ler em Português">PT</a></>
+            )}
+          </small>
+        </p>
       </hgroup>
     </header>
     {posts.map((post) => <PostCard post={post} />)}
   </article>
 </PageLayout>
+
+<style>
+  .lang-badge {
+    display: inline-block;
+    font-size: 0.68rem;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    padding: 0.1em 0.35em;
+    border-radius: 3px;
+    background: color-mix(in srgb, var(--pico-primary) 15%, transparent);
+    color: var(--pico-primary);
+    border: 1px solid color-mix(in srgb, var(--pico-primary) 35%, transparent);
+    text-decoration: none;
+    vertical-align: middle;
+  }
+  .lang-badge:hover {
+    background: color-mix(in srgb, var(--pico-primary) 25%, transparent);
+    text-decoration: none;
+  }
+</style>


### PR DESCRIPTION
## Summary

- **PostNav**: new `PostNav` component with prev/next links between posts of the same language, ordered chronologically. Positioned before Webmentions in the post layout. Grid 2-col desktop → 1-col mobile. Reduces bounce rate and improves crawlability.
- **Tags pages (EN + PT)**: `CollectionPage` JSON-LD with `hasPart` listing all posts under the tag; improved meta descriptions (`"N essays tagged #tag — Franklin Baldo's digital garden on AI, law, and process."`); consistent language badge replacing emoji flags.
- **PostCard**: shows up to 3 clickable tag badges above the "continue reading" link — readers can navigate to related posts without opening the article first.
- **About page**: corrected stale copy "Most posts are in English; some are in Portuguese" → "All essays are available in both English and Portuguese" (100% EN+PT coverage reached in prior sessions).

## Also merged this session

- **PR #152** (feat(seo/ux): home title, archive badge links, WebSite SearchAction) — fixed prettier on `.routines/` files so CI turned green, then squash-merged.

## Test plan

- [ ] `npm run build` — 304 pages, 0 errors
- [ ] `npx astro check` — 0 errors
- [ ] Visit any post (e.g. `/blog/2026-03-21-we-are-all-becoming-lobsters/`) — PostNav with ← Previous / Next → should appear below the post content
- [ ] Visit `/pt/blog/...` — PostNav shows "← Anterior" / "Próximo →"
- [ ] Visit `/tags/ai/` — meta description includes post count and context; JSON-LD should contain `"@type": "CollectionPage"` with `hasPart`; PT badge is a styled link
- [ ] Visit `/pt/tags/ia/` — same but in PT, EN badge present
- [ ] Home page post cards — up to 3 tag badges visible in each card footer
- [ ] Visit `/about/` — reads "All essays are available in both English and Portuguese."

## Session routine

`.routines/2026-05-20-postnav-tags-structured-data-about-fix.md`

---
_Generated by [Claude Code](https://claude.ai/code/session_0174Mpuxf6KTHAUzarYptV5o)_