### PR TITLE
fix(hronir): stop autopilot from silently dying on non-Jules PRs

### DIFF
--- a/.github/workflows/hronir-autopilot.yml
+++ b/.github/workflows/hronir-autopilot.yml
@@ -89,7 +89,10 @@ jobs:
           # 1) Authenticity: the PR must reference a Jules task that verne can
           #    resolve to a real session in our account.
           BODY=$(gh pr view "$PR" --repo "$REPO" --json body --jq '.body')
-          TASK=$(printf '%s' "$BODY" | grep -oiE 'jules\.google\.com/task/[A-Za-z0-9_-]+' | head -1 | sed 's#.*/##')
+          # `|| true`: under `set -euo pipefail`, a no-match grep exits 1 and
+          # pipefail would abort the whole step before the `-z` check below —
+          # silently red instead of a clean skip. Keep the pipeline non-fatal.
+          TASK=$(printf '%s' "$BODY" | grep -oiE 'jules\.google\.com/task/[A-Za-z0-9_-]+' | head -1 | sed 's#.*/##' || true)
           if [ -z "${TASK:-}" ]; then
             echo "PR #$PR has no Jules task link in its body — not ours, skipping."
             echo "merged=" >> "$GITHUB_OUTPUT"; exit 0


### PR DESCRIPTION
## Sintoma

A aba Actions vinha enchendo de execuções **vermelhas e sem nenhum log** do workflow **Hrönir Autopilot** — "falhando silenciosamente". O passo `Authenticate, gate and merge` morria com `exit code 1` logo após começar, sem imprimir uma linha sequer.

## Causa raiz — `.github/workflows/hronir-autopilot.yml`

O passo roda sob `set -euo pipefail` e o GitHub Actions o executa como `bash -e {0}`. Quando o corpo de uma PR **não** contém um link `jules.google.com/task/...`, esta linha:

```bash
TASK=$(printf '%s' "$BODY" | grep -oiE 'jules\.google\.com/task/...' | head -1 | sed 's#.*/##')
```

faz o `grep` sair com código 1; `pipefail` propaga isso ao pipeline inteiro; e `set -e`/`bash -e` **aborta o passo na hora**, com exit 1 e zero output — **antes** de chegar no `if [ -z "$TASK" ]` da linha seguinte, que foi escrito justamente para pular essas PRs de forma graciosa. Esse caminho de skip virou **código morto**.

Resultado: todo "Check" concluído numa PR que não é do Jules (ex.: #287, `ci: guard internal links…`, cujo corpo termina em `https://claude.ai/code/...`) derrubava o autopilot em vermelho, sem diagnóstico. O heartbeat (cron horário) seguia verde, então o loop não parou de vez, mas o caminho event-driven estava quebrado.

### Evidência
- 5 falhas seguidas (08/06 18:41→20:14), todas resolvendo a PR #287; logs mostram o passo morrendo após `##[endgroup]` sem imprimir o primeiro `echo`.
- Reproduzido em `bash -e` + `set -euo pipefail`: a linha pós-`grep` nunca executa quando não há match.

## Correção

Acrescenta `|| true` ao pipeline de extração, neutralizando o exit non-zero do `grep` sem match (e o SIGPIPE do `head`). O `if [ -z "$TASK" ]` volta a tratar "não é nossa" com `exit 0`, deixando o autopilot **verde e pulando** em vez de vermelho silencioso. É o único ponto dos workflows com esse padrão `$(…grep…)`.

```diff
-TASK=$(printf '%s' "$BODY" | grep -oiE 'jules\.google\.com/task/[A-Za-z0-9_-]+' | head -1 | sed 's#.*/##')
+TASK=$(printf '%s' "$BODY" | grep -oiE 'jules\.google\.com/task/[A-Za-z0-9_-]+' | head -1 | sed 's#.*/##' || true)
```

`npx prettier --check` passa.

https://claude.ai/code/session_012p1NnNfuBKGFbTRYMmvTxa

---
_Generated by [Claude Code](https://claude.ai/code/session_012p1NnNfuBKGFbTRYMmvTxa)_