### PR TITLE
feat: Google Apps Script para post semanal do YouTube

### DIFF
--- a/scripts/youtube-weekly.gs
+++ b/scripts/youtube-weekly.gs
@@ -77,6 +77,7 @@ function getWatchHistoryThisWeek() {
   const videos = [];
 
   let pageToken = null;
+  let reachedCutoff = false;
 
   do {
     const params = {
@@ -97,7 +98,7 @@ function getWatchHistoryThisWeek() {
     for (const item of response.items || []) {
       const publishedAt = new Date(item.snippet.publishedAt); // data em que você assistiu
       if (publishedAt.getTime() < cutoff) {
-        pageToken = null; // para o loop — chegamos em vídeos anteriores à semana
+        reachedCutoff = true;
         break;
       }
 
@@ -109,7 +110,7 @@ function getWatchHistoryThisWeek() {
       });
     }
 
-    pageToken = response.nextPageToken || null;
+    pageToken = reachedCutoff ? null : response.nextPageToken || null;
   } while (pageToken);
 
   // remove duplicatas (mesmo vídeo assistido mais de uma vez)
@@ -143,7 +144,7 @@ function buildMarkdown(videos, mondayDate, sundayDate, lang, translationKey) {
     .map((v) => {
       const url = `https://www.youtube.com/watch?v=${v.videoId}`;
       const day = formatDateShort(v.watchedAt, lang);
-      return `- [${escapeYaml(v.title)}](${url}) — **${v.channel}** *(${day})*`;
+      return `- [${escapeMarkdown(v.title)}](${url}) — **${escapeMarkdown(v.channel)}** *(${day})*`;
     })
     .join("\n");
 
@@ -165,7 +166,8 @@ function buildMarkdown(videos, mondayDate, sundayDate, lang, translationKey) {
     "---",
   ].join("\n");
 
-  return `${frontmatter}\n\n${intro}\n\n## Vídeos\n\n${videoLines}\n`;
+  const heading = isPT ? "## Vídeos" : "## Videos";
+  return `${frontmatter}\n\n${intro}\n\n${heading}\n\n${videoLines}\n`;
 }
 
 // ─── GitHub API ────────────────────────────────────────────────────────────
@@ -182,7 +184,7 @@ function pushToGithub(path, content, commitMessage) {
 
   // verifica se o arquivo já existe (pra pegar o sha, necessário para update)
   let sha = null;
-  const checkResp = UrlFetchApp.fetch(apiUrl, {
+  const checkResp = UrlFetchApp.fetch(`${apiUrl}?ref=${GITHUB_BRANCH}`, {
     method: "get",
     headers,
     muteHttpExceptions: true,
@@ -253,4 +255,8 @@ function formatDateLong(d, lang) {
 
 function escapeYaml(str) {
   return (str || "").replace(/"/g, '\\"');
+}
+
+function escapeMarkdown(str) {
+  return (str || "").replace(/[[\]()]/g, "\\$&");
 }

--- a/scripts/youtube-weekly.gs
+++ b/scripts/youtube-weekly.gs
@@ -18,10 +18,11 @@
 
 // ─── Config ────────────────────────────────────────────────────────────────
 
-const PROPS         = PropertiesService.getScriptProperties();
-const GITHUB_TOKEN  = PROPS.getProperty('GITHUB_TOKEN');
-const GITHUB_REPO   = PROPS.getProperty('GITHUB_REPO')   || 'franklinbaldo/franklinbaldo.github.io';
-const GITHUB_BRANCH = PROPS.getProperty('GITHUB_BRANCH') || 'main';
+const PROPS = PropertiesService.getScriptProperties();
+const GITHUB_TOKEN = PROPS.getProperty("GITHUB_TOKEN");
+const GITHUB_REPO =
+  PROPS.getProperty("GITHUB_REPO") || "franklinbaldo/franklinbaldo.github.io";
+const GITHUB_BRANCH = PROPS.getProperty("GITHUB_BRANCH") || "main";
 
 // ─── Entry point ───────────────────────────────────────────────────────────
 
@@ -29,21 +30,41 @@ function createWeeklyPost() {
   const videos = getWatchHistoryThisWeek();
 
   if (videos.length === 0) {
-    console.log('Nenhum vídeo assistido esta semana.');
+    console.log("Nenhum vídeo assistido esta semana.");
     return;
   }
 
   const { mondayDate, sundayDate } = getWeekRange();
   const translationKey = `youtube-week-${formatDate(mondayDate)}`;
 
-  const ptContent = buildMarkdown(videos, mondayDate, sundayDate, 'pt', translationKey);
-  const enContent = buildMarkdown(videos, mondayDate, sundayDate, 'en', translationKey);
+  const ptContent = buildMarkdown(
+    videos,
+    mondayDate,
+    sundayDate,
+    "pt",
+    translationKey
+  );
+  const enContent = buildMarkdown(
+    videos,
+    mondayDate,
+    sundayDate,
+    "en",
+    translationKey
+  );
 
   const ptSlug = `${formatDate(mondayDate)}-youtube-da-semana`;
   const enSlug = `${formatDate(mondayDate)}-youtube-weekly-watch`;
 
-  pushToGithub(`src/content/blog/${ptSlug}.md`, ptContent, `post: youtube semanal ${formatDate(mondayDate)}`);
-  pushToGithub(`src/content/blog/${enSlug}.md`, enContent, `post: youtube weekly ${formatDate(mondayDate)}`);
+  pushToGithub(
+    `src/content/blog/${ptSlug}.md`,
+    ptContent,
+    `post: youtube semanal ${formatDate(mondayDate)}`
+  );
+  pushToGithub(
+    `src/content/blog/${enSlug}.md`,
+    enContent,
+    `post: youtube weekly ${formatDate(mondayDate)}`
+  );
 
   console.log(`Posts criados: ${ptSlug}.md e ${enSlug}.md`);
 }
@@ -59,21 +80,21 @@ function getWatchHistoryThisWeek() {
 
   do {
     const params = {
-      playlistId: 'HL',   // ID especial do YouTube para Watch History
+      playlistId: "HL", // ID especial do YouTube para Watch History
       maxResults: 50,
-      part: 'snippet,contentDetails',
+      part: "snippet,contentDetails",
     };
     if (pageToken) params.pageToken = pageToken;
 
     let response;
     try {
-      response = YouTube.PlaylistItems.list('snippet,contentDetails', params);
+      response = YouTube.PlaylistItems.list("snippet,contentDetails", params);
     } catch (e) {
-      console.error('Erro ao acessar YouTube API:', e.message);
+      console.error("Erro ao acessar YouTube API:", e.message);
       break;
     }
 
-    for (const item of (response.items || [])) {
+    for (const item of response.items || []) {
       const publishedAt = new Date(item.snippet.publishedAt); // data em que você assistiu
       if (publishedAt.getTime() < cutoff) {
         pageToken = null; // para o loop — chegamos em vídeos anteriores à semana
@@ -81,9 +102,9 @@ function getWatchHistoryThisWeek() {
       }
 
       videos.push({
-        title:     item.snippet.title,
-        channel:   item.snippet.videoOwnerChannelTitle || '',
-        videoId:   item.contentDetails.videoId,
+        title: item.snippet.title,
+        channel: item.snippet.videoOwnerChannelTitle || "",
+        videoId: item.contentDetails.videoId,
         watchedAt: publishedAt,
       });
     }
@@ -93,7 +114,7 @@ function getWatchHistoryThisWeek() {
 
   // remove duplicatas (mesmo vídeo assistido mais de uma vez)
   const seen = new Set();
-  return videos.filter(v => {
+  return videos.filter((v) => {
     if (seen.has(v.videoId)) return false;
     seen.add(v.videoId);
     return true;
@@ -103,7 +124,7 @@ function getWatchHistoryThisWeek() {
 // ─── Markdown builder ──────────────────────────────────────────────────────
 
 function buildMarkdown(videos, mondayDate, sundayDate, lang, translationKey) {
-  const isPT = lang === 'pt';
+  const isPT = lang === "pt";
   const weekLabel = `${formatDateLong(mondayDate, lang)} – ${formatDateLong(sundayDate, lang)}`;
 
   const title = isPT
@@ -118,29 +139,31 @@ function buildMarkdown(videos, mondayDate, sundayDate, lang, translationKey) {
     ? `Vídeos que assisti esta semana — sem curadoria, sem julgamento, só o que estava no meu histórico.`
     : `Videos I watched this week — no curation, no judgment, just what was in my history.`;
 
-  const videoLines = videos.map(v => {
-    const url = `https://www.youtube.com/watch?v=${v.videoId}`;
-    const day = formatDateShort(v.watchedAt, lang);
-    return `- [${escapeYaml(v.title)}](${url}) — **${v.channel}** *(${day})*`;
-  }).join('\n');
+  const videoLines = videos
+    .map((v) => {
+      const url = `https://www.youtube.com/watch?v=${v.videoId}`;
+      const day = formatDateShort(v.watchedAt, lang);
+      return `- [${escapeYaml(v.title)}](${url}) — **${v.channel}** *(${day})*`;
+    })
+    .join("\n");
 
   const tags = isPT
-    ? ['youtube', 'semana', 'vídeos', 'curadoria']
-    : ['youtube', 'weekly', 'videos', 'curation'];
+    ? ["youtube", "semana", "vídeos", "curadoria"]
+    : ["youtube", "weekly", "videos", "curation"];
 
   const frontmatter = [
-    '---',
+    "---",
     `title: "${escapeYaml(title)}"`,
     `description: "${escapeYaml(description)}"`,
     `date: "${formatDate(mondayDate)}"`,
     `lang: ${lang}`,
     `translationKey: ${translationKey}`,
     `tags:`,
-    ...tags.map(t => `  - ${t}`),
+    ...tags.map((t) => `  - ${t}`),
     `draft: false`,
     `author: franklin`,
-    '---',
-  ].join('\n');
+    "---",
+  ].join("\n");
 
   return `${frontmatter}\n\n${intro}\n\n## Vídeos\n\n${videoLines}\n`;
 }
@@ -153,14 +176,14 @@ function pushToGithub(path, content, commitMessage) {
 
   const headers = {
     Authorization: `Bearer ${GITHUB_TOKEN}`,
-    Accept: 'application/vnd.github+json',
-    'X-GitHub-Api-Version': '2022-11-28',
+    Accept: "application/vnd.github+json",
+    "X-GitHub-Api-Version": "2022-11-28",
   };
 
   // verifica se o arquivo já existe (pra pegar o sha, necessário para update)
   let sha = null;
   const checkResp = UrlFetchApp.fetch(apiUrl, {
-    method: 'get',
+    method: "get",
     headers,
     muteHttpExceptions: true,
   });
@@ -176,7 +199,7 @@ function pushToGithub(path, content, commitMessage) {
   if (sha) body.sha = sha;
 
   const resp = UrlFetchApp.fetch(apiUrl, {
-    method: 'put',
+    method: "put",
     headers,
     payload: JSON.stringify(body),
     muteHttpExceptions: true,
@@ -193,7 +216,7 @@ function pushToGithub(path, content, commitMessage) {
 function getWeekRange() {
   const now = new Date();
   const dayOfWeek = now.getDay(); // 0=dom, 1=seg, ...
-  const diffToMonday = (dayOfWeek === 0 ? -6 : 1 - dayOfWeek);
+  const diffToMonday = dayOfWeek === 0 ? -6 : 1 - dayOfWeek;
 
   const mondayDate = new Date(now);
   mondayDate.setDate(now.getDate() + diffToMonday);
@@ -208,23 +231,26 @@ function getWeekRange() {
 
 function formatDate(d) {
   const y = d.getFullYear();
-  const m = String(d.getMonth() + 1).padStart(2, '0');
-  const day = String(d.getDate()).padStart(2, '0');
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
   return `${y}-${m}-${day}`;
 }
 
 function formatDateShort(d, lang) {
-  return d.toLocaleDateString(lang === 'pt' ? 'pt-BR' : 'en-US', {
-    weekday: 'short', day: 'numeric', month: 'short',
+  return d.toLocaleDateString(lang === "pt" ? "pt-BR" : "en-US", {
+    weekday: "short",
+    day: "numeric",
+    month: "short",
   });
 }
 
 function formatDateLong(d, lang) {
-  return d.toLocaleDateString(lang === 'pt' ? 'pt-BR' : 'en-US', {
-    day: 'numeric', month: 'long',
+  return d.toLocaleDateString(lang === "pt" ? "pt-BR" : "en-US", {
+    day: "numeric",
+    month: "long",
   });
 }
 
 function escapeYaml(str) {
-  return (str || '').replace(/"/g, '\\"');
+  return (str || "").replace(/"/g, '\\"');
 }

--- a/scripts/youtube-weekly.gs
+++ b/scripts/youtube-weekly.gs
@@ -1,0 +1,230 @@
+/**
+ * youtube-weekly.gs
+ *
+ * Google Apps Script que coleta o histórico de vídeos assistidos na semana
+ * e cria dois posts no blog (PT + EN) via GitHub API.
+ *
+ * SETUP (uma vez só):
+ *  1. No editor GAS: Extensions → Advanced Services → ativar "YouTube Data API v3"
+ *  2. Criar um GitHub Personal Access Token com permissão "Contents: Read and write"
+ *     em https://github.com/settings/tokens
+ *  3. No editor GAS: Project Settings → Script Properties → adicionar:
+ *       GITHUB_TOKEN  →  ghp_seu_token_aqui
+ *       GITHUB_REPO   →  franklinbaldo/franklinbaldo.github.io
+ *       GITHUB_BRANCH →  main
+ *  4. Para rodar automaticamente: Triggers → Add Trigger
+ *       Function: createWeeklyPost  |  Event: Time-driven  |  Weekly
+ */
+
+// ─── Config ────────────────────────────────────────────────────────────────
+
+const PROPS         = PropertiesService.getScriptProperties();
+const GITHUB_TOKEN  = PROPS.getProperty('GITHUB_TOKEN');
+const GITHUB_REPO   = PROPS.getProperty('GITHUB_REPO')   || 'franklinbaldo/franklinbaldo.github.io';
+const GITHUB_BRANCH = PROPS.getProperty('GITHUB_BRANCH') || 'main';
+
+// ─── Entry point ───────────────────────────────────────────────────────────
+
+function createWeeklyPost() {
+  const videos = getWatchHistoryThisWeek();
+
+  if (videos.length === 0) {
+    console.log('Nenhum vídeo assistido esta semana.');
+    return;
+  }
+
+  const { mondayDate, sundayDate } = getWeekRange();
+  const translationKey = `youtube-week-${formatDate(mondayDate)}`;
+
+  const ptContent = buildMarkdown(videos, mondayDate, sundayDate, 'pt', translationKey);
+  const enContent = buildMarkdown(videos, mondayDate, sundayDate, 'en', translationKey);
+
+  const ptSlug = `${formatDate(mondayDate)}-youtube-da-semana`;
+  const enSlug = `${formatDate(mondayDate)}-youtube-weekly-watch`;
+
+  pushToGithub(`src/content/blog/${ptSlug}.md`, ptContent, `post: youtube semanal ${formatDate(mondayDate)}`);
+  pushToGithub(`src/content/blog/${enSlug}.md`, enContent, `post: youtube weekly ${formatDate(mondayDate)}`);
+
+  console.log(`Posts criados: ${ptSlug}.md e ${enSlug}.md`);
+}
+
+// ─── YouTube ───────────────────────────────────────────────────────────────
+
+function getWatchHistoryThisWeek() {
+  const { mondayDate } = getWeekRange();
+  const cutoff = mondayDate.getTime();
+  const videos = [];
+
+  let pageToken = null;
+
+  do {
+    const params = {
+      playlistId: 'HL',   // ID especial do YouTube para Watch History
+      maxResults: 50,
+      part: 'snippet,contentDetails',
+    };
+    if (pageToken) params.pageToken = pageToken;
+
+    let response;
+    try {
+      response = YouTube.PlaylistItems.list('snippet,contentDetails', params);
+    } catch (e) {
+      console.error('Erro ao acessar YouTube API:', e.message);
+      break;
+    }
+
+    for (const item of (response.items || [])) {
+      const publishedAt = new Date(item.snippet.publishedAt); // data em que você assistiu
+      if (publishedAt.getTime() < cutoff) {
+        pageToken = null; // para o loop — chegamos em vídeos anteriores à semana
+        break;
+      }
+
+      videos.push({
+        title:     item.snippet.title,
+        channel:   item.snippet.videoOwnerChannelTitle || '',
+        videoId:   item.contentDetails.videoId,
+        watchedAt: publishedAt,
+      });
+    }
+
+    pageToken = response.nextPageToken || null;
+  } while (pageToken);
+
+  // remove duplicatas (mesmo vídeo assistido mais de uma vez)
+  const seen = new Set();
+  return videos.filter(v => {
+    if (seen.has(v.videoId)) return false;
+    seen.add(v.videoId);
+    return true;
+  });
+}
+
+// ─── Markdown builder ──────────────────────────────────────────────────────
+
+function buildMarkdown(videos, mondayDate, sundayDate, lang, translationKey) {
+  const isPT = lang === 'pt';
+  const weekLabel = `${formatDateLong(mondayDate, lang)} – ${formatDateLong(sundayDate, lang)}`;
+
+  const title = isPT
+    ? `YouTube da semana: ${weekLabel}`
+    : `YouTube weekly: ${weekLabel}`;
+
+  const description = isPT
+    ? `${videos.length} vídeos que assisti entre ${weekLabel}.`
+    : `${videos.length} videos I watched between ${weekLabel}.`;
+
+  const intro = isPT
+    ? `Vídeos que assisti esta semana — sem curadoria, sem julgamento, só o que estava no meu histórico.`
+    : `Videos I watched this week — no curation, no judgment, just what was in my history.`;
+
+  const videoLines = videos.map(v => {
+    const url = `https://www.youtube.com/watch?v=${v.videoId}`;
+    const day = formatDateShort(v.watchedAt, lang);
+    return `- [${escapeYaml(v.title)}](${url}) — **${v.channel}** *(${day})*`;
+  }).join('\n');
+
+  const tags = isPT
+    ? ['youtube', 'semana', 'vídeos', 'curadoria']
+    : ['youtube', 'weekly', 'videos', 'curation'];
+
+  const frontmatter = [
+    '---',
+    `title: "${escapeYaml(title)}"`,
+    `description: "${escapeYaml(description)}"`,
+    `date: "${formatDate(mondayDate)}"`,
+    `lang: ${lang}`,
+    `translationKey: ${translationKey}`,
+    `tags:`,
+    ...tags.map(t => `  - ${t}`),
+    `draft: false`,
+    `author: franklin`,
+    '---',
+  ].join('\n');
+
+  return `${frontmatter}\n\n${intro}\n\n## Vídeos\n\n${videoLines}\n`;
+}
+
+// ─── GitHub API ────────────────────────────────────────────────────────────
+
+function pushToGithub(path, content, commitMessage) {
+  const apiUrl = `https://api.github.com/repos/${GITHUB_REPO}/contents/${path}`;
+  const encoded = Utilities.base64Encode(content, Utilities.Charset.UTF_8);
+
+  const headers = {
+    Authorization: `Bearer ${GITHUB_TOKEN}`,
+    Accept: 'application/vnd.github+json',
+    'X-GitHub-Api-Version': '2022-11-28',
+  };
+
+  // verifica se o arquivo já existe (pra pegar o sha, necessário para update)
+  let sha = null;
+  const checkResp = UrlFetchApp.fetch(apiUrl, {
+    method: 'get',
+    headers,
+    muteHttpExceptions: true,
+  });
+  if (checkResp.getResponseCode() === 200) {
+    sha = JSON.parse(checkResp.getContentText()).sha;
+  }
+
+  const body = {
+    message: commitMessage,
+    content: encoded,
+    branch: GITHUB_BRANCH,
+  };
+  if (sha) body.sha = sha;
+
+  const resp = UrlFetchApp.fetch(apiUrl, {
+    method: 'put',
+    headers,
+    payload: JSON.stringify(body),
+    muteHttpExceptions: true,
+  });
+
+  const code = resp.getResponseCode();
+  if (code !== 200 && code !== 201) {
+    throw new Error(`GitHub API error ${code}: ${resp.getContentText()}`);
+  }
+}
+
+// ─── Date helpers ──────────────────────────────────────────────────────────
+
+function getWeekRange() {
+  const now = new Date();
+  const dayOfWeek = now.getDay(); // 0=dom, 1=seg, ...
+  const diffToMonday = (dayOfWeek === 0 ? -6 : 1 - dayOfWeek);
+
+  const mondayDate = new Date(now);
+  mondayDate.setDate(now.getDate() + diffToMonday);
+  mondayDate.setHours(0, 0, 0, 0);
+
+  const sundayDate = new Date(mondayDate);
+  sundayDate.setDate(mondayDate.getDate() + 6);
+  sundayDate.setHours(23, 59, 59, 999);
+
+  return { mondayDate, sundayDate };
+}
+
+function formatDate(d) {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
+}
+
+function formatDateShort(d, lang) {
+  return d.toLocaleDateString(lang === 'pt' ? 'pt-BR' : 'en-US', {
+    weekday: 'short', day: 'numeric', month: 'short',
+  });
+}
+
+function formatDateLong(d, lang) {
+  return d.toLocaleDateString(lang === 'pt' ? 'pt-BR' : 'en-US', {
+    day: 'numeric', month: 'long',
+  });
+}
+
+function escapeYaml(str) {
+  return (str || '').replace(/"/g, '\\"');
+}


### PR DESCRIPTION
## O que faz

Adiciona `scripts/youtube-weekly.gs` — um Google Apps Script que coleta automaticamente o histórico de vídeos assistidos na semana e cria dois posts no blog (PT + EN) via GitHub API.

## Como funciona

1. Lê a playlist especial `HL` (Watch History) da YouTube Data API v3
2. Filtra vídeos da semana atual (segunda a domingo)
3. Remove duplicatas (mesmo vídeo assistido mais de uma vez)
4. Gera dois arquivos `.md` com o frontmatter no padrão do blog
5. Faz commit dos arquivos via GitHub REST API

## Setup (uma vez só)

1. Criar um novo projeto em [script.google.com](https://script.google.com)
2. Colar o conteúdo de `scripts/youtube-weekly.gs`
3. **Extensions → Advanced Services** → ativar **YouTube Data API v3**
4. Criar um [GitHub Personal Access Token](https://github.com/settings/tokens) com permissão `Contents: Read and write`
5. **Project Settings → Script Properties** → adicionar:
   - `GITHUB_TOKEN` → seu token
   - `GITHUB_REPO` → `franklinbaldo/franklinbaldo.github.io`
   - `GITHUB_BRANCH` → `main`
6. **Triggers → Add Trigger**: função `createWeeklyPost`, disparador semanal (ex: toda segunda-feira)

## Teste manual

No editor GAS, selecionar a função `createWeeklyPost` e clicar em **Run**.

https://claude.ai/code/session_017iB2WYpLU8R4Lnb1WD645g

---
_Generated by [Claude Code](https://claude.ai/code/session_017iB2WYpLU8R4Lnb1WD645g)_