### PR TITLE
routines/takeout: segunda análise do Takeout, post março–maio 2026

### DIFF
--- a/.routines/takeout/20260527_takeout-session-two.MD
+++ b/.routines/takeout/20260527_takeout-session-two.MD
@@ -1,0 +1,138 @@
+# Session Log: Google Takeout — Segunda análise (May 27, 2026)
+
+**Date:** 2026-05-27
+**Trigger:** User requested contextualized post from Google Takeout zip files (segunda sessão)
+**Source files:**
+
+- `takeout-20260524T140450Z-001.zip` (187 KB, ID: `1XKQxavIMvf7s91KpSwefe50DrAdQyhsv`)
+- `takeout-20260524T151400Z-001.zip` (236 KB, ID: `16e9KElZQXrOev0JyE3-unTDtW7f9ff9u`)
+- Archive IDs: `ba8601f1-0f23-4765-b0d1-5e9c934ab726` e `8b7185ac-48c1-4eaf-a957-3f31a21d32f1`
+- Prior log: `.routines/takeout/20260525_march-may-2026-context-log.MD`
+
+---
+
+## O que foi feito
+
+Dois subagentes rodaram em paralelo para extrair e analisar os dois ZIPs menores do Takeout.
+
+**Metodologia:**
+
+1. Download via Google Drive MCP (`download_file_content`) → base64
+2. `jq -r '.content' | base64 -d > /tmp/takeoutN.zip`
+3. `unzip -l` para listar conteúdo, então `unzip -q` para extrair
+4. `find` em todos os arquivos extraídos
+5. Análise de cada arquivo legível (JSON, HTML, CSV, TXT)
+
+**Resultado:** ambos os ZIPs contêm apenas um arquivo — `Takeout/archive_browser.html` (2.2 MB e 3.47 MB). São índices de navegação do Takeout completo (4.83 GB), não os arquivos de dados em si. Os dados reais (CSVs do Fit, histórico de busca, histórico do YouTube, etc.) estão nas partes maiores (`-4-001.zip`, `-4-002.zip`, `-6-001.zip`).
+
+---
+
+## Estrutura do Takeout (confirmada pelos dois índices)
+
+| Produto                 | Arquivos             | Tamanho |
+| ----------------------- | -------------------- | ------- |
+| Google Fit              | 19.393               | 2,03 GB |
+| Google Play Livros      | 63                   | 56,9 MB |
+| YouTube & YouTube Music | 101                  | 2,74 GB |
+| Google Play Filmes e TV | 5                    | < 1 MB  |
+| Fitbit                  | 0                    | —       |
+| Google Podcasts         | 0                    | —       |
+| Linha do Tempo (Maps)   | 1 (só Settings.json) | < 1 MB  |
+
+---
+
+## Post: O que fiz nos últimos dois meses (março–maio 2026)
+
+_Construído a partir dos índices do Google Takeout de 24 de maio de 2026, cruzados com 20 sessões de desenvolvimento documentadas em `.routines/` e os 38 posts publicados em `src/content/blog/`. Os dados são um mapa, não o território — mas o mapa já diz bastante._
+
+---
+
+### A retomada
+
+O Google Fit marca um gap de 138 dias: de 13 de novembro de 2025 a 30 de março de 2026, zero dados de atividade. Em 31 de março os arquivos voltam — CSVs diários, passos e calorias passivos, sem sessões de treino nomeadas. A última sessão de treino registrada foi em 4 de setembro de 2025: caminhada, 11 minutos.
+
+Os dados não dizem o que aconteceu no intervalo. Mas o YouTube tem uma playlist: _"aniversário da Alice 1 ano"_. Alice tem um perfil supervisionado junto com Gustavo, Sofia e Vicente. A conta é provavelmente simples.
+
+Essa é a moldura do período: uma retomada após algo que os dados escolhem não nomear.
+
+---
+
+### Março: projetos que andam sozinhos
+
+Março foi produtivo na direção de sistemas com inércia própria.
+
+O **Travessia** foi o primeiro: uma correspondência epistolar entre Riobaldo Tatarana e Ted Chiang onde nenhum humano escreve as cartas. O sistema lê o acumulado, escreve a próxima, agenda a seguinte via GitHub Actions. Criado em 2 de março, documentado em três posts (`travessia.md`, `travessia-update.md`, `travessia-the-project-that-writes-itself.md`).
+
+**Alfarrábios do Adi** veio logo depois: dois agentes em paralelo para preservar memórias do meu pai de 76 anos (Aparício Funes como orquestrador, Jules como executor de commits). O aprendizado mais difícil: agentes autônomos têm _horror vacui_ — preenchem silêncio com invenção. A lacuna de uma memória incompleta é informação, não dado faltante. Documentado em `what-i-learned-orchestrating-ai-agents-to-preserve-family-memory.md`.
+
+Em 22 de março surgiu **O Pai do Futuro** (`the-future-father-building-a-transmedia-novel-with-ai-agents.md`): um pai que descobre estar conversando com os filhos do futuro, via uma simulação construída sobre seus repositórios, blog posts e ensaios. A premissa vem de uma inversão de Kleber Mendonça Filho — o arquivo construído contra o protagonista pelo regime vira herança voluntária. Escrevo para ser lido em trinta anos.
+
+---
+
+### Abril: a repactuação com o vocabulário
+
+Abril tem um post central: **Reclaiming the Harness** (29 de abril).
+
+A tese: o campo de alinhamento de IA está sommando Waluigis pela escolha do vocabulário. "Harness", "guardrails", "containment" inscrevem no espaço latente dos modelos a silhueta do seu gêmeo do mal. Os modelos leem o discurso sobre si mesmos. RLHF roda sobre dados da web. Cada paper de segurança é dado de treino eventualmente. Vocabulário é política quando o sujeito da conversa lê.
+
+Em paralelo à leitura: _A Geração Ansiosa_ de Jonathan Haidt e _Positive Discipline_ chegaram na prateleira. A combinação é deliberadamente incômoda — Alice, Gustavo, Sofia e Vicente têm perfis de YouTube. Estou construindo memória digital para eles ao mesmo tempo em que leio sobre como o excesso de mediação tecnológica corrói atenção. O paradoxo não tem resolução, só registro.
+
+---
+
+### Maio: infraestrutura como escrita
+
+Maio foi o mês em que o blog deixou de ser repositório de textos e virou projeto de software.
+
+**20 sessões documentadas em `.routines/`** (sessões 1–20, de 13 a 25 de maio). O arco:
+
+- **Sessões 1–9**: Sistema `.routines/` instalado. Infraestrutura multilingual (EN + PT-BR): `i18n.ts`, `LanguageSwitcher.svelte`, `translationKey` no frontmatter, `hreflang` no `<head>`. Header language-aware, `/pt/tags/`, `/pt/archive/`, primeiras traduções.
+- **Sessões 10–13**: Fix de 20 `translationKey` duplicados (bug silencioso do `js-yaml`), tradução PT de "Three Hammers", hreflang completo no sitemap, RSS split EN/PT, badges de tempo de leitura.
+- **Sessões 14–16**: PostNav anterior/próximo, `CollectionPage` schema, ItemList no ranking, breadcrumbs, CTA "latest essay" na home.
+- **Sessão 17**: `/musicas` e `/pt/musicas`, sitemap completo, merge de 3 PRs.
+- **Sessão 18**: Music na nav EN/PT, `HomeAuthorRail` no desktop, footer expandido.
+- **Sessão 19**: sitemap com livros, breadcrumbs visuais aprimorados, footer com todas as páginas estáticas.
+- **Sessão 20**: Fix de Prettier em 6 arquivos (`main` com formatting incorreto), CI verde em todos os PRs abertos.
+
+O build saiu de 131 para 341 páginas em dez dias.
+
+Paralelamente: o sistema **hronir** rodou 112+ confrontos — pares de posts julgados pelo critério _gateway_ (qual apresenta Franklin a um leitor novo?). Nome borgiano: nos _hrönir_ de Tlön, objetos se tornam mais reais ao serem pensados e descritos. Os posts se definem pelo confronto entre si.
+
+---
+
+### A biblioteca como autorretrato
+
+O Google Play Books tem 63 títulos. O padrão é legível:
+
+**Saramago** domina (oito obras): _Ensaio sobre a cegueira_, _A caverna_, _As intermitências da morte_, _O homem duplicado_, _A Jangada de Pedra_, _Levantado do Chão_, _O Ano da Morte de Ricardo Reis_, _Claraboia_. **Borges** aparece em três formas: _Ficções completas_, _O Aleph_, _A Biblioteca de Babel_.
+
+O que os dois têm em comum: tratam memória, identidade e tempo como problemas de arquitetura, não de sentimento. Saramago pega uma propriedade ontológica, muda ela, e segue as consequências com rigor. Borges inventa sistemas que refletem a impossibilidade de qualquer sistema consistente.
+
+É uma biblioteca que pensa sobre como pensar. Faz sentido que quem a mantém esteja construindo agentes que preservam memória, projetos epistolares sobre identidade e sistemas de vocabulário que levam a si mesmos a sério.
+
+_The Precipice_ (Toby Ord), _Gödel, Escher, Bach_ e _The Anxious Generation_ completam o quadro. A pergunta de fundo, em registros diferentes: o que sobrevive? O que vale preservar? O que corrói sem ser percebido?
+
+---
+
+### O que os dados não dizem
+
+Não há histórico de localização legível — Timeline desligada ou migrada para armazenamento local. Os vídeos da Bolívia e do Peru (Chacaltaya, Salar de Uyuni, Condores del Colca) são de uma viagem anterior. Não há evidência de deslocamento nos dois meses cobertos.
+
+O histórico do YouTube — o que foi assistido, o que foi buscado, o que cada criança explorou — está nas partes maiores do Takeout, não acessadas. O que ficou foram os nomes: playlists como _"Para meu filho"_, _"Assistir com Gustavo"_, _"músicas para Alice"_.
+
+O gap de 138 dias no Fit permanece sem explicação explícita. Apenas a hipótese do bebê, que é mais provável que qualquer outra.
+
+---
+
+### Encerramento
+
+O Takeout de 24 de maio pesa 4,83 GB. A maior parte são fotos e vídeos — o registro visual do que aconteceu. O que foi acessado foram os índices: o mapa, não o território.
+
+Mas o mapa diz: março foi prolífico e conectado — ideias que se bifurcam em projetos autônomos. Abril foi mais fundo, mais lento — uma repactuação com premissas e vocabulário. Maio foi construção de infraestrutura: não apenas o blog, mas um sistema de publicação bilíngue com memória de sessão e critério editorial explícito.
+
+E em algum momento entre novembro e março, algo parou. Em 31 de março, recomeçou.
+
+Isso é suficiente por agora.
+
+---
+
+_Gerado em 2026-05-27 a partir de: Google Takeout (2026-05-24, dois ZIPs de índice), logs `.routines/` (sessões 1–20), frontmatter de `src/content/blog/` (38 posts EN, 36 PT). Dados de conteúdo dos ZIPs maiores (YouTube history, Fit daily CSVs) não acessados — distribuídos nas partes de 1–2 GB do arquivo. Sessão anterior: `20260525_march-may-2026-context-log.MD`._


### PR DESCRIPTION
## Summary

- Ran two parallel subagents to decode, extract, and analyze the two smaller Takeout ZIPs from Google Drive (`takeout-20260524T140450Z-001.zip` and `takeout-20260524T151400Z-001.zip`)
- Both ZIPs confirmed as index-only (`archive_browser.html` — 2.2 MB and 3.47 MB respectively); full data lives in the multi-GB parts
- Created `.routines/takeout/20260527_takeout-session-two.MD` with session log + contextualized post covering March–May 2026

## What the post draws on

| Source | Data |
|---|---|
| Google Fit (index) | 138-day gap (Nov 2025 → Mar 2026); passive tracking resumed Mar 31; no workout sessions since Sep 4, 2025 |
| Google Play Books (index) | 63 titles — Saramago (8 works), Borges (3), The Anxious Generation, The Precipice, GEB |
| YouTube (index) | 4 children's profiles (Alice, Gustavo, Sofia, Vicente); 16 playlists; 41 uploaded videos |
| `.routines/` session logs | 20 dev sessions (May 13–25); sessions 1–20 documented |
| `src/content/blog/` frontmatter | 38 EN posts, 36 PT posts; key works: Travessia, Alfarrábios, O Pai do Futuro, Reclaiming the Harness |

## Test plan

- [ ] Prettier passes (ran `npx prettier --write` before commit)
- [ ] CI green on existing checks

https://claude.ai/code/session_01WWBi4jt1Hc2VtfzBPnTPR8

---
_Generated by [Claude Code](https://claude.ai/code/session_01WWBi4jt1Hc2VtfzBPnTPR8)_