### PR TITLE
feat(seo/a11y/ux): robots meta + article:section + lang attr + skip-link fix + PR #200 forward-port

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -3,7 +3,5 @@ dist/
 .astro/
 public/pagefind/
 package-lock.json
-.routines/hronir/
-.routines/takeout/
-.routines/*.md
+.routines/
 hronir_session.json

--- a/.routines/2026-05-31T14-00-00-seo-a11y-pr200-forward.md
+++ b/.routines/2026-05-31T14-00-00-seo-a11y-pr200-forward.md
@@ -1,0 +1,251 @@
+---
+date: 2026-05-31T14:00:00
+slug: seo-a11y-pr200-forward
+branch: claude/great-mccarthy-vuh9u
+status: pr-open
+session: 27
+---
+
+# Sessão 2026-05-31 — SEO/a11y + forward-port do PR #200
+
+## Contexto
+
+Vigésima-sétima sessão. Branch designado: `claude/great-mccarthy-vuh9u`.
+
+Estado ao chegar:
+
+- 3 PRs abertos: #200 (ranking/archive/mobile rail, sem check CI), #205 (takeout), #206 (hronir)
+- Sessão anterior (#203): hreflang pt-BR, html lang, focus management
+- Bilinguismo 100% — todos posts e páginas têm par EN/PT
+
+## PRs revisados
+
+| PR   | Título                                              | Ação                                                    |
+| ---- | --------------------------------------------------- | ------------------------------------------------------- |
+| #205 | takeout: sixth retrospective session log            | **Mergeado** — CI verde (check + GitGuardian), squash   |
+| #206 | hronir: run 2026-05-31                              | **Mergeado** — CI verde (check + GitGuardian), squash   |
+| #200 | feat(ux): ranking in nav + archive year-jump        | **Forward-portado** — cherry-pick + .prettierignore fix |
+
+### Root cause PR #200 sem CI
+
+PR #200 (aberto 2026-05-29) não tinha a workflow `check` executando porque foi
+aberto antes de alguma mudança no trigger da workflow. Tentativa de merge via
+GitHub resultaria em conflito no `.prettierignore` (main adicionou
+`.routines/*.md` enquanto o PR queria simplificar para `.routines/`).
+
+**Solução**: cherry-pick do commit de feature `87b5a9e1` direto no branch desta
+sessão (`claude/great-mccarthy-vuh9u`), que já está baseado no main atual. O
+`.prettierignore` foi simplificado para `.routines/` (cobre todos os arquivos e
+subdiretórios, incluindo hronir/ e takeout/). PR #200 pode ser fechado ou
+auto-fechado quando este PR mergear (as mudanças estão incluídas).
+
+## Ações realizadas nesta sessão
+
+### 1. Forward-port PR #200
+
+**Cherry-pick** do commit `87b5a9e1` (feat: ranking no nav, year-jump no arquivo,
+mobile AuthorRail compact) para o branch atual.
+
+Mudanças incluídas (ver sessão 24 em .routines/2026-05-29T... para detalhes):
+- `nav.ranking` e `archive.jumpToYear` no i18n.ts
+- Ranking no Header.astro (entre Projects e Music)
+- Year-jump nav no archive EN+PT (pills com `#archive-{year}`)
+- HomeAuthorRail mobile compact (grid 56px + 1fr, bio truncada a 3 linhas)
+
+### 2. SEO: `<meta name="robots">` global
+
+**Arquivo**: `src/layouts/PageLayout.astro`
+
+```html
+<meta name="robots" content="max-image-preview:large, max-snippet:-1, max-video-preview:-1" />
+```
+
+**Por que**: Essas diretivas não bloqueiam robots (o blog já é indexável). Elas
+autorizam o Google a usar:
+- `max-image-preview:large` → imagem em tamanho grande nos resultados (melhora CTR)
+- `max-snippet:-1` → snippet de texto sem limite de caracteres (melhora rich results)
+- `max-video-preview:-1` → preview de vídeo completo (não relevante agora, mas
+  inofensivo e futuro-seguro para quando os posts de música/vídeo forem indexados)
+
+**Trade-off**: Sem essa diretiva, o padrão do Google é usar snippets curtos e
+thumbnails pequenas. Para um blog editorial com textos longos, snippets maiores
+aumentam CTR organicamente.
+
+### 3. SEO: `<meta property="article:section">`
+
+**Arquivo**: `src/layouts/PageLayout.astro`
+
+```astro
+{type === 'article' && tags?.[0] && <meta property="article:section" content={tags[0]} />}
+```
+
+**Por que**: O Open Graph `article:section` informa scrapers e search engines
+sobre a categoria do artigo. O primeiro tag é usado como categoria (é uma
+convenção razoável dado que os tags são ordenados por relevância nos frontmatters).
+
+### 4. SEO: `<link rel="author">`
+
+**Arquivo**: `src/layouts/PageLayout.astro`
+
+```astro
+{type === 'article' && <link rel="author" href="/about/" />}
+```
+
+**Por que**: O elemento `<link rel="author">` é reconhecido por motores de busca
+como indicação do autor do conteúdo. Aponta para `/about/` (EN) ou `/pt/about/`
+(PT) dependendo do idioma da página.
+
+### 5. A11y: `lang` attribute no PostCard `<article>`
+
+**Arquivo**: `src/components/PostCard.astro`
+
+```astro
+<article data-post-lang={postLang} lang={postLang}>
+```
+
+**Por que**: Na homepage e no arquivo, listas mistas EN+PT podem aparecer. O
+atributo `lang` no elemento `<article>` informa leitores de tela sobre a mudança
+de idioma entre cards, permitindo síntese de voz correta para o título e descrição
+de cada post.
+
+**Quando ocorre**: Na homepage EN, todos os cards são EN (blog filtra por lang).
+Na homepage PT, todos PT. No arquivo EN, todos EN. No arquivo PT, todos PT.
+Na prática, listas mistas não ocorrem atualmente — mas o atributo é defensivo
+para futuras páginas de tags ou busca que poderiam misturar idiomas.
+
+### 6. A11y: Skip link `:focus` → `:focus-visible`
+
+**Arquivo**: `src/styles/global.css`
+
+```css
+/* antes */
+.skip-link:focus { left: 0.5rem; top: 0.5rem; }
+
+/* depois */
+.skip-link:focus-visible { left: 0.5rem; top: 0.5rem; }
+```
+
+**Por que**: `:focus` mostra o skip link quando qualquer método de foco é usado,
+incluindo clique de mouse. Isso causaria um flash visual indesejado para usuários
+de mouse que clicam na área do skip link (improvável mas possível). `:focus-visible`
+mostra o link apenas quando o usuário está navegando por teclado — que é exatamente
+quando o skip link é útil.
+
+**Suporte**: `:focus-visible` tem suporte universal em browsers modernos (100%
+no caniuse para Chrome 86+, Firefox 85+, Safari 15.4+).
+
+### 7. Fix `.prettierignore`
+
+Simplificado de 3 linhas para 1:
+```
+# antes
+.routines/hronir/
+.routines/takeout/
+.routines/*.md
+
+# depois
+.routines/
+```
+
+Cobre todos os arquivos dentro de `.routines/` incluindo subdiretórios.
+
+## Build
+
+```
+Discovered 2 languages: en, pt-br
+Indexed 80 pages
+Finished in 0.409 seconds
+```
+
+Prettier check: `All matched files use Prettier code style!` ✅
+
+## Estado após esta sessão
+
+- PRs #205 e #206 mergeados ✅
+- PR #200 forward-portado (cherry-pick no branch desta sessão) ✅
+- Ranking no nav ✅ (via PR #200 forward-port)
+- Year-jump no arquivo EN+PT ✅ (via PR #200 forward-port)
+- Mobile AuthorRail compact ✅ (via PR #200 forward-port)
+- `<meta name="robots" content="max-image-preview:large, max-snippet:-1, ...">` ✅
+- `<meta property="article:section">` para posts ✅
+- `<link rel="author">` para posts ✅
+- `lang` attribute no PostCard `<article>` ✅
+- Skip link `:focus-visible` ✅
+- `.prettierignore` simplificado ✅
+
+## Cobertura bilíngue
+
+Estado atual (verificado via blog-translation-pairs.json regenerado no build):
+
+| Métrica                              | Status |
+| ------------------------------------ | ------ |
+| Posts EN com par PT                  | 40/40 ✅ |
+| Posts PT com par EN                  | 40/40 ✅ |
+| Páginas estáticas bilíngues          | ✅ |
+| hreflang pt-BR                       | ✅ |
+| html lang pt-BR para páginas PT      | ✅ |
+| Auto-redirect por preferência        | ✅ |
+| LanguageSwitcher visível             | ✅ |
+| x-default hreflang                   | ✅ |
+
+## Próximas sessões — backlog priorizado
+
+### Alta prioridade
+
+1. **Fechar PR #200** — As mudanças foram forward-portadas para esta sessão.
+   PR #200 pode ser fechado manualmente ou auto-fecha quando este PR mergear.
+   Não é necessário ação adicional.
+
+2. **Livros recentes no HomeAuthorRail** — Mostrar 2–3 livros recentes do
+   Goodreads RSS no rail do autor (desktop). Parser já existe em `BooksPage.astro`.
+   Risco: latência de rede na hora do build. Mitigação: `fetch` com `fallback: []`
+   e timeout curto.
+
+3. **Publicar rascunho EN `the-art-of-delegating-orchestrating-jules`** — ou
+   deletar. Está em `draft: true` sem `translationKey`. Decisão arquitetural:
+   manter como arquivo histórico ou publicar com o par `delegando-para-agentes`?
+   (A versão revisada `the-art-of-delegation.md` já está publicada com o par.)
+
+### Média prioridade
+
+4. **`lang` attribute no `<article>` do post layout** — O post layout
+   `src/pages/blog/[...slug].astro` tem `<article data-pagefind-body>`. Adicionar
+   `lang={postLang}` seria consistente com o PostCard.
+
+5. **Focus management refinamento** — Verificar se focar `<h1>` em vez de `<main>`
+   é melhor para screen readers. Custo: baixo; benefício: anúncio de título após
+   navegação SPA.
+
+6. **Archive pagination** — Threshold: 50+ posts EN no mesmo ano. Atualmente 40+
+   no 2026. Monitorar.
+
+### Baixa prioridade
+
+7. **`lang` switch com `navigate()`** — Migrar `location.href` no LanguageSwitcher
+   para `navigate()` da `astro:transitions/client` para UX SPA mais fluida.
+
+8. **`<meta name="robots" content="noindex">` em páginas /pt/** — Debatable.
+   Atualmente indexam como páginas PT-BR. Isso é correto (elas são conteúdo único
+   em PT-BR, não duplicatas). Manter como está.
+
+## Decisões arquiteturais
+
+- **`max-snippet:-1` no robots meta**: Sem esse valor, Google pode cortar snippets
+  nos resultados de busca. Para essays filosóficos de 1000+ palavras, snippets
+  maiores comunicam melhor o valor do conteúdo e aumentam CTR. Risco: zero (o blog
+  já é público e indexável).
+
+- **Primeiro tag como `article:section`**: Os frontmatters do blog têm tags
+  ordenadas por relevância (e.g., `["ai", "agents", "law"]` → section = "ai").
+  Isso é uma heurística razoável. Alternativa seria um campo `section` dedicado,
+  mas adicionaria complexidade desnecessária para um blog pessoal.
+
+- **`:focus-visible` vs `:focus` no skip link**: O skip link é uma feature de
+  acessibilidade para usuários de teclado. Usar `:focus` o tornaria visível em
+  qualquer interação de foco, incluindo programáticas. `:focus-visible` é mais
+  restritivo e correto: só aparece em navegação por teclado/assistiva.
+
+- **Cherry-pick vs rebase do PR #200**: Cherry-pick foi escolhido sobre rebase
+  por ser mais cirúrgico. O PR #200 tem 3 commits: feature, session log e fix de
+  prettier. Só o commit de feature era necessário; session log e fix já estão
+  incluídos nesta sessão de outra forma.

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -17,6 +17,7 @@ const booksHref    = lang === 'pt' ? `${prefix}/livros/` : '/books/';
 const searchHref   = `${prefix}/search/`;
 const aboutHref    = `${prefix}/about/`;
 const projectsHref = `${prefix}/projects/`;
+const rankingHref  = `${prefix}/ranking/`;
 
 const menuLabel = t(lang, 'nav.menu');
 
@@ -24,6 +25,7 @@ const navLinks = [
   { href: archiveHref,  label: t(lang, 'nav.archive') },
   { href: tagsHref,     label: t(lang, 'nav.tags') },
   { href: projectsHref, label: t(lang, 'nav.projects') },
+  { href: rankingHref,  label: t(lang, 'nav.ranking') },
   { href: musicHref,    label: t(lang, 'nav.music') },
   { href: booksHref,    label: t(lang, 'nav.books') },
   { href: searchHref,   label: t(lang, 'nav.search') },

--- a/src/components/HomeAuthorRail.astro
+++ b/src/components/HomeAuthorRail.astro
@@ -24,7 +24,7 @@ const rssHref = lang === "pt" ? "/pt/rss.xml" : "/rss.xml";
 
   <hr class="rail-divider" />
 
-  <p class="rail-eyebrow"><small>{t(lang, 'author.stayInLoop')}</small></p>
+  <p class="rail-eyebrow rail-loop-eyebrow"><small>{t(lang, 'author.stayInLoop')}</small></p>
   <ul class="rail-links">
     <li>
       <a href={rssHref}>
@@ -110,5 +110,47 @@ const rssHref = lang === "pt" ? "/pt/rss.xml" : "/rss.xml";
     height: 18px;
     color: var(--pico-primary);
     flex-shrink: 0;
+  }
+
+  /* Compact horizontal layout on mobile/tablet */
+  @media (max-width: 1099px) {
+    .home-author-rail {
+      display: grid;
+      grid-template-columns: 56px 1fr;
+      grid-template-rows: auto;
+      column-gap: 1rem;
+      align-items: start;
+    }
+    .rail-avatar {
+      grid-row: 1 / 5;
+      width: 56px;
+      height: 56px;
+      margin-bottom: 0;
+    }
+    .rail-eyebrow { grid-column: 2; }
+    .rail-bio {
+      grid-column: 2;
+      margin-bottom: 0.5rem;
+      font-size: 0.88rem;
+      display: -webkit-box;
+      -webkit-line-clamp: 3;
+      -webkit-box-orient: vertical;
+      overflow: hidden;
+    }
+    .rail-more {
+      grid-column: 2;
+      margin-bottom: 0.5rem;
+      font-size: 0.88rem;
+    }
+    .rail-divider { display: none; }
+    .rail-links {
+      grid-column: 2;
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.75rem;
+    }
+    .rail-links a { font-size: 0.85rem; }
+    /* Hide the "Stay in loop" eyebrow on mobile — links are self-evident */
+    .rail-loop-eyebrow { display: none; }
   }
 </style>

--- a/src/components/PostCard.astro
+++ b/src/components/PostCard.astro
@@ -26,7 +26,7 @@ const visibleTags = allTags.slice(0, 3);
 const overflowCount = allTags.length - visibleTags.length;
 ---
 
-<article data-post-lang={postLang}>
+<article data-post-lang={postLang} lang={postLang}>
   {heroImage && (
     <a href={href}>
       <Image

--- a/src/generated/blog-translation-pairs.json
+++ b/src/generated/blog-translation-pairs.json
@@ -87,6 +87,14 @@
     "pt": "/pt/blog/eles-esto-realmente-usando-uma-postagem-do-reddit-para-ajudar-a-bombardear-um-submarino-no-ir/",
     "en": "/blog/reddit-submarine-osint/"
   },
+  "/pt/blog/esta-chovendo-verdade/": {
+    "pt": "/pt/blog/esta-chovendo-verdade/",
+    "en": "/blog/its-raining-truth/"
+  },
+  "/blog/its-raining-truth/": {
+    "pt": "/pt/blog/esta-chovendo-verdade/",
+    "en": "/blog/its-raining-truth/"
+  },
   "/pt/blog/estamos-todos-nos-tornando-lagostas/": {
     "pt": "/pt/blog/estamos-todos-nos-tornando-lagostas/",
     "en": "/blog/we-are-all-becoming-lobsters/"
@@ -174,14 +182,6 @@
   "/blog/the-agent-that-doesnt-invent-verbs/": {
     "pt": "/pt/blog/o-agente-que-nao-inventa-verbos/",
     "en": "/blog/the-agent-that-doesnt-invent-verbs/"
-  },
-  "/pt/blog/esta-chovendo-verdade/": {
-    "pt": "/pt/blog/esta-chovendo-verdade/",
-    "en": "/blog/its-raining-truth/"
-  },
-  "/blog/its-raining-truth/": {
-    "pt": "/pt/blog/esta-chovendo-verdade/",
-    "en": "/blog/its-raining-truth/"
   },
   "/pt/blog/o-ovo-de-serpente/": {
     "pt": "/pt/blog/o-ovo-de-serpente/",

--- a/src/layouts/PageLayout.astro
+++ b/src/layouts/PageLayout.astro
@@ -127,7 +127,10 @@ const personLd = {
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>{documentTitle}</title>
     <meta name="description" content={description} />
+    <meta name="robots" content="max-image-preview:large, max-snippet:-1, max-video-preview:-1" />
     <meta name="author" content="Franklin Baldo" />
+    {type === 'article' && tags?.[0] && <meta property="article:section" content={tags[0]} />}
+    {type === 'article' && <link rel="author" href={Astro.site ? new URL(lang === 'pt' ? '/pt/about/' : '/about/', Astro.site).href : '/about/'} />}
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png" />
     <link rel="icon" type="image/png" sizes="192x192" href="/favicon-192.png" />
     <link rel="icon" href="/favicon.ico" sizes="any" />

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -8,11 +8,13 @@ const UI_KEYS = [
   "nav.archive",
   "nav.tags",
   "nav.projects",
+  "nav.ranking",
   "nav.music",
   "nav.books",
   "nav.search",
   "nav.about",
   "nav.menu",
+  "archive.jumpToYear",
   "post.continueReading",
   "post.minutesRead",
   "post.updated",
@@ -81,6 +83,7 @@ export const LANGUAGES: Record<string, LangConfig> = {
       "nav.archive": "Archive",
       "nav.tags": "Tags",
       "nav.projects": "Projects",
+      "nav.ranking": "Ranking",
       "nav.music": "Music",
       "nav.books": "Books",
       "nav.search": "Search",
@@ -129,6 +132,7 @@ export const LANGUAGES: Record<string, LangConfig> = {
       "og.siteDescription":
         "Essays on AI agency, process metaphysics, and the architecture of legal systems.",
       "og.qrHint": "Scan to read",
+      "archive.jumpToYear": "Jump to year:",
     },
     targets: {
       pt: {
@@ -146,6 +150,7 @@ export const LANGUAGES: Record<string, LangConfig> = {
       "nav.archive": "Arquivo",
       "nav.tags": "Tags",
       "nav.projects": "Projetos",
+      "nav.ranking": "Ranking",
       "nav.music": "Músicas",
       "nav.books": "Livros",
       "nav.search": "Buscar",
@@ -194,6 +199,7 @@ export const LANGUAGES: Record<string, LangConfig> = {
       "og.siteDescription":
         "Ensaios sobre agentes de IA, metafísica do processo e a arquitetura dos sistemas jurídicos.",
       "og.qrHint": "Aponte para ler",
+      "archive.jumpToYear": "Ir para o ano:",
     },
     targets: {
       en: {

--- a/src/pages/archive.astro
+++ b/src/pages/archive.astro
@@ -2,6 +2,7 @@
 import { getCollection } from "astro:content";
 import PageLayout from "../layouts/PageLayout.astro";
 import { isPublished } from "../lib/publish";
+import { t } from "../lib/i18n";
 
 const all = await getCollection("blog");
 
@@ -54,6 +55,15 @@ const archiveLd = {
     <p><small>{posts.length} essays</small></p>
   </hgroup>
 
+  {years.length > 1 && (
+    <nav class="year-jump" aria-label="Jump to year">
+      <small>{t("en", "archive.jumpToYear")}</small>
+      {years.map((year) => (
+        <a href={`#archive-${year}`}>{year}</a>
+      ))}
+    </nav>
+  )}
+
   {years.map((year) => (
     <section aria-labelledby={`archive-${year}`} class="archive-year">
       <h2 id={`archive-${year}`}>{year}</h2>
@@ -94,6 +104,28 @@ const archiveLd = {
 </PageLayout>
 
 <style>
+  .year-jump {
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+    flex-wrap: wrap;
+    margin-bottom: calc(var(--pico-spacing) * 1.5);
+    color: var(--pico-muted-color);
+  }
+  .year-jump a {
+    font-size: 0.82rem;
+    font-weight: 600;
+    padding: 0.15em 0.5em;
+    border-radius: 4px;
+    background: color-mix(in srgb, var(--pico-primary) 10%, transparent);
+    color: var(--pico-primary);
+    border: 1px solid color-mix(in srgb, var(--pico-primary) 25%, transparent);
+    text-decoration: none;
+  }
+  .year-jump a:hover {
+    background: color-mix(in srgb, var(--pico-primary) 20%, transparent);
+    text-decoration: none;
+  }
   .archive-year { margin-block: calc(var(--pico-spacing) * 1.5); }
   .archive-table { font-size: 0.95rem; }
   .archive-table .col-date {

--- a/src/pages/pt/archive.astro
+++ b/src/pages/pt/archive.astro
@@ -2,6 +2,7 @@
 import { getCollection } from "astro:content";
 import PageLayout from "../../layouts/PageLayout.astro";
 import { isPublished } from "../../lib/publish";
+import { t } from "../../lib/i18n";
 
 const all = await getCollection("blog");
 
@@ -60,6 +61,15 @@ const years = [...byYear.keys()].sort((a, b) => b - a);
     <p><small>{posts.length} ensaios</small></p>
   </hgroup>
 
+  {years.length > 1 && (
+    <nav class="year-jump" aria-label="Ir para o ano">
+      <small>{t("pt", "archive.jumpToYear")}</small>
+      {years.map((year) => (
+        <a href={`#archive-${year}`}>{year}</a>
+      ))}
+    </nav>
+  )}
+
   {years.map((year) => (
     <section aria-labelledby={`archive-${year}`} class="archive-year">
       <h2 id={`archive-${year}`}>{year}</h2>
@@ -100,6 +110,28 @@ const years = [...byYear.keys()].sort((a, b) => b - a);
 </PageLayout>
 
 <style>
+  .year-jump {
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+    flex-wrap: wrap;
+    margin-bottom: calc(var(--pico-spacing) * 1.5);
+    color: var(--pico-muted-color);
+  }
+  .year-jump a {
+    font-size: 0.82rem;
+    font-weight: 600;
+    padding: 0.15em 0.5em;
+    border-radius: 4px;
+    background: color-mix(in srgb, var(--pico-primary) 10%, transparent);
+    color: var(--pico-primary);
+    border: 1px solid color-mix(in srgb, var(--pico-primary) 25%, transparent);
+    text-decoration: none;
+  }
+  .year-jump a:hover {
+    background: color-mix(in srgb, var(--pico-primary) 20%, transparent);
+    text-decoration: none;
+  }
   .archive-year { margin-block: calc(var(--pico-spacing) * 1.5); }
   .archive-table { font-size: 0.95rem; }
   .archive-table .col-date {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -266,7 +266,7 @@ body::before {
   background: var(--pico-background-color);
   color: var(--pico-primary);
 }
-.skip-link:focus {
+.skip-link:focus-visible {
   left: 0.5rem;
   top: 0.5rem;
 }


### PR DESCRIPTION
## Summary

- **Forward-port PR #200** — ranking in nav, archive year-jump pills, mobile AuthorRail compact (cherry-picked into current main; PR #200 can be closed)
- **`<meta name="robots" content="max-image-preview:large, max-snippet:-1, max-video-preview:-1">`** — tells Google to use full image previews + unlimited text snippets → improves CTR from search results
- **`<meta property="article:section">`** — adds OG article section (first tag) for blog posts → helps social scrapers and search engines categorize articles
- **`<link rel="author">`** — standard HTML5 author attribution on article pages → points to `/about/`
- **`lang` attribute on PostCard `<article>`** — screen readers announce language when traversing post lists
- **skip-link `:focus` → `:focus-visible`** — skip link now only appears on keyboard navigation, not mouse click (correct a11y behavior)
- **`.prettierignore` consolidated** — single `.routines/` line replaces three separate lines

## Session log

`.routines/2026-05-31T14-00-00-seo-a11y-pr200-forward.md`

## Test plan

- [ ] Build succeeds (`npm run build`)
- [ ] Prettier passes (`npx prettier --check .`)
- [ ] Archive shows year-jump pills when 2+ years exist (EN + PT)
- [ ] Ranking link appears in header nav
- [ ] Mobile AuthorRail shows compact horizontal layout on ≤1099px
- [ ] `<head>` of any page contains `<meta name="robots" content="max-image-preview:large...">`
- [ ] `<head>` of a blog post contains `<meta property="article:section">`
- [ ] `<head>` of a blog post contains `<link rel="author" href="...about...">`
- [ ] Skip link visible on Tab keypress, not visible on mouse click
- [ ] Screen reader announces `lang="pt"` when a PT PostCard is focused

https://claude.ai/code/session_014yuTyU5BBm7QAjxHbawcdk

---
_Generated by [Claude Code](https://claude.ai/code/session_014yuTyU5BBm7QAjxHbawcdk)_