### PR TITLE
Add Takeout session log: April–May 2026 retrospective

### DIFF
--- a/.routines/takeout/20260530_takeout-analise-abril-maio.md
+++ b/.routines/takeout/20260530_takeout-analise-abril-maio.md
@@ -1,0 +1,95 @@
+# Dois meses rastreados: Abril e Maio de 2026
+
+*Análise gerada a partir do Google Takeout exportado em 24 de maio de 2026*
+
+---
+
+## Metadados da sessão
+
+| Campo | Valor |
+|-------|-------|
+| Data | 2026-05-30 |
+| Fonte | Google Takeout (export 2026-05-24) |
+| Arquivos analisados | `takeout-20260524T140450Z-001.zip` (187 KB), `takeout-20260524T151400Z-001.zip` (235 KB) |
+| Serviços cobertos | Google Fit, Google Play Books, YouTube & YouTube Music, Google Play Movies, Google Maps Timeline |
+| Período foco | Abril–Maio 2026 (+ contexto histórico 2014–2025) |
+| Limitação | Os zips analisados contêm apenas o índice do archive (`archive_browser.html`). Os dados detalhados (histórico de buscas, vídeos assistidos, steps diários) estão nos zips de 2 GB não acessíveis via API. |
+
+---
+
+## O retorno
+
+Em 31 de março de 2026, meu Google Fit voltou a registrar dias. Não sessões de treino, não rotas de bicicleta — só o resumo diário: passos, calorias, tempo ativo. Quarenta e oito dias assim, até 17 de maio.
+
+Antes disso: silêncio. De meados de novembro de 2025 até o final de março de 2026, quatro meses e meio sem um dado sequer. O histórico remonta a outubro de 2014 — doze anos de rastro corporal com um buraco recente. Não sei exatamente o que aconteceu. Troca de dispositivo, provavelmente. Ou cansaço de monitorar tudo.
+
+O retorno em março, sem sessões específicas registradas, parece uma relação diferente com o rastreamento. Mais leve. Menos performática.
+
+---
+
+## O ciclismo como linguagem
+
+O que os dados de 2025 ensinam sobre os últimos meses: pedalar é o verbo central.
+
+Em maio de 2025, um recorde pessoal: 23 saídas, mais de 10 horas na bicicleta. Abril tinha sido 18 saídas, 9,6 horas. Março, 12 saídas. Uma escada que, se continuou em 2026, representa uma transformação de hábito, não só um hobby.
+
+O padrão é preciso demais para ser acidental: 69% das pedaladas entre 17h e 19h, 83% em dias de semana, sextas-feiras como o dia mais frequente. É o commute. É a bicicleta como transporte, não como esporte de fim de semana. O sensor ANT+ conectado — cadência, velocidade — diz que há seriedade nisso.
+
+Comparando com 2024: 24 horas de bicicleta no ano inteiro. Em apenas cinco meses de 2025, quase o mesmo volume. Algo mudou na virada do ano. Uma resolução que pegou? Uma mudança de percurso? Os dados não dizem o *porquê*, só o *quanto*.
+
+---
+
+## Carnaval no fitband
+
+O dia 1º de março de 2025 é o ponto mais quente de todo o histórico. O sensor acordou às 4h44 da manhã. Sete sessões "Outra" e três de caminhada até às 20h22. Dia 2: o mesmo. Vinte e tantos segmentos de atividade distribuídos ao longo do dia, a cada 15–25 minutos.
+
+Não é treino. É Carnaval. O corpo em movimento contínuo que um fitband registra como uma sucessão de microssessões: caminhar até o bloco, dançar, parar, mover, parar. O algoritmo classifica como "Outra atividade" porque não tem nome para isso.
+
+---
+
+## O que estou lendo (ou pretendo ler)
+
+A biblioteca do Google Play Books tem 41 títulos. Treze são de Saramago — quase a obra completa: *Ensaio sobre a Cegueira*, *A Caverna*, *As Intermitências da Morte*, *O Ano da Morte de Ricardo Reis*, *Levantado do Chão*, *A Jangada de Pedra*, *Claraboia*. É a prateleira de alguém que não leu Saramago uma vez; leu várias vezes e voltou.
+
+Quatro Borges: *O Aleph*, *La Biblioteca de Babel*, *Collected Fictions*, *Fiction Complete*. Saramago e Borges como dupla — faz sentido. A realidade como matéria maleável.
+
+O livro que mais me intriga estar ali: *A Geração Ansiosa*, do Jonathan Haidt — nas edições portuguesa e inglesa. Ler o mesmo argumento em dois idiomas não é casual. Haidt sustenta que smartphones e redes sociais destruíram a saúde mental de uma geração inteira. Meus filhos têm perfis no YouTube: Alice, Gustavo, Sofia, Vicente. A tensão entre esse dado e essa leitura não precisa de comentário.
+
+Também na estante: *The Precipice* (Toby Ord, sobre riscos existenciais), *Godel, Escher, Bach* (Hofstadter), *O Problema dos Três Corpos* (Liu Cixin), *Competing for the Future* (Hamel & Prahalad), o *Código Philippino* e *O Poder Judiciário no Regime Militar (1964–1985)*. Uma estante que vai de ficção científica a direito colonial português. Difícil prever o próximo livro.
+
+---
+
+## Família como infraestrutura
+
+Quatro perfis de crianças no YouTube: Alice, Gustavo, Sofia, Vicente. Cada um com histórico de buscas, histórico de vídeos e inscrições próprias. Playlists: "músicas para Alice", "aniversário da Alice 1 ano", "Assistir com Gustavo", "Para meu filho", "brincar de estátua", "Cars", "Sonic", "Clipes de desenho".
+
+Há também *Positive Discipline* e livros de contos clássicos (*Alice no País das Maravilhas*, *Rapunzel*, *Barba Azul*, *O Gato de Botas*) para ler junto. A biblioteca digital já é compartilhada.
+
+Os dados não mostram o cotidiano familiar diretamente — mas a infraestrutura montada ao redor das crianças é visível em todos os serviços. Não é uma família digital-avessa; é uma família que organiza a experiência digital dos filhos com atenção deliberada.
+
+---
+
+## O trabalho que aparece em vídeos
+
+Os vídeos enviados ao YouTube contam outra história: "Dimensão humana nas organizações", "Modelos de governança efetivamente praticados", "Orçamento participativo digital e o cubo da democracia". Não são vídeos de entretenimento. São registros de apresentações sobre gestão pública e democracia digital.
+
+Junto com as viagens — Salar de Uyuni, Chacaltaya, Cânion del Colca, Aquedutos de Nazca, Bonito/MS — aparece o perfil de alguém que viaja para aprender e apresenta o que aprende.
+
+A playlist "Rational Noises" e os uploads de samba (*Meu Samba Sim Senhor*, uma gravação de Marisa Monte) sugerem que música não é só consumo — é prática.
+
+---
+
+## O que este arquivo não tem
+
+Os zips grandes — 2 GB, quase 5 GB no total — ficaram fora do alcance da API. Lá estão:
+
+- O histórico de buscas (o que quis saber)
+- Os vídeos assistidos no YouTube (o que consumi)
+- Os steps e calorias diários de abril e maio de 2026 (os números concretos)
+- O histórico de localização (onde estive)
+
+Este é um retrato feito do índice, não do conteúdo completo. Mas às vezes o índice já diz muita coisa.
+
+---
+
+*Sessão: 2026-05-30 | Fonte: Google Takeout export 2026-05-24 | franklinbaldo@gmail.com*


### PR DESCRIPTION
## Summary\n\n- Adds `.routines/takeout/20260530_takeout-analise-abril-maio.md` — a contextualized personal retrospective for April–May 2026 drawn from Google Takeout data (export 2026-05-24)\n- Source data: two index zips (`takeout-20260524T140450Z-001.zip` and `takeout-20260524T151400Z-001.zip`) parsed to extract file manifests covering Google Fit (19 393 files, 2014–2026), Google Play Books (41 titles), YouTube & YouTube Music (101 files, 4 children's profiles), and Google Maps Timeline\n- Post covers: fitness tracking gap + resumption, cycling commute patterns (peak May 2025 at 10.5 h), Carnival activity signature, reading library (Saramago, Borges, Haidt, Ord, Hofstadter), family digital infrastructure, and civic/governance work traces in uploaded videos\n\n## Notes\n\n- The large zips (2 GB+) were not accessible via API; the post is honest about this limitation\n- Written in Portuguese to match the natural language of the source material\n\nhttps://claude.ai/code/session_01KTiKRCip2rBsk8eYP1ZwDP

---
_Generated by [Claude Code](https://claude.ai/code/session_01KTiKRCip2rBsk8eYP1ZwDP)_