### PR TITLE
Add 2 memes to Suno post (Pooh + Drake)

### DIFF
--- a/src/content/blog/2026-05-20-suno-borges-and-the-caipira.mdx
+++ b/src/content/blog/2026-05-20-suno-borges-and-the-caipira.mdx
@@ -71,6 +71,14 @@ And in January came the one I like best: [Eu ia escrever sobre o infinito de nov
 
 One detail about the tool worth a digression: Suno generates everything in twos. You ask for a song and it hands back two versions, A and B, for you to pick which one stays — it's an A/B test built in, they learn from the one you keep. The trouble is I almost never can decide. A's voice is better, but B has that pretty mistake in the chorus; A nails the tempo, but B looks more like wrong-in-the-right-way. So I publish both. Half the duplicates you see in the list are exactly that: a fossilized A/B test, indecision turned into archive. And there's something in that — the indecision is only cheap because generating is cheap. In a world where recording costs tape and studio time, choosing between A and B isn't a luxury, it's an obligation. Here choosing is the work; publishing both is the path of least effort. Curation stopped being triage and became accumulation.
 
+<figure class="meme">
+  <img
+    src="https://api.memegen.link/images/drake/Choosing_between_A_and_B/Publishing_both_and_going_to_sleep.png?width=500"
+    alt="Drake rejecting 'choosing between A and B'; Drake approving 'publishing both and going to sleep'."
+    loading="lazy"
+  />
+</figure>
+
 And the best part is how easy it is. Adapting _El Aleph_ to moda-de-viola costs one prompt and ten minutes. Borges in cateretê, the ruliad in chamamé, an LLM melting down in a lullaby — all one click away, all cheap to the point of absurdity. There's a vertigo in that, I won't lie: if it's this easy, what am I in the story? But I settled the vertigo on the side of fun. The ease doesn't cheapen the thing — it frees it. It costs so little that I can make exactly what has no audience, doesn't scale, and exists only because the contrast makes me laugh. Nobody's going to spend the time recording Carlos Argentino Daneri complaining in cateretê. I will. It's free and it's mine. I've made birthday songs for people I love — not to publish, to give — because it's the most improbable gift there is and it costs one prompt.
 
 I haven't deleted any of the early ones. The Riobaldo from February isn't wrong — it's unfinished. The idea was there (_Aleph caipira_); the material wasn't, and neither was my willingness to stop wanting it to be important. It took nine months. The idea waited. Good ideas wait.

--- a/src/content/blog/2026-05-20-suno-borges-and-the-caipira.mdx
+++ b/src/content/blog/2026-05-20-suno-borges-and-the-caipira.mdx
@@ -30,6 +30,14 @@ Today it's 92 tracks on [Suno](https://suno.com/@franklinbaldo) and 17 followers
 
 In February 2025 I published [Riobaldo e o Aleph](https://suno.com/song/cc756e14-62c1-4b86-bac1-e3db517a3751). One play, zero likes. The lyrics open: _"i am riobaldo i am sertão i am the crossroads where reality bleeds into mystery."_ No punctuation, broken English, gerunds stacking up like a recited rosary. I asked for "Riobaldo encountering Borges's Aleph" and the model delivered exactly what a request like that deserves: paired opposites with no image attached. _Finite-infinite_, _serpentine-dance_, _silence-song_. Spiritual LLM poetry in its pure form. And I published it.
 
+<figure class="meme">
+  <img
+    src="https://api.memegen.link/images/pooh/Make_a_little_song/Conjure_the_sacred_geometries_of_drought-cracked_earth.png?width=600"
+    alt="Tuxedo Winnie the Pooh: regular Pooh, 'make a little song'; tuxedo Pooh, 'conjure the sacred geometries of drought-cracked earth'."
+    loading="lazy"
+  />
+</figure>
+
 Worse: I liked it.
 
 It wasn't the only one. [Bibliotecário do Infinito](https://suno.com/song/1f024fb6-8005-4e8c-a54c-a635d3eb95f3) was the Library of Babel turned into prog-rock singing "hexagons dissolving into infinity." [Vós](https://suno.com/song/1816b1c0-7064-4c57-af5c-2b84b9face9f), with a style description that still stings to reread: _"ether-whisper, plural-light, silence-dance, singing-mirrors."_ [Sussurros binários](https://suno.com/song/ed0355ef-c7ef-4b84-8826-4b97f3995058), same week, same vibe. I was stuck in a loop of hyphenated spiritual compounds and thought it was making.

--- a/src/content/blog/2026-05-20-suno-borges-caipira.mdx
+++ b/src/content/blog/2026-05-20-suno-borges-caipira.mdx
@@ -30,6 +30,14 @@ Hoje são 92 faixas no [Suno](https://suno.com/@franklinbaldo) e 17 seguidores. 
 
 Em fevereiro de 2025 eu publiquei [Riobaldo e o Aleph](https://suno.com/song/cc756e14-62c1-4b86-bac1-e3db517a3751). Um play, zero curtidas. A letra começa assim: _"i am riobaldo i am sertão i am the crossroads where reality bleeds into mystery"_. Sem pontuação, em inglês macarrônico, empilhando gerúndios como quem reza terço. Eu pedi "Riobaldo encontrando o Aleph de Borges" e o modelo entregou exatamente o que um pedido assim merece: pares opostos sem imagem nenhuma. _Finito-infinito_, _serpentino-dança_, _silêncio-canção_. Poesia espiritual de LLM em estado puro. E eu publiquei.
 
+<figure class="meme">
+  <img
+    src="https://api.memegen.link/images/pooh/Fazer_uma_musiquinha/Conjurar_as_geometrias_sagradas_da_terra_rachada.png?width=600"
+    alt="Tuxedo Winnie the Pooh: Pooh comum, 'fazer uma musiquinha'; Pooh de smoking, 'conjurar as geometrias sagradas da terra rachada'."
+    loading="lazy"
+  />
+</figure>
+
 Pior: eu gostei.
 
 Não foi só essa. [Bibliotecário do Infinito](https://suno.com/song/1f024fb6-8005-4e8c-a54c-a635d3eb95f3) era a Biblioteca de Babel virada prog-rock cantando _"hexágonos se dissolvendo no infinito"_. [Vós](https://suno.com/song/1816b1c0-7064-4c57-af5c-2b84b9face9f), com uma descrição de estilo que ainda dói reler: _"ether-whisper, plural-light, silence-dance, singing-mirrors"_. [Sussurros binários](https://suno.com/song/ed0355ef-c7ef-4b84-8826-4b97f3995058), mesma semana, mesma vibe. Eu estava num looping de compostos espirituais com hífen e achava que era criação.
@@ -62,6 +70,14 @@ E em janeiro saiu a de que mais gosto: [Eu ia escrever sobre o infinito de novo]
 />
 
 Um detalhe da ferramenta que vale o aparte: o Suno gera tudo em dois. Você pede uma música e ele devolve duas versões, A e B, pra você escolher qual fica — é A/B test embutido, eles aprendem com a que você prefere. O problema é que eu quase nunca consigo decidir. A voz da A é melhor, mas a B tem aquele erro bonito no refrão; a A acerta o andamento, mas a B tem mais cara de coisa-errada-do-jeito-certo. Aí publico as duas. Metade das duplicatas que aparecem na lista é isso: A/B test fossilizado, a indecisão virada arquivo. E tem uma coisa nisso — a indecisão só é barata porque gerar é barato. Num mundo onde gravar custa fita e estúdio, escolher entre A e B não é luxo, é obrigação. Aqui escolher é que dá trabalho; publicar as duas é o caminho de menor esforço. A curadoria deixou de ser triagem e virou acúmulo.
+
+<figure class="meme">
+  <img
+    src="https://api.memegen.link/images/drake/Escolher_entre_A_e_B/Publicar_as_duas_e_dormir.png?width=500"
+    alt="Drake recusando 'escolher entre A e B'; Drake aprovando 'publicar as duas e dormir'."
+    loading="lazy"
+  />
+</figure>
 
 E o melhor é o quanto isso é fácil. Adaptar _El Aleph_ pra moda-de-viola custa um prompt e dez minutos. Borges no cateretê, o ruliad em chamamé, um LLM surtando em canção de ninar — tudo a um clique de distância, tudo barato a ponto do absurdo. Tem uma vertigem nisso, não vou mentir: se é tão fácil, o que sou eu nessa história? Mas eu resolvi a vertigem do lado da diversão. A facilidade não barateia a coisa — ela libera. Custa tão pouco que eu posso fazer exatamente o que não tem público, não escala, e só existe porque o contraste me faz rir. Ninguém vai gastar o tempo de gravar Carlos Argentino Daneri reclamando em cateretê. Eu gasto. É de graça e é meu. Já fiz música de aniversário pra gente que eu amo — não pra publicar, pra dar — porque é o presente mais improvável que existe e custa um prompt.
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -290,14 +290,3 @@ body::before {
   text-align: center;
   margin-top: 0.5rem;
 }
-
-figure.meme {
-  max-width: 480px;
-  margin: 2rem auto;
-  text-align: center;
-}
-figure.meme img {
-  width: 100%;
-  height: auto;
-  border-radius: var(--pico-border-radius);
-}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -290,3 +290,14 @@ body::before {
   text-align: center;
   margin-top: 0.5rem;
 }
+
+figure.meme {
+  max-width: 480px;
+  margin: 2rem auto;
+  text-align: center;
+}
+figure.meme img {
+  width: 100%;
+  height: auto;
+  border-radius: var(--pico-border-radius);
+}


### PR DESCRIPTION
## Summary
- Adds two memes to "Suno, Borges e o caipira":
  - **Pooh** (PT + EN), end of first "Low quality slop" paragraph: `fazer uma musiquinha` vs `conjurar as geometrias sagradas da terra rachada` — auto-citation of the post's own "sacred geometries of drought-cracked earth" line.
  - **Drake** (PT only), end of the A/B test aparte: rejects "Escolher entre A e B", approves "Publicar as duas e dormir" — visualizes "curadoria deixou de ser triagem e virou acúmulo".
- Adds `figure.meme` rule to `src/styles/global.css` (max-width 480px, centered, rounded).

Dropped from the original three-meme proposal: the Change My Mind candidate at the strange-loop block. The "argue with me" template clashed with the prose's settled defiance ("Sim. E daí?"), and would have competed with the post's strongest argumentative beat. Two memes, well spaced, no proximity to the existing `<SunoEmbed>` iframes.

Stacked on #162 (TPOT classroom) which is stacked on #161 (strange-loop). Base will auto-cascade once they merge.

## Test plan
- [ ] Open `/blog/suno-borges-caipira` on preview, confirm both memes render with the global CSS (centered, max 480px wide).
- [ ] Open `/blog/suno-borges-and-the-caipira`, confirm Pooh renders with the EN text variant.
- [ ] Verify memegen.link URLs return 200 (already checked locally — all three do).
- [ ] Visual sanity: memes don't crowd the existing embeds; spacing reads as relief, not clutter.

https://claude.ai/code/session_01648NudybYosGbfxuqbywFR

---
_Generated by [Claude Code](https://claude.ai/code/session_01648NudybYosGbfxuqbywFR)_