### PR TITLE
feat(ranking): redesign /ranking/ + /pt/ranking/ with podium, stats, bars

### DIFF
--- a/src/components/RankingView.astro
+++ b/src/components/RankingView.astro
@@ -1,0 +1,612 @@
+---
+import type { RankRow, DuelEntry, RankingStats } from "../lib/hronir-rank";
+
+export interface RankPostInfo {
+  slug: string;
+  title: string;
+  lang: string;
+}
+
+export interface EnrichedRow extends RankRow {
+  rank: number;
+  post?: RankPostInfo;
+}
+
+export interface UnratedItem {
+  slug: string;
+  title: string;
+}
+
+export interface RankingStrings {
+  /** small grey label below H1 */
+  subtitle: string;
+  intro: string;
+  podiumLabel: string;
+  statsTotalDuels: string;
+  statsTotalRated: string;
+  statsLastDuel: string;
+  statsAvgDuels: string;
+  tableCaption: string;
+  thRank: string;
+  thPost: string;
+  thOrdinal: string;
+  thMu: string;
+  thSigma: string;
+  thRecord: string; // V/N or W/N
+  thConfidence: string;
+  unratedHeading: string;
+  unratedBlurb: string;
+  recentHeading: string;
+  recentBlurb: string;
+  recentBeats: string; // e.g. "venceu" / "beat"
+  emptyState: string;
+  ordinalTip: string;
+  muTip: string;
+  sigmaTip: string;
+  confidenceHigh: string;
+  confidenceMedium: string;
+  confidenceLow: string;
+  podiumGold: string;
+  podiumSilver: string;
+  podiumBronze: string;
+  noDate: string;
+}
+
+interface Props {
+  lang: "en" | "pt";
+  rows: EnrichedRow[];
+  unrated: UnratedItem[];
+  recent: DuelEntry[];
+  stats: RankingStats;
+  postByKey: Map<string, RankPostInfo>;
+  strings: RankingStrings;
+}
+
+const { rows, unrated, recent, stats, postByKey, strings, lang } = Astro.props as Props;
+
+const locale = lang === "pt" ? "pt-BR" : "en-US";
+
+function fmtDate(iso: string | null): string {
+  if (!iso) return strings.noDate;
+  const d = new Date(iso);
+  if (Number.isNaN(d.valueOf())) return strings.noDate;
+  return d.toLocaleDateString(locale, { year: "numeric", month: "short", day: "numeric" });
+}
+
+const ordinals = rows.map((r) => r.ordinal);
+const ordMax = ordinals.length > 0 ? Math.max(...ordinals) : 0;
+const ordMin = ordinals.length > 0 ? Math.min(...ordinals) : 0;
+const ordRange = Math.max(ordMax - ordMin, 0.0001);
+
+function barPct(ordinal: number): number {
+  // Map [ordMin, ordMax] -> [6, 100] so even the lowest still shows a sliver.
+  const t = (ordinal - ordMin) / ordRange;
+  return Math.round(6 + t * 94);
+}
+
+function confidenceLevel(sigma: number, appearances: number): {
+  level: "high" | "medium" | "low";
+  label: string;
+} {
+  if (appearances < 3) return { level: "low", label: strings.confidenceLow };
+  if (sigma < 6.4) return { level: "high", label: strings.confidenceHigh };
+  if (sigma < 7.0) return { level: "medium", label: strings.confidenceMedium };
+  return { level: "low", label: strings.confidenceLow };
+}
+
+const podium = rows.slice(0, 3);
+const rest = rows.slice(3);
+
+const podiumMeta = [
+  { label: strings.podiumGold, place: 1 },
+  { label: strings.podiumSilver, place: 2 },
+  { label: strings.podiumBronze, place: 3 },
+];
+
+const avgDuels =
+  stats.totalRated > 0 ? ((stats.totalDuels * 2) / stats.totalRated).toFixed(1) : "0";
+
+function postLabel(key: string): string {
+  return postByKey.get(key)?.title ?? key;
+}
+function postHref(key: string): string | null {
+  const p = postByKey.get(key);
+  return p ? `/blog/${p.slug}/` : null;
+}
+---
+
+<hgroup>
+  <h1>Ranking</h1>
+  <p><small>{strings.subtitle}</small></p>
+</hgroup>
+
+<p class="rank-intro">{strings.intro}</p>
+
+{rows.length > 0 && (
+  <section class="rank-stats" aria-label={strings.statsTotalDuels}>
+    <div class="rank-stat">
+      <span class="rank-stat-value">{stats.totalDuels}</span>
+      <span class="rank-stat-label">{strings.statsTotalDuels}</span>
+    </div>
+    <div class="rank-stat">
+      <span class="rank-stat-value">{stats.totalRated}</span>
+      <span class="rank-stat-label">{strings.statsTotalRated}</span>
+    </div>
+    <div class="rank-stat">
+      <span class="rank-stat-value">{avgDuels}</span>
+      <span class="rank-stat-label">{strings.statsAvgDuels}</span>
+    </div>
+    <div class="rank-stat">
+      <span class="rank-stat-value rank-stat-date">{fmtDate(stats.lastDuelAt)}</span>
+      <span class="rank-stat-label">{strings.statsLastDuel}</span>
+    </div>
+  </section>
+)}
+
+{podium.length > 0 && (
+  <section class="rank-podium" aria-label={strings.podiumLabel}>
+    {podium.map((r, i) => {
+      const meta = podiumMeta[i];
+      const href = r.post ? `/blog/${r.post.slug}/` : null;
+      return (
+        <article class={`podium-card podium-${meta.place}`}>
+          <header class="podium-head">
+            <span class="podium-medal" aria-hidden="true">{meta.place}</span>
+            <span class="podium-label">{meta.label}</span>
+          </header>
+          <h3 class="podium-title">
+            {href ? <a href={href}>{r.post!.title}</a> : <code>{r.key}</code>}
+          </h3>
+          <dl class="podium-stats">
+            <div>
+              <dt>{strings.thOrdinal}</dt>
+              <dd>{r.ordinal.toFixed(2)}</dd>
+            </div>
+            <div>
+              <dt>{strings.thRecord}</dt>
+              <dd>{r.wins}/{r.appearances}</dd>
+            </div>
+          </dl>
+        </article>
+      );
+    })}
+  </section>
+)}
+
+{rows.length > 0 && (
+  <div class="overflow-table rank-table-wrap">
+    <table class="rank-table">
+      <caption class="rank-caption">{strings.tableCaption}</caption>
+      <thead>
+        <tr>
+          <th scope="col" class="col-rank">{strings.thRank}</th>
+          <th scope="col" class="col-post">{strings.thPost}</th>
+          <th scope="col" class="col-ordinal">
+            <abbr title={strings.ordinalTip}>{strings.thOrdinal}</abbr>
+          </th>
+          <th scope="col" class="col-mu">
+            <abbr title={strings.muTip}>{strings.thMu}</abbr>
+          </th>
+          <th scope="col" class="col-sigma">
+            <abbr title={strings.sigmaTip}>{strings.thSigma}</abbr>
+          </th>
+          <th scope="col" class="col-record">{strings.thRecord}</th>
+          <th scope="col" class="col-confidence">{strings.thConfidence}</th>
+        </tr>
+      </thead>
+      <tbody>
+        {rest.map((r) => {
+          const conf = confidenceLevel(r.sigma, r.appearances);
+          const winRate = r.appearances > 0 ? Math.round((r.wins / r.appearances) * 100) : 0;
+          return (
+            <tr>
+              <th scope="row" class="col-rank">{r.rank}</th>
+              <td class="col-post">
+                {r.post ? (
+                  <a href={`/blog/${r.post.slug}/`}>{r.post.title}</a>
+                ) : (
+                  <code>{r.key}</code>
+                )}
+                <div class="ord-bar" aria-hidden="true">
+                  <span style={`width:${barPct(r.ordinal)}%`}></span>
+                </div>
+              </td>
+              <td class="col-ordinal num"><strong>{r.ordinal.toFixed(2)}</strong></td>
+              <td class="col-mu num">{r.mu.toFixed(2)}</td>
+              <td class="col-sigma num">{r.sigma.toFixed(2)}</td>
+              <td class="col-record num" title={`${winRate}%`}>{r.wins}/{r.appearances}</td>
+              <td class="col-confidence">
+                <span class={`conf-badge conf-${conf.level}`}>{conf.label}</span>
+              </td>
+            </tr>
+          );
+        })}
+      </tbody>
+    </table>
+  </div>
+)}
+
+{rows.length === 0 && (
+  <p class="rank-empty"><em>{strings.emptyState}</em></p>
+)}
+
+{unrated.length > 0 && (
+  <section class="rank-unrated">
+    <h2>{strings.unratedHeading}</h2>
+    <p><small>{strings.unratedBlurb}</small></p>
+    <ul>
+      {unrated.map((u) => (
+        <li><a href={`/blog/${u.slug}/`}>{u.title}</a></li>
+      ))}
+    </ul>
+  </section>
+)}
+
+{recent.length > 0 && (
+  <section class="rank-recent">
+    <h2>{strings.recentHeading}</h2>
+    <p><small>{strings.recentBlurb}</small></p>
+    <ol class="recent-list">
+      {recent.map((d) => {
+        const winnerHref = postHref(d.winnerKey);
+        const loserHref = postHref(d.loserKey);
+        return (
+          <li>
+            <span class="recent-date">{fmtDate(d.runAt)}</span>
+            <span class="recent-line">
+              {winnerHref ? (
+                <a class="recent-winner" href={winnerHref}>{postLabel(d.winnerKey)}</a>
+              ) : (
+                <span class="recent-winner"><code>{d.winnerKey}</code></span>
+              )}
+              <span class="recent-verb"> {strings.recentBeats} </span>
+              {loserHref ? (
+                <a class="recent-loser" href={loserHref}>{postLabel(d.loserKey)}</a>
+              ) : (
+                <span class="recent-loser"><code>{d.loserKey}</code></span>
+              )}
+              {d.criterion && (
+                <span class="recent-criterion"> · <code>{d.criterion}</code></span>
+              )}
+            </span>
+          </li>
+        );
+      })}
+    </ol>
+  </section>
+)}
+
+<style>
+  .rank-intro {
+    max-width: 38rem;
+  }
+
+  /* Stats banner ------------------------------------------------------ */
+  .rank-stats {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(8rem, 1fr));
+    gap: 0.75rem;
+    margin: 1.5rem 0 2rem;
+    padding: 1rem 1.1rem;
+    border: 1px solid var(--pico-muted-border-color);
+    border-radius: var(--pico-border-radius);
+    background: var(--pico-card-sectioning-background-color);
+  }
+  .rank-stat {
+    display: flex;
+    flex-direction: column;
+    gap: 0.15rem;
+  }
+  .rank-stat-value {
+    font-family: var(--pico-font-family-monospace);
+    font-size: 1.45rem;
+    font-weight: 600;
+    color: var(--pico-color);
+    line-height: 1.1;
+  }
+  .rank-stat-date {
+    font-size: 1.05rem;
+    font-weight: 500;
+  }
+  .rank-stat-label {
+    font-size: 0.72rem;
+    text-transform: uppercase;
+    letter-spacing: 0.07em;
+    color: var(--pico-muted-color);
+  }
+
+  /* Podium ----------------------------------------------------------- */
+  .rank-podium {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(13rem, 1fr));
+    gap: 0.85rem;
+    margin: 1.5rem 0 2.5rem;
+  }
+  .podium-card {
+    border: 1px solid var(--pico-muted-border-color);
+    border-top: 3px solid var(--pico-primary);
+    border-radius: var(--pico-border-radius);
+    padding: 0.9rem 1rem 0.75rem;
+    background: var(--pico-card-background-color);
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+  .podium-1 { border-top-color: #d4a017; }
+  .podium-2 { border-top-color: #9aa0a6; }
+  .podium-3 { border-top-color: #b07843; }
+
+  .podium-head {
+    display: flex;
+    align-items: baseline;
+    gap: 0.6rem;
+  }
+  .podium-medal {
+    font-family: var(--pico-font-family-monospace);
+    font-size: 1.6rem;
+    font-weight: 700;
+    line-height: 1;
+    color: var(--pico-primary);
+  }
+  .podium-1 .podium-medal { color: #d4a017; }
+  .podium-2 .podium-medal { color: #9aa0a6; }
+  .podium-3 .podium-medal { color: #b07843; }
+  .podium-label {
+    font-size: 0.72rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--pico-muted-color);
+  }
+  .podium-title {
+    font-size: 1.02rem;
+    line-height: 1.3;
+    margin: 0;
+  }
+  .podium-title a {
+    text-decoration: none;
+  }
+  .podium-title a:hover {
+    text-decoration: underline;
+  }
+  .podium-stats {
+    display: flex;
+    gap: 1.25rem;
+    margin: 0;
+    padding-top: 0.35rem;
+    border-top: 1px dashed var(--pico-muted-border-color);
+  }
+  .podium-stats > div {
+    display: flex;
+    flex-direction: column;
+  }
+  .podium-stats dt {
+    font-size: 0.65rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--pico-muted-color);
+    margin: 0;
+  }
+  .podium-stats dd {
+    font-family: var(--pico-font-family-monospace);
+    font-size: 0.95rem;
+    font-weight: 600;
+    margin: 0;
+  }
+
+  /* Table ----------------------------------------------------------- */
+  .rank-table-wrap {
+    margin-top: 0.5rem;
+  }
+  .rank-caption {
+    text-align: left;
+    font-size: 0.78rem;
+    color: var(--pico-muted-color);
+    margin-bottom: 0.4rem;
+    caption-side: top;
+  }
+  .rank-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-variant-numeric: tabular-nums;
+  }
+  .rank-table thead th {
+    position: sticky;
+    top: 0;
+    background: var(--pico-background-color);
+    border-bottom: 2px solid var(--pico-muted-border-color);
+    font-size: 0.78rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--pico-muted-color);
+    text-align: left;
+    padding: 0.55rem 0.5rem;
+    z-index: 1;
+  }
+  .rank-table tbody td,
+  .rank-table tbody th {
+    padding: 0.55rem 0.5rem;
+    border-bottom: 1px solid var(--pico-muted-border-color);
+    vertical-align: top;
+  }
+  .rank-table tbody tr:hover {
+    background: var(--pico-card-sectioning-background-color);
+  }
+  .rank-table .num {
+    font-family: var(--pico-font-family-monospace);
+    text-align: right;
+    white-space: nowrap;
+  }
+  .rank-table th.col-ordinal,
+  .rank-table th.col-mu,
+  .rank-table th.col-sigma,
+  .rank-table th.col-record {
+    text-align: right;
+  }
+  .rank-table .col-rank {
+    width: 2.5rem;
+    text-align: right;
+    font-family: var(--pico-font-family-monospace);
+    font-weight: 500;
+    color: var(--pico-muted-color);
+  }
+  .rank-table .col-post a {
+    text-decoration: none;
+  }
+  .rank-table .col-post a:hover {
+    text-decoration: underline;
+  }
+  .ord-bar {
+    margin-top: 0.4rem;
+    height: 3px;
+    background: var(--pico-muted-border-color);
+    border-radius: 2px;
+    overflow: hidden;
+  }
+  .ord-bar > span {
+    display: block;
+    height: 100%;
+    background: var(--pico-primary);
+    opacity: 0.55;
+  }
+
+  .conf-badge {
+    display: inline-block;
+    font-size: 0.7rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    padding: 0.15rem 0.5rem;
+    border-radius: 999px;
+    border: 1px solid var(--pico-muted-border-color);
+    color: var(--pico-muted-color);
+    white-space: nowrap;
+  }
+  .conf-high {
+    color: #2d6a4f;
+    border-color: #2d6a4f55;
+    background: #2d6a4f12;
+  }
+  .conf-medium {
+    color: #b08300;
+    border-color: #b0830044;
+    background: #b0830012;
+  }
+  .conf-low {
+    color: var(--pico-muted-color);
+    border-color: var(--pico-muted-border-color);
+    background: transparent;
+  }
+  [data-theme="dark"] .conf-high {
+    color: #74c69d;
+    border-color: #74c69d55;
+    background: #74c69d12;
+  }
+  [data-theme="dark"] .conf-medium {
+    color: #f1c453;
+    border-color: #f1c45355;
+    background: #f1c45312;
+  }
+
+  /* On narrow screens fold μ, σ, and confidence columns away — keep
+     ordinal, record, and the bar visible since they carry the visual
+     story. */
+  @media (max-width: 720px) {
+    .rank-table .col-mu,
+    .rank-table .col-sigma,
+    .rank-table .col-confidence {
+      display: none;
+    }
+  }
+
+  /* Unrated --------------------------------------------------------- */
+  .rank-unrated,
+  .rank-recent {
+    margin-top: 3rem;
+  }
+  .rank-unrated h2,
+  .rank-recent h2 {
+    font-size: 1.15rem;
+    margin-bottom: 0.2rem;
+  }
+  .rank-unrated ul {
+    list-style: none;
+    padding: 0;
+    margin: 0.75rem 0 0;
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(15rem, 1fr));
+    gap: 0.4rem 1rem;
+  }
+  .rank-unrated li::before {
+    content: "·";
+    color: var(--pico-muted-color);
+    margin-right: 0.4rem;
+  }
+
+  /* Recent duels --------------------------------------------------- */
+  .recent-list {
+    list-style: none;
+    padding: 0;
+    margin: 0.75rem 0 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+  }
+  .recent-list li {
+    display: grid;
+    grid-template-columns: 6.5rem 1fr;
+    gap: 0.6rem;
+    align-items: baseline;
+    font-size: 0.93rem;
+    padding: 0.35rem 0;
+    border-bottom: 1px dashed var(--pico-muted-border-color);
+  }
+  .recent-list li:last-child {
+    border-bottom: 0;
+  }
+  .recent-date {
+    font-family: var(--pico-font-family-monospace);
+    font-size: 0.78rem;
+    color: var(--pico-muted-color);
+    white-space: nowrap;
+  }
+  .recent-winner {
+    font-weight: 600;
+  }
+  .recent-loser {
+    color: var(--pico-muted-color);
+    text-decoration: line-through;
+    text-decoration-color: var(--pico-muted-border-color);
+  }
+  .recent-loser:hover {
+    color: var(--pico-color);
+  }
+  .recent-verb {
+    color: var(--pico-muted-color);
+    font-size: 0.85rem;
+  }
+  .recent-criterion {
+    color: var(--pico-muted-color);
+    font-size: 0.8rem;
+  }
+
+  @media (max-width: 540px) {
+    .recent-list li {
+      grid-template-columns: 1fr;
+      gap: 0.1rem;
+    }
+  }
+
+  .rank-empty {
+    padding: 2rem 1rem;
+    text-align: center;
+    border: 1px dashed var(--pico-muted-border-color);
+    border-radius: var(--pico-border-radius);
+    color: var(--pico-muted-color);
+  }
+
+  abbr[title] {
+    text-decoration: none;
+    border-bottom: 1px dotted var(--pico-muted-color);
+    cursor: help;
+  }
+</style>

--- a/src/lib/hronir-rank.ts
+++ b/src/lib/hronir-rank.ts
@@ -3,6 +3,11 @@
 // keyed by translationKey, plus a sorted array.
 
 import { computeRatings } from "../../scripts/hronir/lib/ranking.js";
+import {
+  listMatchFiles,
+  readMatch,
+  postKey,
+} from "../../scripts/hronir/lib/matches.js";
 
 export interface RankRow {
   key: string;
@@ -14,7 +19,24 @@ export interface RankRow {
   path: string;
 }
 
+export interface DuelEntry {
+  runAt: string;
+  winnerKey: string;
+  loserKey: string;
+  margin?: number;
+  confidence?: string;
+  criterion?: string;
+}
+
+export interface RankingStats {
+  totalDuels: number;
+  totalRated: number;
+  lastDuelAt: string | null;
+  firstDuelAt: string | null;
+}
+
 let _cache: RankRow[] | null = null;
+let _statsCache: { stats: RankingStats; recent: DuelEntry[] } | null = null;
 
 export function getRanking(): RankRow[] {
   if (_cache) return _cache;
@@ -32,4 +54,59 @@ export function getRankByKey(): Map<
     map.set(rows[i].key, { rank: i + 1, row: rows[i], total: rows.length });
   }
   return map;
+}
+
+function loadDuelData(): { stats: RankingStats; recent: DuelEntry[] } {
+  if (_statsCache) return _statsCache;
+
+  const duels: DuelEntry[] = [];
+  for (const f of listMatchFiles()) {
+    const { data } = readMatch(f);
+    let winner = (data as any).winner;
+    if ((data as any).override && (data as any).override !== "null") {
+      winner = (data as any).override;
+    }
+    if (winner === "TODO" || !winner) continue;
+    const aKey = postKey((data as any).post_a);
+    const bKey = postKey((data as any).post_b);
+    if (!aKey || !bKey) continue;
+    if (winner !== "a" && winner !== "b") continue;
+
+    const rawRunAt = (data as any).run_at ?? (data as any).run_id ?? "";
+    const runAt =
+      rawRunAt instanceof Date ? rawRunAt.toISOString() : String(rawRunAt);
+
+    const winnerKey = winner === "a" ? aKey : bKey;
+    const loserKey = winner === "a" ? bKey : aKey;
+
+    duels.push({
+      runAt,
+      winnerKey,
+      loserKey,
+      margin: typeof (data as any).margin === "number" ? (data as any).margin : undefined,
+      confidence: (data as any).confidence ? String((data as any).confidence) : undefined,
+      criterion: (data as any).criterion ? String((data as any).criterion) : undefined,
+    });
+  }
+
+  duels.sort((a, b) => b.runAt.localeCompare(a.runAt));
+
+  const rated = getRanking();
+  const stats: RankingStats = {
+    totalDuels: duels.length,
+    totalRated: rated.length,
+    lastDuelAt: duels.length > 0 ? duels[0].runAt : null,
+    firstDuelAt: duels.length > 0 ? duels[duels.length - 1].runAt : null,
+  };
+
+  _statsCache = { stats, recent: duels };
+  return _statsCache;
+}
+
+export function getRankingStats(): RankingStats {
+  return loadDuelData().stats;
+}
+
+export function getRecentDuels(limit = 8): DuelEntry[] {
+  return loadDuelData().recent.slice(0, limit);
 }

--- a/src/lib/hronir-rank.ts
+++ b/src/lib/hronir-rank.ts
@@ -83,9 +83,16 @@ function loadDuelData(): { stats: RankingStats; recent: DuelEntry[] } {
       runAt,
       winnerKey,
       loserKey,
-      margin: typeof (data as any).margin === "number" ? (data as any).margin : undefined,
-      confidence: (data as any).confidence ? String((data as any).confidence) : undefined,
-      criterion: (data as any).criterion ? String((data as any).criterion) : undefined,
+      margin:
+        typeof (data as any).margin === "number"
+          ? (data as any).margin
+          : undefined,
+      confidence: (data as any).confidence
+        ? String((data as any).confidence)
+        : undefined,
+      criterion: (data as any).criterion
+        ? String((data as any).criterion)
+        : undefined,
     });
   }
 

--- a/src/pages/pt/ranking.astro
+++ b/src/pages/pt/ranking.astro
@@ -1,10 +1,11 @@
 ---
 import PageLayout from "../../layouts/PageLayout.astro";
 import { getCollection } from "astro:content";
-import { getRanking } from "../../lib/hronir-rank";
+import { getRanking, getRankingStats, getRecentDuels } from "../../lib/hronir-rank";
+import RankingView, { type RankPostInfo, type UnratedItem, type RankingStrings } from "../../components/RankingView.astro";
 
 const all = await getCollection("blog");
-const byKey = new Map<string, { slug: string; title: string; lang: string }>();
+const byKey = new Map<string, RankPostInfo>();
 for (const p of all) {
   if (p.data.draft) continue;
   const key = p.data.translationKey;
@@ -24,6 +25,27 @@ const enriched = rows.map((r, i) => ({
   post: byKey.get(r.key),
 }));
 
+const ratedKeys = new Set(rows.map((r) => r.key));
+const unrated: UnratedItem[] = [];
+const seenUnrated = new Set<string>();
+for (const p of all) {
+  if (p.data.draft) continue;
+  const key = p.data.translationKey;
+  if (!key || ratedKeys.has(key) || seenUnrated.has(key)) continue;
+  // Prefer PT title for this page.
+  const lang = p.data.lang ?? "en";
+  const preferred =
+    lang === "pt"
+      ? p
+      : all.find((q) => q.data.translationKey === key && (q.data.lang ?? "en") === "pt") ?? p;
+  unrated.push({ slug: preferred.id, title: preferred.data.title });
+  seenUnrated.add(key);
+}
+unrated.sort((a, b) => a.title.localeCompare(b.title, "pt-BR"));
+
+const stats = getRankingStats();
+const recent = getRecentDuels(8);
+
 const itemListLd = {
   "@context": "https://schema.org",
   "@type": "ItemList",
@@ -39,6 +61,41 @@ const itemListLd = {
     url: r.post ? `https://franklinbaldo.github.io/blog/${r.post.slug}/` : undefined,
   })).filter((item) => item.url),
 };
+
+const strings: RankingStrings = {
+  subtitle: "Posts ordenados pelo ordinal do OpenSkill (μ − 3σ). Maior é melhor. Atualizado a cada build a partir de .routines/hronir/.",
+  intro:
+    "O sistema Hrönir confronta posts em duelos par-a-par. Um avaliador (às vezes eu, às vezes um modelo) escolhe um vencedor e escreve uma defesa apaixonada. O OpenSkill transforma esses duelos num ranking contínuo com incerteza explícita (σ): posts com poucas aparições têm σ maior e portanto ordinal mais baixo mesmo com μ alto.",
+  podiumLabel: "Pódio",
+  statsTotalDuels: "duelos disputados",
+  statsTotalRated: "posts no ranking",
+  statsAvgDuels: "duelos por post (média)",
+  statsLastDuel: "último duelo",
+  tableCaption: "Ranking completo, ordenado por ordinal decrescente.",
+  thRank: "#",
+  thPost: "Post",
+  thOrdinal: "ordinal",
+  thMu: "μ",
+  thSigma: "σ",
+  thRecord: "V/N",
+  thConfidence: "confiança",
+  unratedHeading: "Ainda sem duelo",
+  unratedBlurb: "Posts publicados que ainda não passaram por nenhuma comparação Hrönir.",
+  recentHeading: "Últimos duelos",
+  recentBlurb: "Os confrontos mais recentes que afetaram o ranking.",
+  recentBeats: "venceu",
+  emptyState: "Sem posts ranqueados ainda — rode uma rodada Hrönir para popular o ranking.",
+  ordinalTip: "Ordinal = μ − 3σ. Combina habilidade estimada com penalidade pela incerteza.",
+  muTip: "μ (mu): habilidade média estimada pelo OpenSkill.",
+  sigmaTip: "σ (sigma): incerteza da estimativa. Cai à medida que o post acumula duelos.",
+  confidenceHigh: "alta",
+  confidenceMedium: "média",
+  confidenceLow: "baixa",
+  podiumGold: "1º lugar",
+  podiumSilver: "2º lugar",
+  podiumBronze: "3º lugar",
+  noDate: "—",
+};
 ---
 
 <PageLayout
@@ -48,55 +105,13 @@ const itemListLd = {
   translations={{ en: "/ranking/" }}
 >
   <script type="application/ld+json" set:html={JSON.stringify(itemListLd)} slot="head" is:inline />
-  <hgroup>
-    <h1>Ranking</h1>
-    <p>
-      <small>
-        Posts ordenados pelo <em>ordinal</em> do OpenSkill (μ − 3σ). Maior é melhor.
-        Atualizado a cada build a partir de <code>.routines/hronir/</code>.
-      </small>
-    </p>
-  </hgroup>
-
-  <p>
-    O sistema Hrönir confronta posts em duelos par-a-par. Um avaliador (às vezes eu, às vezes um modelo)
-    escolhe um vencedor e escreve uma defesa apaixonada. O OpenSkill transforma esses duelos num ranking
-    contínuo com incerteza explícita (σ). Posts com poucas aparições têm σ maior e portanto ordinal mais
-    baixo mesmo com μ alto.
-  </p>
-
-  <table class="striped">
-    <thead>
-      <tr>
-        <th scope="col" style="text-align:right">#</th>
-        <th scope="col">Post</th>
-        <th scope="col" style="text-align:right">ordinal</th>
-        <th scope="col" style="text-align:right">μ</th>
-        <th scope="col" style="text-align:right">σ</th>
-        <th scope="col" style="text-align:right">V/N</th>
-      </tr>
-    </thead>
-    <tbody>
-      {enriched.map((r) => (
-        <tr>
-          <td style="text-align:right">{r.rank}</td>
-          <td>
-            {r.post ? (
-              <a href={`/blog/${r.post.slug}/`}>{r.post.title}</a>
-            ) : (
-              <code>{r.key}</code>
-            )}
-          </td>
-          <td style="text-align:right"><code>{r.ordinal.toFixed(2)}</code></td>
-          <td style="text-align:right"><code>{r.mu.toFixed(2)}</code></td>
-          <td style="text-align:right"><code>{r.sigma.toFixed(2)}</code></td>
-          <td style="text-align:right"><code>{r.wins}/{r.appearances}</code></td>
-        </tr>
-      ))}
-    </tbody>
-  </table>
-
-  {enriched.length === 0 && (
-    <p><em>Sem posts ranqueados ainda — rode uma rodada Hrönir para popular o ranking.</em></p>
-  )}
+  <RankingView
+    lang="pt"
+    rows={enriched}
+    unrated={unrated}
+    recent={recent}
+    stats={stats}
+    postByKey={byKey}
+    strings={strings}
+  />
 </PageLayout>

--- a/src/pages/ranking.astro
+++ b/src/pages/ranking.astro
@@ -1,10 +1,11 @@
 ---
 import PageLayout from "../layouts/PageLayout.astro";
 import { getCollection } from "astro:content";
-import { getRanking } from "../lib/hronir-rank";
+import { getRanking, getRankingStats, getRecentDuels } from "../lib/hronir-rank";
+import RankingView, { type RankPostInfo, type UnratedItem, type RankingStrings } from "../components/RankingView.astro";
 
 const all = await getCollection("blog");
-const byKey = new Map<string, { slug: string; title: string; lang: string }>();
+const byKey = new Map<string, RankPostInfo>();
 for (const p of all) {
   if (p.data.draft) continue;
   const key = p.data.translationKey;
@@ -23,6 +24,26 @@ const enriched = rows.map((r, i) => ({
   post: byKey.get(r.key),
 }));
 
+const ratedKeys = new Set(rows.map((r) => r.key));
+const unrated: UnratedItem[] = [];
+const seenUnrated = new Set<string>();
+for (const p of all) {
+  if (p.data.draft) continue;
+  const key = p.data.translationKey;
+  if (!key || ratedKeys.has(key) || seenUnrated.has(key)) continue;
+  const lang = p.data.lang ?? "en";
+  const preferred =
+    lang === "en"
+      ? p
+      : all.find((q) => q.data.translationKey === key && (q.data.lang ?? "en") === "en") ?? p;
+  unrated.push({ slug: preferred.id, title: preferred.data.title });
+  seenUnrated.add(key);
+}
+unrated.sort((a, b) => a.title.localeCompare(b.title, "en-US"));
+
+const stats = getRankingStats();
+const recent = getRecentDuels(8);
+
 const itemListLd = {
   "@context": "https://schema.org",
   "@type": "ItemList",
@@ -38,6 +59,41 @@ const itemListLd = {
     url: r.post ? `https://franklinbaldo.github.io/blog/${r.post.slug}/` : undefined,
   })).filter((item) => item.url),
 };
+
+const strings: RankingStrings = {
+  subtitle: "Posts ordered by OpenSkill ordinal (μ − 3σ). Higher is better. Updated every build from .routines/hronir/.",
+  intro:
+    "The Hrönir system pits posts against each other in pairwise duels. An evaluator (sometimes me, sometimes a model) picks a winner and writes a passionate defense. OpenSkill turns those duels into a continuous ranking with explicit uncertainty (σ): posts with few appearances have larger σ and therefore a lower ordinal even with high μ.",
+  podiumLabel: "Podium",
+  statsTotalDuels: "duels run",
+  statsTotalRated: "posts ranked",
+  statsAvgDuels: "duels per post (avg)",
+  statsLastDuel: "last duel",
+  tableCaption: "Full ranking, ordered by descending ordinal.",
+  thRank: "#",
+  thPost: "Post",
+  thOrdinal: "ordinal",
+  thMu: "μ",
+  thSigma: "σ",
+  thRecord: "W/N",
+  thConfidence: "confidence",
+  unratedHeading: "Not yet duelled",
+  unratedBlurb: "Published posts that haven't gone through a Hrönir comparison yet.",
+  recentHeading: "Latest duels",
+  recentBlurb: "The most recent matchups that moved the ranking.",
+  recentBeats: "beat",
+  emptyState: "No rated posts yet — run a Hrönir round to populate the ranking.",
+  ordinalTip: "Ordinal = μ − 3σ. Combines estimated skill with a penalty for uncertainty.",
+  muTip: "μ (mu): OpenSkill's estimate of average skill.",
+  sigmaTip: "σ (sigma): uncertainty around the estimate. Shrinks as the post accumulates duels.",
+  confidenceHigh: "high",
+  confidenceMedium: "medium",
+  confidenceLow: "low",
+  podiumGold: "1st place",
+  podiumSilver: "2nd place",
+  podiumBronze: "3rd place",
+  noDate: "—",
+};
 ---
 
 <PageLayout
@@ -47,54 +103,13 @@ const itemListLd = {
   translations={{ pt: "/pt/ranking/" }}
 >
   <script type="application/ld+json" set:html={JSON.stringify(itemListLd)} slot="head" is:inline />
-  <hgroup>
-    <h1>Ranking</h1>
-    <p>
-      <small>
-        Posts ordered by OpenSkill <em>ordinal</em> (μ − 3σ). Higher is better.
-        Updated every build from <code>.routines/hronir/</code>.
-      </small>
-    </p>
-  </hgroup>
-
-  <p>
-    The Hrönir system pits posts against each other in pairwise duels. An evaluator (sometimes me, sometimes a model)
-    picks a winner and writes a passionate defense. OpenSkill turns those duels into a continuous ranking with
-    explicit uncertainty (σ). Posts with few appearances have larger σ and therefore a lower ordinal even with high μ.
-  </p>
-
-  <table class="striped">
-    <thead>
-      <tr>
-        <th scope="col" style="text-align:right">#</th>
-        <th scope="col">Post</th>
-        <th scope="col" style="text-align:right">ordinal</th>
-        <th scope="col" style="text-align:right">μ</th>
-        <th scope="col" style="text-align:right">σ</th>
-        <th scope="col" style="text-align:right">W/N</th>
-      </tr>
-    </thead>
-    <tbody>
-      {enriched.map((r) => (
-        <tr>
-          <td style="text-align:right">{r.rank}</td>
-          <td>
-            {r.post ? (
-              <a href={`/blog/${r.post.slug}/`}>{r.post.title}</a>
-            ) : (
-              <code>{r.key}</code>
-            )}
-          </td>
-          <td style="text-align:right"><code>{r.ordinal.toFixed(2)}</code></td>
-          <td style="text-align:right"><code>{r.mu.toFixed(2)}</code></td>
-          <td style="text-align:right"><code>{r.sigma.toFixed(2)}</code></td>
-          <td style="text-align:right"><code>{r.wins}/{r.appearances}</code></td>
-        </tr>
-      ))}
-    </tbody>
-  </table>
-
-  {enriched.length === 0 && (
-    <p><em>No rated posts yet — run a Hrönir round to populate the ranking.</em></p>
-  )}
+  <RankingView
+    lang="en"
+    rows={enriched}
+    unrated={unrated}
+    recent={recent}
+    stats={stats}
+    postByKey={byKey}
+    strings={strings}
+  />
 </PageLayout>


### PR DESCRIPTION
## Summary

Replaces the bare OpenSkill table on `/pt/ranking/` (and `/ranking/` for parity) with a richer overview built on the same data:

- **Stats banner** — total duels, posts ranked, avg duels per post, last duel date.
- **Top-3 podium** with gold / silver / bronze accents, title, ordinal, and W/N.
- **Ordinal bar** on every table row so the spread between posts is legible at a glance.
- **Confidence badge** derived from σ + appearances (high / medium / low), styled subtly so it works in both themes.
- **Recent duels** list — winner bold, loser struck-through, criterion as caption.
- **Unrated posts** section (hides itself when empty) for entries that have not been compared yet.
- **Mobile-friendly table** that folds μ / σ / confidence columns away below 720px and stacks recent-duel rows below 540px.

Shared visuals live in a new `RankingView.astro`; the EN and PT routes only differ by their localized strings dictionary, so they stay in lockstep going forward.

Also extends `src/lib/hronir-rank.ts` with `getRankingStats()` and `getRecentDuels(n)` helpers that scan the same `.routines/hronir/` match files once at build time.

## Test plan

- [x] `npx astro check` — 0 errors / 0 warnings on changed files
- [x] `npx astro build` — 343 pages built clean
- [x] Drove `/pt/ranking/` in Chromium at 1280×1600 — 3 podium cards, 4 stat tiles, 34 ordinal bars, 34 confidence badges, 8 recent duels; PT strings rendered (`alta`, `1º lugar`, `venceu`, `duelos disputados`)
- [x] Drove `/pt/ranking/` at 390×1800 — μ/σ/confidence columns hidden, podium stacks, stats reflow to 2 cols, recent-duels list stacks
- [x] Drove `/ranking/` at 1280×1600 — same layout, EN strings (`1st/2nd/3rd place`, `beat`, `duels run`)
- [x] Verified unrated section hides itself when every post has ≥1 duel (current state of `.routines/hronir/`)
- [ ] Manual: check `/pt/ranking/` and `/ranking/` after deploy

Screenshots captured locally during verification (desktop + mobile, EN + PT).

---
_Generated by [Claude Code](https://claude.ai/code/session_0119hCdiTM8QYMwWoWfMCGog)_