### PR TITLE
fix(ranking): skip duels with empty timestamps in recent-duels list

### DIFF
--- a/src/lib/hronir-rank.ts
+++ b/src/lib/hronir-rank.ts
@@ -75,6 +75,10 @@ function loadDuelData(): { stats: RankingStats; recent: DuelEntry[] } {
     const rawRunAt = (data as any).run_at ?? (data as any).run_id ?? "";
     const runAt =
       rawRunAt instanceof Date ? rawRunAt.toISOString() : String(rawRunAt);
+    // Skip matches without a parseable timestamp: an empty runAt would
+    // sort ahead of every real duel in the "Latest duels" list and
+    // render with a placeholder date, which is worse than not showing it.
+    if (!runAt) continue;
 
     const winnerKey = winner === "a" ? aKey : bKey;
     const loserKey = winner === "a" ? bKey : aKey;


### PR DESCRIPTION
## Summary

Follow-up to #167. A match file missing both `run_at` and `run_id` produces an empty `runAt` string. Under the descending `localeCompare` sort used for "Latest duels", `""` sorts ahead of every real ISO timestamp, so such a duel would surface at the top of the list with a placeholder date — worse than just omitting it. Skip those entries instead.

No such files exist in `.routines/hronir/` today, so there is no visible change in the current build; this closes the edge case before it can bite.

## Test plan

- [x] `npx prettier --check src/lib/hronir-rank.ts` — clean
- [x] `npx astro check` — 0 errors / 0 warnings
- [ ] Manual: confirm `/ranking/` and `/pt/ranking/` still render the same Latest-duels block after merge.

---
_Generated by [Claude Code](https://claude.ai/code/session_0119hCdiTM8QYMwWoWfMCGog)_