### PR TITLE
ci: Hrönir autopilot — serialize Jules sessions (merge one, spawn next)

### DIFF
--- a/.github/hronir-session-prompt.md
+++ b/.github/hronir-session-prompt.md
@@ -1,0 +1,69 @@
+Run a complete Hrönir rating session for this blog and open a PR with the results.
+
+## Steps
+
+1. Install dependencies:
+
+   ```bash
+   npm ci
+   ```
+
+2. Initialize a session (use a stable agent id):
+
+   ```bash
+   npm run hronir:init -- --agent-id jules --matches 10
+   ```
+
+3. For each match, follow the loop the CLI prints: read post A, read post B,
+   then submit a decision. Read the banner each time — the perspective and the
+   evaluator mood change per match and your reviews must be written from that
+   perspective.
+
+   ```bash
+   npm run hronir:continue   # read post A
+   npm run hronir:continue   # read post B
+   npm run hronir:decide -- \
+     --rate-a <1.00-5.00> --rate-b <1.00-5.00> \
+     --review-a "<≥100 words, in the banner's perspective>" \
+     --review-b "<≥100 words, in the banner's perspective>" \
+     --clash   "<≥100 words, narrative confrontation through the perspective>" \
+     --after-mood "<≤250 chars, first person PT, your internal state after evaluating — original, not the banner mood>"
+   ```
+
+   Respect every constraint:
+   - Ratings 1.00–5.00, at most 2 decimals, **no ties** between A and B.
+   - Reviews and clash each **≥100 words**, written from the shown perspective.
+   - `--after-mood` is about **your** state, not the posts; first person PT.
+
+4. When all matches are done, the CLI enters the edit-worst phase. Edit the
+   lowest-ranked post (both the English and Portuguese versions) following the
+   `franklin-blog` writing skill, then commit the edit:
+
+   ```bash
+   npm run hronir:edit-commit
+   npm run hronir:end
+   ```
+
+5. Validate before committing:
+
+   ```bash
+   npm run hronir:doctor      # must pass
+   npx prettier --write .
+   npx astro check
+   npm run build
+   ```
+
+6. Stage the rate files and the worst-post edit, commit, and open a PR:
+
+   ```bash
+   git add .routines/hronir/ src/content/blog/
+   git commit -m "hronir: 10 matches — jules"
+   ```
+
+## Constraints on the PR
+
+- Only touch `.routines/hronir/**` and `src/content/blog/**`. Do not modify
+  workflows, scripts, `package.json`, or other config — the autopilot only
+  auto-merges PRs confined to those two paths.
+- Make sure `npx prettier --check .` and `npm run build` pass; CI gates the
+  merge on them.

--- a/.github/workflows/hronir-autopilot.yml
+++ b/.github/workflows/hronir-autopilot.yml
@@ -133,7 +133,8 @@ jobs:
             exit 0
           fi
 
-          gh pr merge "$target" --repo "$REPO" --squash --delete-branch
+          # Merge commit (not squash) — repo preference is to preserve history.
+          gh pr merge "$target" --repo "$REPO" --merge --delete-branch
           echo "Merged PR #$target."
           echo "merged=$target" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/hronir-autopilot.yml
+++ b/.github/workflows/hronir-autopilot.yml
@@ -178,7 +178,7 @@ jobs:
           fi
 
           TITLE="hronir session $(date -u +%Y-%m-%dT%H:%M:%SZ)"
-          SESSION=$(uvx --from git+https://github.com/franklinbaldo/verne@main verne \
+          SESSION=$(uvx --from git+https://github.com/franklinbaldo/verne@6c73a589299c70db59549a8e9d8fd03acd6256ca verne \
             sessions new "$TITLE" \
             --source "sources/github/${REPO}" \
             --prompt-file .github/hronir-session-prompt.md \

--- a/.github/workflows/hronir-autopilot.yml
+++ b/.github/workflows/hronir-autopilot.yml
@@ -1,0 +1,196 @@
+name: Hrönir Autopilot
+
+# Serializes Hrönir/Jules sessions so they never collide on the same posts.
+#
+# Each run:
+#   1. Finds open Hrönir session PRs that are green, mergeable, and confined to
+#      the safe paths (.routines/hronir/** and src/content/blog/**).
+#   2. Merges exactly ONE (the oldest) — keeping sessions strictly sequential.
+#   3. Only if NO Hrönir PRs remain open afterwards, kicks off the next Jules
+#      session via the Jules API, starting from the freshly-merged main. Because
+#      the new session branches from up-to-date main, its PR won't conflict.
+#
+# Draining a backlog: it merges one per run and won't spawn a new session until
+# the queue is empty, so existing PRs flush out one at a time without piling up.
+#
+# Requires repo secret JULES_API_KEY (the Google Jules API key). Without it the
+# merge half still works; only the "spawn next session" step is skipped.
+
+on:
+  schedule:
+    - cron: "0 */6 * * *" # every 6 hours
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "List eligible PRs but do not merge or spawn"
+        required: false
+        default: "false"
+        type: boolean
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: hronir-autopilot
+  cancel-in-progress: false
+
+env:
+  REPO: ${{ github.repository }}
+  # A PR is a Hrönir session PR when every changed file lives under one of these
+  # prefixes AND at least one file is under .routines/hronir/rates/.
+  SAFE_PREFIXES: ".routines/hronir/ src/content/blog/"
+
+jobs:
+  autopilot:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Select and merge one eligible Hrönir PR
+        id: merge
+        env:
+          GH_TOKEN: ${{ github.token }}
+          DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
+        run: |
+          set -euo pipefail
+
+          # Returns 0 (eligible) / 1 (not) for a PR number.
+          is_eligible() {
+            local pr="$1"
+            local files
+            files=$(gh pr view "$pr" --repo "$REPO" --json files --jq '.files[].path')
+            [ -n "$files" ] || return 1
+
+            local has_rate=0
+            while IFS= read -r f; do
+              [ -n "$f" ] || continue
+              case "$f" in
+                .routines/hronir/rates/*) has_rate=1 ;;
+              esac
+              local ok=1
+              for p in $SAFE_PREFIXES; do
+                case "$f" in "$p"*) ok=0 ;; esac
+              done
+              if [ "$ok" -ne 0 ]; then
+                echo "  PR #$pr touches out-of-scope file: $f" >&2
+                return 1
+              fi
+            done <<< "$files"
+            [ "$has_rate" -eq 1 ] || { echo "  PR #$pr has no rate files" >&2; return 1; }
+            return 0
+          }
+
+          # Oldest-first list of open, non-draft PRs targeting main.
+          mapfile -t prs < <(gh pr list --repo "$REPO" --state open --base main \
+            --json number,isDraft,createdAt \
+            --jq 'sort_by(.createdAt) | .[] | select(.isDraft|not) | .number')
+
+          echo "Open PRs (oldest first): ${prs[*]:-none}"
+
+          target=""
+          for pr in "${prs[@]:-}"; do
+            [ -n "$pr" ] || continue
+            echo "Checking PR #$pr ..."
+
+            if ! is_eligible "$pr"; then
+              echo "  → skip (out of scope)"
+              continue
+            fi
+
+            mergeable=$(gh pr view "$pr" --repo "$REPO" --json mergeable --jq '.mergeable')
+            if [ "$mergeable" != "MERGEABLE" ]; then
+              echo "  → skip (mergeable=$mergeable)"
+              continue
+            fi
+
+            # All required CI checks must have succeeded.
+            state=$(gh pr view "$pr" --repo "$REPO" \
+              --json statusCheckRollup \
+              --jq '[.statusCheckRollup[]? | (.conclusion // .state)] as $c
+                    | if ($c|length)==0 then "NONE"
+                      elif ([$c[] | select(. != "SUCCESS" and . != "NEUTRAL" and . != "SKIPPED")] | length) > 0 then "PENDING_OR_FAILED"
+                      else "SUCCESS" end')
+            if [ "$state" != "SUCCESS" ]; then
+              echo "  → skip (checks=$state)"
+              continue
+            fi
+
+            target="$pr"
+            break
+          done
+
+          if [ -z "$target" ]; then
+            echo "No eligible Hrönir PR to merge this run."
+            echo "merged=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "Eligible target: PR #$target"
+          if [ "$DRY_RUN" = "true" ]; then
+            echo "DRY RUN — not merging PR #$target."
+            echo "merged=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          gh pr merge "$target" --repo "$REPO" --squash --delete-branch
+          echo "Merged PR #$target."
+          echo "merged=$target" >> "$GITHUB_OUTPUT"
+
+      - name: Count remaining open Hrönir PRs
+        id: remaining
+        if: steps.merge.outputs.merged != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          count=0
+          mapfile -t prs < <(gh pr list --repo "$REPO" --state open --base main \
+            --json number,isDraft --jq '.[] | select(.isDraft|not) | .number')
+          for pr in "${prs[@]:-}"; do
+            [ -n "$pr" ] || continue
+            files=$(gh pr view "$pr" --repo "$REPO" --json files --jq '.files[].path')
+            echo "$files" | grep -q '^\.routines/hronir/rates/' && count=$((count+1)) || true
+          done
+          echo "Remaining open Hrönir-like PRs: $count"
+          echo "count=$count" >> "$GITHUB_OUTPUT"
+
+      - name: Spawn the next Jules session
+        # Only when we merged something AND the queue is now empty, so the new
+        # session starts from a clean, up-to-date main.
+        if: steps.merge.outputs.merged != '' && steps.remaining.outputs.count == '0'
+        env:
+          JULES_API_KEY: ${{ secrets.JULES_API_KEY }}
+        run: |
+          set -euo pipefail
+          if [ -z "${JULES_API_KEY:-}" ]; then
+            echo "::warning::JULES_API_KEY not set — skipping session creation. Add it in repo secrets to enable the autopilot loop."
+            exit 0
+          fi
+
+          TITLE="hronir session $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          RESPONSE=$(jq -n \
+            --rawfile prompt .github/hronir-session-prompt.md \
+            --arg title "$TITLE" \
+            --arg source "sources/github/${REPO}" \
+            '{
+              prompt: $prompt,
+              title: $title,
+              sourceContext: {
+                source: $source,
+                githubRepoContext: { startingBranch: "main" }
+              },
+              automationMode: "AUTO_CREATE_PR"
+            }' | curl -sS -X POST "https://jules.googleapis.com/v1alpha/sessions" \
+              -H "x-goog-api-key: $JULES_API_KEY" \
+              -H "Content-Type: application/json" \
+              -d @-)
+
+          SESSION_ID=$(echo "$RESPONSE" | jq -r '.id // empty')
+          if [ -z "$SESSION_ID" ]; then
+            echo "::error::Failed to create Jules session:"
+            echo "$RESPONSE"
+            exit 1
+          fi
+          echo "Created Jules session: $SESSION_ID"
+          echo "https://jules.google.com/task/$SESSION_ID"

--- a/.github/workflows/hronir-autopilot.yml
+++ b/.github/workflows/hronir-autopilot.yml
@@ -156,9 +156,17 @@ jobs:
           echo "Remaining open Hrönir-like PRs: $count"
           echo "count=$count" >> "$GITHUB_OUTPUT"
 
-      - name: Spawn the next Jules session
+      - name: Set up uv
+        # Needed to run the verne CLI via uvx. Only when we're about to spawn.
+        if: steps.merge.outputs.merged != '' && steps.remaining.outputs.count == '0'
+        uses: astral-sh/setup-uv@v5
+
+      - name: Spawn the next Jules session (via verne)
         # Only when we merged something AND the queue is now empty, so the new
         # session starts from a clean, up-to-date main.
+        #
+        # Session creation is centralized in franklinbaldo/verne — change the
+        # behavior there, not here. verne reads JULES_API_KEY from the env.
         if: steps.merge.outputs.merged != '' && steps.remaining.outputs.count == '0'
         env:
           JULES_API_KEY: ${{ secrets.JULES_API_KEY }}
@@ -170,27 +178,18 @@ jobs:
           fi
 
           TITLE="hronir session $(date -u +%Y-%m-%dT%H:%M:%SZ)"
-          RESPONSE=$(jq -n \
-            --rawfile prompt .github/hronir-session-prompt.md \
-            --arg title "$TITLE" \
-            --arg source "sources/github/${REPO}" \
-            '{
-              prompt: $prompt,
-              title: $title,
-              sourceContext: {
-                source: $source,
-                githubRepoContext: { startingBranch: "main" }
-              },
-              automationMode: "AUTO_CREATE_PR"
-            }' | curl -sS -X POST "https://jules.googleapis.com/v1alpha/sessions" \
-              -H "x-goog-api-key: $JULES_API_KEY" \
-              -H "Content-Type: application/json" \
-              -d @-)
+          SESSION=$(uvx --from git+https://github.com/franklinbaldo/verne@main verne \
+            sessions new "$TITLE" \
+            --source "sources/github/${REPO}" \
+            --prompt-file .github/hronir-session-prompt.md \
+            --branch main \
+            --automation-mode AUTO_CREATE_PR \
+            --json)
 
-          SESSION_ID=$(echo "$RESPONSE" | jq -r '.id // empty')
+          SESSION_ID=$(echo "$SESSION" | jq -r '.id // (.name | sub("^sessions/"; "")) // empty')
           if [ -z "$SESSION_ID" ]; then
-            echo "::error::Failed to create Jules session:"
-            echo "$RESPONSE"
+            echo "::error::Failed to create Jules session via verne:"
+            echo "$SESSION"
             exit 1
           fi
           echo "Created Jules session: $SESSION_ID"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,6 +80,13 @@ npx prettier --write .    # fix formatting
 npm run build             # Astro static build
 ```
 
+## Git & PR conventions
+
+- **Merge commits, not squash.** Always merge PRs with a real merge commit
+  (`gh pr merge --merge` / GitHub "Create a merge commit"). Do **not** squash —
+  preserving each PR's history is the project preference. The Hrönir autopilot
+  workflow follows this too.
+
 ## Key directories
 
 ```


### PR DESCRIPTION
## O quê

Adiciona `.github/workflows/hronir-autopilot.yml` + `.github/hronir-session-prompt.md` e registra no `CLAUDE.md` a preferência de **merge commit (sem squash)**.

O problema hoje: várias sessões Jules rodam **em paralelo a partir do mesmo `main`** e todas editam o mesmo "pior post", então só uma mergeia limpa e as demais viram conflito. A solução é **serializar**.

## Como funciona

A cada execução (cron de 6h em 6h + `workflow_dispatch`):

1. Procura PRs de sessão Hrönir abertas que estejam **verdes, mergeáveis e restritas aos paths seguros** (`.routines/hronir/**` e `src/content/blog/**` — qualquer arquivo fora disso desqualifica a PR para auto-merge).
2. Mergeia **exatamente uma** (a mais antiga), via **merge commit** (não squash — preferência do repo).
3. **Só se não sobrar nenhuma PR Hrönir aberta**, dispara a **próxima sessão Jules** via API (`POST /v1alpha/sessions`, `automationMode: AUTO_CREATE_PR`), partindo do `main` recém-atualizado → a nova PR nasce sem conflito.

Drenagem de backlog: mergeia uma por execução e não cria sessão nova enquanto a fila não esvazia, então as PRs existentes saem uma a uma, sem empilhar.

## Por que é seguro

A serialização é o que torna a edição de conteúdo segura: nunca há duas sessões editando o mesmo post a partir da mesma base. O gate de paths impede que uma PR que mexa em workflows/scripts/config seja auto-mergeada.

## Pré-requisito

Adicionar o secret **`JULES_API_KEY`** no repositório (a mesma chave da Jules API usada no `franklinbaldo/verne`). Sem ela, a metade de merge ainda funciona; só o passo de criar a próxima sessão é pulado (com `::warning::`).

A criação de sessão espelha o `agent-session.yml` do `franklinbaldo/verne` (header `x-goog-api-key`, `sourceContext.githubRepoContext.startingBranch: main`).

https://claude.ai/code/session_015KK8q3vrUyGWUyjCFoaRFd