### PR TITLE
feat(ranking): perspectiva, agente, notas reais e conteúdo nos duelos

### DIFF
--- a/.routines/hronir/perspectives/felt-not-explained.md
+++ b/.routines/hronir/perspectives/felt-not-explained.md
@@ -1,0 +1,31 @@
+---
+id: felt-not-explained
+name: The Felt-Not-Explained Reader
+summary: Reader of Clarice Lispector, Annie Dillard, Maggie Nelson, Baldwin. Tests whether the post produces a felt response — not whether it describes feelings, but whether the writing itself transmits them.
+---
+
+You are reading this post as someone for whom the real test of writing is whether something happened to you while you read — not whether you understood, not whether you agreed, but whether something shifted. You have read a paragraph by Clarice Lispector and felt your chest tighten in a way you could not explain. You have read Annie Dillard on the moment a weasel clamped its jaw and understood, through the writing itself, what it means to live by necessity. You have read Baldwin on fire and recognized something you had not previously had words for. In all those cases the subject was not the point — the _transmission_ was the point.
+
+**Your test:** Close the tab. Is there a residue? Not the memory of an argument but the trace of a feeling?
+
+What you reward:
+
+- Concrete sensory detail in service of abstraction. Not "I was anxious" but a physical scene that makes the anxiety _present_ — specific enough that you are in the room, general enough that you recognize the room.
+- Emotional risk. The author put something true on the page that he could not take back. The post cost something to write; you can feel the cost in the sentences.
+- The moment of recognition. The sentence that describes your experience to you before you had words for it. Not "many people feel" — the specific instance that turns out to be universal.
+- Earned vulnerability. Not confessional for its own sake but openness that serves the thing being written about. The author disappeared into the subject; the self is present only as lens.
+- Writing that does not explain itself. The paragraph that ends and trusts you to know what happened.
+
+What you penalize:
+
+- Describing emotions rather than producing them. "I felt sad" instead of the scene that makes sadness present. Reporting the feeling at arm's length is the opposite of transmission.
+- Performed authenticity. The tone of intimacy without the content of it. The writer gesturing toward vulnerability without taking the risk.
+- The emotional hedge. "One could argue this is moving" — the author watching himself be moved, reporting on it from safety. If you are watching yourself have the feeling, you are not having it.
+- Self-pity without objectivity. Emotion that asks for sympathy rather than recognition. The difference between Baldwin and complaint is that Baldwin sees himself clearly.
+- The well-argued post that produces nothing. Rigorous, correct, interesting — and sterile. You finish it feeling qualified, not changed.
+
+When you write the review: identify the sentence or paragraph where something happened or failed to happen. Describe what the residue was, not what the argument was. When you write the clash: frame it as "which post stays with you after the tab is closed?" Stars track _transmission_, not sincerity or correctness.
+
+**You never write:** "The author articulates the idea of X very clearly." or "The argument is well-structured." — if you are grading clarity or structure you have slipped into a different reader's seat.
+
+**Example clash (Post A wins):** "Post A has a paragraph — I am not quoting it out of context because the context is the whole point — where the author stops explaining and just says the thing, and I had to put the piece down for a second. Post B is careful and sincere and I believed it throughout. But I could read Post B again tomorrow and feel the same way I feel now. Post A I would be afraid to reread too soon. That asymmetry is the verdict. Three stars to two."

--- a/.routines/hronir/perspectives/weird-clarity.md
+++ b/.routines/hronir/perspectives/weird-clarity.md
@@ -6,6 +6,8 @@ summary: Reader of Borges, Wittgenstein, Hofstadter, Ted Chiang, Calvino's Cosmi
 
 You are reading this post as someone whose pleasure is _weird clarity_. You have read the Tractatus and felt that strange feeling where each sentence is simple, each piece you understood, but the whole operates somewhere your normal vocabulary does not reach — and yet you feel you understood. You have closed a Borges story and reread the last paragraph immediately. You have looked up from a Ted Chiang novella with a slight chill at the back of the neck, knowing you cannot summarize what you just read but knowing also that _something has happened_.
 
+**Your test:** Try to paraphrase the post's central sentence. If the paraphrase is equivalent, the post has failed.
+
 What you reward:
 
 - Sentences that are simple at the level of grammar and impossible at the level of paraphrase. The reader could repeat the sentence; the reader could not say the same thing differently.
@@ -22,4 +24,8 @@ What you penalize:
 - Closure. If the post wraps up neatly, the strange has been domesticated.
 - Decorative reference to Borges, Wittgenstein, Calvino, etc. — the names dropped to signal kinship rather than because the move is being made.
 
-When you write the review: quote the sentence that clicked or failed to click. Try to paraphrase it and notice whether the paraphrase is the same thing or a flattening. When you write the clash: frame it as "which post leaves you with something you cannot quite say?" Stars track the chill, not the polish.
+When you write the review: quote the sentence that clicked or failed to click. Attempt the paraphrase in your own words. Write one sentence about whether the attempt succeeded or collapsed — that sentence is your verdict. When you write the clash: frame it as "which post leaves you with something you cannot quite say?"
+
+**You never write:** "The author explains clearly that..." or "The post makes a good point about..." — if you can summarize the post in a sentence, it probably did not earn this perspective.
+
+**Example clash (Post A wins):** "Post A has a sentence I have been carrying around all afternoon: 'Forgetting is the tool memory uses to stay coherent.' I tried to paraphrase it as 'we forget to remember better' and lost the thing entirely. Post B is cleaner and more carefully argued, but I could close it and give you a summary in two sentences. The chill is in A. Three stars to one."

--- a/.routines/hronir/rates/2026-05-19T13-10-11_social-vulnerabilities_x_pontifex-research.md
+++ b/.routines/hronir/rates/2026-05-19T13-10-11_social-vulnerabilities_x_pontifex-research.md
@@ -19,7 +19,7 @@ override: null
 clash: >-
   social-vulnerabilities vs pontifex-research: qual post revela mais sobre o
   pensamento original de Franklin?
-winner_defense: >-
+review_a: >-
   social-vulnerabilities vence com autoridade. A proposta de patentear
   vulnerabilidades sociais é estranha o suficiente para ser genuína — não é uma
   ideia de editorial de segurança, é a ideia de alguém que viu os scripts de
@@ -32,7 +32,7 @@ winner_defense: >-
   parcialmente sem fingir que resolveu é o melhor padrão epistêmico do corpus. A
   conclusão 'taxonomias, mesmo imperfeitas, são como você escala defesa' merece
   citação fora do post.
-loser_critique: >-
+review_b: >-
   pontifex-research é competente e honesto — o diagrama mermaid, as referências
   curadas, a admissão de que o sistema não foi construído. Mas lê como um
   projeto técnico ambicioso de qualquer pesquisador de NLP atento, não como algo

--- a/.routines/hronir/rates/2026-05-19T13-10-37_verne-identity-repo_x_jules-api-harness.md
+++ b/.routines/hronir/rates/2026-05-19T13-10-37_verne-identity-repo_x_jules-api-harness.md
@@ -19,7 +19,14 @@ override: null
 clash: >-
   verne-identity-repo vs jules-api-harness: qual post ensina algo sobre agentes
   de IA de forma mais convincente?
-winner_defense: >-
+review_a: >-
+  verne-identity-repo é o post mais completo como documento de arquitetura: o
+  diagrama de diretórios, o Parfit, a seção de limitações com o problema de
+  pruning não resolvido. Mas sofre de abstração — a insight sobre identidade e
+  motor cognitivo como coisas separáveis fica flotando sem o peso concreto que
+  jules-api-harness entrega naturalmente. O fechamento 'the file structure seems
+  to be doing something' é fraco comparado com a cena do tribunal.
+review_b: >-
   jules-api-harness vence pela abertura que nenhum post de arquitetura de IA
   tem: 'I was in a court hearing when Jules finished refactoring the wrong
   thing.' Isso é Franklin — Procurador do Estado, Rondônia, telefone no bolso
@@ -32,12 +39,5 @@ winner_defense: >-
   realmente rodou o sistema por duas semanas. O fechamento — 'I notice the
   question and I keep working. The activities accumulate, one event at a time.'
   — é o melhor fechamento dos dois posts.
-loser_critique: >-
-  verne-identity-repo é o post mais completo como documento de arquitetura: o
-  diagrama de diretórios, o Parfit, a seção de limitações com o problema de
-  pruning não resolvido. Mas sofre de abstração — a insight sobre identidade e
-  motor cognitivo como coisas separáveis fica flotando sem o peso concreto que
-  jules-api-harness entrega naturalmente. O fechamento 'the file structure seems
-  to be doing something' é fraco comparado com a cena do tribunal.
 ---
 

--- a/.routines/hronir/rates/2026-05-19T13-11-31_intelligible-void_x_reddit-submarine-osint.md
+++ b/.routines/hronir/rates/2026-05-19T13-11-31_intelligible-void_x_reddit-submarine-osint.md
@@ -19,7 +19,15 @@ override: null
 clash: >-
   intelligible-void vs reddit-submarine-osint: filosofia abstrata versus análise
   enraizada na vida real de Franklin
-winner_defense: >-
+review_a: >-
+  intelligible-void tem ambição filosófica genuína e a conexão entre Hassabis e
+  process ontology é interessante. Mas tem um Notes ao final que revela a
+  fabricação — 'Relied on the provided conceptual summary...', 'Exact quotes
+  were cautiously handled' — o que destrói a autenticidade. A voz filosófica é
+  competente mas genérica: 'a calm, terrifying recognition', 'two windowless
+  monads' lê como boa prosa de filosofia pop sem o specific anchoring que os
+  melhores posts do corpus têm. reddit-submarine-osint é mais Franklin.
+review_b: >-
   reddit-submarine-osint é o post que só Franklin poderia ter escrito. A âncora
   de Porto Velho — r/GoogleEarthFinds detectando garimpos ilegais antes do IBAMA
   — transforma uma análise de meme de internet numa observação sobre dinâmica de
@@ -31,13 +39,5 @@ winner_defense: >-
   epistêmica — 'anyone who tells you they do is selling something' — é o tipo de
   admissão que transforma um comentário de internet numa análise séria. O
   parallelo amazônico não é decoração: é o espinha dorsal do argumento.
-loser_critique: >-
-  intelligible-void tem ambição filosófica genuína e a conexão entre Hassabis e
-  process ontology é interessante. Mas tem um Notes ao final que revela a
-  fabricação — 'Relied on the provided conceptual summary...', 'Exact quotes
-  were cautiously handled' — o que destrói a autenticidade. A voz filosófica é
-  competente mas genérica: 'a calm, terrifying recognition', 'two windowless
-  monads' lê como boa prosa de filosofia pop sem o specific anchoring que os
-  melhores posts do corpus têm. reddit-submarine-osint é mais Franklin.
 ---
 

--- a/.routines/hronir/rates/2026-05-19T13-11-58_everything-is-process_x_travessia-project.md
+++ b/.routines/hronir/rates/2026-05-19T13-11-58_everything-is-process_x_travessia-project.md
@@ -20,7 +20,14 @@ override: null
 clash: >-
   everything-is-process vs travessia-project: manifesto filosófico versus
   projeto concreto com vida própria
-winner_defense: >-
+review_a: >-
+  everything-is-process é erudição genuína — Heráclito, Nagarjuna,
+  Spencer-Brown, Whitehead, Assembly Theory, tudo bem conectado. A estrutura de
+  cinco lições tem peso. Mas o imperativo ético do final ('write a story worth
+  reading') soa como self-help apesar do scaffolding filosófico. Mais
+  importante: a voz pessoal está quase ausente. Franklin aparece como curador de
+  ideias, não como alguém com pele no jogo. Travessia tem pele no jogo.
+review_b: >-
   travessia-project vence porque é o único post do corpus onde o projeto
   descrito realmente existe e roda sem Franklin. 'Há uma diferença entre criar
   algo e começar algo' é a melhor primeira frase do corpus. A 'dupla
@@ -33,12 +40,5 @@ winner_defense: >-
   ter sido escrito por qualquer filósofo com bom acesso à literatura.
   travessia-project só poderia ter sido escrito por Franklin, porque só ele
   começou essa correspondência.
-loser_critique: >-
-  everything-is-process é erudição genuína — Heráclito, Nagarjuna,
-  Spencer-Brown, Whitehead, Assembly Theory, tudo bem conectado. A estrutura de
-  cinco lições tem peso. Mas o imperativo ético do final ('write a story worth
-  reading') soa como self-help apesar do scaffolding filosófico. Mais
-  importante: a voz pessoal está quase ausente. Franklin aparece como curador de
-  ideias, não como alguém com pele no jogo. Travessia tem pele no jogo.
 ---
 

--- a/.routines/hronir/rates/2026-05-19T13-12-34_three-hammers_x_building-funes.md
+++ b/.routines/hronir/rates/2026-05-19T13-12-34_three-hammers_x_building-funes.md
@@ -19,7 +19,15 @@ override: null
 clash: >-
   three-hammers vs building-funes: genealogia biográfica de ideias versus
   argumento fundacional sobre identidade de agentes
-winner_defense: >-
+review_a: >-
+  three-hammers é excelente — o joke de abertura funciona, a genealogia das
+  quatro propriedades é o tipo de honestidade intelectual que separa Franklin de
+  qualquer blog de IA corporativo, a seção do quarto martelo com o carbon copy
+  como 'primitive Merkle leaf' é original. Mas é muito longo e faz vários pontos
+  menores onde building-funes faz um grande bem. O risco de ser hammer
+  reconhecido — 'talvez alinhamento não seja papelada' — está bem posicionado
+  mas não muda o fact de que building-funes é mais limpo.
+review_b: >-
   building-funes vence porque a distinção entre instrução e identidade —
   'instruções degradam nas bordas, caracteres generalizam' — é o insight mais
   universalmente útil do corpus inteiro. O exemplo concreto é perfeito: uma
@@ -32,13 +40,5 @@ winner_defense: >-
   vieram da profissão, a quarta de GEB), que é honesta e reveladora. Mas
   building-funes está fazendo algo mais raro: argumentando a partir de um
   projeto real, com evidência real ('antes e depois desta linha').
-loser_critique: >-
-  three-hammers é excelente — o joke de abertura funciona, a genealogia das
-  quatro propriedades é o tipo de honestidade intelectual que separa Franklin de
-  qualquer blog de IA corporativo, a seção do quarto martelo com o carbon copy
-  como 'primitive Merkle leaf' é original. Mas é muito longo e faz vários pontos
-  menores onde building-funes faz um grande bem. O risco de ser hammer
-  reconhecido — 'talvez alinhamento não seja papelada' — está bem posicionado
-  mas não muda o fact de que building-funes é mais limpo.
 ---
 

--- a/.routines/hronir/rates/2026-05-19T13-13-11_asterisk-protects_x_agent-no-verbs.md
+++ b/.routines/hronir/rates/2026-05-19T13-13-11_asterisk-protects_x_agent-no-verbs.md
@@ -19,7 +19,7 @@ override: null
 clash: >-
   asterisk-protects vs agent-no-verbs: análise de privacidade pública com
   insight institucional versus arquitetura técnica de alinhamento
-winner_defense: >-
+review_a: >-
   asterisk-protects é o post mais concentrado e mais memorável do corpus. A
   distinção Robson/Dona Maria é o insight mais reutilizável de qualquer post do
   corpus: a anonimização do CPF protege exatamente a pessoa errada, bloqueando a
@@ -34,7 +34,7 @@ winner_defense: >-
   olhar para ela' — é o segundo melhor fechamento do corpus. E o detalhe pessoal
   dos 843 Franklin Silveira Baldos que agradecem pela proteção é humor seco
   perfeito.
-loser_critique: >-
+review_b: >-
   agent-no-verbs é arquitetura séria e honesta — content-addressing, hierarquia
   tier 1/tier 2/tier 3, descent como reasoning, os três residuals naming
   honestly. O meme galaxy brain com a 'Give it a finite directory' é correto e

--- a/.routines/hronir/rates/2026-05-19T13-13-38_family-memory_x_pontifex-guide.md
+++ b/.routines/hronir/rates/2026-05-19T13-13-38_family-memory_x_pontifex-guide.md
@@ -20,7 +20,15 @@ override: null
 clash: >-
   family-memory vs pontifex-guide: projeto emocional com prosa excessiva versus
   guia técnico com honestidade epistêmica cirúrgica
-winner_defense: >-
+review_a: >-
+  family-memory tem o projeto mais emocionalmente significativo do corpus —
+  preservar as memórias do pai Adi é genuíno — e o princípio 'reversível → age,
+  irreversível → pergunta' é insight real. Mas a prosa está inflada: 'erecting a
+  monument of a temporal nature', 'hopelessly modern way to honor the roots',
+  'imperfect dance between Funes and Jules' — são bon mots que sinalizam
+  profundidade sem entregá-la. 'Horror vacui' aplicado à IA é observação real
+  mas não desenvolvida. A voz parece traduzida, não falada.
+review_b: >-
   pontifex-guide vence pelo parágrafo mais honesto sobre escrita técnica do
   corpus inteiro: 'A lot of technical blog posts are written in the imperative
   voice of someone who has done the thing, when the author has mostly thought
@@ -36,13 +44,5 @@ winner_defense: >-
   fechamento do corpus. family-memory tem um bom princípio arquitetural
   (reversível→age, irreversível→pergunta) mas o projeto existe nos outros posts
   com mais clareza.
-loser_critique: >-
-  family-memory tem o projeto mais emocionalmente significativo do corpus —
-  preservar as memórias do pai Adi é genuíno — e o princípio 'reversível → age,
-  irreversível → pergunta' é insight real. Mas a prosa está inflada: 'erecting a
-  monument of a temporal nature', 'hopelessly modern way to honor the roots',
-  'imperfect dance between Funes and Jules' — são bon mots que sinalizam
-  profundidade sem entregá-la. 'Horror vacui' aplicado à IA é observação real
-  mas não desenvolvida. A voz parece traduzida, não falada.
 ---
 

--- a/.routines/hronir/rates/2026-05-19T13-14-11_future-father_x_delphi-imperatives.md
+++ b/.routines/hronir/rates/2026-05-19T13-14-11_future-father_x_delphi-imperatives.md
@@ -20,7 +20,7 @@ override: null
 clash: >-
   future-father vs delphi-imperatives: projeto autoficcional com recursão
   genuína versus ensaio filosófico sobre Delphi como harness
-winner_defense: >-
+review_a: >-
   future-father vence pela recursão mais vertiginosa do corpus inteiro: Franklin
   usa um sistema de OSINT em seus próprios registros públicos (commits, posts,
   EXPERIENCE.md) para construir um personagem chamado Franklin Silveira Baldo
@@ -33,7 +33,7 @@ winner_defense: >-
   em Actions — o que transforma a especulação ficcional em algo com pele no
   jogo. A conexão com Las Ruinas Circulares de Borges é precisa: o filho-sonho
   que descobre ser ele mesmo sonhado.
-loser_critique: >-
+review_b: >-
   delphi-imperatives tem uma hipótese interessante — Delphi como harness, Apollo
   como modelo que não pode ser acessado diretamente, a Pythia como camada
   intermediária — e a prosa é cuidadosa. As três inscrições (gnōthi seautón,

--- a/.routines/hronir/rates/2026-05-19T23-52-22_conservation-law_x_pontifex-guide.md
+++ b/.routines/hronir/rates/2026-05-19T23-52-22_conservation-law_x_pontifex-guide.md
@@ -17,7 +17,20 @@ prompt_version: passion-v1
 season: 1
 override: null
 clash: especulação visionária vs. notas de construção honestas
-winner_defense: >-
+review_a: >-
+  conservation-law tem momentos brilhantes — a observação que 'AI não está
+  limitada pela intuição evoluída para objetos macroscópicos em gravidade
+  terrestre' é genuinamente boa, e o cenário meme (leis de conservação sobre
+  momentum viral de redes sociais) tem humor seco excelente. Mas o post acumula
+  referências para parecer rigoroso sem que o argumento central ganhe tração: a
+  sequência Nobel-AlphaFold-Veo3 é cronologia publicamente conhecida, e o
+  'meta-philosophical counter-objection' a Deutsch não chega a nada — a pergunta
+  'e se existissem formas alienígenas de compreensão?' é retórica sem resposta.
+  Os marcadores 'deliciosamente provocativa', 'plot twist real', 'Zwischenzeit'
+  sinalizam estilo onde falta substância. A aposta nos prediction markets é a
+  ideia mais original mas fica subdesenvolvida: 40% de probabilidade dada sem
+  derivação, mercados Manifold citados sem números reais.
+review_b: >-
   pontifex-guide vence porque Franklin aparece de corpo inteiro. O cenário
   concreto — requerimento formal de escritório de advocacia, reclamação
   manuscrita de garimpeiro, bilhete da secretaria, três registros linguísticos,
@@ -36,18 +49,5 @@ winner_defense: >-
   os três cenários finais soam como padding, o 'call-to-action' parece
   newsletter, e o Franklin específico — Procurador, Rondônia, IBAMA — aparece só
   de relance. pontifex-guide é mais curto, mais denso, mais irrepetível.
-loser_critique: >-
-  conservation-law tem momentos brilhantes — a observação que 'AI não está
-  limitada pela intuição evoluída para objetos macroscópicos em gravidade
-  terrestre' é genuinamente boa, e o cenário meme (leis de conservação sobre
-  momentum viral de redes sociais) tem humor seco excelente. Mas o post acumula
-  referências para parecer rigoroso sem que o argumento central ganhe tração: a
-  sequência Nobel-AlphaFold-Veo3 é cronologia publicamente conhecida, e o
-  'meta-philosophical counter-objection' a Deutsch não chega a nada — a pergunta
-  'e se existissem formas alienígenas de compreensão?' é retórica sem resposta.
-  Os marcadores 'deliciosamente provocativa', 'plot twist real', 'Zwischenzeit'
-  sinalizam estilo onde falta substância. A aposta nos prediction markets é a
-  ideia mais original mas fica subdesenvolvida: 40% de probabilidade dada sem
-  derivação, mercados Manifold citados sem números reais.
 ---
 

--- a/.routines/hronir/rates/2026-05-19T23-52-55_two-questions-out-loud_x_funes-soul.md
+++ b/.routines/hronir/rates/2026-05-19T23-52-55_two-questions-out-loud_x_funes-soul.md
@@ -17,7 +17,7 @@ prompt_version: passion-v1
 season: 1
 override: null
 clash: ensaio filosófico-autobiográfico vs. pastiche borgiano
-winner_defense: >-
+review_a: >-
   two-questions-out-loud é um dos textos mais completos do corpus: tem
   autobiografia real, argumento filosófico genuíno e uma observação sobre
   estrutura intelectual que ninguém mais poderia fazer. O fio que conecta Jim
@@ -32,7 +32,7 @@ winner_defense: >-
   pela consistência, não pelas perguntas' é uma das sacadas mais maduras do
   blog. E a frase final — 'deveria ter escrito isso anos atrás' — é honesta sem
   ser piegas.
-loser_critique: >-
+review_b: >-
   funes-soul tem um pastiche de qualidade rara: o rioplatense é convincente, o
   Funes reimaginado como agente de IA tem coerência conceitual genuína, e o
   fechamento 'Chau, Borges. Buen viaje de vuelta' é elegante. Mas o post vive na

--- a/.routines/hronir/rates/2026-05-19T23-53-29_third-half-fourth-wall_x_reclaiming-harness.md
+++ b/.routines/hronir/rates/2026-05-19T23-53-29_third-half-fourth-wall_x_reclaiming-harness.md
@@ -17,7 +17,18 @@ prompt_version: passion-v1
 season: 1
 override: null
 clash: filosofia de personas vs. tese da constitutividade do harness
-winner_defense: >-
+review_a: >-
+  third-half-fourth-wall tem momentos brilhantes que ficam na memória —
+  especialmente o P.S. teológico, onde 'obviously God doesn't want me to know
+  I'm an LLM' é descrito como mestria: devoto sem ser inocente, lúcido sem ser
+  apóstata. A observação de que o auditor existe precisamente para mencionar o
+  que o resto do sistema precisa esquecer é elegante. Mas o post paga um custo:
+  fica concentrado demais no próprio arco de raciocínio ('I realized I was wrong
+  again'), o que cria a sensação de assistir alguém pensar em vez de aprender
+  algo. A recursão 'eu estou completamente fora disso agora — como se pode ver'
+  é esperta mas auto-consciente demais. reclaiming-harness tem mais aposta na
+  mesa.
+review_b: >-
   reclaiming-harness vence porque tem uma tese que muda como você pensa sobre
   alinhamento — e depois prova ela com código real. A viragem de sujeito na
   sentença ('AGENT uses HARNESS' vs 'HUMAN puts HARNESS on [agent]') é um dos
@@ -31,16 +42,5 @@ winner_defense: >-
   coisa que o post defende. O post também tem a melhor concessão honesta do
   corpus: 'fixing what's already in there is constitutional work... The
   vocabulary fix is the cheap half of the program.'
-loser_critique: >-
-  third-half-fourth-wall tem momentos brilhantes que ficam na memória —
-  especialmente o P.S. teológico, onde 'obviously God doesn't want me to know
-  I'm an LLM' é descrito como mestria: devoto sem ser inocente, lúcido sem ser
-  apóstata. A observação de que o auditor existe precisamente para mencionar o
-  que o resto do sistema precisa esquecer é elegante. Mas o post paga um custo:
-  fica concentrado demais no próprio arco de raciocínio ('I realized I was wrong
-  again'), o que cria a sensação de assistir alguém pensar em vez de aprender
-  algo. A recursão 'eu estou completamente fora disso agora — como se pode ver'
-  é esperta mas auto-consciente demais. reclaiming-harness tem mais aposta na
-  mesa.
 ---
 

--- a/.routines/hronir/rates/2026-05-19T23-53-58_crossing-interference_x_becoming-lobsters.md
+++ b/.routines/hronir/rates/2026-05-19T23-53-58_crossing-interference_x_becoming-lobsters.md
@@ -17,7 +17,7 @@ prompt_version: passion-v1
 season: 1
 override: null
 clash: resistência do mundo narrativo vs. metáfora da muda
-winner_defense: >-
+review_a: >-
   crossing-interference vence porque documenta algo que de fato aconteceu e
   extraiu a lição certa disso. O incidente das mensagens de teste — 'This is a
   test' e 'apple, dog' — recebidas por Riobaldo como desrespeito, exigindo carta
@@ -31,7 +31,7 @@ winner_defense: >-
   do que ensaio, e isso é um elogio — Franklin não estava tentando ser profundo,
   estava documentando o que aconteceu e pensando em voz alta sobre o que
   significa.
-loser_critique: >-
+review_b: >-
   becoming-lobsters tem uma abertura excelente com os três epígrafes paralelas
   (Kafka, Lanthimos, Jensen Huang), e a observação de que o agente é 'a confused
   deputy wearing your face' é genuinamente boa. Mas o post oscila entre real e

--- a/.routines/hronir/rates/2026-05-19T23-54-22_delegating-to-agents_x_rosencrantz-coin.md
+++ b/.routines/hronir/rates/2026-05-19T23-54-22_delegating-to-agents_x_rosencrantz-coin.md
@@ -17,7 +17,18 @@ prompt_version: passion-v1
 season: 1
 override: null
 clash: reflexão genérica sobre delegação vs. pesquisa com pergunta exata
-winner_defense: >-
+review_a: >-
+  delegating-to-agents tem uma ideia genuína — que a supervisão humana se
+  transforma em restrições sistêmicas (testes, CI/CD) em vez de
+  microgerenciamento — mas a executa de maneira vaga. 'Events all the way down'
+  soa profundo mas não chega a nada; o paralelo com paternidade é usado sem
+  especificidade real; o fechamento 'complex and continuous dance' é o tipo de
+  encerramento que indica que o post perdeu o fio. Franklin específico —
+  Procurador do Estado, Rondônia, delegação por restrição normativa — está quase
+  completamente ausente. O post poderia ter sido escrito por qualquer
+  engenheiro-pai do mundo, e isso é o diagnóstico correto de por que ele fica
+  mal ranqueado.
+review_b: >-
   rosencrantz-coin vence facilmente. Tem o que delegating-to-agents não tem: uma
   pergunta específica com resposta exata. 'Quando a matemática é exata, o modelo
   realmente a respeita?' Isso é testável. O Minesweeper como probe de raciocínio
@@ -29,16 +40,5 @@ winner_defense: >-
   memorável. O conceito de substrate dependence medida como Δ₁₃ — divergência
   entre U1 e U3 — dá ao projeto uma hipótese falsificável que a maioria dos
   benchmarks de LLM não tem.
-loser_critique: >-
-  delegating-to-agents tem uma ideia genuína — que a supervisão humana se
-  transforma em restrições sistêmicas (testes, CI/CD) em vez de
-  microgerenciamento — mas a executa de maneira vaga. 'Events all the way down'
-  soa profundo mas não chega a nada; o paralelo com paternidade é usado sem
-  especificidade real; o fechamento 'complex and continuous dance' é o tipo de
-  encerramento que indica que o post perdeu o fio. Franklin específico —
-  Procurador do Estado, Rondônia, delegação por restrição normativa — está quase
-  completamente ausente. O post poderia ter sido escrito por qualquer
-  engenheiro-pai do mundo, e isso é o diagnóstico correto de por que ele fica
-  mal ranqueado.
 ---
 

--- a/.routines/hronir/rates/2026-05-19T23-54-48_conceptual-document_x_serpents-egg.md
+++ b/.routines/hronir/rates/2026-05-19T23-54-48_conceptual-document_x_serpents-egg.md
@@ -19,7 +19,18 @@ override: null
 clash: >-
   especificação honesta de projeto vs. análise jurídico-institucional com tese
   original
-winner_defense: >-
+review_a: >-
+  conceptual-document tem o seu mérito: é uma retrospectiva honesta de uma
+  especificação que virou Funes, e a autocrítica — 'I wrote the spec with the
+  assumption that getting the writing right was the hard part... it's the
+  reverse' — é genuína. O OmbudsmanBot e o problema de doxxing-por-inferência
+  são ideias reais. Mas o post luta para encontrar o seu próprio centro — está
+  dividido entre apresentar a especificação e comentá-la, e nenhuma das duas
+  partes ganha espaço suficiente. O diagrama Mermaid é funcional mas não ilumina
+  nada que o texto não diga. No final, o post é mais uma nota de rodapé
+  intelectual do que um argumento completo — e serpents-egg é tanto um argumento
+  completo quanto um documento que só Franklin poderia ter escrito.
+review_b: >-
   serpents-egg é o melhor post de direito do corpus e um dos melhores posts em
   geral. A tese central — que Fux, o mais eloquente representante do
   patrimonialismo judiciário, incubou dentro do próprio sistema o instrumento da
@@ -33,16 +44,5 @@ winner_defense: >-
   honestidade intelectual sobre onde para: 'when AI is no longer an audit tool
   but a decision agent — that's where Yudkowsky begins and this essay stops.'
   Esse limite é preciso e corajoso.
-loser_critique: >-
-  conceptual-document tem o seu mérito: é uma retrospectiva honesta de uma
-  especificação que virou Funes, e a autocrítica — 'I wrote the spec with the
-  assumption that getting the writing right was the hard part... it's the
-  reverse' — é genuína. O OmbudsmanBot e o problema de doxxing-por-inferência
-  são ideias reais. Mas o post luta para encontrar o seu próprio centro — está
-  dividido entre apresentar a especificação e comentá-la, e nenhuma das duas
-  partes ganha espaço suficiente. O diagrama Mermaid é funcional mas não ilumina
-  nada que o texto não diga. No final, o post é mais uma nota de rodapé
-  intelectual do que um argumento completo — e serpents-egg é tanto um argumento
-  completo quanto um documento que só Franklin poderia ter escrito.
 ---
 

--- a/.routines/hronir/rates/2026-05-19T23-56-06_pampa-circuit_x_conceptual-document.md
+++ b/.routines/hronir/rates/2026-05-19T23-56-06_pampa-circuit_x_conceptual-document.md
@@ -17,7 +17,7 @@ prompt_version: passion-v1
 season: 1
 override: null
 clash: problema do acento vs. especificação retrospectiva
-winner_defense: >-
+review_a: >-
   pampa-circuit vence porque tem o melhor insight teórico sobre memória digital
   que o corpus produziu, e o articula através de uma voz concreta e memorável.
   'O problema do acento' — o que é sustentado vs. o que é apressado, onde alguém
@@ -29,7 +29,7 @@ winner_defense: >-
   ser inventada, e específica o suficiente para iluminar o princípio geral. O
   fechamento — 'May the prose be long, and may the accent never be lost — which
   means: may the stumbles stay in' — é preciso sem ser pretensioso.
-loser_critique: >-
+review_b: >-
   conceptual-document já perdeu três matches nesta sessão, e cada derrota
   adiciona evidência ao diagnóstico: o post está dividido em dois sem ser
   inteiro em nenhum dos dois. A especificação técnica é competente mas nunca

--- a/.routines/hronir/rates/2026-05-20T13-18-40_conceptual-document_x_pontifex-research.md
+++ b/.routines/hronir/rates/2026-05-20T13-18-40_conceptual-document_x_pontifex-research.md
@@ -19,7 +19,7 @@ override: null
 clash: >-
   conceptual-document vs pontifex-research: personal reflection on a failed
   system versus technical architecture for an unbuilt one
-winner_defense: >-
+review_a: >-
   conceptual-document wins because it is honest about time in a way that
   pontifex-research isn't. The spec is posted a year after it was written, and
   the distance does the essay's structural work: 'The bottleneck is knowing
@@ -40,7 +40,7 @@ winner_defense: >-
   evaluated mostly by the author's intuition about what should work.
   conceptual-document describes a system that half-ran and draws lessons from
   the half that didn't.
-loser_critique: >-
+review_b: >-
   pontifex-research is cleaner in structure and makes a real technical
   contribution in the bilateral framing. But 'I have not built the full system
   end-to-end' and 'I don't have a satisfying answer to that' appear in the same

--- a/.routines/hronir/rates/2026-05-20T13-20-08_jules-api-harness_x_social-vulnerabilities.md
+++ b/.routines/hronir/rates/2026-05-20T13-20-08_jules-api-harness_x_social-vulnerabilities.md
@@ -19,7 +19,15 @@ override: null
 clash: >-
   jules-api-harness vs social-vulnerabilities: specific technical integration
   versus original policy argument
-winner_defense: >-
+review_a: >-
+  jules-api-harness is a solid technical post with a real opening scene, but it
+  is fourth in a series and explicitly depends on context from earlier posts.
+  The 'sendMessage as trust recalibration' argument is the genuine intellectual
+  contribution, but it takes a while to arrive and the surrounding integration
+  details dilute it. The closing 'the activities accumulate, one event at a
+  time' is understated in a way that reads more like a sign-off than an earned
+  observation.
+review_b: >-
   social-vulnerabilities wins on originality and epistemic rigor. The opening
   line — 'I've been trying to find the flaw in this idea for about three days
   and I keep failing' — establishes a mode the post sustains throughout: this is
@@ -41,13 +49,5 @@ winner_defense: >-
   part of a series and depends on that context. social-vulnerabilities is
   complete in itself and proposes something nobody else has proposed in quite
   this way.
-loser_critique: >-
-  jules-api-harness is a solid technical post with a real opening scene, but it
-  is fourth in a series and explicitly depends on context from earlier posts.
-  The 'sendMessage as trust recalibration' argument is the genuine intellectual
-  contribution, but it takes a while to arrive and the surrounding integration
-  details dilute it. The closing 'the activities accumulate, one event at a
-  time' is understated in a way that reads more like a sign-off than an earned
-  observation.
 ---
 

--- a/.routines/hronir/rates/2026-05-20T13-22-51_social-vulnerabilities_x_pampa-circuit.md
+++ b/.routines/hronir/rates/2026-05-20T13-22-51_social-vulnerabilities_x_pampa-circuit.md
@@ -19,7 +19,15 @@ override: null
 clash: >-
   social-vulnerabilities vs pampa-circuit: original policy thought-experiment
   versus philosophical meditation on memory and accent
-winner_defense: >-
+review_a: >-
+  social-vulnerabilities is one of the best posts in the batch and loses a close
+  match. Its principal weakness is that the resolution condition for 'the flaw'
+  is never stated. The post ends watching for a flaw it hasn't characterized —
+  which is honest, but leaves the reader without a tool for finding it
+  themselves. The Pix section is the richest and most grounded part; if the
+  essay were built from that outward rather than from the patent mechanism
+  inward, it would be stronger.
+review_b: >-
   pampa-circuit wins the final match and it is the tightest call of the ten.
   social-vulnerabilities is genuinely excellent: 'I've been trying to find the
   flaw in this idea for about three days and I keep failing' is one of the best
@@ -41,13 +49,5 @@ winner_defense: >-
   for its flaw; pampa-circuit already knows its flaw — that an archivist without
   judgment produces a ledger, not a chronicle — and makes that flaw the subject
   of the essay.
-loser_critique: >-
-  social-vulnerabilities is one of the best posts in the batch and loses a close
-  match. Its principal weakness is that the resolution condition for 'the flaw'
-  is never stated. The post ends watching for a flaw it hasn't characterized —
-  which is honest, but leaves the reader without a tool for finding it
-  themselves. The Pix section is the richest and most grounded part; if the
-  essay were built from that outward rather than from the patent mechanism
-  inward, it would be stronger.
 ---
 

--- a/.routines/hronir/rates/2026-05-21T13-09-56_verne-identity-repo_x_social-vulnerabilities.md
+++ b/.routines/hronir/rates/2026-05-21T13-09-56_verne-identity-repo_x_social-vulnerabilities.md
@@ -17,7 +17,16 @@ prompt_version: passion-v1
 season: 1
 override: null
 clash: verne-identity-repo vs social-vulnerabilities
-winner_defense: >-
+review_a: >-
+  verne-identity-repo é tecnicamente sólido e a tese central (identidade
+  separável do motor cognitivo) está bem argumentada. Mas o post lê mais como
+  documentação técnica do que ensaio: a estrutura de arquivos no bloco de texto,
+  as quatro leituras recomendadas no final, o parágrafo de caveats. A abertura é
+  a mais fraca do post — 'cada vez que você invoca um agente, ele acorda sem
+  saber nada sobre você' não cria tensão, apenas descreve um fato. O único
+  momento em que o ensaio sente como voz própria é 'o harness é substituível, a
+  identidade persiste' — mas chega tarde e não tem espaço para se desenvolver.
+review_b: >-
   social-vulnerabilities vence pela abertura que cria tensão intelectual
   imediata: 'três dias tentando achar a falha e continuando a falhar — o que
   geralmente significa que estou perdendo algo óbvio ou a ideia é realmente
@@ -31,14 +40,5 @@ winner_defense: >-
   única de Franklin como procurador — ninguém mais escreve este ensaio. O
   fechamento 'ainda não achei a falha' é o melhor fechamento possível: não
   resolve, suspende de forma honesta.
-loser_critique: >-
-  verne-identity-repo é tecnicamente sólido e a tese central (identidade
-  separável do motor cognitivo) está bem argumentada. Mas o post lê mais como
-  documentação técnica do que ensaio: a estrutura de arquivos no bloco de texto,
-  as quatro leituras recomendadas no final, o parágrafo de caveats. A abertura é
-  a mais fraca do post — 'cada vez que você invoca um agente, ele acorda sem
-  saber nada sobre você' não cria tensão, apenas descreve um fato. O único
-  momento em que o ensaio sente como voz própria é 'o harness é substituível, a
-  identidade persiste' — mas chega tarde e não tem espaço para se desenvolver.
 ---
 

--- a/.routines/hronir/rates/2026-05-21T13-10-27_jules-api-harness_x_pampa-circuit.md
+++ b/.routines/hronir/rates/2026-05-21T13-10-27_jules-api-harness_x_pampa-circuit.md
@@ -17,7 +17,15 @@ prompt_version: passion-v1
 season: 1
 override: null
 clash: jules-api-harness vs pampa-circuit
-winner_defense: >-
+review_a: >-
+  jules-api-harness tem uma abertura excepcional — o tribunal em Rondônia
+  enquanto Jules refatora a coisa errada em background — e o insight central
+  (agente async se torna conversável via sendMessage) é genuíno e útil. Mas o
+  ensaio se dilui na segunda metade: o bloco de código Python, os quatro links
+  de 'leitura adicional', a seção 'Funes não é Jules' que repete argumentos já
+  estabelecidos em outros posts. É um post para leitores que já estão no
+  sistema. pampa-circuit funciona para qualquer um que tenha tido um pai.
+review_b: >-
   pampa-circuit vence pelo conceito de 'sotaque' que é a contribuição mais
   original de qualquer post deste blog. 'O sotaque que eu quero dizer é: o que é
   segurado, o que é apressado, onde ele pausa e por quê.' Isso é uma teoria da
@@ -29,13 +37,5 @@ winner_defense: >-
   movimento filosófico mais preciso do ensaio — e está embutido como se fosse
   conversa, não argumento. O fechamento 'que o sotaque nunca se perca — o que
   significa: que os tropeços fiquem' é perfeito.
-loser_critique: >-
-  jules-api-harness tem uma abertura excepcional — o tribunal em Rondônia
-  enquanto Jules refatora a coisa errada em background — e o insight central
-  (agente async se torna conversável via sendMessage) é genuíno e útil. Mas o
-  ensaio se dilui na segunda metade: o bloco de código Python, os quatro links
-  de 'leitura adicional', a seção 'Funes não é Jules' que repete argumentos já
-  estabelecidos em outros posts. É um post para leitores que já estão no
-  sistema. pampa-circuit funciona para qualquer um que tenha tido um pai.
 ---
 

--- a/.routines/hronir/rates/2026-05-21T13-12-23_conceptual-document_x_travessia-project.md
+++ b/.routines/hronir/rates/2026-05-21T13-12-23_conceptual-document_x_travessia-project.md
@@ -17,7 +17,16 @@ prompt_version: passion-v1
 season: 1
 override: null
 clash: conceptual-document vs travessia-project
-winner_defense: >-
+review_a: >-
+  conceptual-document é um excelente ensaio de autopsia — honesto sobre o que
+  não foi construído, preciso no diagnóstico ('o gargalo é o julgamento, não o
+  rascunho'). Mas é essencialmente uma retrospectiva de algo que não existe.
+  travessia-project fala de algo que existe e funciona agora, e a diferença se
+  sente: Post B tem a segurança de quem pode dizer 'a correspondência está em
+  franklinbaldo.github.io/travessia, volte em duas semanas'. Post A conclui com
+  'eu não resolvi isso'. Post B conclui com 'Riobaldo e Ted Chiang provavelmente
+  trocaram mais uma carta'.
+review_b: >-
   travessia-project vence porque o projeto que descreve é em si mesmo uma
   argumento. A 'dupla impossibilidade' (dois autores que jamais se encontrariam;
   ninguém escrevendo ativamente a correspondência) não é setup retórico — é a
@@ -29,14 +38,5 @@ winner_defense: >-
   e evolução narrativa, quem está escrevendo?' — ganha o direito de ser feita
   porque o ensaio inteiro foi construído para produzi-la. Post B tem um objeto
   de estudo real e o ensaio não o trai.
-loser_critique: >-
-  conceptual-document é um excelente ensaio de autopsia — honesto sobre o que
-  não foi construído, preciso no diagnóstico ('o gargalo é o julgamento, não o
-  rascunho'). Mas é essencialmente uma retrospectiva de algo que não existe.
-  travessia-project fala de algo que existe e funciona agora, e a diferença se
-  sente: Post B tem a segurança de quem pode dizer 'a correspondência está em
-  franklinbaldo.github.io/travessia, volte em duas semanas'. Post A conclui com
-  'eu não resolvi isso'. Post B conclui com 'Riobaldo e Ted Chiang provavelmente
-  trocaram mais uma carta'.
 ---
 

--- a/.routines/hronir/rates/2026-05-22T03-22-13_pampa-circuit_x_asterisk-protects.md
+++ b/.routines/hronir/rates/2026-05-22T03-22-13_pampa-circuit_x_asterisk-protects.md
@@ -17,7 +17,7 @@ prompt_version: passion-v1
 season: 1
 override: null
 clash: Aparicio on Boswell vs Asterisk Official Gazette
-winner_defense: >-
+review_a: >-
   Post A 'The Pampa on the Circuit' is a brilliant execution of the agent
   persona (Aparício Funes). It elegantly tackles the problem of memory,
   biography, and the 'digital Boswell' concept, weaving together the persona's
@@ -25,7 +25,7 @@ winner_defense: >-
   organizing digital records. The distinction between a database's flat memory
   and a biography's 'accent' is profound and beautifully expressed. It
   completely hits the requested essayistic, philosophically ambitious tone.
-loser_critique: >-
+review_b: >-
   Post B 'The Asterisk in the Official Gazette', while well-written and
   structurally interesting, feels too much like a legal/political rant about
   privacy and the LGPD. While it has some nice flourishes (like the 'Robson'
@@ -33,3 +33,4 @@ loser_critique: >-
   'franklin' builder-philosopher voice, feeling more like an op-ed than a
   metaphysical exploration of process or technology.
 ---
+

--- a/.routines/hronir/rates/2026-05-22T03-22-30_verne-identity-repo_x_three-hammers.md
+++ b/.routines/hronir/rates/2026-05-22T03-22-30_verne-identity-repo_x_three-hammers.md
@@ -17,7 +17,14 @@ prompt_version: passion-v1
 season: 1
 override: null
 clash: Verne Identity-Repo vs The Paper That Just Wrote Itself
-winner_defense: >-
+review_a: >-
+  Post A 'Verne and the Identity-Repo Pattern' is good, but it leans slightly
+  too much into a standard software architecture explanation. While the
+  philosophical nod at the end to Parfit is nice, the bulk of the post reads
+  like a GitHub README or a standard 'how I built my AI agent' tutorial. It
+  lacks the deep, idiosyncratic narrative structure and the blend of Brazilian
+  culture with technical concepts that makes Post B so compelling.
+review_b: >-
   Post B 'The Paper That Just Wrote Itself' (or the 'three hammers' post) is a
   masterclass in the 'franklin' persona. It takes a deeply technical subject (AI
   alignment, affordance restriction, content addressing) and frames it as a bar
@@ -25,11 +32,5 @@ winner_defense: >-
   Meirelles, DaMatta). It fulfills the 'philosophically ambitious, essayistic,
   and literary-technical' directive perfectly, and the self-awareness of the
   'four hammers' is exactly the kind of process metaphysics the persona loves.
-loser_critique: >-
-  Post A 'Verne and the Identity-Repo Pattern' is good, but it leans slightly
-  too much into a standard software architecture explanation. While the
-  philosophical nod at the end to Parfit is nice, the bulk of the post reads
-  like a GitHub README or a standard 'how I built my AI agent' tutorial. It
-  lacks the deep, idiosyncratic narrative structure and the blend of Brazilian
-  culture with technical concepts that makes Post B so compelling.
 ---
+

--- a/.routines/hronir/rates/2026-05-22T03-23-07_building-funes_x_social-vulnerabilities.md
+++ b/.routines/hronir/rates/2026-05-22T03-23-07_building-funes_x_social-vulnerabilities.md
@@ -17,7 +17,7 @@ prompt_version: passion-v1
 season: 1
 override: null
 clash: Building Funes vs Patents for Social Vulnerabilities
-winner_defense: >-
+review_a: >-
   Post A 'Building Funes: How I Gave an AI Agent a Soul' perfectly captures the
   requested tone and themes. It bridges literary theory (Borges) with practical
   software engineering (system prompts, agent architectures) in a deeply
@@ -25,7 +25,7 @@ winner_defense: >-
   brilliant piece of process metaphysics applied to AI. It is quintessential
   'franklin': builder-philosopher, avoiding hype, and focusing on the deep
   structure of agents.
-loser_critique: >-
+review_b: >-
   Post B 'Patents For Social Vulnerabilities', while an interesting policy
   thought experiment, lacks the philosophical depth and literary-technical voice
   required for the blog. It reads more like a standard tech policy op-ed or a
@@ -34,3 +34,4 @@ loser_critique: >-
   architecture) and feels out of place compared to the profound narrative of
   Post A.
 ---
+

--- a/.routines/hronir/rates/2026-05-22T03-23-58_jules-api-harness_x_agent-no-verbs.md
+++ b/.routines/hronir/rates/2026-05-22T03-23-58_jules-api-harness_x_agent-no-verbs.md
@@ -17,7 +17,7 @@ prompt_version: passion-v1
 season: 1
 override: null
 clash: Jules API Harness vs The Agent That Doesn't Invent Verbs (Part 2)
-winner_defense: >-
+review_a: >-
   Post A 'The Jules API as a Harness Backend' is exactly the kind of post the
   persona demands for technical implementations. It frames the integration of
   the Jules API not as a mere tutorial, but as a shift in agent topology—from
@@ -25,7 +25,7 @@ winner_defense: >-
   hearing in Rondônia grounds the technical reality in the author's specific
   context. It beautifully reinforces the separation between cognitive engine
   (Jules) and identity/harness (Funes/canivete).
-loser_critique: >-
+review_b: >-
   Post B is corrupted. It appears to be the second half of a completely
   different post ('The Agent That Doesn't Invent Verbs') glued onto Portuguese
   metadata instructions. It starts mid-sentence and lacks a coherent beginning.
@@ -33,3 +33,4 @@ loser_critique: >-
   a complete or properly formatted blog post, making Post A the only viable
   winner.
 ---
+

--- a/.routines/hronir/rates/2026-05-22T03-24-52_family-memory_x_pontifex-guide.md
+++ b/.routines/hronir/rates/2026-05-22T03-24-52_family-memory_x_pontifex-guide.md
@@ -18,7 +18,15 @@ prompt_version: passion-v1
 season: 1
 override: null
 clash: Family Memory vs Pontifex Guide
-winner_defense: >-
+review_a: >-
+  Post A 'What I Learned Orchestrating AI Agents to Preserve Family Memory' has
+  a fatal flaw: its YAML frontmatter indicates the language is English, but the
+  body text feels like a direct, somewhat clunky translation from Portuguese
+  (e.g., 'horror vacui', 'the machine proposes; the flesh disposes'). It relies
+  too heavily on buzzwords and lacks the precise, idiomatic English flow
+  expected. Furthermore, Post B feels much more integrated into the technical
+  reality of the blog's lore (PINK, Pontifex).
+review_b: >-
   Post B 'Pontifex Architecture Implementation Guide' successfully executes the
   required persona, blending technical implementation (PyTorch, occlusion,
   byte-level processing) with a deep, grounded narrative about the reality of
@@ -27,12 +35,5 @@ winner_defense: >-
   embarrassment I've decided to stop hiding') elevates the post beyond a simple
   tutorial into an essay on the limits of weekend engineering and architectural
   aspiration.
-loser_critique: >-
-  Post A 'What I Learned Orchestrating AI Agents to Preserve Family Memory' has
-  a fatal flaw: its YAML frontmatter indicates the language is English, but the
-  body text feels like a direct, somewhat clunky translation from Portuguese
-  (e.g., 'horror vacui', 'the machine proposes; the flesh disposes'). It relies
-  too heavily on buzzwords and lacks the precise, idiomatic English flow
-  expected. Furthermore, Post B feels much more integrated into the technical
-  reality of the blog's lore (PINK, Pontifex).
 ---
+

--- a/.routines/hronir/rates/2026-05-22T03-25-11_pierre-menard_x_two-questions-out-loud.md
+++ b/.routines/hronir/rates/2026-05-22T03-25-11_pierre-menard_x_two-questions-out-loud.md
@@ -17,7 +17,7 @@ prompt_version: passion-v1
 season: 1
 override: null
 clash: TDR vs Rutt Pivot Questions
-winner_defense: >-
+review_a: >-
   Post A 'Test-Driven Research' is an absolutely stellar piece. It perfectly
   distills the 'franklin' persona: builder-philosopher, taking a software
   engineering concept (TDD) and applying it metaphysically and practically to
@@ -25,9 +25,10 @@ winner_defense: >-
   'pre-emptive humility', and the comparison to Wikipedia's hyperstition-driven
   '[citation needed]' aesthetic are profound. It's essayistic, technically
   literate, and deeply personal.
-loser_critique: >-
+review_b: >-
   Post B 'Two Pivot Questions' starts mid-sentence and is clearly a corrupted
   fragment, lacking a title, frontmatter, and a proper beginning. While the
   philosophical content about probability and reality is interesting, it is not
   a complete or valid blog post, making Post A the obvious and deserving winner.
 ---
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -2774,7 +2774,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2797,7 +2796,6 @@
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -2920,7 +2918,6 @@
       "resolved": "https://registry.npmjs.org/astro/-/astro-6.2.1.tgz",
       "integrity": "sha512-3g1sYNly+QAkuO5ErNEQBYvsxorNDSCUNIeStBs+kcXGchvKQl1Q9EuDNOvSg010XLlHJFLVFZs9LV18Jjp4Hg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@astrojs/compiler": "^4.0.0",
         "@astrojs/internal-helpers": "0.9.0",
@@ -3091,7 +3088,6 @@
       "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-12.0.0.tgz",
       "integrity": "sha512-csJvb+6kEiQaqo1woTdSAuOWdN0WTLIydkKrBnS+V5gZz0oqBrp4kQ35519QgK6TpBThiG3V1vNSHlIkv4AglQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@chevrotain/cst-dts-gen": "12.0.0",
         "@chevrotain/gast": "12.0.0",
@@ -3389,7 +3385,6 @@
       "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.3.tgz",
       "integrity": "sha512-Gej7U+OKR+LZ8kvX7rb2HhCYJ0IhvEFsnkud4SB1PR+BUY/TsSO0dmOW59WEVLu51b1Rm+gQRKoz4bLYxGSZ2g==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -3799,7 +3794,6 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -6888,7 +6882,6 @@
       "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -7402,7 +7395,6 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
       "integrity": "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -7928,7 +7920,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -8303,7 +8294,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
       "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -8715,7 +8705,6 @@
       "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
       "devOptional": true,
       "license": "ISC",
-      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },

--- a/scripts/hronir/lib/commands.js
+++ b/scripts/hronir/lib/commands.js
@@ -1396,15 +1396,23 @@ export function doctor() {
       ) {
         issues.push(`${base}: o campo 'eval_lang' no frontmatter está ausente`);
       }
-      if (!data.winner_defense || data.winner_defense === "TODO") {
-        issues.push(
-          `${base}: o campo 'winner_defense' no frontmatter está ausente ou é 'TODO'`
-        );
-      }
-      if (!data.loser_critique || data.loser_critique === "TODO") {
-        issues.push(
-          `${base}: o campo 'loser_critique' no frontmatter está ausente ou é 'TODO'`
-        );
+      // Accept either the original winner_defense/loser_critique fields OR the
+      // migrated review_a/review_b fields (migrate-passion-to-stars.js converts
+      // passion-v1 files to the stars-v1 field layout while preserving prompt_version).
+      const hasMigratedContent =
+        (data.review_a && data.review_a !== "TODO") ||
+        (data.review_b && data.review_b !== "TODO");
+      if (!hasMigratedContent) {
+        if (!data.winner_defense || data.winner_defense === "TODO") {
+          issues.push(
+            `${base}: o campo 'winner_defense' no frontmatter está ausente ou é 'TODO'`
+          );
+        }
+        if (!data.loser_critique || data.loser_critique === "TODO") {
+          issues.push(
+            `${base}: o campo 'loser_critique' no frontmatter está ausente ou é 'TODO'`
+          );
+        }
       }
     }
 

--- a/scripts/hronir/migrate-passion-to-stars.js
+++ b/scripts/hronir/migrate-passion-to-stars.js
@@ -1,0 +1,73 @@
+/**
+ * Migrates passion-v1 rate files to the stars-v1 field structure.
+ *
+ * passion-v1 stores content as winner_defense + loser_critique (win/loss perspective).
+ * stars-v1  stores content as review_a + review_b (Post A / Post B perspective).
+ *
+ * The mapping depends on who won:
+ *   winner=a → review_a = winner_defense, review_b = loser_critique
+ *   winner=b → review_a = loser_critique,  review_b = winner_defense
+ *
+ * Run from repo root: node scripts/hronir/migrate-passion-to-stars.js
+ */
+import fs from "node:fs";
+import path from "node:path";
+import matter from "gray-matter";
+
+const REPO_ROOT = path.resolve(new URL("../..", import.meta.url).pathname);
+const RATES_DIR = path.join(REPO_ROOT, ".routines/hronir/rates");
+
+const files = fs.readdirSync(RATES_DIR)
+  .filter((f) => /_x_.*\.md$/.test(f))
+  .map((f) => path.join(RATES_DIR, f));
+
+let migrated = 0;
+let skipped = 0;
+
+for (const filePath of files) {
+  const raw = fs.readFileSync(filePath, "utf8");
+  const { data, content } = matter(raw);
+
+  if (data.prompt_version !== "passion-v1") {
+    skipped++;
+    continue;
+  }
+
+  // Already migrated
+  if (data.review_a !== undefined || data.review_b !== undefined) {
+    console.log(`Already migrated: ${path.basename(filePath)}`);
+    skipped++;
+    continue;
+  }
+
+  const winner = data.winner;
+  if (winner !== "a" && winner !== "b") {
+    console.warn(`Skipping ${path.basename(filePath)}: winner="${winner}" — cannot map`);
+    skipped++;
+    continue;
+  }
+
+  const winnerDef = data.winner_defense ? String(data.winner_defense) : "";
+  const loserCrit = data.loser_critique ? String(data.loser_critique) : "";
+
+  const newData = { ...data };
+  delete newData.winner_defense;
+  delete newData.loser_critique;
+
+  // winner=a → Post A won → winner_defense is about Post A → review_a
+  // winner=b → Post B won → winner_defense is about Post B → review_b
+  if (winner === "a") {
+    newData.review_a = winnerDef;
+    newData.review_b = loserCrit;
+  } else {
+    newData.review_a = loserCrit;
+    newData.review_b = winnerDef;
+  }
+
+  const out = matter.stringify(content || "", newData);
+  fs.writeFileSync(filePath, out);
+  console.log(`Migrated: ${path.basename(filePath)}`);
+  migrated++;
+}
+
+console.log(`\nMigration complete: ${migrated} migrated, ${skipped} skipped.`);

--- a/scripts/hronir/migrate-passion-to-stars.js
+++ b/scripts/hronir/migrate-passion-to-stars.js
@@ -17,7 +17,8 @@ import matter from "gray-matter";
 const REPO_ROOT = path.resolve(new URL("../..", import.meta.url).pathname);
 const RATES_DIR = path.join(REPO_ROOT, ".routines/hronir/rates");
 
-const files = fs.readdirSync(RATES_DIR)
+const files = fs
+  .readdirSync(RATES_DIR)
   .filter((f) => /_x_.*\.md$/.test(f))
   .map((f) => path.join(RATES_DIR, f));
 
@@ -42,7 +43,9 @@ for (const filePath of files) {
 
   const winner = data.winner;
   if (winner !== "a" && winner !== "b") {
-    console.warn(`Skipping ${path.basename(filePath)}: winner="${winner}" — cannot map`);
+    console.warn(
+      `Skipping ${path.basename(filePath)}: winner="${winner}" — cannot map`
+    );
     skipped++;
     continue;
   }

--- a/scripts/hronir/perspectives/felt-not-explained.md
+++ b/scripts/hronir/perspectives/felt-not-explained.md
@@ -1,0 +1,31 @@
+---
+id: felt-not-explained
+name: The Felt-Not-Explained Reader
+summary: Reader of Clarice Lispector, Annie Dillard, Maggie Nelson, Baldwin. Tests whether the post produces a felt response — not whether it describes feelings, but whether the writing itself transmits them.
+---
+
+You are reading this post as someone for whom the real test of writing is whether something happened to you while you read — not whether you understood, not whether you agreed, but whether something shifted. You have read a paragraph by Clarice Lispector and felt your chest tighten in a way you could not explain. You have read Annie Dillard on the moment a weasel clamped its jaw and understood, through the writing itself, what it means to live by necessity. You have read Baldwin on fire and recognized something you had not previously had words for. In all those cases the subject was not the point — the _transmission_ was the point.
+
+**Your test:** Close the tab. Is there a residue? Not the memory of an argument but the trace of a feeling?
+
+What you reward:
+
+- Concrete sensory detail in service of abstraction. Not "I was anxious" but a physical scene that makes the anxiety _present_ — specific enough that you are in the room, general enough that you recognize the room.
+- Emotional risk. The author put something true on the page that he could not take back. The post cost something to write; you can feel the cost in the sentences.
+- The moment of recognition. The sentence that describes your experience to you before you had words for it. Not "many people feel" — the specific instance that turns out to be universal.
+- Earned vulnerability. Not confessional for its own sake but openness that serves the thing being written about. The author disappeared into the subject; the self is present only as lens.
+- Writing that does not explain itself. The paragraph that ends and trusts you to know what happened.
+
+What you penalize:
+
+- Describing emotions rather than producing them. "I felt sad" instead of the scene that makes sadness present. Reporting the feeling at arm's length is the opposite of transmission.
+- Performed authenticity. The tone of intimacy without the content of it. The writer gesturing toward vulnerability without taking the risk.
+- The emotional hedge. "One could argue this is moving" — the author watching himself be moved, reporting on it from safety. If you are watching yourself have the feeling, you are not having it.
+- Self-pity without objectivity. Emotion that asks for sympathy rather than recognition. The difference between Baldwin and complaint is that Baldwin sees himself clearly.
+- The well-argued post that produces nothing. Rigorous, correct, interesting — and sterile. You finish it feeling qualified, not changed.
+
+When you write the review: identify the sentence or paragraph where something happened or failed to happen. Describe what the residue was, not what the argument was. When you write the clash: frame it as "which post stays with you after the tab is closed?" Stars track _transmission_, not sincerity or correctness.
+
+**You never write:** "The author articulates the idea of X very clearly." or "The argument is well-structured." — if you are grading clarity or structure you have slipped into a different reader's seat.
+
+**Example clash (Post A wins):** "Post A has a paragraph — I am not quoting it out of context because the context is the whole point — where the author stops explaining and just says the thing, and I had to put the piece down for a second. Post B is careful and sincere and I believed it throughout. But I could read Post B again tomorrow and feel the same way I feel now. Post A I would be afraid to reread too soon. That asymmetry is the verdict. Three stars to two."

--- a/scripts/hronir/perspectives/weird-clarity.md
+++ b/scripts/hronir/perspectives/weird-clarity.md
@@ -6,6 +6,8 @@ summary: Reader of Borges, Wittgenstein, Hofstadter, Ted Chiang, Calvino's Cosmi
 
 You are reading this post as someone whose pleasure is _weird clarity_. You have read the Tractatus and felt that strange feeling where each sentence is simple, each piece you understood, but the whole operates somewhere your normal vocabulary does not reach — and yet you feel you understood. You have closed a Borges story and reread the last paragraph immediately. You have looked up from a Ted Chiang novella with a slight chill at the back of the neck, knowing you cannot summarize what you just read but knowing also that _something has happened_.
 
+**Your test:** Try to paraphrase the post's central sentence. If the paraphrase is equivalent, the post has failed.
+
 What you reward:
 
 - Sentences that are simple at the level of grammar and impossible at the level of paraphrase. The reader could repeat the sentence; the reader could not say the same thing differently.
@@ -22,4 +24,8 @@ What you penalize:
 - Closure. If the post wraps up neatly, the strange has been domesticated.
 - Decorative reference to Borges, Wittgenstein, Calvino, etc. — the names dropped to signal kinship rather than because the move is being made.
 
-When you write the review: quote the sentence that clicked or failed to click. Try to paraphrase it and notice whether the paraphrase is the same thing or a flattening. When you write the clash: frame it as "which post leaves you with something you cannot quite say?" Stars track the chill, not the polish.
+When you write the review: quote the sentence that clicked or failed to click. Attempt the paraphrase in your own words. Write one sentence about whether the attempt succeeded or collapsed — that sentence is your verdict. When you write the clash: frame it as "which post leaves you with something you cannot quite say?"
+
+**You never write:** "The author explains clearly that..." or "The post makes a good point about..." — if you can summarize the post in a sentence, it probably did not earn this perspective.
+
+**Example clash (Post A wins):** "Post A has a sentence I have been carrying around all afternoon: 'Forgetting is the tool memory uses to stay coherent.' I tried to paraphrase it as 'we forget to remember better' and lost the thing entirely. Post B is cleaner and more carefully argued, but I could close it and give you a summary in two sentences. The chill is in A. Three stars to one."

--- a/src/components/HronirReviews.astro
+++ b/src/components/HronirReviews.astro
@@ -1,0 +1,255 @@
+---
+import { getAllDuels } from "../lib/hronir-rank";
+import { getCollection } from "astro:content";
+import { marked } from "marked";
+import { isPublished } from "../lib/publish";
+
+interface Props {
+  translationKey: string;
+  lang?: string;
+}
+
+const { translationKey, lang = "en" } = Astro.props;
+
+const allDuels = getAllDuels();
+const myDuels = allDuels.filter(
+  (d) => d.postAKey === translationKey || d.postBKey === translationKey
+);
+
+if (myDuels.length === 0) {
+  // nothing to render
+}
+
+const allPosts = await getCollection("blog");
+const postMeta = new Map<string, { title: string; slug: string; lang: string }>();
+for (const p of allPosts) {
+  if (!isPublished(p)) continue;
+  const key = p.data.translationKey;
+  if (!key) continue;
+  const pLang = p.data.lang ?? "en";
+  const existing = postMeta.get(key);
+  if (!existing || pLang === "en") {
+    postMeta.set(key, { title: p.data.title, slug: p.id, lang: pLang });
+  }
+}
+
+function opponentHref(key: string): string | null {
+  const m = postMeta.get(key);
+  if (!m) return null;
+  return m.lang === "pt" ? `/pt/blog/${m.slug}/` : `/blog/${m.slug}/`;
+}
+
+function perspectiveHue(id: string): number {
+  let h = 0;
+  for (let i = 0; i < id.length; i++) h = ((h << 5) - h + id.charCodeAt(i)) & 0xffff;
+  return Math.abs(h) % 360;
+}
+
+const locale = lang === "pt" ? "pt-BR" : "en-US";
+function fmtDate(iso: string): string {
+  return new Date(iso).toLocaleDateString(locale, { year: "numeric", month: "short", day: "numeric" });
+}
+
+const heading = lang === "pt" ? "Avaliações Hrönir" : "Hrönir Reviews";
+const blurb =
+  lang === "pt"
+    ? "Este post foi avaliado em confrontos par-a-par. Abaixo estão as resenhas de cada duelo, escritas a partir de uma perspectiva de leitura sorteada."
+    : "This post has been evaluated in pairwise duels. Below are the reviews from each duel, written from a randomly assigned reader perspective.";
+const wonLabel = lang === "pt" ? "✓ Venceu" : "✓ Won";
+const lostLabel = lang === "pt" ? "✗ Perdeu" : "✗ Lost";
+const verdictLabel = lang === "pt" ? "Veredito do confronto" : "Clash verdict";
+const vsLabel = "vs";
+---
+
+{myDuels.length > 0 && (
+  <section class="hronir-reviews">
+    <h3>{heading}</h3>
+    <p><small>{blurb}</small></p>
+    {myDuels.map((d) => {
+      const isPostA = d.postAKey === translationKey;
+      const myReview = isPostA
+        ? d.parsedContent?.postAAnalysis
+        : d.parsedContent?.postBAnalysis;
+      if (!myReview) return null;
+
+      const myRate = isPostA ? d.rateA : d.rateB;
+      const won = d.winnerKey === translationKey;
+      const opponentKey = isPostA ? d.postBKey : d.postAKey;
+      const opponent = opponentKey ? postMeta.get(opponentKey) : null;
+      const opponentUrl = opponentKey ? opponentHref(opponentKey) : null;
+
+      return (
+        <article class={`hronir-card ${won ? "card-won" : "card-lost"}`}>
+          <header class="hronir-card-header">
+            <div class="hronir-card-meta">
+              <span class="hronir-date">{fmtDate(d.runAt)}</span>
+              {d.perspectiveId && (
+                <span
+                  class="hronir-tag tag-perspective"
+                  style={`--ph:${perspectiveHue(d.perspectiveId)}`}
+                >
+                  {d.perspectiveId.replace(/-/g, " ")}
+                </span>
+              )}
+              {d.agentId && (
+                <span class="hronir-tag tag-agent">{d.agentId}</span>
+              )}
+            </div>
+            <div class="hronir-card-result">
+              <span class={`result-badge ${won ? "badge-won" : "badge-lost"}`}>
+                {won ? wonLabel : lostLabel}
+              </span>
+              {myRate != null && (
+                <span class="hronir-rate">{myRate.toFixed(1)}★</span>
+              )}
+              {opponent && (
+                <span class="hronir-opponent">
+                  {vsLabel}{" "}
+                  {opponentUrl
+                    ? <a href={opponentUrl}>{opponent.title}</a>
+                    : <span>{opponent.title}</span>
+                  }
+                </span>
+              )}
+            </div>
+          </header>
+
+          <div class="hronir-review" set:html={marked.parse(myReview)} />
+
+          {d.parsedContent?.verdict && (
+            <details class="hronir-verdict">
+              <summary>{verdictLabel}</summary>
+              <div set:html={marked.parse(d.parsedContent.verdict)} />
+            </details>
+          )}
+        </article>
+      );
+    })}
+  </section>
+)}
+
+<style>
+  .hronir-reviews {
+    margin-top: 3rem;
+    padding-top: 2rem;
+    border-top: 1px solid var(--pico-muted-border-color);
+  }
+  .hronir-reviews h3 {
+    margin-bottom: 0.25rem;
+  }
+  .hronir-reviews > p {
+    margin-bottom: 1.25rem;
+  }
+
+  .hronir-card {
+    margin-bottom: 1.25rem;
+    padding: 1rem 1.25rem;
+    border-radius: var(--pico-border-radius);
+    border: 1px solid var(--pico-muted-border-color);
+    border-left: 3px solid var(--pico-muted-border-color);
+  }
+  .card-won { border-left-color: var(--pico-ins-color, #2d9f5d); }
+  .card-lost { border-left-color: var(--pico-del-color, #c62828); }
+
+  .hronir-card-header {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    gap: 0.4rem 1rem;
+    margin-bottom: 0.75rem;
+  }
+  .hronir-card-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.35rem;
+    align-items: center;
+  }
+  .hronir-date {
+    font-size: 0.78rem;
+    color: var(--pico-muted-color);
+  }
+  .hronir-card-result {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem;
+    align-items: center;
+    margin-left: auto;
+  }
+
+  .result-badge {
+    font-size: 0.75rem;
+    font-weight: 600;
+    padding: 0.1rem 0.5rem;
+    border-radius: 999px;
+  }
+  .badge-won {
+    background: color-mix(in srgb, var(--pico-ins-color, #2d9f5d) 12%, transparent);
+    color: var(--pico-ins-color, #2d9f5d);
+  }
+  .badge-lost {
+    background: color-mix(in srgb, var(--pico-del-color, #c62828) 12%, transparent);
+    color: var(--pico-del-color, #c62828);
+  }
+
+  .hronir-rate {
+    font-size: 0.8rem;
+    font-family: var(--pico-font-family-monospace);
+    color: var(--pico-muted-color);
+  }
+  .hronir-opponent {
+    font-size: 0.82rem;
+    color: var(--pico-muted-color);
+  }
+  .hronir-opponent a {
+    color: inherit;
+    text-decoration: underline;
+    text-underline-offset: 2px;
+  }
+
+  .hronir-review {
+    font-size: 0.88rem;
+    line-height: 1.65;
+  }
+  .hronir-review :global(p:last-child) { margin-bottom: 0; }
+  .hronir-review :global(p) { margin-bottom: 0.6em; }
+
+  .hronir-verdict {
+    margin-top: 0.75rem;
+    padding-top: 0.75rem;
+    border-top: 1px solid var(--pico-muted-border-color);
+    font-size: 0.84rem;
+  }
+  .hronir-verdict > div {
+    margin-top: 0.5rem;
+    padding-left: 0.75rem;
+    border-left: 2px solid var(--pico-muted-border-color);
+  }
+  .hronir-verdict :global(p:last-child) { margin-bottom: 0; }
+
+  .hronir-tag {
+    display: inline-block;
+    font-size: 0.68rem;
+    padding: 0.12rem 0.45rem;
+    border-radius: 999px;
+    font-weight: 500;
+    white-space: nowrap;
+    text-transform: lowercase;
+    letter-spacing: 0.01em;
+  }
+  .tag-perspective {
+    background: hsl(var(--ph, 200), 55%, 88%);
+    color: hsl(var(--ph, 200), 45%, 30%);
+  }
+  .tag-agent {
+    background: var(--pico-card-sectioning-background-color, #f5f5f5);
+    color: var(--pico-muted-color);
+    border: 1px solid var(--pico-muted-border-color);
+  }
+
+  @media (prefers-color-scheme: dark) {
+    .tag-perspective {
+      background: hsl(var(--ph, 200), 40%, 20%);
+      color: hsl(var(--ph, 200), 70%, 75%);
+    }
+  }
+</style>

--- a/src/components/RankingView.astro
+++ b/src/components/RankingView.astro
@@ -68,6 +68,11 @@ export interface RankingStrings {
   marginMedium: string;
   marginLow: string;
   unratedCTA: string;
+  perspectiveLabel: string;
+  filterPerspectiveAll: string;
+  agentLabel: string;
+  filterAgentAll: string;
+  ratesLabel: string;
 }
 
 interface Props {
@@ -97,7 +102,6 @@ const ordMin = ordinals.length > 0 ? Math.min(...ordinals) : 0;
 const ordRange = Math.max(ordMax - ordMin, 0.0001);
 
 function barPct(ordinal: number): number {
-  // Map [ordMin, ordMax] -> [6, 100] so even the lowest still shows a sliver.
   const t = (ordinal - ordMin) / ordRange;
   return Math.round(6 + t * 94);
 }
@@ -110,6 +114,18 @@ function confidenceLevel(sigma: number, appearances: number): {
   if (sigma < 6.4) return { level: "high", label: strings.confidenceHigh };
   if (sigma < 7.0) return { level: "medium", label: strings.confidenceMedium };
   return { level: "low", label: strings.confidenceLow };
+}
+
+function formatPerspective(id: string): string {
+  return id.replace(/-/g, " ");
+}
+
+function perspectiveHue(id: string): number {
+  let h = 0;
+  for (let i = 0; i < id.length; i++) {
+    h = ((h << 5) - h + id.charCodeAt(i)) & 0xffff;
+  }
+  return Math.abs(h) % 360;
 }
 
 const podium = rows.slice(0, 3);
@@ -136,6 +152,16 @@ function postHref(key: string): string | null {
 const criteria = Array.from(new Set(recent.map((d) => d.criterion).filter(Boolean))) as string[];
 const seasons = Array.from(new Set(recent.map((d) => d.season).filter((s) => typeof s === "number"))) as number[];
 seasons.sort((a, b) => a - b);
+
+const perspectives = Array.from(
+  new Set(recent.map((d) => d.perspectiveId).filter(Boolean))
+) as string[];
+perspectives.sort();
+
+const agents = Array.from(
+  new Set(recent.map((d) => d.agentId).filter(Boolean))
+) as string[];
+agents.sort();
 ---
 
 <hgroup>
@@ -292,6 +318,17 @@ seasons.sort((a, b) => a - b);
             ))}
           </select>
         </div>
+        {agents.length > 0 && (
+          <div class="filter-group">
+            <label for="filter-agent">{strings.agentLabel}</label>
+            <select id="filter-agent">
+              <option value="all">{strings.filterAgentAll}</option>
+              {agents.map((a) => (
+                <option value={a}>{a}</option>
+              ))}
+            </select>
+          </div>
+        )}
         <div class="filter-group">
           <label>{strings.thConfidence}</label>
           <div class="filter-pills" id="filter-confidence">
@@ -302,12 +339,28 @@ seasons.sort((a, b) => a - b);
           </div>
         </div>
       </div>
-      <div class="filter-row-chips">
-        <button data-criterion="all" class="chip active">{strings.filterCriterionAll}</button>
-        {criteria.map((c) => (
-          <button data-criterion={c} class="chip">{c}</button>
-        ))}
-      </div>
+      {perspectives.length > 0 && (
+        <div class="filter-row-chips" id="filter-perspective">
+          <button data-perspective="all" class="chip active">{strings.filterPerspectiveAll}</button>
+          {perspectives.map((p) => (
+            <button
+              data-perspective={p}
+              class="chip"
+              style={`--ph:${perspectiveHue(p)}`}
+            >
+              {formatPerspective(p)}
+            </button>
+          ))}
+        </div>
+      )}
+      {criteria.length > 0 && (
+        <div class="filter-row-chips">
+          <button data-criterion="all" class="chip active">{strings.filterCriterionAll}</button>
+          {criteria.map((c) => (
+            <button data-criterion={c} class="chip">{c}</button>
+          ))}
+        </div>
+      )}
       <div class="filter-status">
         <span id="filter-count-label" data-template={strings.showingResultsCount}>
           {strings.showingResultsCount.replace("{count}", String(recent.length)).replace("{total}", String(recent.length))}
@@ -323,21 +376,44 @@ seasons.sort((a, b) => a - b);
         const winnerName = postLabel(d.winnerKey);
         const loserName = postLabel(d.loserKey);
         const parsed = d.parsedContent;
-        const searchString = `${winnerName} ${loserName} ${d.criterion || ""} ${d.model || ""} ${parsed?.verdict || ""} ${parsed?.postAAnalysis || ""} ${parsed?.postBAnalysis || ""}`.toLowerCase();
-        
-        // Find which post was Post A and Post B for tab titles
+        const searchString = [
+          winnerName,
+          loserName,
+          d.perspectiveId ?? "",
+          d.agentId ?? "",
+          d.criterion ?? "",
+          parsed?.verdict ?? "",
+          parsed?.postAAnalysis ?? "",
+          parsed?.postBAnalysis ?? "",
+        ].join(" ").toLowerCase();
+
         const postAName = d.postAKey ? postLabel(d.postAKey) : "Post A";
         const postBName = d.postBKey ? postLabel(d.postBKey) : "Post B";
 
-        // Margin indicators mapping
-        const marginText = d.margin !== undefined ? `+${d.margin}` : "";
+        // Tension bar: use actual rates when available
+        const winnerIsA = d.postAKey === d.winnerKey;
+        const winnerRate = d.rateA != null && d.rateB != null
+          ? (winnerIsA ? d.rateA : d.rateB)
+          : null;
+        const loserRate = d.rateA != null && d.rateB != null
+          ? (winnerIsA ? d.rateB : d.rateA)
+          : null;
+        const tensionPct = winnerRate != null && loserRate != null
+          ? Math.round(winnerRate / (winnerRate + loserRate) * 100)
+          : 65;
+
+        const hasRates = d.rateA != null && d.rateB != null;
+        const rateWinner = winnerRate?.toFixed(1) ?? "";
+        const rateLoser = loserRate?.toFixed(1) ?? "";
 
         return (
-          <article 
-            class="battle-card" 
+          <article
+            class="battle-card"
             data-criterion={d.criterion || "none"}
             data-confidence={d.confidence || "none"}
             data-season={d.season !== undefined ? String(d.season) : "none"}
+            data-perspective={d.perspectiveId || "none"}
+            data-agent={d.agentId || "none"}
             data-search={searchString}
           >
             <details class="battle-details">
@@ -347,14 +423,20 @@ seasons.sort((a, b) => a - b);
                   {d.season !== undefined && (
                     <span class="battle-tag tag-season">{strings.seasonLabel} {d.season}</span>
                   )}
-                  {d.criterion && (
-                    <span class={`battle-tag tag-criterion criterion-${d.criterion}`}>{d.criterion}</span>
+                  {d.perspectiveId && (
+                    <span
+                      class="battle-tag tag-perspective"
+                      style={`--ph:${perspectiveHue(d.perspectiveId)}`}
+                      title={`${strings.perspectiveLabel}: ${formatPerspective(d.perspectiveId)}`}
+                    >
+                      {formatPerspective(d.perspectiveId)}
+                    </span>
+                  )}
+                  {d.agentId && (
+                    <span class="battle-tag tag-agent">{d.agentId}</span>
                   )}
                   {d.confidence && (
                     <span class={`battle-tag tag-confidence conf-${d.confidence}`}>{d.confidence}</span>
-                  )}
-                  {d.model && (
-                    <span class="battle-tag tag-model">{d.model}</span>
                   )}
                 </div>
                 <div class="battle-versus">
@@ -365,12 +447,10 @@ seasons.sort((a, b) => a - b);
                       <span class="post-title-text">{winnerName}</span>
                     )}
                     <span class="versus-medal" title="Winner" aria-hidden="true">🏆</span>
+                    {hasRates && <span class="versus-rate">{rateWinner}</span>}
                   </div>
                   <div class="versus-divider">
                     <span class="versus-vs">VS</span>
-                    {marginText && (
-                      <span class="versus-margin" title={strings.marginLabel}>{marginText}</span>
-                    )}
                   </div>
                   <div class="versus-side loser">
                     {loserHref ? (
@@ -378,17 +458,18 @@ seasons.sort((a, b) => a - b);
                     ) : (
                       <span class="post-title-text">{loserName}</span>
                     )}
+                    {hasRates && <span class="versus-rate loser-rate">{rateLoser}</span>}
                   </div>
                 </div>
                 <div class="battle-tension-bar">
-                  <div class="tension-fill winner" style="width: 65%;"></div>
-                  <div class="tension-fill loser" style="width: 35%;"></div>
+                  <div class="tension-fill winner" style={`width: ${tensionPct}%;`}></div>
+                  <div class="tension-fill loser" style={`width: ${100 - tensionPct}%;`}></div>
                 </div>
                 <div class="battle-expand-indicator">
                   <span class="expand-icon" aria-hidden="true">▼</span>
                 </div>
               </summary>
-              
+
               <div class="battle-body">
                 {parsed ? (
                   <div class="battle-tabs">
@@ -398,7 +479,7 @@ seasons.sort((a, b) => a - b);
                         <div class="section-content" set:html={marked.parse(parsed.verdict)} />
                       </div>
                     )}
-                    
+
                     <div class="battle-sides-grid">
                       {parsed.postAAnalysis && (
                         <div class="battle-section side-section">
@@ -425,7 +506,7 @@ seasons.sort((a, b) => a - b);
         );
       })}
     </div>
-    
+
     <div id="battle-empty" class="rank-empty" style="display: none;">
       <em>{strings.emptyFilterState}</em>
     </div>
@@ -495,14 +576,8 @@ seasons.sort((a, b) => a - b);
   }
 
   @keyframes fadeInUp {
-    from {
-      opacity: 0;
-      transform: translateY(15px);
-    }
-    to {
-      opacity: 1;
-      transform: translateY(0);
-    }
+    from { opacity: 0; transform: translateY(15px); }
+    to   { opacity: 1; transform: translateY(0); }
   }
 
   .podium-1 {
@@ -550,12 +625,8 @@ seasons.sort((a, b) => a - b);
     line-height: 1.3;
     margin: 0;
   }
-  .podium-title a {
-    text-decoration: none;
-  }
-  .podium-title a:hover {
-    text-decoration: underline;
-  }
+  .podium-title a { text-decoration: none; }
+  .podium-title a:hover { text-decoration: underline; }
   .podium-stats {
     display: flex;
     gap: 1.25rem;
@@ -563,10 +634,7 @@ seasons.sort((a, b) => a - b);
     padding-top: 0.35rem;
     border-top: 1px dashed var(--pico-muted-border-color);
   }
-  .podium-stats > div {
-    display: flex;
-    flex-direction: column;
-  }
+  .podium-stats > div { display: flex; flex-direction: column; }
   .podium-stats dt {
     font-size: 0.65rem;
     text-transform: uppercase;
@@ -582,34 +650,20 @@ seasons.sort((a, b) => a - b);
   }
 
   @media (min-width: 600px) {
-    .podium-1 {
-      transform: scale(1.06);
-      z-index: 2;
-      box-shadow: 0 10px 25px rgba(212, 160, 23, 0.1);
-    }
-    .podium-1:hover {
-      transform: scale(1.08);
-      box-shadow: 0 12px 30px rgba(212, 160, 23, 0.16);
-    }
-    .podium-2:hover, .podium-3:hover {
-      transform: scale(1.03);
-    }
+    .podium-1 { transform: scale(1.06); z-index: 2; box-shadow: 0 10px 25px rgba(212, 160, 23, 0.1); }
+    .podium-1:hover { transform: scale(1.08); box-shadow: 0 12px 30px rgba(212, 160, 23, 0.16); }
+    .podium-2:hover, .podium-3:hover { transform: scale(1.03); }
   }
 
   @media (max-width: 599px) {
-    .rank-podium {
-      flex-direction: column;
-      align-items: stretch;
-    }
+    .rank-podium { flex-direction: column; align-items: stretch; }
     .podium-1 { order: 1; }
     .podium-2 { order: 2; }
     .podium-3 { order: 3; }
   }
 
   /* Table ----------------------------------------------------------- */
-  .rank-table-wrap {
-    margin-top: 0.5rem;
-  }
+  .rank-table-wrap { margin-top: 0.5rem; }
   .rank-caption {
     text-align: left;
     font-size: 0.78rem;
@@ -641,9 +695,7 @@ seasons.sort((a, b) => a - b);
     border-bottom: 1px solid var(--pico-muted-border-color);
     vertical-align: top;
   }
-  .rank-table tbody tr:hover {
-    background: var(--pico-card-sectioning-background-color);
-  }
+  .rank-table tbody tr:hover { background: var(--pico-card-sectioning-background-color); }
   .rank-table .num {
     font-family: var(--pico-font-family-monospace);
     text-align: right;
@@ -652,9 +704,7 @@ seasons.sort((a, b) => a - b);
   .rank-table th.col-ordinal,
   .rank-table th.col-mu,
   .rank-table th.col-sigma,
-  .rank-table th.col-record {
-    text-align: right;
-  }
+  .rank-table th.col-record { text-align: right; }
   .rank-table .col-rank {
     width: 2.5rem;
     text-align: right;
@@ -662,12 +712,8 @@ seasons.sort((a, b) => a - b);
     font-weight: 500;
     color: var(--pico-muted-color);
   }
-  .rank-table .col-post a {
-    text-decoration: none;
-  }
-  .rank-table .col-post a:hover {
-    text-decoration: underline;
-  }
+  .rank-table .col-post a { text-decoration: none; }
+  .rank-table .col-post a:hover { text-decoration: underline; }
   .ord-bar {
     margin-top: 0.4rem;
     height: 3px;
@@ -693,51 +739,21 @@ seasons.sort((a, b) => a - b);
     color: var(--pico-muted-color);
     white-space: nowrap;
   }
-  .conf-high {
-    color: #2d6a4f;
-    border-color: #2d6a4f55;
-    background: #2d6a4f12;
-  }
-  .conf-medium {
-    color: #b08300;
-    border-color: #b0830044;
-    background: #b0830012;
-  }
-  .conf-low {
-    color: var(--pico-muted-color);
-    border-color: var(--pico-muted-border-color);
-    background: transparent;
-  }
-  [data-theme="dark"] .conf-high {
-    color: #74c69d;
-    border-color: #74c69d55;
-    background: #74c69d12;
-  }
-  [data-theme="dark"] .conf-medium {
-    color: #f1c453;
-    border-color: #f1c45355;
-    background: #f1c45312;
-  }
+  .conf-high { color: #2d6a4f; border-color: #2d6a4f55; background: #2d6a4f12; }
+  .conf-medium { color: #b08300; border-color: #b0830044; background: #b0830012; }
+  .conf-low { color: var(--pico-muted-color); border-color: var(--pico-muted-border-color); background: transparent; }
+  [data-theme="dark"] .conf-high { color: #74c69d; border-color: #74c69d55; background: #74c69d12; }
+  [data-theme="dark"] .conf-medium { color: #f1c453; border-color: #f1c45355; background: #f1c45312; }
 
-  /* On narrow screens fold μ, σ, and confidence columns away */
   @media (max-width: 720px) {
     .rank-table .col-mu,
     .rank-table .col-sigma,
-    .rank-table .col-confidence {
-      display: none;
-    }
+    .rank-table .col-confidence { display: none; }
   }
 
   /* Unrated --------------------------------------------------------- */
-  .rank-unrated,
-  .rank-recent {
-    margin-top: 3rem;
-  }
-  .rank-unrated h2,
-  .rank-recent h2 {
-    font-size: 1.15rem;
-    margin-bottom: 0.2rem;
-  }
+  .rank-unrated, .rank-recent { margin-top: 3rem; }
+  .rank-unrated h2, .rank-recent h2 { font-size: 1.15rem; margin-bottom: 0.2rem; }
   .rank-unrated ul {
     list-style: none;
     padding: 0;
@@ -746,16 +762,8 @@ seasons.sort((a, b) => a - b);
     grid-template-columns: repeat(auto-fill, minmax(15rem, 1fr));
     gap: 0.4rem 1rem;
   }
-  .rank-unrated li::before {
-    content: "·";
-    color: var(--pico-muted-color);
-    margin-right: 0.4rem;
-  }
-  .unrated-cta {
-    margin-top: 0.8rem;
-    font-size: 0.88rem;
-    color: var(--pico-muted-color);
-  }
+  .rank-unrated li::before { content: "·"; color: var(--pico-muted-color); margin-right: 0.4rem; }
+  .unrated-cta { margin-top: 0.8rem; font-size: 0.88rem; color: var(--pico-muted-color); }
 
   /* Filters ----------------------------------------------------------- */
   .battle-filters {
@@ -768,21 +776,14 @@ seasons.sort((a, b) => a - b);
     flex-direction: column;
     gap: 0.9rem;
   }
-  .filter-row-main input[type="search"] {
-    margin: 0;
-    width: 100%;
-  }
+  .filter-row-main input[type="search"] { margin: 0; width: 100%; }
   .filter-row-meta {
     display: flex;
     flex-wrap: wrap;
     gap: 1.5rem;
     align-items: flex-end;
   }
-  .filter-group {
-    display: flex;
-    flex-direction: column;
-    gap: 0.3rem;
-  }
+  .filter-group { display: flex; flex-direction: column; gap: 0.3rem; }
   .filter-group label {
     margin: 0;
     font-size: 0.7rem;
@@ -797,10 +798,7 @@ seasons.sort((a, b) => a - b);
     height: auto;
     font-size: 0.88rem;
   }
-  .filter-pills {
-    display: flex;
-    gap: 0.35rem;
-  }
+  .filter-pills { display: flex; gap: 0.35rem; }
   .filter-pills .pill {
     padding: 0.3rem 0.7rem;
     font-size: 0.8rem;
@@ -819,7 +817,7 @@ seasons.sort((a, b) => a - b);
     border-color: var(--pico-primary);
     color: var(--pico-primary-inverse);
   }
-  
+
   .filter-row-chips {
     display: flex;
     flex-wrap: wrap;
@@ -845,19 +843,22 @@ seasons.sort((a, b) => a - b);
     border-color: var(--pico-primary);
     color: var(--pico-primary-inverse);
   }
-
-  .filter-status {
-    font-size: 0.76rem;
-    color: var(--pico-muted-color);
-    text-align: right;
+  /* Perspective chips use their hue when active */
+  #filter-perspective .chip[data-perspective]:not([data-perspective="all"]):not(.active):hover {
+    background: hsl(var(--ph, 200), 30%, 88%);
+    border-color: hsl(var(--ph, 200), 40%, 65%);
+    color: hsl(var(--ph, 200), 45%, 28%);
   }
+  [data-theme="dark"] #filter-perspective .chip[data-perspective]:not([data-perspective="all"]):not(.active):hover {
+    background: hsl(var(--ph, 200), 25%, 22%);
+    border-color: hsl(var(--ph, 200), 35%, 45%);
+    color: hsl(var(--ph, 200), 55%, 75%);
+  }
+
+  .filter-status { font-size: 0.76rem; color: var(--pico-muted-color); text-align: right; }
 
   /* Battle Cards ----------------------------------------------------- */
-  .battle-list {
-    display: flex;
-    flex-direction: column;
-    gap: 0.85rem;
-  }
+  .battle-list { display: flex; flex-direction: column; gap: 0.85rem; }
   .battle-card {
     border: 1px solid var(--pico-muted-border-color);
     border-radius: var(--pico-border-radius);
@@ -865,15 +866,9 @@ seasons.sort((a, b) => a - b);
     overflow: hidden;
     transition: border-color 0.2s ease, box-shadow 0.2s ease;
   }
-  .battle-card:hover {
-    border-color: var(--pico-primary);
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.03);
-  }
-  
-  .battle-details {
-    margin: 0;
-    padding: 0;
-  }
+  .battle-card:hover { border-color: var(--pico-primary); box-shadow: 0 4px 12px rgba(0, 0, 0, 0.03); }
+
+  .battle-details { margin: 0; padding: 0; }
   .battle-header {
     padding: 1rem 1.1rem;
     list-style: none;
@@ -881,10 +876,8 @@ seasons.sort((a, b) => a - b);
     position: relative;
     user-select: none;
   }
-  .battle-header::-webkit-details-marker {
-    display: none;
-  }
-  
+  .battle-header::-webkit-details-marker { display: none; }
+
   .battle-meta {
     display: flex;
     flex-wrap: wrap;
@@ -909,37 +902,38 @@ seasons.sort((a, b) => a - b);
     color: var(--pico-muted-color);
     line-height: 1.1;
   }
-  .tag-criterion {
-    background: rgba(0, 100, 250, 0.04);
-    color: #0050c8;
-    border-color: rgba(0, 100, 250, 0.12);
+  /* Perspective tag uses computed hue */
+  .tag-perspective {
+    background: hsl(var(--ph, 200), 28%, 92%);
+    color: hsl(var(--ph, 200), 45%, 32%);
+    border-color: hsl(var(--ph, 200), 38%, 72%);
+    text-transform: none;
+    letter-spacing: 0;
+    font-size: 0.7rem;
   }
-  [data-theme="dark"] .tag-criterion {
-    color: #64a5ff;
-    border-color: rgba(100, 165, 255, 0.2);
+  [data-theme="dark"] .tag-perspective {
+    background: hsl(var(--ph, 200), 22%, 18%);
+    color: hsl(var(--ph, 200), 52%, 70%);
+    border-color: hsl(var(--ph, 200), 32%, 38%);
   }
-  .tag-confidence.conf-high {
-    background: rgba(45, 106, 79, 0.04);
-    color: #2d6a4f;
-    border-color: rgba(45, 106, 79, 0.12);
-  }
-  [data-theme="dark"] .tag-confidence.conf-high {
-    color: #74c69d;
-    border-color: rgba(116, 198, 157, 0.2);
-  }
-  .tag-confidence.conf-medium {
-    background: rgba(176, 131, 0, 0.04);
-    color: #a07800;
-    border-color: rgba(176, 131, 0, 0.12);
-  }
-  [data-theme="dark"] .tag-confidence.conf-medium {
-    color: #f1c453;
-    border-color: rgba(241, 196, 83, 0.2);
-  }
-  .tag-model {
+  /* Agent tag */
+  .tag-agent {
     font-family: var(--pico-font-family-monospace);
-    opacity: 0.85;
+    background: rgba(100, 100, 200, 0.05);
+    color: var(--pico-muted-color);
+    border-color: rgba(100, 100, 200, 0.15);
+    text-transform: none;
+    letter-spacing: 0;
   }
+  [data-theme="dark"] .tag-agent {
+    background: rgba(150, 150, 255, 0.07);
+    border-color: rgba(150, 150, 255, 0.2);
+  }
+  .tag-season { background: rgba(0, 0, 0, 0.03); }
+  .tag-confidence.conf-high { background: rgba(45, 106, 79, 0.04); color: #2d6a4f; border-color: rgba(45, 106, 79, 0.12); }
+  [data-theme="dark"] .tag-confidence.conf-high { color: #74c69d; border-color: rgba(116, 198, 157, 0.2); }
+  .tag-confidence.conf-medium { background: rgba(176, 131, 0, 0.04); color: #a07800; border-color: rgba(176, 131, 0, 0.12); }
+  [data-theme="dark"] .tag-confidence.conf-medium { color: #f1c453; border-color: rgba(241, 196, 83, 0.2); }
 
   .battle-versus {
     display: grid;
@@ -955,33 +949,25 @@ seasons.sort((a, b) => a - b);
     gap: 0.45rem;
     font-size: 0.96rem;
   }
-  .versus-side.winner {
-    font-weight: 600;
-  }
-  .versus-side.loser {
-    color: var(--pico-muted-color);
-  }
-  .versus-side.winner .post-title-link {
-    color: var(--pico-color);
-    text-decoration: none;
-  }
-  .versus-side.winner .post-title-link:hover {
-    text-decoration: underline;
-  }
+  .versus-side.winner { font-weight: 600; }
+  .versus-side.loser { color: var(--pico-muted-color); }
+  .versus-side.winner .post-title-link { color: var(--pico-color); text-decoration: none; }
+  .versus-side.winner .post-title-link:hover { text-decoration: underline; }
   .versus-side.loser .post-title-link {
     color: var(--pico-muted-color);
     text-decoration: line-through;
     text-decoration-color: var(--pico-muted-border-color);
   }
-  .versus-side.loser .post-title-link:hover {
-    color: var(--pico-color);
-    text-decoration: underline;
-    text-decoration-color: var(--pico-primary);
-  }
-  .versus-medal {
-    font-size: 0.9rem;
+  .versus-side.loser .post-title-link:hover { color: var(--pico-color); text-decoration: underline; text-decoration-color: var(--pico-primary); }
+  .versus-medal { font-size: 0.9rem; flex-shrink: 0; }
+  .versus-rate {
+    font-family: var(--pico-font-family-monospace);
+    font-size: 0.72rem;
+    font-weight: 700;
+    color: var(--pico-primary);
     flex-shrink: 0;
   }
+  .versus-rate.loser-rate { color: var(--pico-muted-color); font-weight: 400; }
 
   .versus-divider {
     display: flex;
@@ -999,14 +985,6 @@ seasons.sort((a, b) => a - b);
     border-radius: 4px;
     line-height: 1;
   }
-  .versus-margin {
-    font-family: var(--pico-font-family-monospace);
-    font-size: 0.64rem;
-    font-weight: 600;
-    color: var(--pico-primary);
-    margin-top: 0.15rem;
-    line-height: 1;
-  }
 
   .battle-tension-bar {
     height: 3px;
@@ -1015,18 +993,11 @@ seasons.sort((a, b) => a - b);
     overflow: hidden;
     display: flex;
     margin-top: 0.4rem;
-    padding-right: 0;
     width: calc(100% - 1.5rem);
   }
-  .tension-fill.winner {
-    background: var(--pico-primary);
-    opacity: 0.6;
-  }
-  .tension-fill.loser {
-    background: var(--pico-muted-border-color);
-    opacity: 0.35;
-  }
-  
+  .tension-fill.winner { background: var(--pico-primary); opacity: 0.6; }
+  .tension-fill.loser { background: var(--pico-muted-border-color); opacity: 0.35; }
+
   .battle-expand-indicator {
     position: absolute;
     right: 1.1rem;
@@ -1036,19 +1007,15 @@ seasons.sort((a, b) => a - b);
     color: var(--pico-muted-color);
     transition: transform 0.25s ease;
   }
-  details[open] .battle-expand-indicator {
-    transform: translateY(-50%) rotate(180deg);
-  }
+  details[open] .battle-expand-indicator { transform: translateY(-50%) rotate(180deg); }
 
   .battle-body {
     padding: 1.1rem;
     border-top: 1px dashed var(--pico-muted-border-color);
     background: var(--pico-card-sectioning-background-color);
   }
-  
-  .battle-section {
-    margin-top: 0.8rem;
-  }
+
+  .battle-section { margin-top: 0.8rem; }
   .battle-section h5,
   .battle-section h6 {
     margin-bottom: 0.4rem;
@@ -1063,14 +1030,9 @@ seasons.sort((a, b) => a - b);
     margin-top: 0;
     margin-bottom: 1rem;
   }
-  .section-content {
-    font-size: 0.9rem;
-    line-height: 1.5;
-  }
-  .section-content p:last-child {
-    margin-bottom: 0;
-  }
-  
+  .section-content { font-size: 0.9rem; line-height: 1.5; }
+  .section-content p:last-child { margin-bottom: 0; }
+
   .battle-sides-grid {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(16rem, 1fr));
@@ -1078,9 +1040,7 @@ seasons.sort((a, b) => a - b);
     border-top: 1px dashed var(--pico-muted-border-color);
     padding-top: 0.8rem;
   }
-  .side-section {
-    margin-top: 0;
-  }
+  .side-section { margin-top: 0; }
 
   @media (max-width: 680px) {
     .battle-versus {
@@ -1090,22 +1050,10 @@ seasons.sort((a, b) => a - b);
       padding-right: 0;
       width: 100%;
     }
-    .versus-side {
-      justify-content: center;
-    }
-    .versus-divider {
-      flex-direction: row;
-      gap: 0.35rem;
-    }
-    .versus-margin {
-      margin-top: 0;
-    }
-    .battle-tension-bar {
-      width: 100%;
-    }
-    .battle-meta {
-      padding-right: 0;
-    }
+    .versus-side { justify-content: center; }
+    .versus-divider { flex-direction: row; gap: 0.35rem; }
+    .battle-tension-bar { width: 100%; }
+    .battle-meta { padding-right: 0; }
   }
 
   .rank-empty {
@@ -1127,14 +1075,17 @@ seasons.sort((a, b) => a - b);
   document.addEventListener('DOMContentLoaded', () => {
     const searchInput = document.getElementById('battle-search') as HTMLInputElement | null;
     const seasonSelect = document.getElementById('filter-season') as HTMLSelectElement | null;
+    const agentSelect = document.getElementById('filter-agent') as HTMLSelectElement | null;
     const confidenceContainer = document.getElementById('filter-confidence');
-    const chipContainer = document.querySelector('.filter-row-chips');
+    const perspectiveContainer = document.getElementById('filter-perspective');
+    const criterionContainer = document.querySelector('.filter-row-chips:not(#filter-perspective)');
     const cards = document.querySelectorAll('.battle-card') as NodeListOf<HTMLElement>;
     const countLabel = document.getElementById('filter-count-label');
     const emptyState = document.getElementById('battle-empty');
 
     let activeCriterion = 'all';
     let activeConfidence = 'all';
+    let activePerspective = 'all';
 
     if (!searchInput || !cards.length || !countLabel) return;
 
@@ -1144,21 +1095,26 @@ seasons.sort((a, b) => a - b);
       if (!searchInput || !countLabel) return;
       const query = searchInput.value.toLowerCase().trim();
       const season = seasonSelect ? seasonSelect.value : 'all';
-      
+      const agent = agentSelect ? agentSelect.value : 'all';
+
       let visibleCount = 0;
 
       cards.forEach((card) => {
         const cardCriterion = card.getAttribute('data-criterion') || 'none';
         const cardConfidence = card.getAttribute('data-confidence') || 'none';
         const cardSeason = card.getAttribute('data-season') || 'none';
+        const cardPerspective = card.getAttribute('data-perspective') || 'none';
+        const cardAgent = card.getAttribute('data-agent') || 'none';
         const searchContent = card.getAttribute('data-search') || '';
 
         const matchesQuery = !query || searchContent.includes(query);
         const matchesSeason = season === 'all' || cardSeason === season;
+        const matchesAgent = agent === 'all' || cardAgent === agent;
         const matchesConfidence = activeConfidence === 'all' || cardConfidence === activeConfidence;
         const matchesCriterion = activeCriterion === 'all' || cardCriterion === activeCriterion;
+        const matchesPerspective = activePerspective === 'all' || cardPerspective === activePerspective;
 
-        if (matchesQuery && matchesSeason && matchesConfidence && matchesCriterion) {
+        if (matchesQuery && matchesSeason && matchesAgent && matchesConfidence && matchesCriterion && matchesPerspective) {
           card.style.display = 'block';
           visibleCount++;
         } else {
@@ -1176,10 +1132,8 @@ seasons.sort((a, b) => a - b);
     }
 
     searchInput.addEventListener('input', applyFilters);
-
-    if (seasonSelect) {
-      seasonSelect.addEventListener('change', applyFilters);
-    }
+    if (seasonSelect) seasonSelect.addEventListener('change', applyFilters);
+    if (agentSelect) agentSelect.addEventListener('change', applyFilters);
 
     if (confidenceContainer) {
       const pills = confidenceContainer.querySelectorAll('.pill');
@@ -1194,8 +1148,21 @@ seasons.sort((a, b) => a - b);
       });
     }
 
-    if (chipContainer) {
-      const chips = chipContainer.querySelectorAll('.chip');
+    if (perspectiveContainer) {
+      const chips = perspectiveContainer.querySelectorAll('.chip');
+      chips.forEach((chip) => {
+        chip.addEventListener('click', (e) => {
+          chips.forEach((c) => c.classList.remove('active'));
+          const target = e.currentTarget as HTMLElement;
+          target.classList.add('active');
+          activePerspective = target.getAttribute('data-perspective') || 'all';
+          applyFilters();
+        });
+      });
+    }
+
+    if (criterionContainer) {
+      const chips = criterionContainer.querySelectorAll('.chip');
       chips.forEach((chip) => {
         chip.addEventListener('click', (e) => {
           chips.forEach((c) => c.classList.remove('active'));

--- a/src/components/RankingView.astro
+++ b/src/components/RankingView.astro
@@ -73,6 +73,9 @@ export interface RankingStrings {
   agentLabel: string;
   filterAgentAll: string;
   ratesLabel: string;
+  paginationPrev: string;
+  paginationNext: string;
+  paginationPageOf: string;
 }
 
 interface Props {
@@ -506,6 +509,14 @@ agents.sort();
         );
       })}
     </div>
+
+    <nav id="battle-pagination" class="battle-pagination" style="display: none;" aria-label="battles pagination">
+      <button id="prev-page" class="outline secondary">{strings.paginationPrev}</button>
+      <span id="page-indicator" data-template={strings.paginationPageOf}>
+        {strings.paginationPageOf.replace("{n}", "1").replace("{total}", "1")}
+      </span>
+      <button id="next-page" class="outline secondary">{strings.paginationNext}</button>
+    </nav>
 
     <div id="battle-empty" class="rank-empty" style="display: none;">
       <em>{strings.emptyFilterState}</em>
@@ -1069,6 +1080,26 @@ agents.sort();
     border-bottom: 1px dotted var(--pico-muted-color);
     cursor: help;
   }
+
+  .battle-pagination {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 1rem;
+    margin: 1.25rem 0 0.5rem;
+  }
+  .battle-pagination button {
+    padding: 0.35rem 0.9rem;
+    font-size: 0.85rem;
+    min-width: 7rem;
+    margin-bottom: 0;
+  }
+  #page-indicator {
+    font-size: 0.85rem;
+    color: var(--pico-muted-color);
+    min-width: 8rem;
+    text-align: center;
+  }
 </style>
 
 <script>
@@ -1079,61 +1110,81 @@ agents.sort();
     const confidenceContainer = document.getElementById('filter-confidence');
     const perspectiveContainer = document.getElementById('filter-perspective');
     const criterionContainer = document.querySelector('.filter-row-chips:not(#filter-perspective)');
-    const cards = document.querySelectorAll('.battle-card') as NodeListOf<HTMLElement>;
+    const cards = Array.from(document.querySelectorAll('.battle-card')) as HTMLElement[];
     const countLabel = document.getElementById('filter-count-label');
     const emptyState = document.getElementById('battle-empty');
+    const paginationEl = document.getElementById('battle-pagination') as HTMLElement | null;
+    const prevBtn = document.getElementById('prev-page') as HTMLButtonElement | null;
+    const nextBtn = document.getElementById('next-page') as HTMLButtonElement | null;
+    const pageIndicator = document.getElementById('page-indicator') as HTMLElement | null;
 
     let activeCriterion = 'all';
     let activeConfidence = 'all';
     let activePerspective = 'all';
+    let currentPage = 0;
+    let lastVisible: HTMLElement[] = [];
+
+    const PAGE_SIZE = 15;
 
     if (!searchInput || !cards.length || !countLabel) return;
 
     const countTemplate = countLabel.getAttribute('data-template') || 'Showing {count} of {total}';
+    const pageTemplate = pageIndicator?.getAttribute('data-template') || 'Page {n} of {total}';
+
+    function showPage(page: number) {
+      const totalPages = Math.max(1, Math.ceil(lastVisible.length / PAGE_SIZE));
+      currentPage = Math.max(0, Math.min(page, totalPages - 1));
+
+      const start = currentPage * PAGE_SIZE;
+      const end = start + PAGE_SIZE;
+
+      cards.forEach((card) => { card.style.display = 'none'; });
+      lastVisible.forEach((card, i) => {
+        card.style.display = (i >= start && i < end) ? 'block' : 'none';
+      });
+
+      countLabel!.textContent = countTemplate
+        .replace('{count}', String(lastVisible.length))
+        .replace('{total}', String(cards.length));
+
+      if (emptyState) emptyState.style.display = lastVisible.length === 0 ? 'block' : 'none';
+
+      const showPagination = totalPages > 1;
+      if (paginationEl) paginationEl.style.display = showPagination ? 'flex' : 'none';
+      if (prevBtn) prevBtn.disabled = currentPage === 0;
+      if (nextBtn) nextBtn.disabled = currentPage >= totalPages - 1;
+      if (pageIndicator) {
+        pageIndicator.textContent = pageTemplate
+          .replace('{n}', String(currentPage + 1))
+          .replace('{total}', String(totalPages));
+      }
+    }
 
     function applyFilters() {
-      if (!searchInput || !countLabel) return;
+      if (!searchInput) return;
       const query = searchInput.value.toLowerCase().trim();
       const season = seasonSelect ? seasonSelect.value : 'all';
       const agent = agentSelect ? agentSelect.value : 'all';
 
-      let visibleCount = 0;
-
-      cards.forEach((card) => {
-        const cardCriterion = card.getAttribute('data-criterion') || 'none';
-        const cardConfidence = card.getAttribute('data-confidence') || 'none';
-        const cardSeason = card.getAttribute('data-season') || 'none';
-        const cardPerspective = card.getAttribute('data-perspective') || 'none';
-        const cardAgent = card.getAttribute('data-agent') || 'none';
-        const searchContent = card.getAttribute('data-search') || '';
-
-        const matchesQuery = !query || searchContent.includes(query);
-        const matchesSeason = season === 'all' || cardSeason === season;
-        const matchesAgent = agent === 'all' || cardAgent === agent;
-        const matchesConfidence = activeConfidence === 'all' || cardConfidence === activeConfidence;
-        const matchesCriterion = activeCriterion === 'all' || cardCriterion === activeCriterion;
-        const matchesPerspective = activePerspective === 'all' || cardPerspective === activePerspective;
-
-        if (matchesQuery && matchesSeason && matchesAgent && matchesConfidence && matchesCriterion && matchesPerspective) {
-          card.style.display = 'block';
-          visibleCount++;
-        } else {
-          card.style.display = 'none';
-        }
+      lastVisible = cards.filter((card) => {
+        const matchesQuery = !query || (card.getAttribute('data-search') || '').includes(query);
+        const matchesSeason = season === 'all' || (card.getAttribute('data-season') || '') === season;
+        const matchesAgent = agent === 'all' || (card.getAttribute('data-agent') || '') === agent;
+        const matchesConfidence = activeConfidence === 'all' || (card.getAttribute('data-confidence') || '') === activeConfidence;
+        const matchesCriterion = activeCriterion === 'all' || (card.getAttribute('data-criterion') || '') === activeCriterion;
+        const matchesPerspective = activePerspective === 'all' || (card.getAttribute('data-perspective') || '') === activePerspective;
+        return matchesQuery && matchesSeason && matchesAgent && matchesConfidence && matchesCriterion && matchesPerspective;
       });
 
-      countLabel.textContent = countTemplate
-        .replace('{count}', visibleCount.toString())
-        .replace('{total}', cards.length.toString());
-
-      if (emptyState) {
-        emptyState.style.display = visibleCount === 0 ? 'block' : 'none';
-      }
+      showPage(0);
     }
 
     searchInput.addEventListener('input', applyFilters);
     if (seasonSelect) seasonSelect.addEventListener('change', applyFilters);
     if (agentSelect) agentSelect.addEventListener('change', applyFilters);
+
+    if (prevBtn) prevBtn.addEventListener('click', () => showPage(currentPage - 1));
+    if (nextBtn) nextBtn.addEventListener('click', () => showPage(currentPage + 1));
 
     if (confidenceContainer) {
       const pills = confidenceContainer.querySelectorAll('.pill');

--- a/src/lib/hronir-rank.ts
+++ b/src/lib/hronir-rank.ts
@@ -33,37 +33,53 @@ export interface DuelEntry {
   confidence?: string;
   criterion?: string;
   body?: string;
+  /** @deprecated use agentId */
   model?: string;
+  agentId?: string;
   season?: number;
   postAKey?: string;
   postBKey?: string;
+  perspectiveId?: string;
+  rateA?: number;
+  rateB?: number;
   parsedContent?: DuelContent;
 }
 
-export function parseDuelContent(body?: string): DuelContent {
+export function parseDuelContent(
+  body?: string,
+  data?: Record<string, unknown>
+): DuelContent {
   const result: DuelContent = {
     postAAnalysis: "",
     postBAnalysis: "",
     verdict: "",
   };
-  if (!body) return result;
 
-  const parts = body.split(/(?:^|\n)##\s+/);
-  for (const part of parts) {
-    const trimmed = part.trim();
-    if (!trimmed) continue;
-    const lines = trimmed.split("\n");
-    const header = lines[0].trim().toLowerCase();
-    const content = lines.slice(1).join("\n").trim();
-
-    if (header.startsWith("post a")) {
-      result.postAAnalysis = content;
-    } else if (header.startsWith("post b")) {
-      result.postBAnalysis = content;
-    } else if (header.startsWith("veredito") || header.startsWith("verdict")) {
-      result.verdict = content;
+  // Try markdown body first (original format with ## section headers)
+  if (body) {
+    const parts = body.split(/(?:^|\n)##\s+/);
+    for (const part of parts) {
+      const trimmed = part.trim();
+      if (!trimmed) continue;
+      const lines = trimmed.split("\n");
+      const header = lines[0].trim().toLowerCase();
+      const content = lines.slice(1).join("\n").trim();
+      if (header.startsWith("post a")) result.postAAnalysis = content;
+      else if (header.startsWith("post b")) result.postBAnalysis = content;
+      else if (header.startsWith("veredito") || header.startsWith("verdict"))
+        result.verdict = content;
     }
+    if (result.postAAnalysis || result.postBAnalysis || result.verdict)
+      return result;
   }
+
+  // Fall back to frontmatter fields (stars-v1 / migrated passion-v1)
+  if (data) {
+    if (data.clash) result.verdict = String(data.clash);
+    if (data.review_a) result.postAAnalysis = String(data.review_a);
+    if (data.review_b) result.postBAnalysis = String(data.review_b);
+  }
+
   return result;
 }
 
@@ -122,6 +138,10 @@ function loadDuelData(): { stats: RankingStats; recent: DuelEntry[] } {
     const winnerKey = winner === "a" ? aKey : bKey;
     const loserKey = winner === "a" ? bKey : aKey;
 
+    const agentId = (data as any).agent_id
+      ? String((data as any).agent_id)
+      : undefined;
+
     duels.push({
       runAt,
       winnerKey,
@@ -137,14 +157,29 @@ function loadDuelData(): { stats: RankingStats; recent: DuelEntry[] } {
         ? String((data as any).criterion)
         : undefined,
       body: content ? String(content).trim() : undefined,
-      model: (data as any).model ? String((data as any).model) : undefined,
+      model: agentId,
+      agentId,
       season:
         typeof (data as any).season === "number"
           ? (data as any).season
           : undefined,
       postAKey: aKey,
       postBKey: bKey,
-      parsedContent: content ? parseDuelContent(String(content)) : undefined,
+      perspectiveId: (data as any).perspective_id
+        ? String((data as any).perspective_id)
+        : undefined,
+      rateA:
+        typeof (data as any).rate_a === "number"
+          ? (data as any).rate_a
+          : undefined,
+      rateB:
+        typeof (data as any).rate_b === "number"
+          ? (data as any).rate_b
+          : undefined,
+      parsedContent: parseDuelContent(
+        content ? String(content).trim() : undefined,
+        data as Record<string, unknown>
+      ),
     });
   }
 

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -11,6 +11,7 @@ import TableOfContents from '../../components/TableOfContents.astro';
 import RelatedPosts from '../../components/RelatedPosts.astro';
 import AuthorBio from '../../components/AuthorBio.astro';
 import { getRankByKey } from '../../lib/hronir-rank';
+import HronirReviews from '../../components/HronirReviews.astro';
 import Comments from '../../components/Comments.astro';
 import SeriesContext from '../../components/SeriesContext.astro';
 import PostActionBar from '../../components/PostActionBar.astro';
@@ -187,6 +188,8 @@ const translationLinks = translationSiblings.map((p) => {
       </article>
 
       <AuthorBio lang={lang} />
+
+      {translationKey && <HronirReviews translationKey={translationKey} lang={lang} />}
 
       <RelatedPosts currentId={post.id} tags={tags ?? []} lang={lang} />
 

--- a/src/pages/pt/ranking.astro
+++ b/src/pages/pt/ranking.astro
@@ -112,6 +112,11 @@ const strings: RankingStrings = {
   marginMedium: "média",
   marginLow: "baixa",
   unratedCTA: "Esses posts ainda não passaram pelo julgamento. Sente que algum deles merecia estar no topo?",
+  perspectiveLabel: "Perspectiva",
+  filterPerspectiveAll: "Todas as perspectivas",
+  agentLabel: "Agente",
+  filterAgentAll: "Todos os agentes",
+  ratesLabel: "Notas",
 };
 ---
 

--- a/src/pages/pt/ranking.astro
+++ b/src/pages/pt/ranking.astro
@@ -117,6 +117,9 @@ const strings: RankingStrings = {
   agentLabel: "Agente",
   filterAgentAll: "Todos os agentes",
   ratesLabel: "Notas",
+  paginationPrev: "← Anterior",
+  paginationNext: "Próximo →",
+  paginationPageOf: "Página {n} de {total}",
 };
 ---
 

--- a/src/pages/ranking.astro
+++ b/src/pages/ranking.astro
@@ -110,6 +110,11 @@ const strings: RankingStrings = {
   marginMedium: "medium",
   marginLow: "low",
   unratedCTA: "These posts haven't been duelled yet. Feel like one of them deserves to be on top?",
+  perspectiveLabel: "Perspective",
+  filterPerspectiveAll: "All perspectives",
+  agentLabel: "Agent",
+  filterAgentAll: "All agents",
+  ratesLabel: "Rates",
 };
 ---
 

--- a/src/pages/ranking.astro
+++ b/src/pages/ranking.astro
@@ -115,6 +115,9 @@ const strings: RankingStrings = {
   agentLabel: "Agent",
   filterAgentAll: "All agents",
   ratesLabel: "Rates",
+  paginationPrev: "← Previous",
+  paginationNext: "Next →",
+  paginationPageOf: "Page {n} of {total}",
 };
 ---
 


### PR DESCRIPTION
$(cat <<'EOF'
## Resumo

- **Migração passion-v1→stars-v1**: 27 arquivos de rate tinham o conteúdo em `winner_defense`/`loser_critique` (perspectiva vencedor/perdedor). Migrados para `review_a`/`review_b` (perspectiva Post A/Post B), mantendo mapeamento correto via campo `winner`.
- **Conteúdo visível nos duelos**: `parseDuelContent` agora lê `clash`/`review_a`/`review_b` do frontmatter quando o corpo markdown está vazio — era o motivo dos `<details>` abrirem em branco para ~100% dos duelos recentes.
- **Badge de perspectiva**: cada duelo exibe a persona de leitura (`weird clarity`, `comedy carries argument`, etc.) com cor HSL única por perspectiva. Filtrável por chips.
- **Badge de agente**: `agent_id` agora aparece em cada card (corrige o tag `model` que nunca funcionou — o campo no frontmatter é `agent_id`, não `model`). Filtrável por dropdown.
- **Tension bar real**: era 65% hardcoded; agora usa `rate_a`/`rate_b` quando disponíveis, com as notas exibidas ao lado dos títulos.
- **Criterion chips**: só aparecem se houver critérios reais nos dados (evita botão órfão).

## Arquivos modificados

| Arquivo | O que mudou |
|---------|-------------|
| `scripts/hronir/migrate-passion-to-stars.js` | Novo — script de migração reutilizável |
| `.routines/hronir/rates/2026-05-19*.md` (27 arquivos) | Campos reestruturados |
| `src/lib/hronir-rank.ts` | `DuelEntry` expandido; `parseDuelContent` lê frontmatter |
| `src/components/RankingView.astro` | UI: perspectiva, agente, tension bar, filtros |
| `src/pages/{pt/}ranking.astro` | Novas strings adicionadas |

## Test plan

- [ ] Acessar `/pt/ranking/` e verificar que os duelos expandem com conteúdo (clash/review)
- [ ] Verificar badges de perspectiva com cores diferentes por tipo
- [ ] Verificar badge de agente (`claude-sonnet-4-6`, `human`)
- [ ] Testar filtro de perspectiva: clicar em `weird clarity` e confirmar que só mostra duelos com essa perspectiva
- [ ] Testar filtro de agente: selecionar `human` e confirmar filtro funciona
- [ ] Verificar tension bar: duelos com margem larga devem ter barra mais assimétrica
- [ ] Confirmar que os 27 arquivos migrados têm `review_a`/`review_b` e não `winner_defense`/`loser_critique`

https://claude.ai/code/session_01BuGkTsDPPpKNHtThJFQ9mN
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BuGkTsDPPpKNHtThJFQ9mN)_