### PR TITLE
feat(ux/seo): reading time in archive, CollectionPage + ItemList schemas

### DIFF
--- a/.routines/2026-05-20T03-32-22-archive-readtime-tags-schema.md
+++ b/.routines/2026-05-20T03-32-22-archive-readtime-tags-schema.md
@@ -1,0 +1,165 @@
+---
+date: 2026-05-20
+slug: archive-readtime-tags-schema
+branch: claude/great-mccarthy-5fu2T
+status: pr-open
+session: 15
+---
+
+# Sessão 2026-05-20 (T03) — Reading time no arquivo, ItemList schema para tags, fechamento de PRs obsoletos
+
+## Contexto
+
+Décima-quinta sessão com o sistema `.routines/`. Branch designado: `claude/great-mccarthy-5fu2T`.
+
+Estado ao chegar:
+
+- PR #155 aberto (4 posts bilíngues: Suno, Manifold, GitHub, franklinbaldo handle) — CI verde ✅
+- PR #150 aberto (consolidação) — CI failed, Kilo failed
+- PRs #124–128, #136, #147 — hronir runs com base muito desatualizada
+- PR #102 — Kilo Review failed, base extremamente desatualizada
+- Commit `a1c52ff` em main: PostNav prev/next, CollectionPage schema nas tags, PostCard tags, about fix (sessão 14)
+- 36 pares EN↔PT (36 EN + 36 PT, incluindo 4 novos posts de PR #155)
+- Cobertura bilingual: 100% posts + 100% páginas estáticas ✅
+
+## PRs revisados
+
+| PR                     | Título                                            | Ação                                                        |
+| ---------------------- | ------------------------------------------------- | ----------------------------------------------------------- |
+| #155                   | 4 bilingual posts (Suno, Manifold, GitHub, handle) | **Mergeado** (squash) — CI verde: check ✅ Kilo ✅ GitGuardian ✅ |
+| #150                   | Consolidação                                      | **Fechado** — CI/Kilo failed, conteúdo já absorvido         |
+| #147                   | hronir run 2026-05-18T19 (delegating-to-agents)   | **Fechado** — base desatualizada, dirty merge state         |
+| #136                   | hronir run 2026-05-18T12 (inaugural-post)         | **Fechado** — base muito desatualizada                      |
+| #124, #125, #126, #127, #128 | hronir runs 2026-05-18T05–09               | **Fechados** — base extremamente desatualizada              |
+| #102                   | Optimize profile visuals                          | **Mantido aberto** — tem valor real (pixel art, latest essay) |
+
+## Ações realizadas nesta sessão
+
+### 1. Reading time na tabela do arquivo (EN e PT)
+
+**Problema**: A tabela do arquivo mostrava data e título, mas não dava ao leitor nenhuma indicação de quanto tempo demora cada ensaio. Leitores precisavam abrir o post para ver o tempo de leitura na metadata do artigo.
+
+**Arquivos modificados**:
+- `src/pages/archive.astro`
+- `src/pages/pt/archive.astro`
+
+**Como funciona**:
+
+```typescript
+function estMinutes(body: string | undefined): number {
+  if (!body) return 1;
+  const words = body.trim().split(/\s+/).length;
+  return Math.max(1, Math.round(words / 200));
+}
+```
+
+A função usa `post.body` (raw markdown do glob loader do Astro 5) para estimar palavras a 200 wpm — a mesma taxa usada pelo `remark-reading-time` plugin. O resultado aparece como coluna `~min` na tabela, com estilo muted e `tabular-nums`.
+
+**UX**: Coluna oculta em mobile (<480px) para manter a tabela legível em telas pequenas. Em desktop, aparece antes da badge de idioma.
+
+### 2. CollectionPage JSON-LD para /archive/ e /pt/archive/
+
+**Problema**: As páginas do arquivo tinham bom conteúdo mas nenhum structured data. O Google não conseguia inferir que `/archive/` é uma coleção de artigos.
+
+**Arquivos modificados**: `src/pages/archive.astro`, `src/pages/pt/archive.astro`
+
+**Mudança**: Adicionado `CollectionPage` JSON-LD com `hasPart` listando todos os posts (headline, url, datePublished), injetado via `slot="head"` no PageLayout.
+
+```json
+{
+  "@type": "CollectionPage",
+  "name": "Archive — Franklin Baldo",
+  "inLanguage": "en-US",
+  "hasPart": [{ "@type": "BlogPosting", "headline": "...", "url": "...", "datePublished": "..." }]
+}
+```
+
+### 3. ItemList JSON-LD para /tags/ e /pt/tags/
+
+**Problema**: As páginas de índice de tags não tinham structured data. O Google não sabia que era uma lista de tópicos disponíveis para browsing.
+
+**Arquivos modificados**: `src/pages/tags/index.astro`, `src/pages/pt/tags/index.astro`
+
+**Mudança**: Adicionado `ItemList` JSON-LD com `itemListElement` mapeando cada tag para sua URL e posição na lista (ordenada por frequência):
+
+```json
+{
+  "@type": "ItemList",
+  "name": "Tags — Franklin Baldo",
+  "numberOfItems": 28,
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "#ia (12)", "url": ".../tags/ia/" }
+  ]
+}
+```
+
+## Build
+
+343 páginas — sem erros, 0 type errors.
+
+## Estado atual após esta sessão
+
+- Reading time (`~N min`) na tabela do arquivo EN e PT ✅ (novo)
+- CollectionPage JSON-LD em /archive/ e /pt/archive/ ✅ (novo)
+- ItemList JSON-LD em /tags/ e /pt/tags/ ✅ (novo)
+- PRs obsoletos fechados: #124, #125, #126, #127, #128, #136, #147, #150 ✅ (limpeza)
+- PostNav prev/next ✅ (sessão 14)
+- Tags CollectionPage JSON-LD ✅ (sessão 14)
+- Tags descrições melhoradas ✅ (sessão 14)
+- About: 100% EN+PT ✅ (sessão 14)
+- PostCard: tags visíveis ✅ (sessão 14)
+- Home title descritivo EN/PT ✅ (sessão 13)
+- Archive badges → links diretos ✅ (sessão 13)
+- WebSite JSON-LD SearchAction ✅ (sessão 13)
+- og:image width/height ✅ (sessão 12)
+- article:author ✅ (sessão 12)
+- TOC IntersectionObserver ✅ (sessão 12)
+- 36 pares EN↔PT via translationKey ✅
+- LanguageSwitcher auto-redirect por navegador ✅
+- Hreflang sitemap ✅
+- RSS split EN/PT ✅
+
+## PRs abertos remanescentes
+
+- **PR #102** (Optimize profile visuals): Kilo Review failed, base muito desatualizada. O valor real está em: (a) pixel art avatar, (b) Astro Image para bio/home rail, (c) lógica "latest essay" no home. Implementar do zero em novo PR sobre main atual.
+
+## Próximas sessões — backlog priorizado
+
+### Alta prioridade
+
+1. **PR #102 reimplementação** — Implementar do zero as 3 features do PR #102:
+   - Pixel art avatar na home (`/avatar-pixel.png`)
+   - Astro `<Image>` nos componentes `HomeAuthorRail.astro` e `AuthorBio.astro`
+   - "Read latest essay" link correto apontando para o post mais recente
+
+2. **Suno post restructuring** — O usuário enviou um request detalhado nesta sessão para:
+   - Criar componente `SunoPlaylist.svelte` com `<audio>` HTML5 para playlists
+   - Reestruturar post Suno em "Low quality slop" / "High quality slop"
+   - Usar dados de `src/data/suno-songs.jsonl` (aguardando arquivo do usuário)
+   - **BLOQUEADO**: requer que Franklin faça drop do arquivo JSONL no repo
+
+3. **OG image per-post**: verificar se `/og/[...slug].png` está sendo gerado e servido corretamente no deploy. Spot-check 3–5 posts com social card preview.
+
+### Média prioridade
+
+4. **Archive pagination**: Astro `paginate()` antes de ter >60 posts (atualmente 36 EN, 36 PT).
+
+5. **Pagefind URL param**: verificar se o handler `?q=` pré-popula a search box no deploy real.
+
+6. **Ranking page structure data**: `/ranking/` e `/pt/ranking/` poderiam ter `ItemList` JSON-LD.
+
+7. **PR #38** (dependabot defu 6.1.4 → 6.1.6): atualização simples de patch.
+
+### Baixa prioridade
+
+8. **Focus management** (ClientRouter) — acessibilidade em transições de página.
+
+9. **Visual breadcrumbs** — JSON-LD breadcrumbs já existem; adicionar UI visual no header dos posts.
+
+## Decisões arquiteturais
+
+- **`post.body` vs `render()` para reading time no arquivo**: Chamar `render(post)` em todos os 36 posts EN seria caro (processamento de cada markdown em build time). Usar `post.body` diretamente é O(n) sobre o texto raw e produz estimativas suficientemente precisas (±1 minuto). O remark plugin usa a mesma taxa de 200 wpm.
+
+- **CollectionPage no /archive/ vs paginação**: O `hasPart` lista todos os posts — quando a paginação for implementada, o JSON-LD deverá ser atualizado para usar `@type: "DataFeed"` ou referenciar apenas os posts da página atual.
+
+- **ItemList ordenado por frequência**: A ordem reflete como os tags aparecem na UI (mais frequentes primeiro). O `position` no JSON-LD segue essa mesma ordem, o que é semanticamente correto.

--- a/.routines/2026-05-20T03-32-22-archive-readtime-tags-schema.md
+++ b/.routines/2026-05-20T03-32-22-archive-readtime-tags-schema.md
@@ -24,14 +24,14 @@ Estado ao chegar:
 
 ## PRs revisados
 
-| PR                     | Título                                            | Ação                                                        |
-| ---------------------- | ------------------------------------------------- | ----------------------------------------------------------- |
-| #155                   | 4 bilingual posts (Suno, Manifold, GitHub, handle) | **Mergeado** (squash) — CI verde: check ✅ Kilo ✅ GitGuardian ✅ |
-| #150                   | Consolidação                                      | **Fechado** — CI/Kilo failed, conteúdo já absorvido         |
-| #147                   | hronir run 2026-05-18T19 (delegating-to-agents)   | **Fechado** — base desatualizada, dirty merge state         |
-| #136                   | hronir run 2026-05-18T12 (inaugural-post)         | **Fechado** — base muito desatualizada                      |
-| #124, #125, #126, #127, #128 | hronir runs 2026-05-18T05–09               | **Fechados** — base extremamente desatualizada              |
-| #102                   | Optimize profile visuals                          | **Mantido aberto** — tem valor real (pixel art, latest essay) |
+| PR                           | Título                                             | Ação                                                              |
+| ---------------------------- | -------------------------------------------------- | ----------------------------------------------------------------- |
+| #155                         | 4 bilingual posts (Suno, Manifold, GitHub, handle) | **Mergeado** (squash) — CI verde: check ✅ Kilo ✅ GitGuardian ✅ |
+| #150                         | Consolidação                                       | **Fechado** — CI/Kilo failed, conteúdo já absorvido               |
+| #147                         | hronir run 2026-05-18T19 (delegating-to-agents)    | **Fechado** — base desatualizada, dirty merge state               |
+| #136                         | hronir run 2026-05-18T12 (inaugural-post)          | **Fechado** — base muito desatualizada                            |
+| #124, #125, #126, #127, #128 | hronir runs 2026-05-18T05–09                       | **Fechados** — base extremamente desatualizada                    |
+| #102                         | Optimize profile visuals                           | **Mantido aberto** — tem valor real (pixel art, latest essay)     |
 
 ## Ações realizadas nesta sessão
 
@@ -40,6 +40,7 @@ Estado ao chegar:
 **Problema**: A tabela do arquivo mostrava data e título, mas não dava ao leitor nenhuma indicação de quanto tempo demora cada ensaio. Leitores precisavam abrir o post para ver o tempo de leitura na metadata do artigo.
 
 **Arquivos modificados**:
+
 - `src/pages/archive.astro`
 - `src/pages/pt/archive.astro`
 

--- a/src/pages/archive.astro
+++ b/src/pages/archive.astro
@@ -23,9 +23,31 @@ for (const post of posts) {
   byYear.get(year)!.push(post);
 }
 const years = [...byYear.keys()].sort((a, b) => b - a);
+
+function estMinutes(body: string | undefined): number {
+  if (!body) return 1;
+  const words = body.trim().split(/\s+/).length;
+  return Math.max(1, Math.round(words / 200));
+}
+
+const archiveLd = {
+  "@context": "https://schema.org",
+  "@type": "CollectionPage",
+  name: "Archive — Franklin Baldo",
+  description: "All essays by Franklin Baldo, organized by year.",
+  inLanguage: "en-US",
+  url: Astro.site ? new URL("/archive/", Astro.site).href : "/archive/",
+  hasPart: posts.map((p) => ({
+    "@type": "BlogPosting",
+    headline: p.data.title,
+    url: Astro.site ? new URL(`/blog/${p.id}/`, Astro.site).href : `/blog/${p.id}/`,
+    datePublished: p.data.date.toISOString(),
+  })),
+};
 ---
 
 <PageLayout title="Archive | Franklin Baldo" description="All essays, by year." lang="en" translations={{ pt: "/pt/archive/" }}>
+  <script type="application/ld+json" set:html={JSON.stringify(archiveLd)} is:inline slot="head" />
   <hgroup>
     <h1>Archive</h1>
     <p><small>{posts.length} essays</small></p>
@@ -39,12 +61,14 @@ const years = [...byYear.keys()].sort((a, b) => b - a);
           <tr>
             <th scope="col" class="col-date">Date</th>
             <th scope="col">Title</th>
+            <th scope="col" class="col-min" aria-label="Estimated reading time">~min</th>
             <th scope="col" class="col-pt" aria-label="Portuguese version available">PT</th>
           </tr>
         </thead>
         <tbody>
           {byYear.get(year)!.map((post) => {
             const ptId = post.data.translationKey ? ptByKey.get(post.data.translationKey) : undefined;
+            const mins = estMinutes(post.body);
             return (
               <tr>
                 <td class="col-date">
@@ -53,6 +77,7 @@ const years = [...byYear.keys()].sort((a, b) => b - a);
                   </time>
                 </td>
                 <td><a href={`/blog/${post.id}/`}>{post.data.title}</a></td>
+                <td class="col-min">{mins}</td>
                 <td class="col-pt">
                   {ptId && (
                     <a class="pt-badge" href={`/blog/${ptId}/`} aria-label="Portuguese version available" title="Ler em Português">PT</a>
@@ -76,6 +101,14 @@ const years = [...byYear.keys()].sort((a, b) => b - a);
     white-space: nowrap;
   }
   .archive-table th { font-weight: 600; }
+  .col-min {
+    width: 3.5rem;
+    text-align: right;
+    color: var(--pico-muted-color);
+    font-size: 0.82rem;
+    font-variant-numeric: tabular-nums;
+    white-space: nowrap;
+  }
   .col-pt {
     width: 2.5rem;
     text-align: center;
@@ -96,5 +129,8 @@ const years = [...byYear.keys()].sort((a, b) => b - a);
   a.pt-badge:hover {
     background: color-mix(in srgb, var(--pico-primary) 25%, transparent);
     text-decoration: underline;
+  }
+  @media (max-width: 480px) {
+    .col-min { display: none; }
   }
 </style>

--- a/src/pages/pt/archive.astro
+++ b/src/pages/pt/archive.astro
@@ -16,6 +16,27 @@ const posts = all
   .filter((p) => (p.data.lang ?? 'en') === 'pt')
   .sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf());
 
+function estMinutes(body: string | undefined): number {
+  if (!body) return 1;
+  const words = body.trim().split(/\s+/).length;
+  return Math.max(1, Math.round(words / 200));
+}
+
+const archiveLd = {
+  "@context": "https://schema.org",
+  "@type": "CollectionPage",
+  name: "Arquivo — Franklin Baldo",
+  description: "Todos os ensaios de Franklin Baldo, organizados por ano.",
+  inLanguage: "pt-BR",
+  url: Astro.site ? new URL("/pt/archive/", Astro.site).href : "/pt/archive/",
+  hasPart: posts.map((p) => ({
+    "@type": "BlogPosting",
+    headline: p.data.title,
+    url: Astro.site ? new URL(`/blog/${p.id}/`, Astro.site).href : `/blog/${p.id}/`,
+    datePublished: p.data.date.toISOString(),
+  })),
+};
+
 const byYear = new Map<number, typeof posts>();
 for (const post of posts) {
   const year = post.data.date.getFullYear();
@@ -31,6 +52,7 @@ const years = [...byYear.keys()].sort((a, b) => b - a);
   lang="pt"
   translations={{ en: "/archive/" }}
 >
+  <script type="application/ld+json" set:html={JSON.stringify(archiveLd)} is:inline slot="head" />
   <hgroup>
     <h1>Arquivo</h1>
     <p><small>{posts.length} ensaios</small></p>
@@ -44,12 +66,14 @@ const years = [...byYear.keys()].sort((a, b) => b - a);
           <tr>
             <th scope="col" class="col-date">Data</th>
             <th scope="col">Título</th>
+            <th scope="col" class="col-min" aria-label="Tempo estimado de leitura">~min</th>
             <th scope="col" class="col-en" aria-label="Versão em inglês disponível">EN</th>
           </tr>
         </thead>
         <tbody>
           {byYear.get(year)!.map((post) => {
             const enId = post.data.translationKey ? enByKey.get(post.data.translationKey) : undefined;
+            const mins = estMinutes(post.body);
             return (
               <tr>
                 <td class="col-date">
@@ -58,6 +82,7 @@ const years = [...byYear.keys()].sort((a, b) => b - a);
                   </time>
                 </td>
                 <td><a href={`/blog/${post.id}/`}>{post.data.title}</a></td>
+                <td class="col-min">{mins}</td>
                 <td class="col-en">
                   {enId && (
                     <a class="en-badge" href={`/blog/${enId}/`} aria-label="English version available" title="Read in English">EN</a>
@@ -81,6 +106,14 @@ const years = [...byYear.keys()].sort((a, b) => b - a);
     white-space: nowrap;
   }
   .archive-table th { font-weight: 600; }
+  .col-min {
+    width: 3.5rem;
+    text-align: right;
+    color: var(--pico-muted-color);
+    font-size: 0.82rem;
+    font-variant-numeric: tabular-nums;
+    white-space: nowrap;
+  }
   .col-en {
     width: 2.5rem;
     text-align: center;
@@ -101,5 +134,8 @@ const years = [...byYear.keys()].sort((a, b) => b - a);
   a.en-badge:hover {
     background: color-mix(in srgb, var(--pico-primary) 25%, transparent);
     text-decoration: underline;
+  }
+  @media (max-width: 480px) {
+    .col-min { display: none; }
   }
 </style>

--- a/src/pages/pt/tags/index.astro
+++ b/src/pages/pt/tags/index.astro
@@ -14,6 +14,21 @@ for (const post of posts) {
 }
 
 const tags = [...counts.entries()].sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]));
+
+const itemListLd = {
+  "@context": "https://schema.org",
+  "@type": "ItemList",
+  name: "Etiquetas — Franklin Baldo",
+  description: `${tags.length} etiquetas em ${posts.length} ensaios sobre IA, direito e processo.`,
+  url: Astro.site ? new URL("/pt/tags/", Astro.site).href : "/pt/tags/",
+  numberOfItems: tags.length,
+  itemListElement: tags.map(([tag, count], i) => ({
+    "@type": "ListItem",
+    position: i + 1,
+    name: `#${tag} (${count})`,
+    url: Astro.site ? new URL(`/pt/tags/${tag}/`, Astro.site).href : `/pt/tags/${tag}/`,
+  })),
+};
 ---
 
 <PageLayout
@@ -22,6 +37,7 @@ const tags = [...counts.entries()].sort((a, b) => b[1] - a[1] || a[0].localeComp
   lang="pt"
   translations={{ en: "/tags/" }}
 >
+  <script type="application/ld+json" set:html={JSON.stringify(itemListLd)} is:inline slot="head" />
   <h1>Etiquetas</h1>
   <p><small>{tags.length} etiquetas · ordenadas por frequência</small></p>
   <ul class="tag-cloud" aria-label="Todas as etiquetas">

--- a/src/pages/tags/index.astro
+++ b/src/pages/tags/index.astro
@@ -14,9 +14,25 @@ for (const post of posts) {
 }
 
 const tags = [...counts.entries()].sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]));
+
+const itemListLd = {
+  "@context": "https://schema.org",
+  "@type": "ItemList",
+  name: "Tags — Franklin Baldo",
+  description: `${tags.length} tags across ${posts.length} essays on AI, law, and process.`,
+  url: Astro.site ? new URL("/tags/", Astro.site).href : "/tags/",
+  numberOfItems: tags.length,
+  itemListElement: tags.map(([tag, count], i) => ({
+    "@type": "ListItem",
+    position: i + 1,
+    name: `#${tag} (${count})`,
+    url: Astro.site ? new URL(`/tags/${tag}/`, Astro.site).href : `/tags/${tag}/`,
+  })),
+};
 ---
 
 <PageLayout title="Tags | Franklin Baldo" description="Browse essays by tag." lang="en" translations={{ pt: "/pt/tags/" }}>
+  <script type="application/ld+json" set:html={JSON.stringify(itemListLd)} is:inline slot="head" />
   <h1>Tags</h1>
   <p><small>{tags.length} tags · sorted by frequency</small></p>
   <ul class="tag-cloud" aria-label="All tags">


### PR DESCRIPTION
## Summary

- **Archive EN+PT**: nova coluna `~min` com tempo estimado de leitura (word count do `post.body` a 200 wpm, oculta em mobile). CollectionPage JSON-LD com `hasPart` listando todos os posts.
- **Tags index EN+PT**: ItemList JSON-LD com `numberOfItems` e `itemListElement` mapeando cada tag para sua URL e posição por frequência.
- **Housekeeping**: PRs #124–128, #136, #147, #150 fechados (hronir runs obsoletos + consolidação com CI failed — conteúdo já absorvido por merges posteriores).

## Test plan

- [ ] Build passa sem erros (`npm run build` → 343 páginas)
- [ ] `/archive/` mostra coluna `~min` com valores razoáveis por post
- [ ] `/pt/archive/` idem em PT
- [ ] `/tags/` e `/pt/tags/` têm `<script type="application/ld+json">` com `ItemList` no `<head>`
- [ ] `/archive/` tem `CollectionPage` no `<head>`
- [ ] Mobile (<480px): coluna `~min` oculta (só data + título + badge)

https://claude.ai/code/session_01Xfr74e6eDyaayocTBew9W1

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xfr74e6eDyaayocTBew9W1)_