### PR TITLE
Add video queue post: 35 talks on AI agents and civic tech

### DIFF
--- a/src/content/blog/2026-05-24-video-queue-ai-civictech.mdx
+++ b/src/content/blog/2026-05-24-video-queue-ai-civictech.mdx
@@ -25,28 +25,28 @@ Two clusters. The first is software engineering and AI, mostly conferences from 
 
 The AI engineering cluster runs from very practical (how to build reliable agents) to philosophical (what are we actually doing here). Dex Horthy appears twice because his 12-factor agents framing keeps coming up in conversations and I want to read the source, not the second-hand summaries.
 
-| # | Talk |
-|--:|------|
-| 1 | [2025 in LLMs so far, illustrated by Pelicans on Bicycles — Simon Willison](https://www.youtube.com/watch?v=YpY83-kA7Bo) |
-| 2 | [Software engineering with GenAI — Gergely Orosz / LeadDev LDX3 2025](https://www.youtube.com/watch?v=S6hIHPudbYw) |
-| 3 | [How We Build Effective Agents — Barry Zhang, Anthropic](https://www.youtube.com/watch?v=D7_ipDqhtwk) |
-| 4 | [Don't Build Agents, Build Skills Instead — Barry Zhang & Mahesh Murag, Anthropic](https://www.youtube.com/watch?v=CEvIs9y1uog) |
-| 5 | [12-Factor Agents: Patterns of reliable LLM applications — Dex Horthy](https://www.youtube.com/watch?v=8kMaTybvDUw) |
-| 6 | [Building and evaluating AI Agents — Sayash Kapoor](https://www.youtube.com/watch?v=d5EltXhbcfA) |
-| 7 | [Claude Code & the evolution of agentic coding — Boris Cherny](https://www.youtube.com/watch?v=Lue8K2jqfKk) |
-| 8 | [No Vibes Allowed: Solving Hard Problems in Complex Codebases — Dex Horthy](https://www.youtube.com/watch?v=rmvDxxNubIg) |
-| 9 | [Will AI outsmart human intelligence? — Geoffrey Hinton, Royal Institution](https://www.youtube.com/watch?v=IkdziSLYzHw) |
-| 10 | [Mathematics: The rise of the machines — Yang-Hui He](https://www.youtube.com/watch?v=oOYcPkBaotg) |
-| 11 | [The New Code — Sean Grove, OpenAI](https://www.youtube.com/watch?v=8rABwKRsec4) |
-| 12 | [MCP is all you need — Samuel Colvin, Pydantic](https://www.youtube.com/watch?v=bmWZk9vTze0) |
-| 13 | [2026: The Year The IDE Died — Steve Yegge & Gene Kim](https://www.youtube.com/watch?v=7Dtu2bilcFs) |
-| 14 | [AI without the BS, for humans — Scott Hanselman, NDC London 2025](https://www.youtube.com/watch?v=kYUicaho5k8) |
-| 15 | [Keynote Speaker — Cory Doctorow, PyCon US](https://www.youtube.com/watch?v=ydVmzg_SJLw) |
-| 16 | [Vite Beyond a Build Tool — Evan You, ViteConf 2025](https://www.youtube.com/watch?v=x7Jsmt_o9ek) |
-| 17 | [You Don't Know Git — Edward Thomson, NDC London 2025](https://www.youtube.com/watch?v=DZI0Zl-1JqQ) |
-| 18 | [Decoding the secrets of life with AI — Mikhail Burtsev](https://www.youtube.com/watch?v=l28WCnZXNNg) |
-| 19 | [The Battle of Khasham — The Operations Room](https://www.youtube.com/watch?v=T6Ii45jxsLE) |
-| 20 | [New CSS features to know for 2025 — Kevin Powell](https://www.youtube.com/watch?v=jSCgZqoebsM) |
+|   # | Talk                                                                                                                            |
+| --: | ------------------------------------------------------------------------------------------------------------------------------- |
+|   1 | [2025 in LLMs so far, illustrated by Pelicans on Bicycles — Simon Willison](https://www.youtube.com/watch?v=YpY83-kA7Bo)        |
+|   2 | [Software engineering with GenAI — Gergely Orosz / LeadDev LDX3 2025](https://www.youtube.com/watch?v=S6hIHPudbYw)              |
+|   3 | [How We Build Effective Agents — Barry Zhang, Anthropic](https://www.youtube.com/watch?v=D7_ipDqhtwk)                           |
+|   4 | [Don't Build Agents, Build Skills Instead — Barry Zhang & Mahesh Murag, Anthropic](https://www.youtube.com/watch?v=CEvIs9y1uog) |
+|   5 | [12-Factor Agents: Patterns of reliable LLM applications — Dex Horthy](https://www.youtube.com/watch?v=8kMaTybvDUw)             |
+|   6 | [Building and evaluating AI Agents — Sayash Kapoor](https://www.youtube.com/watch?v=d5EltXhbcfA)                                |
+|   7 | [Claude Code & the evolution of agentic coding — Boris Cherny](https://www.youtube.com/watch?v=Lue8K2jqfKk)                     |
+|   8 | [No Vibes Allowed: Solving Hard Problems in Complex Codebases — Dex Horthy](https://www.youtube.com/watch?v=rmvDxxNubIg)        |
+|   9 | [Will AI outsmart human intelligence? — Geoffrey Hinton, Royal Institution](https://www.youtube.com/watch?v=IkdziSLYzHw)        |
+|  10 | [Mathematics: The rise of the machines — Yang-Hui He](https://www.youtube.com/watch?v=oOYcPkBaotg)                              |
+|  11 | [The New Code — Sean Grove, OpenAI](https://www.youtube.com/watch?v=8rABwKRsec4)                                                |
+|  12 | [MCP is all you need — Samuel Colvin, Pydantic](https://www.youtube.com/watch?v=bmWZk9vTze0)                                    |
+|  13 | [2026: The Year The IDE Died — Steve Yegge & Gene Kim](https://www.youtube.com/watch?v=7Dtu2bilcFs)                             |
+|  14 | [AI without the BS, for humans — Scott Hanselman, NDC London 2025](https://www.youtube.com/watch?v=kYUicaho5k8)                 |
+|  15 | [Keynote Speaker — Cory Doctorow, PyCon US](https://www.youtube.com/watch?v=ydVmzg_SJLw)                                        |
+|  16 | [Vite Beyond a Build Tool — Evan You, ViteConf 2025](https://www.youtube.com/watch?v=x7Jsmt_o9ek)                               |
+|  17 | [You Don't Know Git — Edward Thomson, NDC London 2025](https://www.youtube.com/watch?v=DZI0Zl-1JqQ)                             |
+|  18 | [Decoding the secrets of life with AI — Mikhail Burtsev](https://www.youtube.com/watch?v=l28WCnZXNNg)                           |
+|  19 | [The Battle of Khasham — The Operations Room](https://www.youtube.com/watch?v=T6Ii45jxsLE)                                      |
+|  20 | [New CSS features to know for 2025 — Kevin Powell](https://www.youtube.com/watch?v=jSCgZqoebsM)                                 |
 
 ---
 

--- a/src/content/blog/2026-05-24-video-queue-ai-civictech.mdx
+++ b/src/content/blog/2026-05-24-video-queue-ai-civictech.mdx
@@ -1,0 +1,105 @@
+---
+title: "35 talks I'm planning to watch: AI agents, civic tech, and digital democracy"
+description: >-
+  From pelicans on bicycles to Querido Diário, vTaiwan, and Polis — a personal queue of 35 videos across AI engineering, govtech, and participatory infrastructure.
+date: "2026-05-24"
+lang: en
+translationKey: video-queue-ai-civictech-2026-05
+tags:
+  - ai
+  - civic-tech
+  - govtech
+  - agents
+  - video-queue
+draft: false
+emoji: 📺
+---
+
+These are the talks I'm planning to watch. Not a retrospective, not a recommendation post — just a snapshot of what's sitting in my queue this weekend, annotated enough that I'll remember why I put them there.
+
+Two clusters. The first is software engineering and AI, mostly conferences from 2025. The second is civic tech and govtech, which I've been calling "civil tech" but probably should not — the field has a name and the name is **civic tech**.
+
+---
+
+## Software engineering & AI
+
+The AI engineering cluster runs from very practical (how to build reliable agents) to philosophical (what are we actually doing here). Dex Horthy appears twice because his 12-factor agents framing keeps coming up in conversations and I want to read the source, not the second-hand summaries.
+
+| # | Talk |
+|--:|------|
+| 1 | [2025 in LLMs so far, illustrated by Pelicans on Bicycles — Simon Willison](https://www.youtube.com/watch?v=YpY83-kA7Bo) |
+| 2 | [Software engineering with GenAI — Gergely Orosz / LeadDev LDX3 2025](https://www.youtube.com/watch?v=S6hIHPudbYw) |
+| 3 | [How We Build Effective Agents — Barry Zhang, Anthropic](https://www.youtube.com/watch?v=D7_ipDqhtwk) |
+| 4 | [Don't Build Agents, Build Skills Instead — Barry Zhang & Mahesh Murag, Anthropic](https://www.youtube.com/watch?v=CEvIs9y1uog) |
+| 5 | [12-Factor Agents: Patterns of reliable LLM applications — Dex Horthy](https://www.youtube.com/watch?v=8kMaTybvDUw) |
+| 6 | [Building and evaluating AI Agents — Sayash Kapoor](https://www.youtube.com/watch?v=d5EltXhbcfA) |
+| 7 | [Claude Code & the evolution of agentic coding — Boris Cherny](https://www.youtube.com/watch?v=Lue8K2jqfKk) |
+| 8 | [No Vibes Allowed: Solving Hard Problems in Complex Codebases — Dex Horthy](https://www.youtube.com/watch?v=rmvDxxNubIg) |
+| 9 | [Will AI outsmart human intelligence? — Geoffrey Hinton, Royal Institution](https://www.youtube.com/watch?v=IkdziSLYzHw) |
+| 10 | [Mathematics: The rise of the machines — Yang-Hui He](https://www.youtube.com/watch?v=oOYcPkBaotg) |
+| 11 | [The New Code — Sean Grove, OpenAI](https://www.youtube.com/watch?v=8rABwKRsec4) |
+| 12 | [MCP is all you need — Samuel Colvin, Pydantic](https://www.youtube.com/watch?v=bmWZk9vTze0) |
+| 13 | [2026: The Year The IDE Died — Steve Yegge & Gene Kim](https://www.youtube.com/watch?v=7Dtu2bilcFs) |
+| 14 | [AI without the BS, for humans — Scott Hanselman, NDC London 2025](https://www.youtube.com/watch?v=kYUicaho5k8) |
+| 15 | [Keynote Speaker — Cory Doctorow, PyCon US](https://www.youtube.com/watch?v=ydVmzg_SJLw) |
+| 16 | [Vite Beyond a Build Tool — Evan You, ViteConf 2025](https://www.youtube.com/watch?v=x7Jsmt_o9ek) |
+| 17 | [You Don't Know Git — Edward Thomson, NDC London 2025](https://www.youtube.com/watch?v=DZI0Zl-1JqQ) |
+| 18 | [Decoding the secrets of life with AI — Mikhail Burtsev](https://www.youtube.com/watch?v=l28WCnZXNNg) |
+| 19 | [The Battle of Khasham — The Operations Room](https://www.youtube.com/watch?v=T6Ii45jxsLE) |
+| 20 | [New CSS features to know for 2025 — Kevin Powell](https://www.youtube.com/watch?v=jSCgZqoebsM) |
+
+---
+
+## Civic tech / govtech
+
+This is the cluster I'm more interested in right now. I work in public administration in Rondônia and I've been thinking about what it would take for accountability data to actually reach the people who should be reading it. The Brazilian videos are where I start. The international ones are where I go for mental models that Brazil hasn't built yet.
+
+### Brazil
+
+**[Querido Diário: hoje eu tornei um Diário Oficial acessível para todo mundo](https://www.youtube.com/watch?v=eBGAg45oMpM)** — entry point to the project: municipal official gazettes made searchable and usable. This is the [Open Knowledge Brasil](https://docs.queridodiario.ok.org.br/) project for extracting and centralizing official municipal gazette data with a public API.
+
+**[Navegando na API do Querido Diário](https://www.youtube.com/watch?v=vgrqw2HLFJY)** — the more useful one if I actually want to build something on top of the data.
+
+**[Navegando no site do Querido Diário](https://www.youtube.com/watch?v=Qk5oQ9g1iX8)** — less technical, good for seeing the public-facing UX before diving into the API.
+
+**[Brasil.IO: Dados abertos para mais democracia — Álvaro Justen](https://www.youtube.com/watch?v=1FEYQBmyk2Y)** — [Brasil.IO](https://brasil.io/) is a repository of Brazilian public data in accessible formats. A classic of Brazilian open-data infrastructure.
+
+**[Ativismo digital e tecnologia cívica — Operação Serenata de Amor](https://m.youtube.com/watch?v=3N_qRFyhZs8)** — older, but important. [Serenata de Amor / Rosie](https://serenata.ai/) used AI to analyze reimbursed parliamentary spending under CEAP and flag suspicious cases. One of the canonical Brazilian civic-tech stories.
+
+**DadosJusBr** — I'm following the project more than looking for a single video. Highly relevant: structured remuneration and transparency data for the Judiciary and Ministério Público. The kind of thing that should be standard and isn't.
+
+### Abroad
+
+**[AI Studio: Solving government's PDF problem with AI — Code for America Summit 2025](https://www.youtube.com/watch?v=Aw9GRtY_4Cg)** — PDFs as the graveyard of public information. Relevant everywhere, but especially in Brazilian public administration where the PDF is load-bearing infrastructure.
+
+**[Putting policy to work: Guiding AI use inside government — Code for America Summit 2025](https://www.youtube.com/watch?v=eUSKDtAXo_A)** — procurement, guardrails, implementation. The better civic-tech version of "AI in government," without the demo magic.
+
+**[How Summer EBT is delivering on a new promise for families — Code for America Summit 2025](https://www.youtube.com/watch?v=BR8Im8YMEUg)** — concrete benefits-delivery civic tech. [GetCalFresh](https://codeforamerica.org/success-stories/simplifying-californias-online-application-for-food-benefits/) helped 6.2 million people get food benefits from 2017–2025. That is the unit of measurement I want to be using.
+
+**[vTaiwan: new experiments in digital democracy](https://www.youtube.com/watch?v=qkXxcwUkdyw)** — Taiwan is probably the world's most interesting case for civic tech that actually touched governance. The [g0v](https://g0v.tw/intl/en/) ecosystem is decentralized, transparent, and has shipped things that worked.
+
+**[How digital democracy can heal polarisation — Audrey Tang](https://www.youtube.com/watch?v=lzmYVYHVXp4)** — the philosophical version: not just better forms, but different institutional affordances.
+
+**[Decidim secret sauce: Building an international community](https://www.youtube.com/watch?v=6ImrcgD0OR0)** — [Decidim](https://decidim.org/) is a free/open platform for citizen participation. Infrastructure for participatory processes and assemblies.
+
+**[Scaling Deliberation: Polis and the Computational Democracy Project](https://www.youtube.com/watch?v=b4j_2JDh_Rc)** — one of the most interesting "AI + democracy" lines: [Polis](https://compdemocracy.org/) tries to find consensus structure rather than maximize engagement. Opposite of social media.
+
+**[The Department of Government Improvement: Civic Tech and Why It Matters](https://www.youtube.com/watch?v=QXmlEDvq48Y)** — 18F/USDS framing: government improvement as craft, not ideology.
+
+**[2025 State of Digital Public Infrastructure Report Launch](https://www.youtube.com/watch?v=YmBpHGmZC9g)** — the broader "digital public infrastructure" frame: identity, payments, data exchange, public rails. The [Digital Public Goods Alliance](https://digitalpublicgoods.net/) framing is useful here.
+
+---
+
+## Watch order I'm following
+
+The civic tech sequence matters more than the AI one, so I'm starting there:
+
+1. **Querido Diário API** — Brazilian data liberation, close to home
+2. **Brasil.IO: Dados abertos para mais democracia** — the infrastructure that makes the data usable
+3. **AI Studio: government's PDF problem** — where AI meets public administration concretely
+4. **Summer EBT / GetCalFresh** — benefits delivery as the unit of real civic-tech success
+5. **vTaiwan** — the most complete case study of civic tech that actually changed governance
+6. **Polis / Computational Democracy** — the mathematical infrastructure for deliberation at scale
+7. **Decidim** — the platform layer for participatory processes
+
+That sequence moves from **Brazilian data liberation** → **public-service delivery** → **deliberative and democratic infrastructure**. It ends at questions I don't know how to answer yet, which is usually a sign the queue is worth the time.


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- New post `2026-05-24-video-queue-ai-civictech.mdx` with 35 curated videos split into two clusters
- **Software/AI engineering** (20 talks): agents, LLMs, MCP, git, CSS — from Simon Willison, Gergely Orosz, Anthropic, Dex Horthy, Geoffrey Hinton, and others
- **Civic tech / govtech** (15 talks): Brazilian open-data projects (Querido Diário, Brasil.IO, Serenata de Amor) and international cases (vTaiwan, Polis, Decidim, Code for America, Digital Public Goods)
- Includes a recommended watch order moving from Brazilian data liberation → public-service delivery → deliberative infrastructure

## Test plan

- [ ] Build passes with no schema errors
- [ ] Post appears in blog listing with correct date and tags
- [ ] All YouTube links are valid (copied from source)
- [ ] `translationKey` is unique across the blog

https://claude.ai/code/session_01116vdjanEsKetF8GdBHALP
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01116vdjanEsKetF8GdBHALP)_