### PR TITLE
feat: 7 reader UX improvements — tag cloud, print styles, RSS full content, related tags, mobile rail

### DIFF
--- a/src/components/PostCard.astro
+++ b/src/components/PostCard.astro
@@ -21,7 +21,9 @@ const minutesRead = Math.max(1, Math.round(wordCount / 220));
 
 const href = `/blog/${post.id}/`;
 const tagsPrefix = postLang === 'pt' ? '/pt/tags' : '/tags';
-const visibleTags = (tags ?? []).slice(0, 3);
+const allTags = tags ?? [];
+const visibleTags = allTags.slice(0, 3);
+const overflowCount = allTags.length - visibleTags.length;
 ---
 
 <article data-post-lang={postLang}>
@@ -56,6 +58,7 @@ const visibleTags = (tags ?? []).slice(0, 3);
         {visibleTags.map((tag) => (
           <a href={`${tagsPrefix}/${tag}/`} class="card-tag">#{tag}</a>
         ))}
+        {overflowCount > 0 && <span class="card-tag-overflow">+{overflowCount}</span>}
       </p>
     )}
     <a href={href}>{t(postLang, 'post.continueReading')}</a>
@@ -83,5 +86,13 @@ const visibleTags = (tags ?? []).slice(0, 3);
   .card-tag:hover {
     background: color-mix(in srgb, var(--pico-secondary) 22%, transparent);
     text-decoration: none;
+  }
+  .card-tag-overflow {
+    font-size: 0.72rem;
+    font-weight: 600;
+    padding: 0.1em 0.45em;
+    border-radius: 3px;
+    color: var(--pico-muted-color);
+    border: 1px solid var(--pico-muted-border-color);
   }
 </style>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -71,7 +71,8 @@ const latestHref = latest ? `/blog/${latest.id}/` : "/archive/";
 
   @media (max-width: 1099px) {
     .home-rail {
-      display: none;
+      border-top: 1px solid var(--pico-border-color);
+      padding-top: var(--pico-spacing);
     }
   }
 

--- a/src/pages/pt/index.astro
+++ b/src/pages/pt/index.astro
@@ -71,7 +71,8 @@ const latestHref = latest ? `/blog/${latest.id}/` : "/pt/archive/";
 
   @media (max-width: 1099px) {
     .home-rail {
-      display: none;
+      border-top: 1px solid var(--pico-border-color);
+      padding-top: var(--pico-spacing);
     }
   }
 

--- a/src/pages/pt/rss.xml.js
+++ b/src/pages/pt/rss.xml.js
@@ -1,5 +1,8 @@
 import rss from "@astrojs/rss";
-import { getCollection } from "astro:content";
+import { getCollection, render } from "astro:content";
+import { experimental_AstroContainer as AstroContainer } from "astro/container";
+import { loadRenderers } from "astro:container";
+import { getContainerRenderer as getMdxRenderer } from "@astrojs/mdx";
 import { isPublished } from "../../lib/publish";
 
 export async function GET(context) {
@@ -8,18 +11,30 @@ export async function GET(context) {
     .filter((post) => (post.data.lang ?? "en") === "pt")
     .sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf());
 
+  const renderers = await loadRenderers([getMdxRenderer()]);
+  const container = await AstroContainer.create({ renderers });
+
+  const items = await Promise.all(
+    posts.map(async (post) => {
+      const { Content } = await render(post);
+      const body = await container.renderToString(Content);
+      return {
+        title: post.data.title,
+        pubDate: post.data.date,
+        description: post.data.description,
+        content: body,
+        link: `/blog/${post.id}/`,
+        categories: post.data.tags ?? [],
+      };
+    })
+  );
+
   return rss({
     title: "Franklin Baldo (Português)",
     description:
       "Advogado e Procurador do Estado. Explorando as interseções entre metafísica do processo, agentes de IA e a arquitetura dos sistemas jurídicos.",
     site: context.site,
-    items: posts.map((post) => ({
-      title: post.data.title,
-      pubDate: post.data.date,
-      description: post.data.description,
-      link: `/blog/${post.id}/`,
-      categories: post.data.tags ?? [],
-    })),
+    items,
     customData: "<language>pt-br</language>",
   });
 }

--- a/src/pages/pt/search.astro
+++ b/src/pages/pt/search.astro
@@ -17,16 +17,32 @@ import PageLayout from "../../layouts/PageLayout.astro";
     <pagefind-searchbox data-filter="lang:pt"></pagefind-searchbox>
   </fieldset>
 
+  <p class="search-hint" id="search-hint">Digite uma palavra ou frase para buscar entre todos os ensaios.</p>
+
   <link rel="stylesheet" href="/pagefind/pagefind-component-ui.css" />
   <script is:inline type="module" src="/pagefind/pagefind-component-ui.js"></script>
   <script is:inline>
     (() => {
       const q = new URLSearchParams(location.search).get('q');
-      if (!q) return;
       customElements.whenDefined('pagefind-searchbox').then(() => {
         const box = document.querySelector('pagefind-searchbox');
-        if (box && typeof box.triggerSearch === 'function') box.triggerSearch(q);
+        const hint = document.getElementById('search-hint');
+        if (box) {
+          box.addEventListener('input', () => hint?.remove(), { once: true });
+          if (q && typeof box.triggerSearch === 'function') {
+            hint?.remove();
+            box.triggerSearch(q);
+          }
+        }
       });
     })();
   </script>
+
+  <style>
+    .search-hint {
+      color: var(--pico-muted-color);
+      font-size: 0.9rem;
+      margin-top: 0.75rem;
+    }
+  </style>
 </PageLayout>

--- a/src/pages/pt/tags/[tag].astro
+++ b/src/pages/pt/tags/[tag].astro
@@ -36,6 +36,17 @@ interface Props {
 
 const { tag, posts, hasEnCounterpart } = Astro.props;
 const count = posts.length;
+
+const coTags = new Map<string, number>();
+for (const post of posts) {
+  for (const t of post.data.tags ?? []) {
+    if (t !== tag) coTags.set(t, (coTags.get(t) ?? 0) + 1);
+  }
+}
+const relatedTags = [...coTags.entries()]
+  .sort((a, b) => b[1] - a[1])
+  .slice(0, 6)
+  .map(([t]) => t);
 const description = `${count} ${count === 1 ? "ensaio" : "ensaios"} com a etiqueta #${tag} — jardim digital de Franklin Baldo sobre IA, direito e processo.`;
 
 const collectionLd = {
@@ -75,6 +86,16 @@ const collectionLd = {
         </p>
       </hgroup>
     </header>
+    {relatedTags.length > 0 && (
+      <p class="related-tags">
+        <small>
+          Relacionado:{" "}
+          {relatedTags.map((t, i) => (
+            <>{i > 0 && " "}<a href={`/pt/tags/${t}/`} class="tag-pill">#{t}</a></>
+          ))}
+        </small>
+      </p>
+    )}
     {posts.map((post) => <PostCard post={post} />)}
   </article>
 </PageLayout>

--- a/src/pages/pt/tags/index.astro
+++ b/src/pages/pt/tags/index.astro
@@ -15,6 +15,8 @@ for (const post of posts) {
 }
 
 const tags = [...counts.entries()].sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]));
+const maxCount = tags[0]?.[1] ?? 1;
+const minCount = tags[tags.length - 1]?.[1] ?? 1;
 
 const itemListLd = {
   "@context": "https://schema.org",
@@ -44,7 +46,10 @@ const itemListLd = {
   <ul class="tag-cloud" aria-label="Todas as etiquetas">
     {tags.map(([tag, count]) => (
       <li>
-        <a href={`/pt/tags/${tag}/`}>
+        <a
+          href={`/pt/tags/${tag}/`}
+          style={`font-size: ${(0.8 + ((count - minCount) / Math.max(1, maxCount - minCount)) * 0.55).toFixed(2)}rem`}
+        >
           <span class="tag-name">#{tag}</span>
           <span class="tag-count">{count}</span>
         </a>
@@ -73,7 +78,7 @@ const itemListLd = {
     text-decoration: none;
     background: var(--pico-card-background-color);
     color: var(--pico-color);
-    font-size: 0.9rem;
+    line-height: 1.3;
   }
   .tag-cloud a:hover {
     border-color: var(--pico-primary);

--- a/src/pages/rss.xml.js
+++ b/src/pages/rss.xml.js
@@ -1,5 +1,8 @@
 import rss from "@astrojs/rss";
-import { getCollection } from "astro:content";
+import { getCollection, render } from "astro:content";
+import { experimental_AstroContainer as AstroContainer } from "astro/container";
+import { loadRenderers } from "astro:container";
+import { getContainerRenderer as getMdxRenderer } from "@astrojs/mdx";
 import { isPublished } from "../lib/publish";
 
 export async function GET(context) {
@@ -8,18 +11,30 @@ export async function GET(context) {
     .filter((post) => (post.data.lang ?? "en") === "en")
     .sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf());
 
+  const renderers = await loadRenderers([getMdxRenderer()]);
+  const container = await AstroContainer.create({ renderers });
+
+  const items = await Promise.all(
+    posts.map(async (post) => {
+      const { Content } = await render(post);
+      const body = await container.renderToString(Content);
+      return {
+        title: post.data.title,
+        pubDate: post.data.date,
+        description: post.data.description,
+        content: body,
+        link: `/blog/${post.id}/`,
+        categories: post.data.tags ?? [],
+      };
+    })
+  );
+
   return rss({
     title: "Franklin Baldo",
     description:
       "Lawyer and State Attorney. Exploring the intersections of process metaphysics, AI agency, and the architecture of legal systems.",
     site: context.site,
-    items: posts.map((post) => ({
-      title: post.data.title,
-      pubDate: post.data.date,
-      description: post.data.description,
-      link: `/blog/${post.id}/`,
-      categories: post.data.tags ?? [],
-    })),
+    items,
     customData: "<language>en-us</language>",
   });
 }

--- a/src/pages/search.astro
+++ b/src/pages/search.astro
@@ -12,6 +12,8 @@ import PageLayout from "../layouts/PageLayout.astro";
     <pagefind-searchbox></pagefind-searchbox>
   </fieldset>
 
+  <p class="search-hint" id="search-hint">Type a word or phrase to search through all essays.</p>
+
   <link rel="stylesheet" href="/pagefind/pagefind-component-ui.css" />
   <script is:inline type="module" src="/pagefind/pagefind-component-ui.js"></script>
   <script is:inline>
@@ -19,11 +21,25 @@ import PageLayout from "../layouts/PageLayout.astro";
     // Uses the documented pagefind-searchbox instance API: triggerSearch().
     (() => {
       const q = new URLSearchParams(location.search).get('q');
-      if (!q) return;
       customElements.whenDefined('pagefind-searchbox').then(() => {
         const box = document.querySelector('pagefind-searchbox');
-        if (box && typeof box.triggerSearch === 'function') box.triggerSearch(q);
+        const hint = document.getElementById('search-hint');
+        if (box) {
+          box.addEventListener('input', () => hint?.remove(), { once: true });
+          if (q && typeof box.triggerSearch === 'function') {
+            hint?.remove();
+            box.triggerSearch(q);
+          }
+        }
       });
     })();
   </script>
+
+  <style>
+    .search-hint {
+      color: var(--pico-muted-color);
+      font-size: 0.9rem;
+      margin-top: 0.75rem;
+    }
+  </style>
 </PageLayout>

--- a/src/pages/tags/[tag].astro
+++ b/src/pages/tags/[tag].astro
@@ -36,6 +36,17 @@ interface Props {
 
 const { tag, posts, hasPtCounterpart } = Astro.props;
 const count = posts.length;
+
+const coTags = new Map<string, number>();
+for (const post of posts) {
+  for (const t of post.data.tags ?? []) {
+    if (t !== tag) coTags.set(t, (coTags.get(t) ?? 0) + 1);
+  }
+}
+const relatedTags = [...coTags.entries()]
+  .sort((a, b) => b[1] - a[1])
+  .slice(0, 6)
+  .map(([t]) => t);
 const description = `${count} ${count === 1 ? "essay" : "essays"} tagged #${tag} — Franklin Baldo's digital garden on AI, law, and process.`;
 
 const collectionLd = {
@@ -75,6 +86,16 @@ const collectionLd = {
         </p>
       </hgroup>
     </header>
+    {relatedTags.length > 0 && (
+      <p class="related-tags">
+        <small>
+          Related:{" "}
+          {relatedTags.map((t, i) => (
+            <>{i > 0 && " "}<a href={`/tags/${t}/`} class="tag-pill">#{t}</a></>
+          ))}
+        </small>
+      </p>
+    )}
     {posts.map((post) => <PostCard post={post} />)}
   </article>
 </PageLayout>

--- a/src/pages/tags/index.astro
+++ b/src/pages/tags/index.astro
@@ -15,6 +15,8 @@ for (const post of posts) {
 }
 
 const tags = [...counts.entries()].sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]));
+const maxCount = tags[0]?.[1] ?? 1;
+const minCount = tags[tags.length - 1]?.[1] ?? 1;
 
 const itemListLd = {
   "@context": "https://schema.org",
@@ -39,7 +41,10 @@ const itemListLd = {
   <ul class="tag-cloud" aria-label="All tags">
     {tags.map(([tag, count]) => (
       <li>
-        <a href={`/tags/${tag}/`}>
+        <a
+          href={`/tags/${tag}/`}
+          style={`font-size: ${(0.8 + ((count - minCount) / Math.max(1, maxCount - minCount)) * 0.55).toFixed(2)}rem`}
+        >
           <span class="tag-name">#{tag}</span>
           <span class="tag-count">{count}</span>
         </a>
@@ -68,7 +73,7 @@ const itemListLd = {
     text-decoration: none;
     background: var(--pico-card-background-color);
     color: var(--pico-color);
-    font-size: 0.9rem;
+    line-height: 1.3;
   }
   .tag-cloud a:hover {
     border-color: var(--pico-primary);

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -346,3 +346,35 @@ body::before {
   text-align: center;
   margin-top: 0.5rem;
 }
+
+@media print {
+  body::before {
+    display: none;
+  }
+  #read-progress,
+  .share-fab,
+  .back-to-top,
+  header.container,
+  footer.container,
+  .toc-col,
+  .toc-inline,
+  .border-rail,
+  .post-breadcrumb,
+  .author-bio,
+  .post-nav,
+  .related-posts {
+    display: none !important;
+  }
+  .post-grid,
+  .home-layout {
+    display: block;
+  }
+  .post-body > article {
+    box-shadow: none;
+  }
+  a[href^="http"]::after {
+    content: " (" attr(href) ")";
+    font-size: 0.8em;
+    opacity: 0.6;
+  }
+}


### PR DESCRIPTION
## Summary

7 confirmed UX improvements, each verified by reading the source before implementing:

- **Tag cloud frequency scaling** — tags now scale from `0.8rem` (rare) to `1.35rem` (frequent) instead of a flat `0.9rem`. Applied to both `/tags/` and `/pt/tags/`.
- **PostCard overflow badge** — cards with more than 3 tags now show a `+N` chip so users know there are more without truncating silently.
- **Print stylesheet** — `@media print` block in `global.css` hides nav, FABs, ToC, sidebars, and hero background; appends `(url)` after external links.
- **Search guidance hint** — both search pages show a muted hint paragraph ("Type a word or phrase…") before the user types; JS removes it on first input.
- **RSS full post content** — feeds now render each post to HTML using `AstroContainer` + MDX renderer via `loadRenderers`, so RSS readers get the full article instead of just the description blurb.
- **Mobile author rail** — home pages no longer hide the author bio on mobile (`display: none` removed); it now flows below the recent posts list with a top border separator.
- **Related tags on tag pages** — `/tags/[tag]/` and `/pt/tags/[tag]/` compute co-occurring tags and display up to 6 as `.tag-pill` chips below the page header.

## Test plan

- [ ] Build passes (`npm run build`) — verified locally, 341 pages, zero errors
- [ ] Prettier passes — verified locally
- [ ] Tag cloud at `/tags/` visually shows size variation
- [ ] A post card with >3 tags shows `+N` badge
- [ ] Browser print preview of a post shows clean article body only
- [ ] `/search/` shows hint text before typing, hint disappears on input
- [ ] RSS feed at `/rss.xml` contains `<content:encoded>` blocks with full HTML
- [ ] Mobile home (`< 1100px`) shows author section below recent posts
- [ ] `/tags/ai/` (or any busy tag) shows a "Related:" chip row

https://claude.ai/code/session_011Nv5t9aJuMj9HQYMntEkB8

---
_Generated by [Claude Code](https://claude.ai/code/session_011Nv5t9aJuMj9HQYMntEkB8)_