### PR TITLE
ux: archive — colapsar anos antigos com details/summary

### DIFF
--- a/.routines/2026-06-08T05-05-27-archive-collapse-years.md
+++ b/.routines/2026-06-08T05-05-27-archive-collapse-years.md
@@ -4,7 +4,7 @@ slug: archive-collapse-years
 branch: claude/sleepy-pasteur-9Tnom
 status: pr-open
 issues: [240]
-pr_opened: null
+pr_opened: 268
 pr_merged: null
 ---
 

--- a/.routines/2026-06-08T05-05-27-archive-collapse-years.md
+++ b/.routines/2026-06-08T05-05-27-archive-collapse-years.md
@@ -1,0 +1,65 @@
+---
+date: 2026-06-08T05:05:27
+slug: archive-collapse-years
+branch: claude/sleepy-pasteur-9Tnom
+status: pr-open
+issues: [240]
+pr_opened: null
+pr_merged: null
+---
+
+# Sessão 2026-06-08 — Archive: colapsar anos antigos (issue #240)
+
+## Contexto ao chegar
+
+Trigésima-quarta sessão. Branch designado: `claude/sleepy-pasteur-9Tnom`.
+
+Estado ao chegar:
+- **13 issues `routine` abertas** — backlog saudável (10–20), sem necessidade de criar ou fechar
+- **0 PRs `routine` abertos** — nenhum PR da run anterior para mergear
+- Últimas runs: #238 (Webmentions i18n, 2026-06-07), #237 (font-display: optional), #236 (font Inter + footer + lang-switcher)
+
+Os três PRs `routine` pendentes da fila eram todos de hronir/Jules — ignorados conforme regras.
+
+## Trabalho executado: issue #240 — Archive collapse
+
+### Problema
+
+O `/archive/` e `/pt/archive/` renderizavam todos os anos em scroll contínuo. Com 97 posts EN (40 só em 2026), a página virava parede de texto sem hierarquia visual navegável.
+
+### Solução
+
+Substituí `<section>/<h2>` por `<details>/<summary>` em ambas as páginas:
+
+- **Ano mais recente** (`years[0]`): `<details open>` — expandido por default
+- **Anos anteriores**: `<details>` sem `open` — colapsados por default
+- **Summary**: `YYYY — N posts` — título clicável com count contextual
+- **Indicador de estado**: `▶` (colapsado) / `▼` (expandido) via CSS `::before`
+- **Sem JS**: disclosure nativo HTML, funciona sem JavaScript
+
+**Invariantes verificados:**
+- `id="archive-{year}"` permanece nos `<details>` → nav de anos ainda faz anchor links
+- JSON-LD `hasPart` em `<head>` inalterado → 97 posts listados no schema
+- `npm run build`: ✓ Completed (0 erros)
+- `npx astro check`: 0 erros, 0 warnings
+- `npx prettier --check .`: All matched files use Prettier code style
+
+### Arquivos alterados
+
+- `src/pages/archive.astro` — `<section>/<h2>` → `<details>/<summary>` + CSS
+- `src/pages/pt/archive.astro` — idem para PT
+
+### Nota sobre produção
+
+Mudança visual. Screenshots de prod chegam na run seguinte (Jina só alcança URL pública).
+Onde olhar no deploy: `/archive/` e `/pt/archive/` — anos 2025 e 2024 devem aparecer colapsados; 2026 aberto.
+
+## Plano para próximas sessões
+
+Por prioridade `alta` restante:
+1. **#239**: Pagefind warnings PT — build noise mascara erros reais
+2. **#241**: Taxonomia de tipo de documento (essay/letter/fiction) — maior escopo
+
+---
+
+_Sessão: 2026-06-08 | Branch: `claude/sleepy-pasteur-9Tnom` | franklinbaldo@gmail.com_

--- a/src/pages/archive.astro
+++ b/src/pages/archive.astro
@@ -67,9 +67,9 @@ const archiveLd = {
     </nav>
   )}
 
-  {years.map((year) => (
-    <section aria-labelledby={`archive-${year}`} class="archive-year">
-      <h2 id={`archive-${year}`}>{year}</h2>
+  {years.map((year, idx) => (
+    <details id={`archive-${year}`} class="archive-year" open={idx === 0}>
+      <summary class="archive-year-summary">{year} — {byYear.get(year)!.length} posts</summary>
       <table class="striped archive-table">
         <thead>
           <tr>
@@ -111,7 +111,7 @@ const archiveLd = {
           })}
         </tbody>
       </table>
-    </section>
+    </details>
   ))}
 </PageLayout>
 
@@ -138,7 +138,29 @@ const archiveLd = {
     background: color-mix(in srgb, var(--pico-primary) 20%, transparent);
     text-decoration: none;
   }
-  .archive-year { margin-block: calc(var(--pico-spacing) * 1.5); }
+  details.archive-year {
+    margin-block: calc(var(--pico-spacing) * 1.5);
+    border: none;
+    padding: 0;
+  }
+  details.archive-year > summary {
+    font-size: 1.15rem;
+    font-weight: 700;
+    cursor: pointer;
+    padding-block: 0.3em;
+    color: var(--pico-heading-color, inherit);
+    list-style: none;
+    user-select: none;
+  }
+  details.archive-year > summary::-webkit-details-marker { display: none; }
+  details.archive-year > summary::before {
+    content: "▶ ";
+    font-size: 0.65em;
+    opacity: 0.45;
+    display: inline-block;
+    margin-inline-end: 0.2em;
+  }
+  details.archive-year[open] > summary::before { content: "▼ "; }
   .archive-table { font-size: 0.95rem; }
   .archive-table .col-date {
     width: 6rem;

--- a/src/pages/pt/archive.astro
+++ b/src/pages/pt/archive.astro
@@ -73,9 +73,9 @@ const years = [...byYear.keys()].sort((a, b) => b - a);
     </nav>
   )}
 
-  {years.map((year) => (
-    <section aria-labelledby={`archive-${year}`} class="archive-year">
-      <h2 id={`archive-${year}`}>{year}</h2>
+  {years.map((year, idx) => (
+    <details id={`archive-${year}`} class="archive-year" open={idx === 0}>
+      <summary class="archive-year-summary">{year} — {byYear.get(year)!.length} posts</summary>
       <table class="striped archive-table">
         <thead>
           <tr>
@@ -117,7 +117,7 @@ const years = [...byYear.keys()].sort((a, b) => b - a);
           })}
         </tbody>
       </table>
-    </section>
+    </details>
   ))}
 </PageLayout>
 
@@ -144,7 +144,29 @@ const years = [...byYear.keys()].sort((a, b) => b - a);
     background: color-mix(in srgb, var(--pico-primary) 20%, transparent);
     text-decoration: none;
   }
-  .archive-year { margin-block: calc(var(--pico-spacing) * 1.5); }
+  details.archive-year {
+    margin-block: calc(var(--pico-spacing) * 1.5);
+    border: none;
+    padding: 0;
+  }
+  details.archive-year > summary {
+    font-size: 1.15rem;
+    font-weight: 700;
+    cursor: pointer;
+    padding-block: 0.3em;
+    color: var(--pico-heading-color, inherit);
+    list-style: none;
+    user-select: none;
+  }
+  details.archive-year > summary::-webkit-details-marker { display: none; }
+  details.archive-year > summary::before {
+    content: "▶ ";
+    font-size: 0.65em;
+    opacity: 0.45;
+    display: inline-block;
+    margin-inline-end: 0.2em;
+  }
+  details.archive-year[open] > summary::before { content: "▼ "; }
   .archive-table { font-size: 0.95rem; }
   .archive-table .col-date {
     width: 6rem;


### PR DESCRIPTION
Closes #240

## UX

- Anos anteriores ao mais recente ficam **colapsados por default** usando `<details>/<summary>` nativo do HTML — sem JS, funciona em qualquer browser
- Ano mais recente (2026) permanece expandido (`open` attribute)
- Summary de cada ano mostra `YYYY — N posts` como título clicável
- Indicador `▶` / `▼` via CSS `::before` sinaliza estado collapsed/open

## Verificação em produção (próxima run)

Checar `/archive/` e `/pt/archive/` no deploy:
- Anos 2025 e 2024 devem aparecer colapsados
- 2026 deve aparecer aberto com a tabela visível
- Clicar em 2025/2024 deve expandir a tabela sem JS

## Invariantes

- JSON-LD `hasPart` em `<head>` não foi alterado — 97 posts listados no schema
- `id="archive-{year}"` permanece em `<details>` → nav de anos ainda funciona como anchor links
- `npx astro check`: 0 erros
- `npm run build`: ✓ Completed
- `npx prettier --check .`: All matched files use Prettier code style

https://claude.ai/code/session_01UUf7eQWmW9CGeR3Ced3m4h

---
_Generated by [Claude Code](https://claude.ai/code/session_01UUf7eQWmW9CGeR3Ced3m4h)_