### PR TITLE
hronir workflows: fail loud on real errors + share verne setup/spawn

### DIFF
--- a/.github/actions/setup-verne/action.yml
+++ b/.github/actions/setup-verne/action.yml
@@ -1,0 +1,26 @@
+name: Set up verne
+description: >
+  Install the uv toolchain and the pinned verne CLI, then verify it is on PATH.
+  Centralizes the verne version for every Hrönir workflow: bump it here, once.
+
+inputs:
+  ref:
+    description: "uv/pip requirement for verne (a git URL pinned to a commit SHA)."
+    required: false
+    default: "git+https://github.com/franklinbaldo/verne@6c73a589299c70db59549a8e9d8fd03acd6256ca"
+
+runs:
+  using: composite
+  steps:
+    - uses: astral-sh/setup-uv@v5
+
+    - name: Install verne (fail fast if it can't be built or found)
+      shell: bash
+      run: |
+        set -euo pipefail
+        uv tool install "${{ inputs.ref }}"
+        echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+        # Guard: if the entry point isn't where we expect, fail loud HERE rather
+        # than let a later `verne` call resolve to "command not found" and get
+        # swallowed by an `if ! ...` as a silent "not ours" skip.
+        test -x "$HOME/.local/bin/verne"

--- a/.github/workflows/hronir-autopilot.yml
+++ b/.github/workflows/hronir-autopilot.yml
@@ -36,7 +36,6 @@ concurrency:
 
 env:
   REPO: ${{ github.repository }}
-  VERNE: "git+https://github.com/franklinbaldo/verne@6c73a589299c70db59549a8e9d8fd03acd6256ca"
   # A PR is a Hrönir session PR when every changed file lives under one of these
   # prefixes AND at least one file is under .routines/hronir/rates/.
   SAFE_PREFIXES: ".routines/hronir/ src/content/blog/"
@@ -53,7 +52,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: astral-sh/setup-uv@v5
+      - uses: ./.github/actions/setup-verne
 
       - name: Resolve target PR
         id: resolve
@@ -110,7 +109,7 @@ jobs:
           # silent — if the conveyor stalls on legit PRs, this is where to look.
           # Telling "session not found" apart from "verne unavailable" needs
           # verne to expose distinct exit codes; until then we stay conservative.
-          if ! VERNE_OUT=$(uvx --from "$VERNE" verne sessions show "$TASK" --json 2>&1); then
+          if ! VERNE_OUT=$(verne sessions show "$TASK" --json 2>&1); then
             echo "verne could not resolve session $TASK — treating as not-ours, skipping. verne said:"
             echo "$VERNE_OUT"
             echo "merged=" >> "$GITHUB_OUTPUT"; exit 0
@@ -163,8 +162,8 @@ jobs:
 
       - name: Spawn the next Jules session (via verne)
         # Right after a merge: the new session starts from the up-to-date main.
-        # Session creation is centralized in franklinbaldo/verne — change it
-        # there, not here. verne reads JULES_API_KEY from the env.
+        # Session config is shared with the heartbeat in
+        # scripts/hronir/spawn-session.sh. verne reads JULES_API_KEY from the env.
         if: steps.merge.outputs.merged != ''
         env:
           JULES_API_KEY: ${{ secrets.JULES_API_KEY }}
@@ -174,17 +173,4 @@ jobs:
             echo "::error::JULES_API_KEY not set — cannot create the next session. Fix the repo secret."
             exit 1
           fi
-          TITLE="hronir session $(date -u +%Y-%m-%dT%H:%M:%SZ)"
-          SESSION=$(uvx --from "$VERNE" verne \
-            sessions new "$TITLE" \
-            --source "sources/github/${REPO}" \
-            --prompt-file .github/hronir-session-prompt.md \
-            --branch main \
-            --automation-mode AUTO_CREATE_PR \
-            --json)
-          SESSION_ID=$(echo "$SESSION" | jq -r '.id // (.name | sub("^sessions/"; "")) // empty')
-          if [ -z "$SESSION_ID" ]; then
-            echo "::error::Failed to create Jules session via verne:"; echo "$SESSION"; exit 1
-          fi
-          echo "Created Jules session: $SESSION_ID"
-          echo "https://jules.google.com/task/$SESSION_ID"
+          bash scripts/hronir/spawn-session.sh

--- a/.github/workflows/hronir-autopilot.yml
+++ b/.github/workflows/hronir-autopilot.yml
@@ -97,12 +97,22 @@ jobs:
             echo "PR #$PR has no Jules task link in its body — not ours, skipping."
             echo "merged=" >> "$GITHUB_OUTPUT"; exit 0
           fi
+          # Missing key is a config error, not a skip: a non-Jules PR already
+          # exited above, so reaching here with no key means the secret is gone.
+          # Fail loud (exit 1) instead of going green and stalling the conveyor.
           if [ -z "${JULES_API_KEY:-}" ]; then
-            echo "::warning::JULES_API_KEY not set — cannot verify session; skipping."
-            echo "merged=" >> "$GITHUB_OUTPUT"; exit 0
+            echo "::error::JULES_API_KEY not set — cannot verify the session. Fix the repo secret."
+            exit 1
           fi
-          if ! uvx --from "$VERNE" verne sessions show "$TASK" --json >/dev/null 2>&1; then
-            echo "verne could not resolve session $TASK — not one of ours, skipping."
+          # Conservative: any verne failure is treated as "not ours" and we skip
+          # (exit 0) rather than merge unverified. But capture and print verne's
+          # output so an infra failure (verne/network down) is visible, not
+          # silent — if the conveyor stalls on legit PRs, this is where to look.
+          # Telling "session not found" apart from "verne unavailable" needs
+          # verne to expose distinct exit codes; until then we stay conservative.
+          if ! VERNE_OUT=$(uvx --from "$VERNE" verne sessions show "$TASK" --json 2>&1); then
+            echo "verne could not resolve session $TASK — treating as not-ours, skipping. verne said:"
+            echo "$VERNE_OUT"
             echo "merged=" >> "$GITHUB_OUTPUT"; exit 0
           fi
           echo "Authenticated PR #$PR as Jules session $TASK."
@@ -161,8 +171,8 @@ jobs:
         run: |
           set -euo pipefail
           if [ -z "${JULES_API_KEY:-}" ]; then
-            echo "::warning::JULES_API_KEY not set — skipping session creation."
-            exit 0
+            echo "::error::JULES_API_KEY not set — cannot create the next session. Fix the repo secret."
+            exit 1
           fi
           TITLE="hronir session $(date -u +%Y-%m-%dT%H:%M:%SZ)"
           SESSION=$(uvx --from "$VERNE" verne \

--- a/.github/workflows/hronir-heartbeat.yml
+++ b/.github/workflows/hronir-heartbeat.yml
@@ -46,9 +46,11 @@ jobs:
           JULES_API_KEY: ${{ secrets.JULES_API_KEY }}
         run: |
           set -euo pipefail
+          # Missing key means the conveyor cannot run at all — fail loud (exit 1)
+          # so a removed/expired secret surfaces, instead of an hourly green no-op.
           if [ -z "${JULES_API_KEY:-}" ]; then
-            echo "::warning::JULES_API_KEY not set — cannot run heartbeat."
-            exit 0
+            echo "::error::JULES_API_KEY not set — heartbeat cannot ensure a session. Fix the repo secret."
+            exit 1
           fi
 
           SESSIONS=$(uvx --from "$VERNE" verne sessions list --json --page-size 100)

--- a/.github/workflows/hronir-heartbeat.yml
+++ b/.github/workflows/hronir-heartbeat.yml
@@ -29,17 +29,13 @@ concurrency:
   group: hronir-session
   cancel-in-progress: false
 
-env:
-  REPO: ${{ github.repository }}
-  VERNE: "git+https://github.com/franklinbaldo/verne@6c73a589299c70db59549a8e9d8fd03acd6256ca"
-
 jobs:
   ensure-session:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
-      - uses: astral-sh/setup-uv@v5
+      - uses: ./.github/actions/setup-verne
 
       - name: Ensure a recent open session exists
         env:
@@ -53,7 +49,7 @@ jobs:
             exit 1
           fi
 
-          SESSIONS=$(uvx --from "$VERNE" verne sessions list --json --page-size 100)
+          SESSIONS=$(verne sessions list --json --page-size 100)
           NOW=$(date -u +%s)
 
           # Open = status not terminal.
@@ -86,17 +82,4 @@ jobs:
             exit 0
           fi
 
-          TITLE="hronir session $(date -u +%Y-%m-%dT%H:%M:%SZ)"
-          SESSION=$(uvx --from "$VERNE" verne \
-            sessions new "$TITLE" \
-            --source "sources/github/${REPO}" \
-            --prompt-file .github/hronir-session-prompt.md \
-            --branch main \
-            --automation-mode AUTO_CREATE_PR \
-            --json)
-          SESSION_ID=$(echo "$SESSION" | jq -r '.id // (.name | sub("^sessions/"; "")) // empty')
-          if [ -z "$SESSION_ID" ]; then
-            echo "::error::Failed to create Jules session via verne:"; echo "$SESSION"; exit 1
-          fi
-          echo "Created Jules session: $SESSION_ID"
-          echo "https://jules.google.com/task/$SESSION_ID"
+          bash scripts/hronir/spawn-session.sh

--- a/scripts/hronir/spawn-session.sh
+++ b/scripts/hronir/spawn-session.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Create the next Hrönir/Jules session via verne.
+#
+# Shared by hronir-autopilot.yml and hronir-heartbeat.yml so the session config
+# (source, prompt, branch, automation mode) and the fail-fast parsing live in
+# exactly one place — no drift between the reactive and the liveness paths.
+#
+# Requires: `verne` on PATH (see .github/actions/setup-verne) and JULES_API_KEY
+# in the environment (verne reads it). The callers gate on the key before this.
+set -euo pipefail
+
+REPO="${GITHUB_REPOSITORY:?GITHUB_REPOSITORY not set}"
+TITLE="hronir session $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+SESSION=$(verne sessions new "$TITLE" \
+  --source "sources/github/${REPO}" \
+  --prompt-file .github/hronir-session-prompt.md \
+  --branch main \
+  --automation-mode AUTO_CREATE_PR \
+  --json)
+
+SESSION_ID=$(echo "$SESSION" | jq -r '.id // (.name | sub("^sessions/"; "")) // empty')
+if [ -z "$SESSION_ID" ]; then
+  echo "::error::Failed to create Jules session via verne:"
+  echo "$SESSION"
+  exit 1
+fi
+
+echo "Created Jules session: $SESSION_ID"
+echo "https://jules.google.com/task/$SESSION_ID"


### PR DESCRIPTION
Dois commits relacionados, ambos endurecendo o conveyor Hrönir contra silent failures. Continuação da #289.

## 1. `fail loud on real errors, never silently green`

Os workflows pulavam **erros operacionais** com `::warning:: + exit 0` → run verde. Se `JULES_API_KEY` expirasse/fosse removida, os três pontos passariam enquanto o conveyor parava — silent failure pior que o da #289.

- **Erro operacional → `::error:: + exit 1`** (fail-fast loud): `JULES_API_KEY` ausente no step de merge e no de spawn do autopilot, e no heartbeat.
- **Condição de negócio esperada → `exit 0` com log** (mantido): PR não é nossa, fora de escopo, não mergeável, sem rate file, "nenhuma sessão a criar".
- **Para de engolir a saída do verne** no check de autenticidade (`>/dev/null 2>&1` → captura `2>&1` e imprime no fail), pra uma queda do verne ficar visível em vez de virar "not ours" mudo. Comportamento segue conservador (skip).

## 2. `share verne setup + session spawn across workflows`

Autopilot e heartbeat duplicavam 3 coisas drift-prone: a ref pinada do verne, a invocação `uvx --from "$VERNE" verne`, e o bloco inteiro de `verne sessions new …`. Extraído:

- **`.github/actions/setup-verne/`** (composite action) — instala uv + o verne CLI pinado e **verifica que está no PATH** (guard fail-fast: PATH errado falha alto agora, em vez de virar `verne: command not found` engolido como "not ours"). A versão do verne passa a viver **num lugar só**. Os dois workflows usam o action no lugar do `astral-sh/setup-uv` e chamam `verne …` direto — sem mais `uvx`.
- **`scripts/hronir/spawn-session.sh`** — o bloco de criação de sessão compartilhado, pra o caminho reativo (autopilot) e o de liveness (heartbeat) não divergirem.

Instalar o verne como tool no setup também faz um verne quebrado/inacessível **falhar alto no setup**, não no meio da lógica.

### Decisão de arquitetura
Mantidos **dois workflows separados** (gatilhos e permissões distintos: autopilot reage a `workflow_run` com `write`; heartbeat é cron com `read`), removendo a duplicação via action + script — em vez de unificar num arquivo só com `if: github.event_name`.

## Validação
`prettier --check` passa · YAML parseável · `bash -n` no script OK · sem `$VERNE`/`uvx` órfãos. Auditados os 5 workflows; `deploy.yml`/`generate-qrs.yml`/`check.yml` não tinham silent failures.

https://claude.ai/code/session_012p1NnNfuBKGFbTRYMmvTxa