### PR TITLE
ci: guard internal links + translation pairing, redirect legacy blog URLs

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-node@v4
         with:
@@ -24,6 +26,14 @@ jobs:
 
       - name: Hrönir doctor
         run: npm run hronir:doctor
+
+      - name: Internal link check
+        run: npm run check:links
+
+      - name: Translation pairing check
+        run: npm run check:translations
+        env:
+          BASE_REF: ${{ github.event_name == 'pull_request' && format('origin/{0}', github.base_ref) || '' }}
 
       - name: Astro type check
         run: npx astro check

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -13,6 +13,16 @@ try {
   // File not yet generated — sitemap will emit blog posts without hreflang.
 }
 
+/** @type {Record<string, string>} */
+let blogRedirects = {};
+try {
+  blogRedirects = JSON.parse(
+    readFileSync("./src/generated/blog-redirects.json", "utf-8")
+  );
+} catch {
+  // File not yet generated — legacy date-prefixed URLs won't redirect.
+}
+
 import mdx from "@astrojs/mdx";
 import sitemap from "@astrojs/sitemap";
 import remarkMath from "remark-math";
@@ -83,6 +93,7 @@ export default defineConfig({
   ],
   redirects: {
     "/musicas/": "/music/",
+    ...blogRedirects,
   },
   prefetch: {
     defaultStrategy: "viewport",

--- a/package.json
+++ b/package.json
@@ -6,8 +6,10 @@
     "node": ">=22.12.0"
   },
   "scripts": {
-    "prebuild": "node scripts/copy-katex.mjs && node scripts/generate-translation-pairs.mjs",
-    "predev": "node scripts/copy-katex.mjs && node scripts/generate-translation-pairs.mjs",
+    "prebuild": "node scripts/copy-katex.mjs && node scripts/generate-translation-pairs.mjs && node scripts/generate-redirects.mjs",
+    "predev": "node scripts/copy-katex.mjs && node scripts/generate-translation-pairs.mjs && node scripts/generate-redirects.mjs",
+    "check:links": "node scripts/check-links.mjs",
+    "check:translations": "node scripts/check-translations.mjs",
     "dev": "astro dev",
     "build": "astro build && pagefind --site dist",
     "preview": "astro preview",

--- a/scripts/check-links.mjs
+++ b/scripts/check-links.mjs
@@ -1,0 +1,34 @@
+// CI guard: no internal blog link may point at a page that doesn't exist.
+//
+// A link is OK if it resolves to a real post directly, or if it's a legacy
+// date-prefixed URL that generate-redirects.mjs will redirect to the canonical
+// slug. Anything left over (a link to a deleted/never-created post) fails the
+// build so it gets fixed at the source instead of 404'ing silently.
+import { loadPosts, analyzeLinks } from "./lib/blog-links.mjs";
+
+const posts = loadPosts();
+const { redirects, dangling } = analyzeLinks(posts);
+
+const redirectCount = Object.keys(redirects).length;
+if (redirectCount > 0) {
+  console.log(
+    `ℹ ${redirectCount} legacy date-prefixed link(s) covered by generated redirects.`
+  );
+}
+
+if (dangling.length > 0) {
+  console.error(
+    `\n✗ ${dangling.length} broken internal blog link(s) with no valid target:\n`
+  );
+  for (const { file, link } of dangling) {
+    console.error(`  ${file}\n    → ${link}`);
+  }
+  console.error(
+    "\nFix: point the link at an existing post, or remove it if the target was deleted."
+  );
+  process.exit(1);
+}
+
+console.log(
+  `✔ check-links: ${posts.length} posts scanned, no broken internal links.`
+);

--- a/scripts/check-translations.mjs
+++ b/scripts/check-translations.mjs
@@ -16,6 +16,9 @@ const posts = loadPosts();
 const errors = [];
 
 // ── 1. Completeness ────────────────────────────────────────────────────────
+// Intentionally uses `draft`, not `published`: a post whose counterpart is a
+// draft (but not yet published) still counts as incomplete — we want CI to go
+// red even when the translation exists but hasn't shipped yet.
 const groups = new Map();
 for (const p of posts) {
   if (p.draft || !p.translationKey) continue;
@@ -55,9 +58,13 @@ if (baseRef) {
       .map((l) => l.trim())
       .filter(Boolean);
   } catch (e) {
-    console.warn(
-      `⚠ Could not compute git diff against ${baseRef}: ${e.message}`
+    // If git diff fails while BASE_REF is explicitly set (i.e. on a real PR),
+    // a silent no-op would mean the sync check is disabled — fail loudly instead.
+    console.error(
+      `✗ git diff --name-only ${baseRef}...HEAD failed: ${e.message}\n` +
+        `Hint: ensure the workflow uses fetch-depth: 0.`
     );
+    process.exit(1);
   }
 
   const changedFiles = new Set(changed.map((p) => p.split("/").pop()));

--- a/scripts/check-translations.mjs
+++ b/scripts/check-translations.mjs
@@ -1,0 +1,99 @@
+// CI guard for the en/pt translation pairing.
+//
+// Two checks:
+//   1. Completeness (always): every non-draft post that carries a
+//      `translationKey` must have a counterpart in the other language. An
+//      orphaned translation (key present in only one language) fails.
+//   2. Sync (PR only, when BASE_REF is set): if a PR edits a post body but
+//      leaves its counterpart untouched, the check fails — turning the PR
+//      check red. Deploy is a separate workflow, so a red check never blocks
+//      a merge; it's a visible nudge to mirror the edit.
+import { execSync } from "node:child_process";
+import { loadPosts } from "./lib/blog-links.mjs";
+
+const LANGS = ["en", "pt"];
+const posts = loadPosts();
+const errors = [];
+
+// ── 1. Completeness ────────────────────────────────────────────────────────
+const groups = new Map();
+for (const p of posts) {
+  if (p.draft || !p.translationKey) continue;
+  if (!groups.has(p.translationKey)) groups.set(p.translationKey, []);
+  groups.get(p.translationKey).push(p);
+}
+
+for (const [key, members] of groups) {
+  const langs = new Set(members.map((m) => m.lang));
+  const missing = LANGS.filter((l) => !langs.has(l));
+  if (missing.length > 0) {
+    errors.push(
+      `Incomplete pair "${key}": has [${[...langs].join(", ")}], missing [${missing.join(", ")}] ` +
+        `(${members.map((m) => m.file).join(", ")})`
+    );
+  }
+}
+
+// Posts with no translationKey at all can never be paired — surface as a warning.
+for (const p of posts) {
+  if (!p.draft && !p.translationKey) {
+    console.warn(`⚠ ${p.file} has no translationKey — cannot be paired.`);
+  }
+}
+
+// ── 2. Sync (PR only) ──────────────────────────────────────────────────────
+const baseRef = process.env.BASE_REF;
+if (baseRef) {
+  let changed = [];
+  try {
+    const out = execSync(
+      `git diff --name-only ${baseRef}...HEAD -- src/content/blog`,
+      { encoding: "utf-8" }
+    );
+    changed = out
+      .split("\n")
+      .map((l) => l.trim())
+      .filter(Boolean);
+  } catch (e) {
+    console.warn(
+      `⚠ Could not compute git diff against ${baseRef}: ${e.message}`
+    );
+  }
+
+  const changedFiles = new Set(changed.map((p) => p.split("/").pop()));
+  const byKey = new Map();
+  for (const p of posts) {
+    if (!p.translationKey) continue;
+    if (!byKey.has(p.translationKey)) byKey.set(p.translationKey, []);
+    byKey.get(p.translationKey).push(p);
+  }
+
+  for (const post of posts) {
+    if (post.draft || !post.translationKey) continue;
+    if (!changedFiles.has(post.file)) continue;
+    const siblings = (byKey.get(post.translationKey) ?? []).filter(
+      (s) => s.file !== post.file
+    );
+    const untouched = siblings.filter((s) => !changedFiles.has(s.file));
+    if (siblings.length > 0 && untouched.length === siblings.length) {
+      errors.push(
+        `${post.file} (${post.lang}) was edited but its counterpart ` +
+          `${untouched.map((s) => `${s.file} (${s.lang})`).join(", ")} was not. ` +
+          `Mirror the change in the other language.`
+      );
+    }
+  }
+} else {
+  console.log(
+    "ℹ BASE_REF unset — skipping per-PR sync check (completeness only)."
+  );
+}
+
+// ── Report ─────────────────────────────────────────────────────────────────
+if (errors.length > 0) {
+  console.error(`\n✗ check-translations: ${errors.length} issue(s):\n`);
+  for (const e of errors) console.error(`  • ${e}`);
+  process.exit(1);
+}
+
+console.log(`✔ check-translations: ${groups.size} pairs complete.`);

--- a/scripts/generate-redirects.mjs
+++ b/scripts/generate-redirects.mjs
@@ -1,0 +1,26 @@
+// Emits src/generated/blog-redirects.json — a { [oldUrl]: canonicalUrl } map
+// for legacy date-prefixed blog URLs (e.g. /blog/2026-05-10-jules-api-harness-backend/
+// → /blog/jules-api-harness-backend/). astro.config.mjs spreads this into its
+// `redirects` so old links and external bookmarks keep resolving.
+import { writeFileSync, mkdirSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { loadPosts, analyzeLinks } from "./lib/blog-links.mjs";
+
+const __dir = dirname(fileURLToPath(import.meta.url));
+const outDir = join(__dir, "../src/generated");
+const outFile = join(outDir, "blog-redirects.json");
+
+const posts = loadPosts();
+const { redirects } = analyzeLinks(posts);
+
+const sorted = Object.fromEntries(
+  Object.entries(redirects).sort(([a], [b]) => a.localeCompare(b))
+);
+
+mkdirSync(outDir, { recursive: true });
+writeFileSync(outFile, JSON.stringify(sorted, null, 2) + "\n");
+
+console.log(
+  `✔ blog-redirects.json: ${Object.keys(sorted).length} legacy redirect(s)`
+);

--- a/scripts/generate-translation-pairs.mjs
+++ b/scripts/generate-translation-pairs.mjs
@@ -2,54 +2,23 @@
 // src/generated/blog-translation-pairs.json — a bidirectional map
 // { "/blog/slug/": { en: "/blog/en-slug/", pt: "/blog/pt-slug/" } }
 // Used by astro.config.mjs to inject hreflang links into the sitemap.
-import { readFileSync, readdirSync, writeFileSync, mkdirSync } from "node:fs";
+import { writeFileSync, mkdirSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { DEFAULT_LANG, LANG_META } from "../src/lib/languages.mjs";
+import { loadPosts } from "./lib/blog-links.mjs";
 
 const __dir = dirname(fileURLToPath(import.meta.url));
-const blogDir = join(__dir, "../src/content/blog");
 const outDir = join(__dir, "../src/generated");
 const outFile = join(outDir, "blog-translation-pairs.json");
 
-const files = readdirSync(blogDir).filter(
-  (f) => f.endsWith(".md") || f.endsWith(".mdx")
-);
-
-const posts = [];
-for (const file of files) {
-  const raw = readFileSync(join(blogDir, file), "utf-8");
-  const match = raw.match(/^---\r?\n([\s\S]*?)\r?\n---/);
-  if (!match) continue;
-  const fm = match[1];
-
-  const get = (key) => {
-    const m = fm.match(new RegExp(`^${key}:\\s*([^\r\n]+)$`, "m"));
-    return m ? m[1].trim() : undefined;
-  };
-
-  if (get("draft") === "true") continue;
-
-  const publishDateRaw = get("publishDate");
-  if (publishDateRaw) {
-    const publishDate = new Date(publishDateRaw);
-    if (!Number.isNaN(publishDate.valueOf()) && publishDate > new Date())
-      continue;
-  }
-
-  const key = get("translationKey");
-  if (!key) continue;
-
-  const lang = get("lang") ?? DEFAULT_LANG;
-  const id = file.replace(/\.mdx?$/, "");
-  posts.push({ id, lang, key });
-}
+const eligible = loadPosts().filter((p) => p.published && p.translationKey);
 
 // Group by translationKey → { [lang]: url }
 const grouped = {};
-for (const p of posts) {
-  if (!grouped[p.key]) grouped[p.key] = {};
-  grouped[p.key][p.lang] =
+for (const p of eligible) {
+  if (!grouped[p.translationKey]) grouped[p.translationKey] = {};
+  grouped[p.translationKey][p.lang] =
     p.lang === "pt" ? `/pt/blog/${p.id}/` : `/blog/${p.id}/`;
 }
 

--- a/scripts/lib/blog-links.mjs
+++ b/scripts/lib/blog-links.mjs
@@ -1,0 +1,117 @@
+// Shared helpers for internal blog-link validation and redirect generation.
+//
+// Background: blog files used to be named `YYYY-MM-DD-<slug>.md` and served at
+// `/blog/YYYY-MM-DD-<slug>/`. A cleanup renamed every file to a plain `<slug>`
+// (the URL is now literally the filename — see src/pages/blog/[...slug].astro,
+// which maps `params.slug = post.id`), but many inter-post links kept the old
+// date-prefixed form and silently 404'd. This module is the single source of
+// truth for both the CI link check (scripts/check-links.mjs) and the redirect
+// generator (scripts/generate-redirects.mjs).
+import { readFileSync, readdirSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dir = dirname(fileURLToPath(import.meta.url));
+export const BLOG_DIR = join(__dir, "../../src/content/blog");
+
+function parseFrontmatter(raw) {
+  const m = raw.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (!m) return { get: () => undefined, body: raw };
+  const fmBlock = m[1];
+  const body = raw.slice(m[0].length);
+  const get = (key) => {
+    const mm = fmBlock.match(new RegExp(`^${key}:\\s*([^\r\n]+)$`, "m"));
+    if (!mm) return undefined;
+    return mm[1].trim().replace(/^['"]|['"]$/g, "");
+  };
+  return { get, body };
+}
+
+/** Load every blog post with the frontmatter fields the checks care about. */
+export function loadPosts() {
+  const files = readdirSync(BLOG_DIR).filter((f) => /\.mdx?$/.test(f));
+  return files.map((file) => {
+    const raw = readFileSync(join(BLOG_DIR, file), "utf-8");
+    const { get, body } = parseFrontmatter(raw);
+    const draft = get("draft") === "true";
+    let published = !draft;
+    const publishDateRaw = get("publishDate");
+    if (published && publishDateRaw) {
+      const d = new Date(publishDateRaw);
+      if (!Number.isNaN(d.valueOf()) && d > new Date()) published = false;
+    }
+    return {
+      file,
+      id: file.replace(/\.mdx?$/, ""),
+      lang: get("lang") ?? "en",
+      draft,
+      published,
+      translationKey: get("translationKey"),
+      date: get("date"),
+      body,
+    };
+  });
+}
+
+/** Strip anchor/query and force a single trailing slash. */
+function normalizePath(p) {
+  let s = p.split("#")[0].split("?")[0];
+  if (!s.endsWith("/")) s += "/";
+  return s;
+}
+
+// Both /blog/<id>/ and /pt/blog/<id>/ resolve for every published post: each
+// route's getStaticPaths includes all published posts and cross-redirects by
+// lang. So the canonical target set is language-agnostic.
+export function validTargets(posts) {
+  const set = new Set();
+  for (const p of posts) {
+    if (!p.published) continue;
+    set.add(`/blog/${p.id}/`);
+    set.add(`/pt/blog/${p.id}/`);
+  }
+  return set;
+}
+
+// Internal blog links in markdown bodies, as `](/blog/...)` or href="/blog/...".
+const MD_LINK_RE = /\]\((\/(?:pt\/)?blog\/[^)\s]+)\)/g;
+const HREF_RE = /href="(\/(?:pt\/)?blog\/[^"]+)"/g;
+
+export function extractBlogLinks(body) {
+  const out = [];
+  for (const re of [MD_LINK_RE, HREF_RE]) {
+    re.lastIndex = 0;
+    let m;
+    while ((m = re.exec(body))) out.push(m[1]);
+  }
+  return out;
+}
+
+const DATE_PREFIX_RE = /^(\/(?:pt\/)?blog\/)\d{4}-\d{2}-\d{2}-/;
+
+/**
+ * Scan every post body and classify each internal blog link:
+ *   - resolves directly  → fine, ignored
+ *   - legacy date-prefixed URL whose de-dated form is a real post → redirect
+ *   - anything else → dangling (target gone; needs a manual fix)
+ *
+ * Returns { redirects: { [oldPath]: canonicalPath }, dangling: [{ file, link }] }.
+ */
+export function analyzeLinks(posts) {
+  const targets = validTargets(posts);
+  const redirects = {};
+  const dangling = [];
+  for (const p of posts) {
+    for (const raw of extractBlogLinks(p.body)) {
+      const path = normalizePath(raw);
+      if (targets.has(path)) continue;
+      const deDated = path.replace(DATE_PREFIX_RE, "$1");
+      if (deDated !== path && targets.has(deDated)) {
+        redirects[path] = deDated;
+      } else if (!redirects[path]) {
+        dangling.push({ file: p.file, link: raw });
+      }
+    }
+  }
+  return { redirects, dangling };
+}

--- a/scripts/lib/blog-links.mjs
+++ b/scripts/lib/blog-links.mjs
@@ -47,7 +47,6 @@ export function loadPosts() {
       draft,
       published,
       translationKey: get("translationKey"),
-      date: get("date"),
       body,
     };
   });

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -14,6 +14,7 @@ const blog = defineCollection({
       heroImage: image().optional(),
       heroImageAlt: z.string().optional(),
       lang: z.enum(["en", "pt"]).optional(),
+      author: z.string().optional(),
       translationKey: z.string().optional(),
       series: z.string().optional(),
       seriesOrder: z.number().optional(),

--- a/src/content/blog/pontifex-novel-architecture-semantic-probing.md
+++ b/src/content/blog/pontifex-novel-architecture-semantic-probing.md
@@ -128,7 +128,7 @@ So the architecture is exactly as good as the care taken in choosing the spaces.
 
 ## The notebook that hasn't compiled
 
-Pontifex is an architecture, not a result. I've built the occlusion engine and run some bilateral comparisons across multilingual models; the convergence layer exists at the level of detail you've just read and no finer. The [repo](https://github.com/franklinbaldo/pontifex) went up before any of it, which is how I work — [I open a repository whenever an idea is odd enough that I want it to argue back at me](/blog/2026-05-22-github-a-tour-of-the-repos/), and the README is where the arguing happens.
+Pontifex is an architecture, not a result. I've built the occlusion engine and run some bilateral comparisons across multilingual models; the convergence layer exists at the level of detail you've just read and no finer. The [repo](https://github.com/franklinbaldo/pontifex) went up before any of it, which is how I work — I open a repository whenever an idea is odd enough that I want it to argue back at me, and the README is where the arguing happens.
 
 Call it a Pierre Menard move with the sign flipped. Menard set out to write a book that already existed and to reach it from inside his own life. I'm doing the inverse: writing the README of a system that doesn't exist yet, on the bet that the right architecture is already sitting somewhere in the space of possible architectures, and that my job is to become the person who would transcribe it. The README is that person's notebook. Sometimes the notebook is enough to discover the person was wrong about the whole thing. Sometimes the notebook slowly starts to compile.
 

--- a/src/content/blog/pontifex-uma-nova-arquitetura-para-investigao-semntica.md
+++ b/src/content/blog/pontifex-uma-nova-arquitetura-para-investigao-semntica.md
@@ -132,7 +132,7 @@ Então a arquitetura é exatamente tão boa quanto o cuidado empregado na escolh
 
 ## O caderno que não compilou
 
-Pontifex é uma arquitetura, não um resultado. Eu construí o motor de oclusão e rodei algumas comparações bilaterais em modelos multilíngues; a camada de convergência existe no nível de detalhe que você acabou de ler e não além disso. O [repositório](https://github.com/franklinbaldo/pontifex) foi pro ar antes de qualquer coisa, que é como eu trabalho — [abro um repositório sempre que uma ideia é estranha o bastante pra que eu queira que ela discuta comigo](/blog/2026-05-22-github-um-tour-pelos-repos/), e o README é onde a discussão acontece.
+Pontifex é uma arquitetura, não um resultado. Eu construí o motor de oclusão e rodei algumas comparações bilaterais em modelos multilíngues; a camada de convergência existe no nível de detalhe que você acabou de ler e não além disso. O [repositório](https://github.com/franklinbaldo/pontifex) foi pro ar antes de qualquer coisa, que é como eu trabalho — abro um repositório sempre que uma ideia é estranha o bastante pra que eu queira que ela discuta comigo, e o README é onde a discussão acontece.
 
 Chame de gesto à Pierre Menard com o sinal trocado. Menard partiu pra escrever um livro que já existia e alcançá-lo a partir de dentro da própria vida. Eu estou fazendo o inverso: escrevendo o README de um sistema que ainda não existe, apostando que a arquitetura certa já está em algum lugar do espaço das arquiteturas possíveis, e que meu trabalho é me tornar a pessoa que a transcreveria. O README é o caderno dessa pessoa. Às vezes o caderno basta pra descobrir que a pessoa errou sobre tudo. Às vezes o caderno começa devagar a compilar.
 

--- a/src/generated/blog-redirects.json
+++ b/src/generated/blog-redirects.json
@@ -1,0 +1,19 @@
+{
+  "/blog/2026-03-02-travessia-the-project-that-writes-itself/": "/blog/travessia-the-project-that-writes-itself/",
+  "/blog/2026-03-02-travessia/": "/blog/travessia/",
+  "/blog/2026-03-17-travessia-update/": "/blog/travessia-update/",
+  "/blog/2026-03-18-verne-e-o-padro-identity-repo-como-os-agentes-de-ia-se-lembram/": "/blog/verne-e-o-padro-identity-repo-como-os-agentes-de-ia-se-lembram/",
+  "/blog/2026-03-18-verne-identity-repo/": "/blog/verne-identity-repo/",
+  "/blog/2026-03-28-delegando-para-agentes/": "/blog/delegando-para-agentes/",
+  "/blog/2026-03-28-the-art-of-delegation/": "/blog/the-art-of-delegation/",
+  "/blog/2026-04-29-reclaiming-the-harness/": "/blog/reclaiming-the-harness/",
+  "/blog/2026-04-29-recuperando-o-harness/": "/blog/recuperando-o-harness/",
+  "/blog/2026-05-01-a-terceira-metade-e-a-quarta-parede/": "/blog/a-terceira-metade-e-a-quarta-parede/",
+  "/blog/2026-05-01-the-third-half-and-the-fourth-wall/": "/blog/the-third-half-and-the-fourth-wall/",
+  "/blog/2026-05-10-a-api-do-jules-como-backend-do-harness/": "/blog/a-api-do-jules-como-backend-do-harness/",
+  "/blog/2026-05-10-jules-api-harness-backend/": "/blog/jules-api-harness-backend/",
+  "/blog/2026-05-14-o-agente-que-nao-inventa-verbos/": "/blog/o-agente-que-nao-inventa-verbos/",
+  "/blog/2026-05-14-pierre-menard-computational-researcher/": "/blog/pierre-menard-computational-researcher/",
+  "/blog/2026-05-14-the-agent-that-doesnt-invent-verbs/": "/blog/the-agent-that-doesnt-invent-verbs/",
+  "/blog/2026-05-15-three-hammers-walk-into-a-bar/": "/blog/three-hammers-walk-into-a-bar/"
+}


### PR DESCRIPTION
## What started this

The draft **"The Art of Delegating: Orchestrating Jules and Claude"** linked twice to `/blog/2026-05-10-jules-api-harness-backend/` — a URL that 404s. The file is `jules-api-harness-backend.md`, served at `/blog/jules-api-harness-backend/` (the slug is the filename; there is no date-prefix routing).

That turned out to be a **systemic** problem, not a one-off.

## Root cause

Commit `46776e6` ("Remove 16 low-quality blog posts and fix broken references") renamed every blog file to drop its `YYYY-MM-DD-` prefix and deleted 16 posts — but missed many inter-post links. Result today:

- **19 distinct broken internal links** across the blog, all still using the old date-prefixed form.
  - **17** point at posts that still exist under the de-dated slug → fixable via redirect.
  - **2** (`github-a-tour-of-the-repos` / `github-um-tour-pelos-repos`, in the two Pontifex posts) point at one of the 16 deleted posts → no target.

No CI step caught this: `prettier` / `astro check` / `build` validate neither internal links nor the link graph, and Zod silently drops unknown frontmatter keys.

## What this PR adds

**1. Internal link check (`scripts/check-links.mjs`)** — fails CI on any `/blog/` or `/pt/blog/` link with no valid target. A link is OK if it resolves to a real post *or* is covered by a generated redirect.

**2. Legacy URL redirects (`scripts/generate-redirects.mjs`)** — emits `src/generated/blog-redirects.json` (old date-prefixed URL → canonical), spread into `astro.config.mjs`. Old links and external bookmarks now resolve via meta-refresh + canonical instead of 404'ing. Runs in `prebuild`/`predev`.

**3. Translation pairing check (`scripts/check-translations.mjs`)**
   - *Completeness* (always): every non-draft post with a `translationKey` must have its en/pt counterpart. Orphans fail.
   - *Sync* (PR only): if a PR edits a post body but not its counterpart, the check goes **red on the PR**. Since `deploy.yml` is an independent workflow (push/schedule, no `needs: check`), a red check never blocks a merge/deploy — it's a visible nudge to mirror the edit.

**4. Shared logic** in `scripts/lib/blog-links.mjs` so the link check and redirect generator stay in sync.

**5. `author` added to the content schema** — it was used by 37 posts but absent from the Zod schema (silently dropped).

## Content fixes
- Removed the 2 dangling `github-tour` links from the Pontifex posts (kept the prose; target was deleted).

## Verification
- `check-links`: 65 posts scanned, 17 legacy links covered by redirects, 0 broken. ✓
- `check-translations`: 32 pairs complete; sync check confirmed red when only one language is edited, green when both are. ✓
- `npm run build`: succeeds; redirect pages generated (e.g. `/blog/2026-05-10-jules-api-harness-backend/` → `/blog/jules-api-harness-backend/`). ✓
- `prettier --check .`: clean. ✓

## Not touched (needs author's call)
The delegating post is still `draft: true`, has **no `translationKey`** (the only post without one, so no PT counterpart), and is dated `2026-03-28` while referencing a May 2026 post. Its broken link now resolves via redirect, but the date/draft/translation gaps are editorial decisions left to you.

https://claude.ai/code/session_01W5aWnhJ68LVYFcMKD86sPa

---
_Generated by [Claude Code](https://claude.ai/code/session_01W5aWnhJ68LVYFcMKD86sPa)_