### PR TITLE
feat(i18n): /pt/musicas page, fix /musicas to EN, complete sitemap hreflang

### DIFF
--- a/.routines/2026-05-21T14-20-00-bilingual-musicas-sitemap-prs.md
+++ b/.routines/2026-05-21T14-20-00-bilingual-musicas-sitemap-prs.md
@@ -1,0 +1,149 @@
+---
+date: 2026-05-21
+slug: bilingual-musicas-sitemap-prs
+branch: claude/great-mccarthy-FAk6w
+status: pr-open
+session: 17
+---
+
+# Sessão 2026-05-21 — /pt/musicas, sitemap completo, merge de PRs
+
+## Contexto
+
+Décima-sétima sessão com o sistema `.routines/`. Branch designado: `claude/great-mccarthy-FAk6w`.
+
+Estado ao chegar:
+
+- PR #165 aberto (hronir run 2026-05-21T13-07-20 + edit-worst github-repo-tour) — CI "check" failed (Prettier MDX)
+- PR #164 aberto (Restore TPOT classroom + memes) — conflito de merge (squash-merge history)
+- main em `f7eafeba` (home CTA, ranking schema, breadcrumbs visuais)
+- `/musicas` existia mas: (a) UI toda em pt-BR, (b) sem `translations` prop, (c) sem `/pt/musicas`
+- `/ranking/` e `/musicas/` ausentes do sitemap staticPairs
+
+## PRs revisados
+
+| PR   | Título                                                          | Ação                                                                                          |
+| ---- | --------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| #165 | hronir: run 2026-05-21T13-07-20 + edit-worst (github-repo-tour) | **Fix + Merge** — Prettier falhou em MDX (editHistory YAML), fix via API push, CI ✅ → squash |
+| #164 | Restore TPOT classroom + memes onto main                        | **Fix + aguardando Kilo** — conflito squash-merge resolvido via push completo ao branch       |
+
+### Detalhes do fix PR #165
+
+CI "check" falhou em 24s → Prettier no MDX. Os arquivos `2026-05-22-github-a-tour-of-the-repos.mdx` e PT tinham YAML frontmatter com `editHistory` em formato que Prettier reformatou (timestamps com aspas simples → duplas, `msg` como folded scalar). Corrigido via `mcp__github__push_files`.
+
+### Detalhes do fix PR #164
+
+O branch `claude/suno-tpot-classroom` estava baseado na versão não-squash do PR #161, causando conflito ao tentar merge com main. Resolução: push das Suno posts completas (conteúdo atual do main + TPOT classroom + memes Pooh/Drake) diretamente ao branch via API. CI ✅.
+
+## Ações realizadas nesta sessão
+
+### 1. Página `/musicas` convertida para inglês (EN padrão)
+
+**Problema**: `/musicas` era a única página estática sem versão PT-BR, e além disso estava em português sendo servida como página EN. Violava o requisito "blog default EN, toda página com versão pt-BR".
+
+**Arquivo modificado**: `src/pages/musicas.astro`
+
+Mudanças:
+
+- `fmtDate` → `en-US` locale
+- `title` → "Music | Franklin Baldo"
+- `description` → inglês
+- UI labels: "All songs", "songs" (singular/plural), "Cover art for...", "(untitled)", "Lyrics"
+- Adicionado `lang="en"` e `translations={{ pt: "/pt/musicas/" }}` ao PageLayout
+
+### 2. Página `/pt/musicas` criada
+
+**Arquivo criado**: `src/pages/pt/musicas.astro`
+
+- Versão em português completa, com mesma lógica de fetch do Suno
+- `lang="pt"`, `translations={{ en: "/musicas/" }}`
+- LanguageSwitcher agora funciona nessa página (mostra botão para alternar)
+- `fmtDate` com `pt-BR` locale
+- Labels em PT: "Músicas", "Todas as músicas", "música/músicas", "Letra", "sem título"
+
+### 3. Sitemap atualizado com pares faltando
+
+**Arquivo modificado**: `astro.config.mjs`
+
+Adicionados aos `staticPairs`:
+
+- `/ranking/` ↔ `/pt/ranking/`
+- `/musicas/` ↔ `/pt/musicas/`
+
+Agora TODAS as páginas estáticas bilíngues têm `hreflang` no sitemap.
+
+### 4. Fix link interno no post PT do Suno
+
+O post `2026-05-20-suno-borges-caipira.mdx` linkava para `/musicas` (EN). Corrigido para `/pt/musicas/`.
+
+## Build
+
+343 páginas — sem erros, 0 type errors.
+
+## Estado atual após esta sessão
+
+- `/musicas` em inglês com LanguageSwitcher ✅ (novo)
+- `/pt/musicas` em português com LanguageSwitcher ✅ (novo)
+- Sitemap hreflang completo: ranking + musicas ✅ (novo)
+- PR #165 mergeado ✅
+- PR #164 fix aplicado, aguardando Kilo ✅
+- Home CTA "Read latest essay" / "Ler último ensaio" ✅ (sessão 16)
+- ItemList JSON-LD em /ranking/ ✅ (sessão 16)
+- Breadcrumbs visuais nos posts ✅ (sessão 16)
+- Reading time no arquivo ✅ (sessão 15)
+- CollectionPage JSON-LD em /archive/ ✅ (sessão 15)
+- 36+ pares EN↔PT via translationKey ✅
+- LanguageSwitcher auto-redirect por navegador ✅
+- Hreflang sitemap ✅ (agora completo)
+- RSS split EN/PT ✅
+
+## Cobertura bilíngue de páginas estáticas
+
+| Página     | EN            | PT            | Sitemap hreflang |
+| ---------- | ------------- | ------------- | ---------------- |
+| Home       | /             | /pt/          | ✅               |
+| About      | /about/       | /pt/about/    | ✅               |
+| Archive    | /archive/     | /pt/archive/  | ✅               |
+| Tags index | /tags/        | /pt/tags/     | ✅               |
+| Search     | /search/      | /pt/search/   | ✅               |
+| Projects   | /projects/    | /pt/projects/ | ✅               |
+| Ranking    | /ranking/     | /pt/ranking/  | ✅ (novo)        |
+| Music      | /musicas/     | /pt/musicas/  | ✅ (novo)        |
+| 404        | /404.html     | /pt/404.html  | —                |
+| Posts      | /blog/[slug]/ | /blog/[slug]/ | ✅ (hreflang)    |
+
+## Próximas sessões — backlog priorizado
+
+### Alta prioridade
+
+1. **PR #164 merge** — Aguardando Kilo Code Review (check ✅ GitGuardian ✅). Conteúdo: TPOT classroom + memes Pooh/Drake no post Suno.
+
+2. **Pixel art avatar** — BLOQUEADO: requer drop de `/public/avatar-pixel.png` por Franklin.
+
+3. **OG image per-post** — Verificar se `/og/[...slug].png` está sendo gerado no deploy.
+
+### Média prioridade
+
+4. **Archive pagination** — `paginate()` antes de ter >60 posts (atualmente 36 EN + 36 PT).
+
+5. **Nav: link para Músicas** — Avaliar se vale adicionar "Music" ao Header nav (atualmente só acessível via posts do Suno).
+
+6. **HomeAuthorRail** — O componente existe mas não está integrado na home.
+
+7. **PR #38** (dependabot defu 6.1.4 → 6.1.6) — Atualização patch simples.
+
+### Baixa prioridade
+
+8. **Focus management** (ClientRouter) — Acessibilidade em transições de página.
+
+9. **Breadcrumb truncation mobile** — `max-width: 40ch` pode truncar títulos longos.
+
+10. **`/musicas` nav link** — Avaliar adicionar ao menu.
+
+## Decisões arquiteturais
+
+- **Duplicar lógica de fetch em `/musicas` e `/pt/musicas`**: Seria mais DRY extrair para um helper, mas as duas páginas têm UI distinta (labels EN/PT) e a lógica de fetch já está em `src/lib/suno.ts` parcialmente. A duplicação é aceitável neste momento (2 páginas, mesma lógica). Quando/se surgir uma terceira página similar, extrair.
+
+- **`/musicas` mantém o path EN** (sem redirect para `/pt/musicas` automático): O LanguageSwitcher já faz auto-redirect por preferência do browser. Não precisamos de redirect hard-coded na página.
+
+- **Sitemap com `x-default` apontando para EN**: Consistente com todas as outras páginas bilíngues do blog. A versão EN é canônica por padrão.

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -53,6 +53,8 @@ export default defineConfig({
           [base + "/tags/"]: base + "/pt/tags/",
           [base + "/search/"]: base + "/pt/search/",
           [base + "/projects/"]: base + "/pt/projects/",
+          [base + "/ranking/"]: base + "/pt/ranking/",
+          [base + "/musicas/"]: base + "/pt/musicas/",
         };
         const ptToEn = Object.fromEntries(
           Object.entries(staticPairs).map(([en, pt]) => [pt, en])

--- a/src/content/blog/2026-05-20-suno-borges-caipira.mdx
+++ b/src/content/blog/2026-05-20-suno-borges-caipira.mdx
@@ -67,4 +67,4 @@ Fico pensando se eu melhorei ou se foi o Suno. Os modelos ficaram melhores, a in
 
 "Mas você só aperta o botão." Sim. E daí? Apertar o botão é fácil. Saber quando parar de apertar, e parar pelo motivo certo, é a única coisa que a máquina não faz por mim. O editor que rejeita oitenta versões de uma frase e aceita a octogésima-primeira é autor da frase, mesmo sem ter escrito nenhuma das oitenta e uma. Crédito nunca foi pra quem gerou os tokens. Foi pra quem não ficou satisfeito com eles e uma hora parou. O laço já tinha meu nome antes de eu abrir o Suno. A ferramenta só deixou ele audível.
 
-Eu não sei se isso é música. Sei que é slop. O catálogo inteiro — 92 faixas, com as letras e as que eu devia ter vergonha — tá [aqui](/musicas).
+Eu não sei se isso é música. Sei que é slop. O catálogo inteiro — 92 faixas, com as letras e as que eu devia ter vergonha — tá [aqui](/pt/musicas/).

--- a/src/pages/musicas.astro
+++ b/src/pages/musicas.astro
@@ -100,7 +100,7 @@ try {
   console.warn(`[musicas] failed: ${error}`);
 }
 
-const fmtDate = new Intl.DateTimeFormat("pt-BR", {
+const fmtDate = new Intl.DateTimeFormat("en-US", {
   year: "numeric",
   month: "short",
   day: "2-digit",
@@ -125,21 +125,23 @@ function parseTags(raw?: string): string[] {
 ---
 
 <PageLayout
-  title="Músicas | Franklin Baldo"
-  description="Músicas e playlists publicadas no Suno, buscadas ao vivo no build."
+  title="Music | Franklin Baldo"
+  description="Songs and playlists published on Suno, fetched live at build time."
+  lang="en"
+  translations={{ pt: "/pt/musicas/" }}
 >
   <hgroup>
-    <h1>Músicas</h1>
+    <h1>Music</h1>
     <p><small>
-      Músicas públicas de <a href={`https://suno.com/@${HANDLE}`}>@{HANDLE}</a> no Suno,
-      ordenadas pelas mais recentes · atualizado no build.
+      Public songs from <a href={`https://suno.com/@${HANDLE}`}>@{HANDLE}</a> on Suno,
+      sorted by most recent · updated at build time.
     </small></p>
   </hgroup>
 
   {error && (
     <p><small>
-      Não consegui carregar as músicas agora (<code>{error.slice(0, 120)}</code>).
-      Veja direto em <a href={`https://suno.com/@${HANDLE}`}>suno.com/@{HANDLE}</a>.
+      Couldn't load songs right now (<code>{error.slice(0, 120)}</code>).
+      See them directly at <a href={`https://suno.com/@${HANDLE}`}>suno.com/@{HANDLE}</a>.
     </small></p>
   )}
 
@@ -150,7 +152,7 @@ function parseTags(raw?: string): string[] {
         {playlists.map((p) => (
           <article class="playlist-card">
             <a href={`https://suno.com/playlist/${p.id}`}>
-              <img src={p.image_url} alt={`Capa da playlist ${p.name}`} loading="lazy" width="200" height="200" />
+              <img src={p.image_url} alt={`Cover art for playlist ${p.name}`} loading="lazy" width="200" height="200" />
             </a>
             <header>
               <h3><a href={`https://suno.com/playlist/${p.id}`}>{p.name}</a></h3>
@@ -158,7 +160,7 @@ function parseTags(raw?: string): string[] {
             </header>
             <footer>
               <small>
-                {p.song_count} {p.song_count === 1 ? "música" : "músicas"}
+                {p.song_count} {p.song_count === 1 ? "song" : "songs"}
                 {p.total_duration ? ` · ${fmtDuration(p.total_duration)}` : ""}
               </small>
             </footer>
@@ -170,7 +172,7 @@ function parseTags(raw?: string): string[] {
 
   {clips.length > 0 && (
     <section>
-      <h2>Todas as músicas <small>({clips.length})</small></h2>
+      <h2>All songs <small>({clips.length})</small></h2>
       <div class="songs-grid">
         {clips.map((c) => {
           const tags = parseTags(c.metadata?.tags);
@@ -181,7 +183,7 @@ function parseTags(raw?: string): string[] {
               <a href={`https://suno.com/song/${c.id}`} class="cover">
                 <img
                   src={c.image_url}
-                  alt={`Capa de ${c.title}`}
+                  alt={`Cover art for ${c.title}`}
                   loading="lazy"
                   width="300"
                   height="300"
@@ -189,7 +191,7 @@ function parseTags(raw?: string): string[] {
               </a>
               <header>
                 <h3>
-                  <a href={`https://suno.com/song/${c.id}`}>{c.title || "(sem título)"}</a>
+                  <a href={`https://suno.com/song/${c.id}`}>{c.title || "(untitled)"}</a>
                 </h3>
                 <p>
                   <small>
@@ -216,7 +218,7 @@ function parseTags(raw?: string): string[] {
                 </small>
                 {lyrics.trim() && (
                   <details>
-                    <summary><small>Letra</small></summary>
+                    <summary><small>Lyrics</small></summary>
                     <pre class="lyrics">{lyrics}</pre>
                   </details>
                 )}

--- a/src/pages/pt/musicas.astro
+++ b/src/pages/pt/musicas.astro
@@ -1,0 +1,331 @@
+---
+import PageLayout from "../../layouts/PageLayout.astro";
+import { sleep } from "../../lib/suno";
+
+const HANDLE = "franklinbaldo";
+const SUNO_API = "https://studio-api-prod.suno.com/api";
+
+interface Clip {
+  id: string;
+  title: string;
+  audio_url: string;
+  image_url: string;
+  image_large_url?: string;
+  created_at: string;
+  play_count: number;
+  upvote_count: number;
+  major_model_version?: string;
+  metadata?: {
+    tags?: string;
+    prompt?: string;
+    duration?: number | null;
+    make_instrumental?: boolean;
+  };
+  is_public: boolean;
+}
+
+interface Playlist {
+  id: string;
+  name: string;
+  description?: string;
+  image_url: string;
+  song_count: number;
+  total_duration?: number;
+  play_count?: number;
+  upvote_count?: number;
+  is_public: boolean;
+  playlist_clips?: { clip: Clip; relative_index: number }[];
+}
+
+interface ProfileResponse {
+  clips: Clip[];
+  playlists: Playlist[];
+  num_total_clips: number;
+  display_name: string;
+  profile_description?: string;
+  avatar_image_url: string;
+}
+
+let clips: Clip[] = [];
+let playlists: Playlist[] = [];
+let profile: ProfileResponse | null = null;
+let error: string | null = null;
+
+async function fetchJSON<T>(url: string): Promise<T> {
+  for (let attempt = 0; attempt < 4; attempt++) {
+    const res = await fetch(url, { headers: { Accept: "application/json" } });
+    if (res.ok) return (await res.json()) as T;
+    if ((res.status === 429 || res.status >= 500) && attempt < 3) {
+      await sleep(1000 * Math.pow(2, attempt));
+      continue;
+    }
+    throw new Error(`HTTP ${res.status} on ${url}`);
+  }
+  throw new Error(`exhausted retries on ${url}`);
+}
+
+try {
+  const first = await fetchJSON<ProfileResponse>(
+    `${SUNO_API}/profiles/${HANDLE}/?page=1&playlists_sort_by=created_at&clips_sort_by=created_at`
+  );
+  profile = first;
+  playlists = (first.playlists ?? []).filter((p) => p.is_public);
+
+  const total = Math.max(0, first.num_total_clips ?? 0);
+  const seen = new Set<string>();
+  for (const c of first.clips ?? []) {
+    if (!seen.has(c.id)) {
+      seen.add(c.id);
+      clips.push(c);
+    }
+  }
+  let page = 2;
+  while (clips.length < total) {
+    const next = await fetchJSON<ProfileResponse>(
+      `${SUNO_API}/profiles/${HANDLE}/?page=${page}&playlists_sort_by=created_at&clips_sort_by=created_at`
+    );
+    const got = next.clips ?? [];
+    if (got.length === 0) break;
+    for (const c of got) {
+      if (!seen.has(c.id)) {
+        seen.add(c.id);
+        clips.push(c);
+      }
+    }
+    page++;
+  }
+
+  clips = clips
+    .filter((c) => c.is_public)
+    .sort(
+      (a, b) =>
+        new Date(b.created_at).valueOf() - new Date(a.created_at).valueOf()
+    );
+} catch (e) {
+  error = e instanceof Error ? e.message : String(e);
+  console.warn(`[musicas] failed: ${error}`);
+}
+
+const fmtDate = new Intl.DateTimeFormat("pt-BR", {
+  year: "numeric",
+  month: "short",
+  day: "2-digit",
+});
+
+function fmtDuration(sec?: number | null): string {
+  if (!sec || sec <= 0) return "";
+  const total = Math.round(sec);
+  const m = Math.floor(total / 60);
+  const s = total % 60;
+  return `${m}:${s.toString().padStart(2, "0")}`;
+}
+
+function parseTags(raw?: string): string[] {
+  if (!raw) return [];
+  return raw
+    .split(/[,;]/)
+    .map((t) => t.trim())
+    .filter(Boolean)
+    .slice(0, 6);
+}
+---
+
+<PageLayout
+  title="Músicas | Franklin Baldo"
+  description="Músicas e playlists publicadas no Suno, buscadas ao vivo no build."
+  lang="pt"
+  translations={{ en: "/musicas/" }}
+>
+  <hgroup>
+    <h1>Músicas</h1>
+    <p
+      ><small>
+        Músicas públicas de <a href={`https://suno.com/@${HANDLE}`}
+          >@{HANDLE}</a
+        > no Suno, ordenadas pelas mais recentes · atualizado no build.
+      </small></p
+    >
+  </hgroup>
+
+  {
+    error && (
+      <p>
+        <small>
+          Não consegui carregar as músicas agora (
+          <code>{error.slice(0, 120)}</code>). Veja direto em{" "}
+          <a href={`https://suno.com/@${HANDLE}`}>suno.com/@{HANDLE}</a>.
+        </small>
+      </p>
+    )
+  }
+
+  {
+    playlists.length > 0 && (
+      <section>
+        <h2>Playlists</h2>
+        <div class="playlists-grid">
+          {playlists.map((p) => (
+            <article class="playlist-card">
+              <a href={`https://suno.com/playlist/${p.id}`}>
+                <img
+                  src={p.image_url}
+                  alt={`Capa da playlist ${p.name}`}
+                  loading="lazy"
+                  width="200"
+                  height="200"
+                />
+              </a>
+              <header>
+                <h3>
+                  <a href={`https://suno.com/playlist/${p.id}`}>{p.name}</a>
+                </h3>
+                {p.description && (
+                  <p>
+                    <small>{p.description}</small>
+                  </p>
+                )}
+              </header>
+              <footer>
+                <small>
+                  {p.song_count} {p.song_count === 1 ? "música" : "músicas"}
+                  {p.total_duration ? ` · ${fmtDuration(p.total_duration)}` : ""}
+                </small>
+              </footer>
+            </article>
+          ))}
+        </div>
+      </section>
+    )
+  }
+
+  {
+    clips.length > 0 && (
+      <section>
+        <h2>
+          Todas as músicas <small>({clips.length})</small>
+        </h2>
+        <div class="songs-grid">
+          {clips.map((c) => {
+            const tags = parseTags(c.metadata?.tags);
+            const duration = fmtDuration(c.metadata?.duration);
+            const lyrics = c.metadata?.prompt ?? "";
+            return (
+              <article class="song-card" id={c.id}>
+                <a href={`https://suno.com/song/${c.id}`} class="cover">
+                  <img
+                    src={c.image_url}
+                    alt={`Capa de ${c.title}`}
+                    loading="lazy"
+                    width="300"
+                    height="300"
+                  />
+                </a>
+                <header>
+                  <h3>
+                    <a href={`https://suno.com/song/${c.id}`}>
+                      {c.title || "(sem título)"}
+                    </a>
+                  </h3>
+                  <p>
+                    <small>
+                      <time datetime={c.created_at}>
+                        {fmtDate.format(new Date(c.created_at))}
+                      </time>
+                      {duration && <> · {duration}</>}
+                      {c.major_model_version && <> · {c.major_model_version}</>}
+                    </small>
+                  </p>
+                </header>
+
+                {c.audio_url && (
+                  <audio controls preload="none" src={c.audio_url} />
+                )}
+
+                {tags.length > 0 && (
+                  <p class="tags">{tags.map((t) => <kbd>{t}</kbd>)}</p>
+                )}
+
+                <footer>
+                  <small>
+                    ▶ {c.play_count ?? 0} · ♥ {c.upvote_count ?? 0}
+                  </small>
+                  {lyrics.trim() && (
+                    <details>
+                      <summary>
+                        <small>Letra</small>
+                      </summary>
+                      <pre class="lyrics">{lyrics}</pre>
+                    </details>
+                  )}
+                </footer>
+              </article>
+            );
+          })}
+        </div>
+      </section>
+    )
+  }
+</PageLayout>
+
+<style>
+  .playlists-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+    gap: 1rem;
+    margin-bottom: 2rem;
+  }
+  .playlist-card img {
+    width: 100%;
+    height: auto;
+    aspect-ratio: 1 / 1;
+    object-fit: cover;
+    border-radius: var(--pico-border-radius);
+  }
+  .playlist-card h3 {
+    font-size: 1rem;
+    margin: 0.5rem 0 0.25rem;
+  }
+
+  .songs-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+    gap: 1.25rem;
+  }
+  .song-card {
+    display: flex;
+    flex-direction: column;
+  }
+  .song-card .cover img {
+    width: 100%;
+    height: auto;
+    aspect-ratio: 1 / 1;
+    object-fit: cover;
+    border-radius: var(--pico-border-radius);
+  }
+  .song-card h3 {
+    font-size: 1.05rem;
+    margin: 0.5rem 0 0.25rem;
+  }
+  .song-card audio {
+    width: 100%;
+    margin: 0.5rem 0;
+  }
+  .song-card .tags {
+    margin: 0.25rem 0;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.25rem;
+  }
+  .song-card .tags kbd {
+    font-size: 0.7rem;
+  }
+  .song-card .lyrics {
+    white-space: pre-wrap;
+    font-size: 0.85rem;
+    max-height: 20rem;
+    overflow-y: auto;
+    background: var(--pico-code-background-color);
+    padding: 0.75rem;
+    border-radius: var(--pico-border-radius);
+  }
+</style>


### PR DESCRIPTION
## Summary

- **`/musicas` converted to English** — was the only static page with Portuguese UI serving as the default EN page. Fixed title, labels (`All songs`, `Lyrics`, `Cover art for…`), date locale (`en-US`), and added `lang="en"` + `translations` prop so the LanguageSwitcher works.
- **`/pt/musicas` created** — full Portuguese counterpart with `lang="pt"` and `translations={{ en: "/musicas/" }}`, matching the bilingual pattern of every other static page.
- **Sitemap hreflang now complete** — `/ranking/` ↔ `/pt/ranking/` and `/musicas/` ↔ `/pt/musicas/` were missing from `staticPairs` in `astro.config.mjs`. Added both. Every static page now has proper `hreflang` + `x-default` in the sitemap.
- **Suno PT post link fixed** — `2026-05-20-suno-borges-caipira.mdx` was linking to `/musicas` (EN). Corrected to `/pt/musicas/`.
- **Session 17 routine file** added at `.routines/2026-05-21T14-20-00-bilingual-musicas-sitemap-prs.md`.

## PR reviews done this session

| PR | Action |
|---|---|
| #165 (hronir run edit-worst) | Fixed Prettier on MDX frontmatter, merged ✅ |
| #164 (TPOT classroom + memes) | Resolved squash-merge conflict via full file push, CI ✅ — awaiting Kilo |

## Test plan

- [ ] `/musicas/` renders with English labels: "Music", "All songs", "Lyrics", "Cover art for…"
- [ ] `/pt/musicas/` renders with Portuguese labels: "Músicas", "Todas as músicas", "Letra", "Capa de…"
- [ ] LanguageSwitcher on `/musicas/` shows PT button → clicking navigates to `/pt/musicas/`
- [ ] LanguageSwitcher on `/pt/musicas/` shows EN button → clicking navigates to `/musicas/`
- [ ] Browser with `Accept-Language: pt-BR` visiting `/musicas/` auto-redirects to `/pt/musicas/` (first visit)
- [ ] Sitemap includes `hreflang` links for `/musicas/` ↔ `/pt/musicas/` and `/ranking/` ↔ `/pt/ranking/`
- [ ] Suno PT post end link goes to `/pt/musicas/` (not `/musicas`)

https://claude.ai/code/session_01VS3cmf58oQWisGxUD51sfq

---
_Generated by [Claude Code](https://claude.ai/code/session_01VS3cmf58oQWisGxUD51sfq)_