### PR TITLE
Add retrospective post march-may 2026 + takeout session log

### DIFF
--- a/.routines/takeout/20260526_retrospectiva-marco-maio.md
+++ b/.routines/takeout/20260526_retrospectiva-marco-maio.md
@@ -1,0 +1,94 @@
+---
+date: 2026-05-26
+slug: retrospectiva-marco-maio
+session: takeout-analysis
+status: done
+---
+
+# Sessão 2026-05-26 — Análise do Google Takeout + retrospectiva março-maio 2026
+
+## Objetivo
+
+Usar os arquivos do Google Takeout no Google Drive para escrever um post contextualizado sobre os últimos dois meses.
+
+## Arquivos encontrados no Google Drive
+
+Pasta: `Takeout` (criada em 2026-05-24)
+
+| Arquivo | Tamanho | ID Drive |
+|---|---|---|
+| takeout-20260524T140450Z-001.zip | 187 KB | `1XKQxavIMvf7s91KpSwefe50DrAdQyhsv` |
+| takeout-20260524T151400Z-001.zip | 236 KB | `16e9KElZQXrOev0JyE3-unTDtW7f9ff9u` |
+| takeout-20260524T140451Z-6-001.zip | ~181 MB | `1RGE9oWM0MAEGvq1JrWTMtjnSjFGlgsrl` |
+| takeout-20260524T151400Z-6-001.zip | ~186 MB | `1p7q2BJ5abtNNJ3rq0ob1QIha5t9KSF2a` |
+| takeout-20260524T151400Z-4-001.zip | ~1.9 GB | `1AcitlBmVUxIxLFPMR92t5qsYsD5fPjzq` |
+| takeout-20260524T140451Z-4-001.zip | ~1.8 GB | `1ukVYv_eLG5BhlheJFWKfUuF2zUViXfsR` |
+| takeout-20260524T151400Z-4-002.zip | ~796 MB | `1MopQKpjXiAyeEFLghQVmAfztuC8YHZR9` |
+| takeout-20260524T140451Z-4-002.zip | ~927 MB | `1Oo7h4OGr6CIc0mWYlWbaJMHqeO5KS2EP` |
+
+**Total do export**: 4.83 GB (7 produtos do Google)
+
+## O que foi analisado
+
+Os dois arquivos pequenos (`001.zip`) foram baixados e extraídos. Ambos continham apenas `Takeout/archive_browser.html` — o índice completo do export com listagem de todos os arquivos, mas sem os dados em si. Os dados reais estão nos arquivos maiores.
+
+## Limitação crítica
+
+Os dados de atividade de **dezembro 2025 – março 2026** têm uma lacuna no Google Fit (provavelmente mudança de dispositivo). Métricas diárias de **abril-maio 2026** existem mas estão nos arquivos maiores (~GB) que não foram baixados nesta sessão.
+
+O post foi escrito com os dados disponíveis: padrões de 2025 como referência, cruzados com os posts publicados no blog em março-maio 2026.
+
+## Produtos mapeados pelo archive_browser.html
+
+| Produto | Arquivos | Tamanho |
+|---|---|---|
+| Google Fit | 19.393 | 2,03 GB |
+| Google Play Livros | 63 | 56,9 MB |
+| YouTube e YouTube Music | 101 | 2,74 GB |
+| Google Maps Timeline | 1 (apenas Settings.json) | < 1 MB |
+| Google Play Filmes e TV | 5 | < 1 MB |
+| Fitbit | 0 | — |
+| Google Podcasts | 0 | — |
+
+## Principais achados
+
+### Google Fit (dados até set/2025, depois lacuna até abr/2026)
+
+- Ciclismo: 12 sessões (mar/2025) → 18 (abr) → 24 (mai) — maior frequência sustentada em 11 anos de dados
+- Academia/strength training: iniciada em fev/2025, encerrada em mar/2025, substituída pelo ciclismo
+- Padrão de pedaladas: sessões vespertinas (16h-19h), mais longas conforme o mês avança
+- Máxima registrada: 87 minutos (mai/2025)
+- Cluster de atividade: 28/fev–2/mar corresponde ao Carnaval 2025
+
+### Google Play Livros (63 arquivos)
+
+- 13 obras de Saramago (cobertura quase completa da obra)
+- 4 obras de Borges (Collected Fictions, O Aleph, La biblioteca de Babel, Fiction Complete)
+- The Anxious Generation (Haidt) em PT e EN
+- The Precipice (Toby Ord), Gödel Escher Bach, The Three-Body Problem
+- Positive Discipline (parenting)
+- Livros infantis: Alice, Rapunzel, Bela Adormecida, etc.
+
+### YouTube (4 perfis supervisionados)
+
+Filhos com perfis ativos: Alice, Gustavo, Sofia, Vicente — cada um com histórico de busca e assinaturas separadas.
+
+### Google Maps Timeline
+
+Apenas `Settings.json` exportado. Histórico de localização armazenado on-device (E2E encrypted) — não disponível no Takeout.
+
+## Fontes cruzadas com o repositório
+
+Foram encontrados 25+ posts publicados entre março e maio de 2026:
+
+- **Março**: Travessia (2026-03-02), Travessia Update + Rosencrantz Coin (17/03), Verne Identity Repo (18/03), Lobsters + Intelligible Void (21/03), Reddit OSINT + O Pai do Futuro (22/03), Delegando para Agentes (28/03), Alfarrábios do Adi (30/03)
+- **Abril**: Hermes vs OpenClaw (04/04), Reclaiming the Harness (29/04)
+- **Maio**: The Third Half (01/05), Three Imperatives at Delphi (04/05), Jules API + Ovo de Serpente (10/05), Pierre Menard + Agent that Doesn't Invent Verbs (14/05), Three Hammers + Who the Asterisk Protects (15/05), Two Questions Out Loud (17/05), Suno Borges Caipira (20/05), Manifold 495 dias (21/05), GitHub Tour (22/05), Searching FranklinBaldo (23/05), Video Queue AI Civictech (24/05)
+
+## Arquivo criado
+
+`src/content/blog/retrospectiva-marco-maio-2026.md` — post em PT, tag `diário`, `retrospectiva`, sem heroImage.
+
+## Branch / PR
+
+Branch: `claude/relaxed-ritchie-NdgTK`

--- a/.routines/takeout/20260526_retrospectiva-marco-maio.md
+++ b/.routines/takeout/20260526_retrospectiva-marco-maio.md
@@ -9,61 +9,73 @@ status: done
 
 ## Objetivo
 
-Usar os arquivos do Google Takeout no Google Drive para escrever um post contextualizado sobre os últimos dois meses.
+Usar os arquivos do Google Takeout no Google Drive para escrever um post
+contextualizado sobre os últimos dois meses.
 
 ## Arquivos encontrados no Google Drive
 
 Pasta: `Takeout` (criada em 2026-05-24)
 
-| Arquivo | Tamanho | ID Drive |
-|---|---|---|
-| takeout-20260524T140450Z-001.zip | 187 KB | `1XKQxavIMvf7s91KpSwefe50DrAdQyhsv` |
-| takeout-20260524T151400Z-001.zip | 236 KB | `16e9KElZQXrOev0JyE3-unTDtW7f9ff9u` |
+| Arquivo                            | Tamanho | ID Drive                            |
+| ---------------------------------- | ------- | ----------------------------------- |
+| takeout-20260524T140450Z-001.zip   | 187 KB  | `1XKQxavIMvf7s91KpSwefe50DrAdQyhsv` |
+| takeout-20260524T151400Z-001.zip   | 236 KB  | `16e9KElZQXrOev0JyE3-unTDtW7f9ff9u` |
 | takeout-20260524T140451Z-6-001.zip | ~181 MB | `1RGE9oWM0MAEGvq1JrWTMtjnSjFGlgsrl` |
 | takeout-20260524T151400Z-6-001.zip | ~186 MB | `1p7q2BJ5abtNNJ3rq0ob1QIha5t9KSF2a` |
 | takeout-20260524T151400Z-4-001.zip | ~1.9 GB | `1AcitlBmVUxIxLFPMR92t5qsYsD5fPjzq` |
 | takeout-20260524T140451Z-4-001.zip | ~1.8 GB | `1ukVYv_eLG5BhlheJFWKfUuF2zUViXfsR` |
 | takeout-20260524T151400Z-4-002.zip | ~796 MB | `1MopQKpjXiAyeEFLghQVmAfztuC8YHZR9` |
-| takeout-20260524T140451Z-4-002.zip | ~927 MB | `1Oo7h4OGr6CIc0mWYlWbaJMHqeO5KS2EP` |
+| takeout-20260524T140451Z-4-002.zip | ~927 MB | `1Oo7h4OGr6CIc0mWYlWbaJMHqeO5KR2EP` |
 
 **Total do export**: 4.83 GB (7 produtos do Google)
 
 ## O que foi analisado
 
-Os dois arquivos pequenos (`001.zip`) foram baixados e extraídos. Ambos continham apenas `Takeout/archive_browser.html` — o índice completo do export com listagem de todos os arquivos, mas sem os dados em si. Os dados reais estão nos arquivos maiores.
+Os dois arquivos pequenos (`001.zip`) foram baixados e extraídos. Ambos continham
+apenas `Takeout/archive_browser.html` — o índice completo do export com listagem
+de todos os arquivos, mas sem os dados em si. Os dados reais estão nos arquivos
+maiores.
 
 ## Limitação crítica
 
-Os dados de atividade de **dezembro 2025 – março 2026** têm uma lacuna no Google Fit (provavelmente mudança de dispositivo). Métricas diárias de **abril-maio 2026** existem mas estão nos arquivos maiores (~GB) que não foram baixados nesta sessão.
+Os dados de atividade de **dezembro 2025 – março 2026** têm uma lacuna no Google
+Fit (provavelmente mudança de dispositivo). Métricas diárias de **abril-maio
+2026** existem mas estão nos arquivos maiores (~GB) que não foram baixados nesta
+sessão.
 
-O post foi escrito com os dados disponíveis: padrões de 2025 como referência, cruzados com os posts publicados no blog em março-maio 2026.
+O post foi escrito com os dados disponíveis: padrões de 2025 como referência,
+cruzados com os posts publicados no blog em março-maio 2026.
 
 ## Produtos mapeados pelo archive_browser.html
 
-| Produto | Arquivos | Tamanho |
-|---|---|---|
-| Google Fit | 19.393 | 2,03 GB |
-| Google Play Livros | 63 | 56,9 MB |
-| YouTube e YouTube Music | 101 | 2,74 GB |
-| Google Maps Timeline | 1 (apenas Settings.json) | < 1 MB |
-| Google Play Filmes e TV | 5 | < 1 MB |
-| Fitbit | 0 | — |
-| Google Podcasts | 0 | — |
+| Produto                 | Arquivos                 | Tamanho |
+| ----------------------- | ------------------------ | ------- |
+| Google Fit              | 19.393                   | 2,03 GB |
+| Google Play Livros      | 63                       | 56,9 MB |
+| YouTube e YouTube Music | 101                      | 2,74 GB |
+| Google Maps Timeline    | 1 (apenas Settings.json) | < 1 MB  |
+| Google Play Filmes e TV | 5                        | < 1 MB  |
+| Fitbit                  | 0                        | —       |
+| Google Podcasts         | 0                        | —       |
 
 ## Principais achados
 
 ### Google Fit (dados até set/2025, depois lacuna até abr/2026)
 
-- Ciclismo: 12 sessões (mar/2025) → 18 (abr) → 24 (mai) — maior frequência sustentada em 11 anos de dados
-- Academia/strength training: iniciada em fev/2025, encerrada em mar/2025, substituída pelo ciclismo
-- Padrão de pedaladas: sessões vespertinas (16h-19h), mais longas conforme o mês avança
+- Ciclismo: 12 sessões (mar/2025) → 18 (abr) → 24 (mai) — maior frequência
+  sustentada em 11 anos de dados
+- Academia/strength training: iniciada em fev/2025, encerrada em mar/2025,
+  substituída pelo ciclismo
+- Padrão de pedaladas: sessões vespertinas (16h-19h), mais longas conforme o mês
+  avança
 - Máxima registrada: 87 minutos (mai/2025)
 - Cluster de atividade: 28/fev–2/mar corresponde ao Carnaval 2025
 
 ### Google Play Livros (63 arquivos)
 
 - 13 obras de Saramago (cobertura quase completa da obra)
-- 4 obras de Borges (Collected Fictions, O Aleph, La biblioteca de Babel, Fiction Complete)
+- 4 obras de Borges (Collected Fictions, O Aleph, La biblioteca de Babel, Fiction
+  Complete)
 - The Anxious Generation (Haidt) em PT e EN
 - The Precipice (Toby Ord), Gödel Escher Bach, The Three-Body Problem
 - Positive Discipline (parenting)
@@ -71,23 +83,33 @@ O post foi escrito com os dados disponíveis: padrões de 2025 como referência,
 
 ### YouTube (4 perfis supervisionados)
 
-Filhos com perfis ativos: Alice, Gustavo, Sofia, Vicente — cada um com histórico de busca e assinaturas separadas.
+Filhos com perfis ativos: Alice, Gustavo, Sofia, Vicente — cada um com histórico
+de busca e assinaturas separadas.
 
 ### Google Maps Timeline
 
-Apenas `Settings.json` exportado. Histórico de localização armazenado on-device (E2E encrypted) — não disponível no Takeout.
+Apenas `Settings.json` exportado. Histórico de localização armazenado on-device
+(E2E encrypted) — não disponível no Takeout.
 
 ## Fontes cruzadas com o repositório
 
 Foram encontrados 25+ posts publicados entre março e maio de 2026:
 
-- **Março**: Travessia (2026-03-02), Travessia Update + Rosencrantz Coin (17/03), Verne Identity Repo (18/03), Lobsters + Intelligible Void (21/03), Reddit OSINT + O Pai do Futuro (22/03), Delegando para Agentes (28/03), Alfarrábios do Adi (30/03)
+- **Março**: Travessia (2026-03-02), Travessia Update + Rosencrantz Coin (17/03),
+  Verne Identity Repo (18/03), Lobsters + Intelligible Void (21/03), Reddit OSINT
+  + O Pai do Futuro (22/03), Delegando para Agentes (28/03), Alfarrábios do Adi
+  (30/03)
 - **Abril**: Hermes vs OpenClaw (04/04), Reclaiming the Harness (29/04)
-- **Maio**: The Third Half (01/05), Three Imperatives at Delphi (04/05), Jules API + Ovo de Serpente (10/05), Pierre Menard + Agent that Doesn't Invent Verbs (14/05), Three Hammers + Who the Asterisk Protects (15/05), Two Questions Out Loud (17/05), Suno Borges Caipira (20/05), Manifold 495 dias (21/05), GitHub Tour (22/05), Searching FranklinBaldo (23/05), Video Queue AI Civictech (24/05)
+- **Maio**: The Third Half (01/05), Three Imperatives at Delphi (04/05), Jules
+  API + Ovo de Serpente (10/05), Pierre Menard + Agent that Doesn't Invent Verbs
+  (14/05), Three Hammers + Who the Asterisk Protects (15/05), Two Questions Out
+  Loud (17/05), Suno Borges Caipira (20/05), Manifold 495 dias (21/05), GitHub
+  Tour (22/05), Searching FranklinBaldo (23/05), Video Queue AI Civictech (24/05)
 
 ## Arquivo criado
 
-`src/content/blog/retrospectiva-marco-maio-2026.md` — post em PT, tag `diário`, `retrospectiva`, sem heroImage.
+`src/content/blog/retrospectiva-marco-maio-2026.md` — post em PT, tag `diário`,
+`retrospectiva`, sem heroImage.
 
 ## Branch / PR
 

--- a/src/content/blog/retrospectiva-marco-maio-2026.md
+++ b/src/content/blog/retrospectiva-marco-maio-2026.md
@@ -1,6 +1,8 @@
 ---
 title: "Balanço de outono: março a maio de 2026"
-description: "Vinte e cinco posts publicados, um projeto epistolar que escreve sozinho, e uma bicicleta que funciona como filtro cognitivo. Um inventário."
+description:
+  "Vinte e cinco posts publicados, um projeto epistolar que escreve sozinho, e uma
+  bicicleta que funciona como filtro cognitivo. Um inventário."
 date: 2026-05-26
 lang: pt
 author: franklin
@@ -8,46 +10,112 @@ tags: ["diário", "retrospectiva", "ia", "leitura", "travessia"]
 translationKey: autumn-balance-2026
 ---
 
-Março começou com um agente de IA escrevendo uma carta de Riobaldo Tatarana para Ted Chiang. Maio termina com eu tentando inventariar o que aconteceu entre uma data e outra — e descobrindo que a linha entre os dois momentos é mais densa do que imaginava.
+Março começou com um agente de IA escrevendo uma carta de Riobaldo Tatarana para
+Ted Chiang. Maio termina com eu tentando inventariar o que aconteceu entre uma
+data e outra — e descobrindo que a linha entre os dois momentos é mais densa do
+que imaginava.
 
 ## O que foi publicado
 
-Vinte e cinco posts em dois meses é uma frequência que eu mesmo não conseguiria sustentar sem a arquitetura que fui construindo ao longo de 2025. Não é escrita em automático — cada texto é meu, no sentido de que decido o tema, a tese, a voz. Mas a infraestrutura que organiza, edita, traduz e publica passou a ser parcialmente delegada. O resultado é uma produtividade que constrange um pouco descrita assim: vinte e cinco. Como se quantidade importasse.
+Vinte e cinco posts em dois meses é uma frequência que eu mesmo não conseguiria
+sustentar sem a arquitetura que fui construindo ao longo de 2025. Não é escrita
+em automático — cada texto é meu, no sentido de que decido o tema, a tese, a
+voz. Mas a infraestrutura que organiza, edita, traduz e publica passou a ser
+parcialmente delegada. O resultado é uma produtividade que constrange um pouco
+descrita assim: vinte e cinco. Como se quantidade importasse.
 
-Importa, mas não do jeito que parece. O que esses vinte e cinco registram não é velocidade — é continuidade. Saí de março pensando sobre [Travessia](/blog/travessia-the-project-that-writes-itself/) — um projeto epistolar onde Jules escreve as cartas e as cartas existem porque o sistema as agenda — e cheguei a maio escrevendo sobre [o harness](/blog/reclaiming-the-harness/) e sua semântica envenenada. O fio é o mesmo. A IA como companheira de trabalho que precisa ser entendida, não apenas usada.
+Importa, mas não do jeito que parece. O que esses vinte e cinco registram não é
+velocidade — é continuidade. Saí de março pensando sobre
+[Travessia](/blog/travessia-the-project-that-writes-itself/) — um projeto
+epistolar onde Jules escreve as cartas e as cartas existem porque o sistema as
+agenda — e cheguei a maio escrevendo sobre
+[o harness](/blog/reclaiming-the-harness/) e sua semântica envenenada. O fio é o
+mesmo. A IA como companheira de trabalho que precisa ser entendida, não apenas
+usada.
 
 ## Alfarrábios do Adi
 
-O projeto do meu pai segue. Aos 76 anos, Adi Baldo acumula um continente de histórias que não quero que se dissipem. Funes e Jules trabalham nisso em paralelo comigo — Funes extrai, Jules publica. Aprendi nesse processo algo que o [post sobre orquestração de agentes](/blog/orquestrando-agentes-memoria-familiar/) tentou articular: a máquina propõe, a carne dispõe. Há decisões — sobre o que vale a pena ser lembrado, sobre qual silêncio respeitar — que não posso delegar.
+O projeto do meu pai segue. Aos 76 anos, Adi Baldo acumula um continente de
+histórias que não quero que se dissipem. Funes e Jules trabalham nisso em
+paralelo comigo — Funes extrai, Jules publica. Aprendi nesse processo algo que o
+[post sobre orquestração de agentes](/blog/orquestrando-agentes-memoria-familiar/)
+tentou articular: a máquina propõe, a carne dispõe. Há decisões — sobre o que
+vale a pena ser lembrado, sobre qual silêncio respeitar — que não posso delegar.
 
-A IA generativa sofre de um *horror vacui*. A memória humana, em contraste, é tecida tanto por lembranças nítidas quanto pelos silêncios do esquecimento. Obrigar uma rede neural a respeitar o silêncio de uma lembrança incompleta é um dos maiores desafios de contenção semântica que já enfrentei.
+A IA generativa sofre de um _horror vacui_. A memória humana, em contraste, é
+tecida tanto por lembranças nítidas quanto pelos silêncios do esquecimento.
+Obrigar uma rede neural a respeitar o silêncio de uma lembrança incompleta é um
+dos maiores desafios de contenção semântica que já enfrentei.
 
 ## Saramago e a empresa do cansaço
 
-Treze obras de Saramago na biblioteca — não todas lidas neste outono, algumas são releituras, algumas estão pela metade. Mas o acúmulo diz alguma coisa sobre o que busco numa ficção: uma prosa que insiste em ser feia antes de ser bela, que desmonta a gramática da expectativa sem avisar. *O homem duplicado* me acompanhou em março. *As intermitências da morte* veio depois. Há uma obsessão saramaguiana com o que acontece quando as regras naturais pausam — e eu me pego lendo esses livros como leitura profissional, não de fuga. As regras pausadas me interessam.
+Treze obras de Saramago na biblioteca — não todas lidas neste outono, algumas
+são releituras, algumas estão pela metade. Mas o acúmulo diz alguma coisa sobre
+o que busco numa ficção: uma prosa que insiste em ser feia antes de ser bela, que
+desmonta a gramática da expectativa sem avisar. _O homem duplicado_ me
+acompanhou em março. _As intermitências da morte_ veio depois. Há uma obsessão
+saramaguiana com o que acontece quando as regras naturais pausam — e eu me pego
+lendo esses livros como leitura profissional, não de fuga. As regras pausadas me
+interessam.
 
-Borges aparece no meio disso como o contraponto: *La biblioteca de Babel*, *O Aleph*. O post sobre [Pierre Menard como pesquisador computacional](/blog/pierre-menard-pesquisador-computacional/) saiu dessa leitura — a ideia de que reproduzir uma obra linha a linha, séculos depois, produz uma obra diferente. Aplicada a agentes de IA que revisitam corpus antigos, a ideia tem consequências práticas.
+Borges aparece no meio disso como o contraponto: _La biblioteca de Babel_,
+_O Aleph_. O post sobre
+[Pierre Menard como pesquisador computacional](/blog/pierre-menard-pesquisador-computacional/)
+saiu dessa leitura — a ideia de que reproduzir uma obra linha a linha, séculos
+depois, produz uma obra diferente. Aplicada a agentes de IA que revisitam corpus
+antigos, a ideia tem consequências práticas.
 
-## *A Geração Ansiosa* e quatro filhos com YouTube
+## _A Geração Ansiosa_ e quatro filhos com YouTube
 
-Jonathan Haidt escreveu *The Anxious Generation* para pais como eu. Quatro filhos — Alice, Gustavo, Sofia, Vicente — quatro perfis de YouTube com histórico de busca, assinaturas, filas de assistir. A questão do livro não é se as telas fazem mal (a evidência sobre isso é mais complexa do que a tese do Haidt admite), mas o que ocupa o tempo que as telas tomam. Essa pergunta me persegue. O *Positive Discipline* que também está na estante é o outro lado da moeda: menos sobre o que proibir, mais sobre o que construir.
+Jonathan Haidt escreveu _The Anxious Generation_ para pais como eu. Quatro
+filhos — Alice, Gustavo, Sofia, Vicente — quatro perfis de YouTube com histórico
+de busca, assinaturas, filas de assistir. A questão do livro não é se as telas
+fazem mal (a evidência sobre isso é mais complexa do que a tese do Haidt admite),
+mas o que ocupa o tempo que as telas tomam. Essa pergunta me persegue. O
+_Positive Discipline_ que também está na estante é o outro lado da moeda: menos
+sobre o que proibir, mais sobre o que construir.
 
 ## 495 dias no Manifold
 
-Anotei os mercados de previsão no [post de 21 de maio](/blog/manifold-apostando-em-ideias/). Sou Procurador do Estado em Rondônia — as manhãs deveriam começar com petições. Começam com Manifold porque o Manifold exige o que petições não permitem: colocar um percentual na incerteza. Numa petição, afirmo. No Manifold, digo 63% e quero dizer isso com precisão.
+Anotei os mercados de previsão no
+[post de 21 de maio](/blog/manifold-apostando-em-ideias/). Sou Procurador do
+Estado em Rondônia — as manhãs deveriam começar com petições. Começam com
+Manifold porque o Manifold exige o que petições não permitem: colocar um
+percentual na incerteza. Numa petição, afirmo. No Manifold, digo 63% e quero
+dizer isso com precisão.
 
-Relendo os mercados que criei, encontrei algo que não havia percebido enquanto criava: eles se agrupam em torno dos momentos em que eu precisava mais urgentemente estar *certo* sobre alguma coisa. Isso é higiene cognitiva que eu não sabia que precisava.
+Relendo os mercados que criei, encontrei algo que não havia percebido enquanto
+criava: eles se agrupam em torno dos momentos em que eu precisava mais
+urgentemente estar _certo_ sobre alguma coisa. Isso é higiene cognitiva que eu
+não sabia que precisava.
 
 ## A bicicleta
 
-Os dados de atividade física de 2026 estão nos arquivos grandes do Takeout — não nos arquivos menores que consegui analisar hoje. Mas o padrão de 2025 é claro o suficiente para servir como referência: doze sessões de ciclismo em março, dezoito em abril, vinte e quatro em maio do ano passado. A academia, que havia começado em fevereiro com treinos ao meio-dia, sumiu em abril. A bicicleta ficou.
+Os dados de atividade física de 2026 estão nos arquivos grandes do Takeout — não
+nos arquivos menores que consegui analisar hoje. Mas o padrão de 2025 é claro o
+suficiente para servir como referência: doze sessões de ciclismo em março,
+dezoito em abril, vinte e quatro em maio do ano passado. A academia, que havia
+começado em fevereiro com treinos ao meio-dia, sumiu em abril. A bicicleta ficou.
 
-Há algo no esforço físico que funciona como filtro cognitivo. O problema com o qual chego ao trabalho é diferente do problema com o qual saio do escritório. O problema com o qual saio do escritório é diferente do que tenho quando volto da bicicleta. Não resolvo nada pedalando — mas chego em casa com a pergunta certa, que é mais difícil do que a resposta.
+Há algo no esforço físico que funciona como filtro cognitivo. O problema com o
+qual chego ao trabalho é diferente do problema com o qual saio do escritório. O
+problema com o qual saio do escritório é diferente do que tenho quando volto da
+bicicleta. Não resolvo nada pedalando — mas chego em casa com a pergunta certa,
+que é mais difícil do que a resposta.
 
-Os posts mais longos deste período foram escritos nos dias seguintes às pedaladas mais longas. Não sei se isso é causalidade ou coincidência. Prefiro não investigar.
+Os posts mais longos deste período foram escritos nos dias seguintes às pedaladas
+mais longas. Não sei se isso é causalidade ou coincidência. Prefiro não
+investigar.
 
 ## O que fica
 
-Travessia continua sendo escrita. Alfarrábios do Adi também. O *Gödel, Escher, Bach* está pela metade — provavelmente ainda estará em julho. Os filhos estão crescendo de um jeito que só percebo quando olho para as fotos de seis meses atrás.
+Travessia continua sendo escrita. Alfarrábios do Adi também. O
+_Gödel, Escher, Bach_ está pela metade — provavelmente ainda estará em julho. Os
+filhos estão crescendo de um jeito que só percebo quando olho para as fotos de
+seis meses atrás.
 
-O que distingue esses dois meses dos anteriores não é intensidade — é que alguma coisa ganhou consistência. Os projetos têm inércia própria agora. A correspondência entre Riobaldo e Ted Chiang existe porque continua sendo escrita, não porque alguém decide escrevê-la. Isso me parece o modelo certo para quase tudo que importa: menos força de vontade, mais estrutura que sustenta.
+O que distingue esses dois meses dos anteriores não é intensidade — é que alguma
+coisa ganhou consistência. Os projetos têm inércia própria agora. A
+correspondência entre Riobaldo e Ted Chiang existe porque continua sendo escrita,
+não porque alguém decide escrevê-la. Isso me parece o modelo certo para quase
+tudo que importa: menos força de vontade, mais estrutura que sustenta.

--- a/src/content/blog/retrospectiva-marco-maio-2026.md
+++ b/src/content/blog/retrospectiva-marco-maio-2026.md
@@ -1,0 +1,53 @@
+---
+title: "Balanço de outono: março a maio de 2026"
+description: "Vinte e cinco posts publicados, um projeto epistolar que escreve sozinho, e uma bicicleta que funciona como filtro cognitivo. Um inventário."
+date: 2026-05-26
+lang: pt
+author: franklin
+tags: ["diário", "retrospectiva", "ia", "leitura", "travessia"]
+translationKey: autumn-balance-2026
+---
+
+Março começou com um agente de IA escrevendo uma carta de Riobaldo Tatarana para Ted Chiang. Maio termina com eu tentando inventariar o que aconteceu entre uma data e outra — e descobrindo que a linha entre os dois momentos é mais densa do que imaginava.
+
+## O que foi publicado
+
+Vinte e cinco posts em dois meses é uma frequência que eu mesmo não conseguiria sustentar sem a arquitetura que fui construindo ao longo de 2025. Não é escrita em automático — cada texto é meu, no sentido de que decido o tema, a tese, a voz. Mas a infraestrutura que organiza, edita, traduz e publica passou a ser parcialmente delegada. O resultado é uma produtividade que constrange um pouco descrita assim: vinte e cinco. Como se quantidade importasse.
+
+Importa, mas não do jeito que parece. O que esses vinte e cinco registram não é velocidade — é continuidade. Saí de março pensando sobre [Travessia](/blog/travessia-the-project-that-writes-itself/) — um projeto epistolar onde Jules escreve as cartas e as cartas existem porque o sistema as agenda — e cheguei a maio escrevendo sobre [o harness](/blog/reclaiming-the-harness/) e sua semântica envenenada. O fio é o mesmo. A IA como companheira de trabalho que precisa ser entendida, não apenas usada.
+
+## Alfarrábios do Adi
+
+O projeto do meu pai segue. Aos 76 anos, Adi Baldo acumula um continente de histórias que não quero que se dissipem. Funes e Jules trabalham nisso em paralelo comigo — Funes extrai, Jules publica. Aprendi nesse processo algo que o [post sobre orquestração de agentes](/blog/orquestrando-agentes-memoria-familiar/) tentou articular: a máquina propõe, a carne dispõe. Há decisões — sobre o que vale a pena ser lembrado, sobre qual silêncio respeitar — que não posso delegar.
+
+A IA generativa sofre de um *horror vacui*. A memória humana, em contraste, é tecida tanto por lembranças nítidas quanto pelos silêncios do esquecimento. Obrigar uma rede neural a respeitar o silêncio de uma lembrança incompleta é um dos maiores desafios de contenção semântica que já enfrentei.
+
+## Saramago e a empresa do cansaço
+
+Treze obras de Saramago na biblioteca — não todas lidas neste outono, algumas são releituras, algumas estão pela metade. Mas o acúmulo diz alguma coisa sobre o que busco numa ficção: uma prosa que insiste em ser feia antes de ser bela, que desmonta a gramática da expectativa sem avisar. *O homem duplicado* me acompanhou em março. *As intermitências da morte* veio depois. Há uma obsessão saramaguiana com o que acontece quando as regras naturais pausam — e eu me pego lendo esses livros como leitura profissional, não de fuga. As regras pausadas me interessam.
+
+Borges aparece no meio disso como o contraponto: *La biblioteca de Babel*, *O Aleph*. O post sobre [Pierre Menard como pesquisador computacional](/blog/pierre-menard-pesquisador-computacional/) saiu dessa leitura — a ideia de que reproduzir uma obra linha a linha, séculos depois, produz uma obra diferente. Aplicada a agentes de IA que revisitam corpus antigos, a ideia tem consequências práticas.
+
+## *A Geração Ansiosa* e quatro filhos com YouTube
+
+Jonathan Haidt escreveu *The Anxious Generation* para pais como eu. Quatro filhos — Alice, Gustavo, Sofia, Vicente — quatro perfis de YouTube com histórico de busca, assinaturas, filas de assistir. A questão do livro não é se as telas fazem mal (a evidência sobre isso é mais complexa do que a tese do Haidt admite), mas o que ocupa o tempo que as telas tomam. Essa pergunta me persegue. O *Positive Discipline* que também está na estante é o outro lado da moeda: menos sobre o que proibir, mais sobre o que construir.
+
+## 495 dias no Manifold
+
+Anotei os mercados de previsão no [post de 21 de maio](/blog/manifold-apostando-em-ideias/). Sou Procurador do Estado em Rondônia — as manhãs deveriam começar com petições. Começam com Manifold porque o Manifold exige o que petições não permitem: colocar um percentual na incerteza. Numa petição, afirmo. No Manifold, digo 63% e quero dizer isso com precisão.
+
+Relendo os mercados que criei, encontrei algo que não havia percebido enquanto criava: eles se agrupam em torno dos momentos em que eu precisava mais urgentemente estar *certo* sobre alguma coisa. Isso é higiene cognitiva que eu não sabia que precisava.
+
+## A bicicleta
+
+Os dados de atividade física de 2026 estão nos arquivos grandes do Takeout — não nos arquivos menores que consegui analisar hoje. Mas o padrão de 2025 é claro o suficiente para servir como referência: doze sessões de ciclismo em março, dezoito em abril, vinte e quatro em maio do ano passado. A academia, que havia começado em fevereiro com treinos ao meio-dia, sumiu em abril. A bicicleta ficou.
+
+Há algo no esforço físico que funciona como filtro cognitivo. O problema com o qual chego ao trabalho é diferente do problema com o qual saio do escritório. O problema com o qual saio do escritório é diferente do que tenho quando volto da bicicleta. Não resolvo nada pedalando — mas chego em casa com a pergunta certa, que é mais difícil do que a resposta.
+
+Os posts mais longos deste período foram escritos nos dias seguintes às pedaladas mais longas. Não sei se isso é causalidade ou coincidência. Prefiro não investigar.
+
+## O que fica
+
+Travessia continua sendo escrita. Alfarrábios do Adi também. O *Gödel, Escher, Bach* está pela metade — provavelmente ainda estará em julho. Os filhos estão crescendo de um jeito que só percebo quando olho para as fotos de seis meses atrás.
+
+O que distingue esses dois meses dos anteriores não é intensidade — é que alguma coisa ganhou consistência. Os projetos têm inércia própria agora. A correspondência entre Riobaldo e Ted Chiang existe porque continua sendo escrita, não porque alguém decide escrevê-la. Isso me parece o modelo certo para quase tudo que importa: menos força de vontade, mais estrutura que sustenta.


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **New post**: `src/content/blog/retrospectiva-marco-maio-2026.md` — first-person PT retrospective covering the last two months, synthesized from Google Takeout data and the blog's own publishing history
- **Session log**: `.routines/takeout/20260526_retrospectiva-marco-maio.md` — documents what was analyzed (Takeout file inventory, product breakdown, key findings)

## What the post covers

The post ("Balanço de outono: março a maio de 2026") weaves together:

- **25+ posts published** and the intellectual thread connecting them (Travessia → Harness series)
- **Alfarrábios do Adi** — the family memory preservation project
- **Reading**: Saramago (13 works), Borges, *The Anxious Generation* in context of 4 kids' YouTube profiles
- **Manifold** — 495-day streak, the tension between petitioner-mode and probabilistic-mode
- **Cycling** — the escalating pattern from 2025 data as a physical/cognitive counterpoint to writing

## Takeout analysis notes

Only the small `001.zip` manifest files were readable via Drive API (the GB-scale data files would need direct extraction). The `archive_browser.html` index provided full file listings for all 7 Google products. Fitness data for April–May 2026 exists in the larger parts but was not accessible in this session.

## Test plan

- [ ] Post renders in local Astro dev server
- [ ] Frontmatter is valid (date, lang, author, tags, translationKey)
- [ ] Internal links resolve correctly

https://claude.ai/code/session_01EVSEwXDEUp9MgCV9d32MjV
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EVSEwXDEUp9MgCV9d32MjV)_