### PR TITLE
chore(ci): update Node.js to v24 in GitHub Actions to fix deprecation warning

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -14,7 +14,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           cache: npm
 
       - run: npm ci

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           cache: npm
       - run: npm ci
       - run: npm run build

--- a/.github/workflows/generate-qrs.yml
+++ b/.github/workflows/generate-qrs.yml
@@ -23,7 +23,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "22"
+          node-version: "24"
           cache: npm
 
       - run: npm ci


### PR DESCRIPTION
- Updated Node.js version in `.github/workflows/check.yml`, `.github/workflows/deploy.yml`, and `.github/workflows/generate-qrs.yml` from `22` to `24`.
- This resolves a deprecation warning indicating that `actions/checkout@v4` and `actions/setup-node@v4` will require Node 24 moving forward, which caused the CI checks to fail.

---
*PR created automatically by Jules for task [11456546293195857954](https://jules.google.com/task/11456546293195857954) started by @franklinbaldo*