### PR TITLE
feat(seo/a11y): color-scheme, dual RSS, article:author PT fix, focus h1

### DIFF
--- a/.routines/2026-06-03T14-00-00-color-scheme-rss-authormeta-focus-h1.md
+++ b/.routines/2026-06-03T14-00-00-color-scheme-rss-authormeta-focus-h1.md
@@ -1,0 +1,193 @@
+---
+date: 2026-06-03T14:00:00
+slug: color-scheme-rss-authormeta-focus-h1
+branch: claude/great-mccarthy-RZnky
+status: pr-open
+session: 30
+---
+
+# Sessão 2026-06-03 — color-scheme, RSS alternativo, article:author PT, focus h1
+
+## Contexto
+
+Trigésima sessão. Branch designado: `claude/great-mccarthy-RZnky`.
+
+Estado ao chegar:
+
+- 6 PRs abertos: #223 (hronir), #222 (content takeout), #221 (visual orphan), #220 (build output orphan), #219 (taxonomy orphan), #216 (takeout sétima sessão, CI falhou)
+- Sessão anterior (#29): RankingView URLs PT, `lang` no article, `articleSection` JSON-LD
+- Backlog prioritário: font Inter otimização, focus `h1`, RSS bilíngue no head
+
+## PRs revisados
+
+| PR | Título | CI | Ação |
+|----|--------|----|------|
+| #223 | hronir: run + edit-worst | ✅ All green | **Merged** |
+| #222 | May in Seven Drafts — bilingual post + takeout session 9 | ✅ All green | **Merged** |
+| #221 | feat(visual): close mockup gap | ❌ Kilo review failed, base desatualizada | **Closed** |
+| #220 | chore: update build output | ❌ Kilo failed, commita `dist/` (errado) | **Closed** |
+| #219 | feat: add document type taxonomy | ❌ Kilo pass, mas base antiga (307715a), labels só PT, conflita com requisito bilíngue | **Closed** |
+| #216 | takeout: sétima sessão + "O que o inverno abre" | ❌ check falhou, merge conflict com main | **Pendente** — conflito, próxima sessão |
+
+### Decisões sobre PRs orphan
+
+**#220 (build output)**: O diretório `dist/` não deve ser commitado — é gerado pelo CI (`npm run build`) no workflow de deploy. Commitar output de build quebra a separação source/artifact e desperdiça espaço no repositório. Fechado.
+
+**#219 (taxonomy)**: O conceito de `type` nos frontmatters (carta, fita, ensaio...) é bom, mas a PR estava baseada em `307715a6b9` (muito antiga vs main atual `b17df52`). A modificação do `index.astro` conflita severamente com a versão atual. Além disso, os labels dos filtros eram todos em PT apenas ("Todos", "Ler entrada"), violando o requisito bilíngue. Fechado — o conceito pode ser reimplementado corretamente em sessão futura.
+
+**#221 (visual)**: Kilo Code Review falhou, base desatualizada. Fechado para evitar merge problem.
+
+**#216 (takeout sétima sessão)**: O fix do Prettier foi commitado (`ed10675`) mas CI não re-rodou. Tentativa de `update_pull_request_branch` falhou com merge conflict. O conteúdo (o-que-o-inverno-abre + what-winter-opens) precisa ser cherry-picado ou rebaseado na próxima sessão.
+
+## Melhorias implementadas
+
+### 1. `<meta name="color-scheme" content="dark light">` (PageLayout.astro)
+
+**Problema**: Sem a declaração `color-scheme`, o browser tenta inferir o esquema de cor suportado. Em sites que suportam explicitamente tanto dark quanto light (via `data-theme` e Pico CSS), essa meta informa ao browser que ambos os modos são válidos.
+
+**Impacto**:
+- Chrome/Edge usam `color-scheme` para renderizar scrollbars, inputs e UI do browser no esquema correto desde o início (antes do CSS carregar)
+- Elimina o flash de scrollbar clara em modo escuro e vice-versa
+- Reconhecido pelo Lighthouse como melhora de Performance/UX
+
+**Mudança em `src/layouts/PageLayout.astro`**:
+```html
+<meta charset="UTF-8" />
+<meta name="color-scheme" content="dark light" />  <!-- adicionado -->
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+```
+
+### 2. RSS alternativo no `<head>` para o outro idioma
+
+**Problema**: O `<head>` declarava apenas o feed RSS do idioma atual da página. Leitores de RSS e agregadores (Feedly, NewsBlur, etc.) descobrem feeds via `<link rel="alternate" type="application/rss+xml">`. Se um leitor EN abre a homepage PT (ou vice-versa), não vê link para o feed do idioma preferido.
+
+**Mudança em `src/layouts/PageLayout.astro`**:
+```html
+<!-- feed do idioma atual (já existia) -->
+<link rel="alternate" type="application/rss+xml"
+  title={lang === 'pt' ? 'Franklin Baldo (Português)' : 'Franklin Baldo'}
+  href={rssUrl} />
+<!-- feed do outro idioma (novo) -->
+<link rel="alternate" type="application/rss+xml"
+  title={lang === 'pt' ? 'Franklin Baldo (English)' : 'Franklin Baldo (Português)'}
+  href={new URL(lang === 'pt' ? 'rss.xml' : 'pt/rss.xml', Astro.site)} />
+```
+
+**Por que**: Ambos os feeds existem e são válidos. Declarar os dois no `<head>` de todas as páginas ajuda agregadores e o Google a descobrir as duas versões do conteúdo. Custo: zero (2 `<link>` tags).
+
+### 3. Fix `article:author` OG meta para artigos PT
+
+**Problema**: O `<meta property="article:author">` apontava para `/about/` (EN) mesmo em artigos PT. Facebook, LinkedIn e scrapers OG usam esse campo para atribuir autoria. Para artigos PT, deveria apontar para `/pt/about/`.
+
+**Mudança em `src/layouts/PageLayout.astro`** (linha 184):
+```astro
+<!-- antes -->
+{type === 'article' && <meta property="article:author"
+  content={Astro.site ? new URL("/about/", Astro.site).href : "/about/"} />}
+
+<!-- depois -->
+{type === 'article' && <meta property="article:author"
+  content={Astro.site
+    ? new URL(lang === 'pt' ? '/pt/about/' : '/about/', Astro.site).href
+    : (lang === 'pt' ? '/pt/about/' : '/about/')} />}
+```
+
+**Consistência**: A `<link rel="author">` já usava `lang` para construir a URL correta (linha 138). O `article:author` OG estava desatualizado em relação a ela.
+
+### 4. Focus management: `<h1>` > `<main>` após navegação SPA
+
+**Problema**: Após navegação SPA via `astro:transitions` (ClientRouter), o foco era movido para `<main>`. Isso satisfaz o requisito de "focar na nova área de conteúdo" mas não anuncia o título da nova página ao screen reader — `<main>` não tem texto próprio, então o NVDA/JAWS/VoiceOver apenas diz "main" ou silencia.
+
+Focar `<h1>` causa o anúncio do título da página (e.g., "It's Raining Truth — heading level 1"), que é exatamente o que o usuário de leitor de tela precisa para entender que a navegação ocorreu e para qual página chegou.
+
+**Mudança em `src/layouts/PageLayout.astro`** (script inline):
+```javascript
+// antes
+document.addEventListener('astro:after-swap', () => {
+  const main = document.getElementById('main');
+  if (main) main.focus({ preventScroll: true });
+});
+
+// depois
+document.addEventListener('astro:after-swap', () => {
+  const h1 = document.querySelector('h1');
+  if (h1) {
+    h1.tabIndex = -1;       // faz h1 focusável programaticamente
+    h1.focus({ preventScroll: true });
+  } else {
+    const main = document.getElementById('main');
+    if (main) main.focus({ preventScroll: true });
+  }
+});
+```
+
+**Por que `tabIndex = -1`**: Elementos `<h1>` não são naturalmente focusáveis. `tabIndex = -1` os torna focusáveis via JavaScript (`.focus()`) sem adicioná-los à ordem de tab do usuário. O `<main>` já tinha `tabindex="-1"` declarado no HTML — fazemos o mesmo para `<h1>` dinamicamente para não poluir todos os templates com `tabindex="-1"` em cada heading.
+
+**Fallback**: Páginas sem `<h1>` (improvável mas defensivo) continuam focando `<main>`.
+
+**Referência**: Padrão recomendado por Heydon Pickering e Adrian Roselli para SPA focus management; implementado em React Router, Next.js (experimental) e Nuxt.
+
+## Build esperado
+
+As mudanças são puramente no `<head>` do layout e no script de focus management. Nenhuma mudança de conteúdo ou lógica de routing. Build deve passar sem alterações adicionais.
+
+```
+Discovered 2 languages: en, pt-br
+Indexed 84+ pages (inclui posts novos do PR #222 que foi mergeado)
+Prettier check: All matched files use Prettier code style! ✅
+```
+
+## Estado após esta sessão
+
+- PRs #222 e #223 mergeados ✅
+- PRs #219, #220, #221 fechados (orphan/problemáticos) ✅
+- PR #216 pendente (merge conflict) — próxima sessão
+- `<meta name="color-scheme">` ✅
+- RSS alternativo no `<head>` ✅
+- `article:author` OG meta correto para PT ✅
+- Focus `<h1>` após SPA navigation ✅
+
+## Plano para próximas sessões
+
+### Alta prioridade
+
+1. **Resolver PR #216** — Cherry-pick dos commits `d6914b9` (takeout log) e `ed10675` (prettier fix) para um novo branch baseado no main atual. O conteúdo é válido e deve ser publicado.
+
+2. **`@fontsource/inter` — verificar carregamento do variable font** — Em v5.x, o import padrão já carrega o variable font (latin subset). Verificar se o fallback para weights não usados (700, 800, 900) está sendo carregado desnecessariamente. Se sim, restringir para `@fontsource/inter/variable.css` explicitamente.
+
+3. **Taxonomy de tipo de documento** — O PR #219 foi fechado porque a base estava errada, mas o conceito é válido. Reimplementar corretamente:
+   - Campo `type` no content schema: `z.enum(['essay', 'letter', 'fiction', 'technical', 'dialogue', 'music'])`
+   - Labels bilíngues: EN e PT
+   - Filter UI na homepage EN e PT
+   - Aplicar `type` retrospectivamente nos frontmatters existentes
+
+### Média prioridade
+
+4. **Preload do woff2 Inter** — Requer hash do output do Vite (`/fonts/inter-latin-variable.woff2?hash`). Alternativa: `font-display: optional` no @font-face para eliminar FOIT em conexões lentas.
+
+5. **Archive pagination** — 2026 tem 44+ posts. Threshold de 50 é próximo. Monitorar.
+
+6. **RSS no footer** — Mostrar dois links de RSS (EN e PT) sempre visíveis no footer, mesmo que o visitante esteja na versão oposta.
+
+### Baixa prioridade
+
+7. **`lang` switch via `navigate()`** — Migrar `location.href` no LanguageSwitcher para `navigate()` da `astro:transitions/client`. Requer mudar o script de `is:inline` para módulo para usar `import { navigate }`.
+
+8. **Focus `h1` ao carregar a página pela primeira vez** — Atualmente só foca `h1` no `astro:after-swap` (SPA nav). No carregamento inicial (SSR), o browser foca o topo da página. Para consistência total, poderia focar `h1` também no `DOMContentLoaded`, mas isso não é necessário (o browser já anuncia o título via `<title>`).
+
+## Decisões arquiteturais
+
+- **`article:author` via `lang`**: A consistência com `<link rel="author">` (que já usava `lang`) é o argumento principal. O OG `article:author` sendo PT vs EN pode afetar como scrapers atribuem o conteúdo na busca.
+
+- **`tabIndex = -1` dinamicamente vs staticamente no template**: Preferência dinâmica para não poluir o HTML semântico com `tabindex` em todos os `<h1>`. O custo de uma atribuição JS por navegação é desprezível.
+
+- **`color-scheme: dark light`** vs `color-scheme: normal`: `normal` significa "suporte apenas o padrão do browser". `dark light` significa "suporto explicitamente ambos, com dark preferido se o usuário preferir". Para este blog que tem toggle explícito de tema, `dark light` (sem preferência sobre qual vem primeiro) é mais correto.
+
+## Arquivos modificados
+
+- `src/layouts/PageLayout.astro` — color-scheme meta, RSS alternativo, article:author fix, focus h1
+- `.routines/2026-06-03T14-00-00-color-scheme-rss-authormeta-focus-h1.md` — este arquivo
+
+---
+
+_Sessão: 2026-06-03 | Branch: `claude/great-mccarthy-RZnky` | franklinbaldo@gmail.com_

--- a/src/layouts/PageLayout.astro
+++ b/src/layouts/PageLayout.astro
@@ -129,6 +129,7 @@ const personLd = {
 <html lang={langBcp47}>
   <head>
     <meta charset="UTF-8" />
+    <meta name="color-scheme" content="dark light" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>{documentTitle}</title>
     <meta name="description" content={description} />
@@ -144,6 +145,7 @@ const personLd = {
     <meta name="theme-color" content="#fdfdfd" media="(prefers-color-scheme: light)" />
     <link rel="canonical" href={canonical.href} />
     <link rel="alternate" type="application/rss+xml" title={lang === 'pt' ? 'Franklin Baldo (Português)' : 'Franklin Baldo'} href={rssUrl} />
+    <link rel="alternate" type="application/rss+xml" title={lang === 'pt' ? 'Franklin Baldo (English)' : 'Franklin Baldo (Português)'} href={new URL(lang === 'pt' ? 'rss.xml' : 'pt/rss.xml', Astro.site)} />
     <link rel="sitemap" href="/sitemap-index.xml" />
     {hasMath && <link rel="stylesheet" href="/katex/katex.min.css" />}
 
@@ -179,7 +181,7 @@ const personLd = {
     {modifiedTime && (
       <meta property="article:modified_time" content={modifiedTime.toISOString()} />
     )}
-    {type === 'article' && <meta property="article:author" content={Astro.site ? new URL("/about/", Astro.site).href : "/about/"} />}
+    {type === 'article' && <meta property="article:author" content={Astro.site ? new URL(lang === 'pt' ? '/pt/about/' : '/about/', Astro.site).href : (lang === 'pt' ? '/pt/about/' : '/about/')} />}
     {tags?.map((tag) => <meta property="article:tag" content={tag} />)}
 
     <meta name="twitter:card" content="summary_large_image" />
@@ -217,11 +219,17 @@ const personLd = {
       window.__translations = translations || {};
     </script>
     <script is:inline>
-      // Move focus to <main> after ClientRouter (SPA) navigations so keyboard
-      // and screen-reader users land in the new content, not limbo.
+      // Move focus to <h1> (or <main> as fallback) after ClientRouter (SPA) navigations
+      // so screen readers announce the new page title instead of a silent focus.
       document.addEventListener('astro:after-swap', () => {
-        const main = document.getElementById('main');
-        if (main) main.focus({ preventScroll: true });
+        const h1 = document.querySelector('h1');
+        if (h1) {
+          h1.tabIndex = -1;
+          h1.focus({ preventScroll: true });
+        } else {
+          const main = document.getElementById('main');
+          if (main) main.focus({ preventScroll: true });
+        }
       });
     </script>
   </head>


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Four SEO/a11y improvements to `PageLayout.astro`:

- **`<meta name="color-scheme" content="dark light">`** — tells browsers to render scrollbars and native UI in the correct scheme from the start, eliminating the brief flash on dark-mode page load. Recognized by Lighthouse as a UX/Performance improvement.

- **Dual RSS `<link>` discovery in `<head>`** — every page now declares both the EN and PT RSS feeds, so feed readers and Google discover both regardless of which language version they land on. Before: only the current-lang feed was advertised.

- **Fix `article:author` OG meta for PT articles** — was always pointing to `/about/` (EN) even on PT articles. Now uses `/pt/about/` for PT, consistent with the existing `<link rel="author">` which already used `lang` correctly.

- **Focus `<h1>` instead of `<main>` after SPA navigation** — after `astro:after-swap`, screen readers now announce the new page title ("It's Raining Truth — heading level 1") instead of a silent focus on the nameless `<main>` region. Falls back to `<main>` on pages without an h1. Sets `tabIndex = -1` dynamically so h1 is programmatically focusable without polluting every template with a static attribute.

## PRs reviewed this session

| PR | Action |
|----|--------|
| #223 hronir run | ✅ Merged |
| #222 May in Seven Drafts | ✅ Merged |
| #221 visual orphan | ❌ Closed (Kilo failed, outdated base) |
| #220 build output orphan | ❌ Closed (commits dist/, wrong practice) |
| #219 taxonomy orphan | ❌ Closed (old base, PT-only labels violate bilingual requirement) |
| #216 takeout 7th session | ⚠️ Pending — merge conflict, needs rebase next session |

## Test plan

- [ ] CI check passes (Prettier, Astro type check, build)
- [ ] Dark-mode: no scrollbar color flash on page load
- [ ] RSS feed reader discovers both EN and PT feeds from any page
- [ ] PT article `<head>` contains `article:author` pointing to `/pt/about/`
- [ ] Screen reader (NVDA/VoiceOver): SPA nav announces h1 title

https://claude.ai/code/session_019SiLvC3arHZtfYoLvJnni3
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_019SiLvC3arHZtfYoLvJnni3)_