### PR TITLE
fix(i18n): add missing translation pairs for library and dark-forest posts

### DIFF
--- a/src/generated/blog-translation-pairs.json
+++ b/src/generated/blog-translation-pairs.json
@@ -7,6 +7,14 @@
     "pt": "/pt/blog/a-api-do-jules-como-backend-do-harness/",
     "en": "/blog/jules-api-harness-backend/"
   },
+  "/pt/blog/a-biblioteca-que-o-blog-nao-citou/": {
+    "pt": "/pt/blog/a-biblioteca-que-o-blog-nao-citou/",
+    "en": "/blog/the-library-the-blog-didnt-cite/"
+  },
+  "/blog/the-library-the-blog-didnt-cite/": {
+    "pt": "/pt/blog/a-biblioteca-que-o-blog-nao-citou/",
+    "en": "/blog/the-library-the-blog-didnt-cite/"
+  },
   "/pt/blog/a-ia-descobrir-uma-nova-lei-de-conservao-antes-de-2050/": {
     "pt": "/pt/blog/a-ia-descobrir-uma-nova-lei-de-conservao-antes-de-2050/",
     "en": "/blog/will-ai-discover-new-conservation-law-before-2050/"
@@ -214,6 +222,14 @@
   "/blog/the-pampa-on-the-circuit-a-mate-with-boswell-digital/": {
     "pt": "/pt/blog/o-pampa-no-circuito-um-mate-com-o-boswell-digital/",
     "en": "/blog/the-pampa-on-the-circuit-a-mate-with-boswell-digital/"
+  },
+  "/pt/blog/o-que-a-floresta-escura-tem-a-ver-com-isso/": {
+    "pt": "/pt/blog/o-que-a-floresta-escura-tem-a-ver-com-isso/",
+    "en": "/blog/what-the-dark-forest-has-to-do-with-it/"
+  },
+  "/blog/what-the-dark-forest-has-to-do-with-it/": {
+    "pt": "/pt/blog/o-que-a-floresta-escura-tem-a-ver-com-isso/",
+    "en": "/blog/what-the-dark-forest-has-to-do-with-it/"
   },
   "/pt/blog/o-que-o-inverno-abre/": {
     "pt": "/pt/blog/o-que-o-inverno-abre/",


### PR DESCRIPTION
## Summary

- Adds two missing entries to `src/generated/blog-translation-pairs.json`:
  - `the-library-the-blog-didnt-cite` ↔ `a-biblioteca-que-o-blog-nao-citou`
  - `what-the-dark-forest-has-to-do-with-it` ↔ `o-que-a-floresta-escura-tem-a-ver-com-isso`

Both posts were merged to main but their translation-pair entries were absent, breaking the language switcher for those pages.

## Test plan

- [ ] `npm run hronir:doctor` reports 0 inconsistências
- [ ] Language switcher on `/blog/the-library-the-blog-didnt-cite/` links to the PT version
- [ ] Language switcher on `/blog/what-the-dark-forest-has-to-do-with-it/` links to the PT version

https://claude.ai/code/session_01RiKRqki7Y4yV1U8DmcimHm

---
_Generated by [Claude Code](https://claude.ai/code/session_01RiKRqki7Y4yV1U8DmcimHm)_