### PR TITLE
i18n: Webmentions — traduzir labels EN-only para PT-BR

### DIFF
--- a/.routines/2026-06-07T05-00-00-webmentions-i18n.md
+++ b/.routines/2026-06-07T05-00-00-webmentions-i18n.md
@@ -1,0 +1,83 @@
+---
+date: 2026-06-07T05:00:00
+slug: webmentions-i18n
+branch: claude/sleepy-pasteur-doYZt
+status: pr-open
+issues: [238]
+pr_opened: null
+pr_merged: null
+---
+
+# Sessão 2026-06-07 — Webmentions i18n (issue #238)
+
+## Contexto ao chegar
+
+Trigésima-terceira sessão. Branch designado: `claude/sleepy-pasteur-doYZt`.
+
+Estado ao chegar:
+- **14 issues `routine` abertas** — backlog saudável (10–20)
+- **1 PR aberto**: #254 (hronir/run-2026-06-06, não é meu — ignorado)
+- PR routine pendente: PR #252 (claude/sleepy-pasteur-Jkm3y, font-display: optional) já foi mergeado por Franklin em 2026-06-06T22:09:09Z
+- Sem PR routine aberto para mergear nesta run
+- Verificação de prod do PR #252: homepage carrega sem erros, CI verde confirmado pelo merge
+
+## Verificação de prod (PR #252 — font-display: optional)
+
+O PR #252 foi mergeado por Franklin antes desta run. Fiz fetch da homepage em produção — página carrega sem erros estruturais. A inspeção de screenshot de prod ficará para a próxima run (via Jina, que requer URL pública — a pipeline normal).
+
+## Backlog
+
+14 issues abertas → dentro da faixa 10–20. Sem criação de novas issues.
+
+Issues `priority:alta` disponíveis:
+- #238: Webmentions i18n (escolhida)
+- #239: Pagefind warnings build noise
+- #240: Archive colapsar anos antigos
+- #241: Taxonomia de tipo de documento
+
+## Trabalho executado: issue #238 — Webmentions i18n
+
+### Problema
+
+`src/components/Webmentions.astro` exibia strings hardcoded em inglês em posts PT-BR:
+- "Mentions across the web" (heading)
+- "like" / "likes" / "repost" / "reposts"
+- "from" 
+- "+N more"
+- "someone" / "anonymous" (fallbacks de nome de autor)
+
+O componente era chamado em `src/pages/pt/blog/[...slug].astro` sem receber `lang`, causando regressão de i18n.
+
+### Solução
+
+**1. `src/lib/i18n.ts`** — 9 novas chaves `webmentions.*`:
+- EN: heading, like, likes, repost, reposts, from, more, someone, anonymous
+- PT: Menções na web, curtida, curtidas, repostagem, repostagens, de, mais, alguém, anônimo
+
+**2. `src/components/Webmentions.astro`** — Aceita `lang?: string` prop. Todas as strings hardcoded substituídas por `t(lang, 'webmentions.X')`. Data localizada via `toLocaleDateString` com locale `pt-BR` para posts PT.
+
+**3. `src/pages/blog/[...slug].astro`** — Passa `lang={postLang}` ao componente.
+
+**4. `src/pages/pt/blog/[...slug].astro`** — Idem.
+
+### Verificação
+
+- `npm run build`: 0 erros ✅
+- `npx astro check`: 0 erros, 0 warnings ✅
+- `npx prettier --check .`: All matched files use Prettier code style ✅
+
+### Nota sobre UI visual
+
+O Webmentions só renderiza quando há mentions reais (API webmention.io). A verificação visual em produção depende de posts com mentions — a seção simplesmente não aparece em posts sem delas. A correção é de paridade i18n, verificável pelo código.
+
+## Plano para próximas sessões
+
+Por prioridade:
+1. **#239**: Pagefind warnings — build noise mascara erros reais
+2. **#240**: Archive collapse — UX degradando com 90+ posts
+3. **#241**: Taxonomia de tipo de documento
+4. **#242**: Novo reading path "Law and AI"
+
+---
+
+_Sessão: 2026-06-07 | Branch: `claude/sleepy-pasteur-doYZt` | franklinbaldo@gmail.com_

--- a/src/components/Webmentions.astro
+++ b/src/components/Webmentions.astro
@@ -1,6 +1,9 @@
 ---
+import { t, DEFAULT_LANG } from '../lib/i18n';
+
 interface Props {
   url: string | URL;
+  lang?: string;
 }
 
 interface Mention {
@@ -16,7 +19,7 @@ interface Mention {
     | "bookmark-of";
 }
 
-const { url } = Astro.props;
+const { url, lang } = Astro.props;
 const target = typeof url === "string" ? url : url.href;
 
 let mentions: Mention[] = [];
@@ -53,22 +56,22 @@ const replies = mentions.filter(
 
 {mentions.length > 0 && (
   <section aria-labelledby="webmentions-heading">
-    <h3 id="webmentions-heading">Mentions across the web</h3>
+    <h3 id="webmentions-heading">{t(lang, 'webmentions.heading')}</h3>
 
     {(likes.length > 0 || reposts.length > 0) && (
       <p>
         <small>
-          {likes.length > 0 && <>{likes.length} {likes.length === 1 ? 'like' : 'likes'}</>}
+          {likes.length > 0 && <>{likes.length} {likes.length === 1 ? t(lang, 'webmentions.like') : t(lang, 'webmentions.likes')}</>}
           {likes.length > 0 && reposts.length > 0 && ' · '}
-          {reposts.length > 0 && <>{reposts.length} {reposts.length === 1 ? 'repost' : 'reposts'}</>}
-          {' from '}
+          {reposts.length > 0 && <>{reposts.length} {reposts.length === 1 ? t(lang, 'webmentions.repost') : t(lang, 'webmentions.reposts')}</>}
+          {' '}{t(lang, 'webmentions.from')}{' '}
           {[...likes, ...reposts].slice(0, 5).map((m, i) => (
             <>
               {i > 0 && ', '}
-              <a href={m.author?.url ?? m.url ?? '#'}>{m.author?.name ?? 'anonymous'}</a>
+              <a href={m.author?.url ?? m.url ?? '#'}>{m.author?.name ?? t(lang, 'webmentions.anonymous')}</a>
             </>
           ))}
-          {likes.length + reposts.length > 5 && <> +{likes.length + reposts.length - 5} more</>}
+          {likes.length + reposts.length > 5 && <> +{likes.length + reposts.length - 5} {t(lang, 'webmentions.more')}</>}
         </small>
       </p>
     )}
@@ -78,10 +81,10 @@ const replies = mentions.filter(
         {replies.map((m) => (
           <li>
             <a href={m.url ?? m.author?.url ?? "#"}>
-              <strong>{m.author?.name ?? "someone"}</strong>
+              <strong>{m.author?.name ?? t(lang, 'webmentions.someone')}</strong>
             </a>
             {m.published && (
-              <small> · <time datetime={m.published}>{new Date(m.published).toLocaleDateString("en-US", { year: "numeric", month: "short", day: "2-digit" })}</time></small>
+              <small> · <time datetime={m.published}>{new Date(m.published).toLocaleDateString(lang === 'pt' ? 'pt-BR' : 'en-US', { year: "numeric", month: "short", day: "2-digit" })}</time></small>
             )}
           </li>
         ))}

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -55,6 +55,15 @@ const UI_KEYS = [
   "og.siteEyebrow",
   "og.siteDescription",
   "og.qrHint",
+  "webmentions.heading",
+  "webmentions.like",
+  "webmentions.likes",
+  "webmentions.repost",
+  "webmentions.reposts",
+  "webmentions.from",
+  "webmentions.more",
+  "webmentions.someone",
+  "webmentions.anonymous",
 ] as const;
 
 export type UIKey = (typeof UI_KEYS)[number];
@@ -133,6 +142,15 @@ export const LANGUAGES: Record<string, LangConfig> = {
         "Essays on AI agency, process metaphysics, and the architecture of legal systems.",
       "og.qrHint": "Scan to read",
       "archive.jumpToYear": "Jump to year:",
+      "webmentions.heading": "Mentions across the web",
+      "webmentions.like": "like",
+      "webmentions.likes": "likes",
+      "webmentions.repost": "repost",
+      "webmentions.reposts": "reposts",
+      "webmentions.from": "from",
+      "webmentions.more": "more",
+      "webmentions.someone": "someone",
+      "webmentions.anonymous": "anonymous",
     },
     targets: {
       pt: {
@@ -200,6 +218,15 @@ export const LANGUAGES: Record<string, LangConfig> = {
         "Ensaios sobre agentes de IA, metafísica do processo e a arquitetura dos sistemas jurídicos.",
       "og.qrHint": "Aponte para ler",
       "archive.jumpToYear": "Ir para o ano:",
+      "webmentions.heading": "Menções na web",
+      "webmentions.like": "curtida",
+      "webmentions.likes": "curtidas",
+      "webmentions.repost": "repostagem",
+      "webmentions.reposts": "repostagens",
+      "webmentions.from": "de",
+      "webmentions.more": "mais",
+      "webmentions.someone": "alguém",
+      "webmentions.anonymous": "anônimo",
     },
     targets: {
       en: {

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -194,7 +194,7 @@ const translationLinks = translationSiblings.map((p) => {
 
       <PostNav prev={prevNav} next={nextNav} lang={lang} />
 
-      <Webmentions url={new URL(Astro.url.pathname, Astro.site!)} />
+      <Webmentions url={new URL(Astro.url.pathname, Astro.site!)} lang={postLang} />
 
       <Comments lang={lang} />
 

--- a/src/pages/pt/blog/[...slug].astro
+++ b/src/pages/pt/blog/[...slug].astro
@@ -196,7 +196,7 @@ const translationLinks = translationSiblings.map((p) => {
 
       <PostNav prev={prevNav} next={nextNav} lang={lang} />
 
-      <Webmentions url={new URL(Astro.url.pathname, Astro.site!)} />
+      <Webmentions url={new URL(Astro.url.pathname, Astro.site!)} lang={postLang} />
 
       <Comments lang={lang} />
 


### PR DESCRIPTION
Closes #238

## i18n

`Webmentions.astro` exibia strings hardcoded em inglês dentro de posts PT-BR. Esta PR corrige a regressão de i18n adicionando traduções completas EN/PT e passando `lang` do contexto do post.

### Mudanças

**`src/lib/i18n.ts`** — 9 novas chaves `webmentions.*`:

| Chave | EN | PT |
|---|---|---|
| `webmentions.heading` | Mentions across the web | Menções na web |
| `webmentions.like` | like | curtida |
| `webmentions.likes` | likes | curtidas |
| `webmentions.repost` | repost | repostagem |
| `webmentions.reposts` | reposts | repostagens |
| `webmentions.from` | from | de |
| `webmentions.more` | more | mais |
| `webmentions.someone` | someone | alguém |
| `webmentions.anonymous` | anonymous | anônimo |

**`src/components/Webmentions.astro`** — Aceita `lang?: string` prop; todas as strings via `t(lang, key)`. Data localizada (`pt-BR` para posts PT, `en-US` para EN).

**`src/pages/blog/[...slug].astro`** e **`src/pages/pt/blog/[...slug].astro`** — Passam `lang={postLang}` ao componente.

### Gates

- `npm run build`: ✅ 0 erros
- `npx astro check`: ✅ 0 erros, 0 warnings
- `npx prettier --check .`: ✅ All matched files use Prettier code style

### Verificação visual

O componente só renderiza quando há webmentions reais (API webmention.io). Conferir em post com mentions: heading deve aparecer no idioma do post. A próxima run verifica screenshot de prod.

https://claude.ai/code/session_01ULYLAx3fsKsgw7cGi6dknD

---
_Generated by [Claude Code](https://claude.ai/code/session_01ULYLAx3fsKsgw7cGi6dknD)_