### PR TITLE
Hrönir Fase 3: de-confounding, stars por perspectiva e amostragem objetiva (RFC 0002)

### DIFF
--- a/docs/rfcs/0002-hronir-de-confounding-e-amostragem-objetiva.md
+++ b/docs/rfcs/0002-hronir-de-confounding-e-amostragem-objetiva.md
@@ -1,0 +1,240 @@
+# RFC 0002 — De-confounding de qualidade e amostragem ciente do objetivo
+
+|                 |                                                                                                       |
+| --------------- | ----------------------------------------------------------------------------------------------------- |
+| **Status**      | Proposed / Implemented                                                                                |
+| **Autor**       | Franklin Baldo (proposta assistida)                                                                   |
+| **Criado em**   | 2026-06-09                                                                                            |
+| **Branch / PR** | `claude/hronir-fase3-deconfound` (empilhada sobre a #292)                                             |
+| **Depende de**  | RFC 0001 (trilha de qualidade absoluta) — `computeAbsoluteQuality`, campos `version` nos rate files   |
+| **Afeta**       | `scripts/hronir/lib/ranking.js`, `scripts/hronir/lib/commands.js`, `index.js` (leitura, sem migração) |
+
+> Esta é a **Fase 3** esboçada no §5 da RFC 0001, agora detalhada e
+> implementada. Continua o padrão: RFC + implementação na mesma PR, fase verde
+> antes de prosseguir (testes + `prettier --check`).
+
+---
+
+## 1. Resumo
+
+A RFC 0001 expôs a **qualidade absoluta** (EWMA das estrelas) ao lado do ordinal
+do OpenSkill. Mas a estrela crua é **confundida**: um post pode ter média alta
+só porque calhou de ser avaliado por um agente generoso ou sob uma perspectiva
+tolerante. O sistema **injeta humor e sorteia perspectivas de propósito** — ou
+seja, ele introduz esses confundidores deliberadamente.
+
+Esta RFC introduz três coisas, todas usando sinais **já gravados** nos rate
+files (`agent_id`, `perspective_id`) e a trilha de versão da RFC 0001:
+
+1. **De-confounding por mínimos quadrados (ridge):** separa a qualidade do post
+   do viés do avaliador e do efeito da perspectiva.
+2. **Stars por perspectiva:** uma trilha EWMA independente por perspectiva.
+3. **Amostragem ciente do objetivo (opt-in):** orienta a geração de pares para
+   refinar o topo ou caçar o pior.
+
+Tudo é exposto num comando novo de **leitura pura**, `diagnose`. Nada muda o
+ranking existente nem o schema.
+
+---
+
+## 2. Motivação
+
+### 2.1. A estrela crua é confundida
+
+Cada observação de estrela é, na verdade:
+
+```
+rate = qualidade_do_post + viés_do_avaliador + efeito_da_perspectiva + ruído
+```
+
+A trilha absoluta da RFC 0001 reporta a **média** (EWMA) dessas observações, o
+que mistura os quatro termos. Dois posts igualmente bons divergem na trilha se
+um pegou avaliadores/perspectivas mais generosos. Como o sorteio de perspectiva
+é aleatório e o humor é injetado, esse confundimento **não é** ruído que some no
+volume — é estrutural.
+
+### 2.2. Os confundidores já estão nos dados
+
+Todo rate file `stars-v1` carrega `agent_id` e `perspective_id`. Dentro de um
+clash, ambos os lados compartilham o mesmo avaliador e a mesma perspectiva —
+por isso a **diferença** `a − b` cancela esses termos (e vai pro OpenSkill),
+enquanto a **soma**/nível os carrega. Modelar o nível com esses fatores como
+regressores os torna **separáveis**.
+
+---
+
+## 3. O modelo de de-confounding
+
+Cada lado avaliado de cada clash é uma observação. Ajustamos:
+
+```
+rate_obs = μ + q[post] + α[agent] + π[perspective] + ε
+```
+
+por **mínimos quadrados com regularização ridge**:
+
+```
+minimize  Σ ε²  +  λ (Σ q² + Σ α² + Σ π²)
+```
+
+- **μ** (intercepto) **não** é penalizado → absorve a média global (~3.27 nos
+  dados atuais).
+- **q[post]** é o desvio de qualidade do post, líquido de quem avaliou e sob
+  qual perspectiva. A **qualidade de-confundida** reportada é `μ + q`.
+- **α[agent]** é o viés do avaliador; **π[perspective]** o efeito da
+  perspectiva. Ambos encolhem para 0 sob ridge.
+
+### Por que ridge
+
+O intercepto + dummies completos de cada fator são colineares (cada conjunto de
+dummies soma a coluna de 1s do intercepto). Sem regularização o sistema é
+singular. O ridge:
+
+1. garante invertibilidade de `XᵀX + λI`;
+2. encolhe efeitos de níveis com pouca evidência (um post visto 3× é amaciado
+   ~25% com `λ = 1`), o que é exatamente o comportamento desejado para
+   amostras finas;
+3. mantém os efeitos **identificáveis** apesar da colinearidade dummy/intercepto.
+
+`DECONFOUND_RIDGE = 1.0` é o default (constante nomeada, ajustável).
+
+### Implementação
+
+- `_solveLinear(A, b)` — eliminação de Gauss com pivoteamento parcial. As
+  equações normais são montadas **direto** (`XᵀX`, `Xᵀy`), sem materializar a
+  matriz de design `(obs × params)`. Dimensão típica: `1 + P + A + K ≈ 60`,
+  trivial.
+- `_computeDeconfoundedQuality(raw, ridge)` — pura, testável, retorna
+  `{ quality, agentBias, perspectiveBias, intercept }`.
+
+### Resultado nos dados reais
+
+O modelo recupera exatamente o que o design previa:
+
+| Perspectiva               | π (viés)  | leitura                           |
+| ------------------------- | --------- | --------------------------------- |
+| `internet-native`         | **+0.18** | tolerante, paga digressão         |
+| `curious-outsider`        | **+0.17** | generoso (pedagógico)             |
+| …                         | …         | …                                 |
+| `skeptical-specialist`    | **−0.03** | adversarial (caça alegação fraca) |
+| `comedy-carries-argument` | **−0.11** | exigente (piada como alavanca)    |
+| `applied-thinker`         | **−0.15** | o mais severo                     |
+
+E posts **subnotados** emergem com `gap = de-confundido − cru` positivo:
+`three-hammers` (+0.70), `pierre-menard` (+0.38), `conservation-law` (+0.35) —
+melhores em absoluto do que as estrelas cruas sugerem, porque pegaram plateias
+duras.
+
+---
+
+## 4. Stars por perspectiva
+
+`_computePerPerspectiveQuality(raw)` espelha a EWMA da RFC 0001, mas em baldes
+por `perspective_id` (com o mesmo reset-on-edit keyed por `path`). Responde
+"qual post lidera **para cada tipo de leitor**" — um post pode brilhar para o
+`internet-native` e fracassar para o `skeptical-specialist`. Útil pra detectar
+posts de nicho vs. consensuais.
+
+---
+
+## 5. Amostragem ciente do objetivo (opt-in)
+
+Hoje `generateNextMatch` é agnóstico ao objetivo: maximiza informação
+(incerteza do resultado + sigma + staleness). A Fase 3 adiciona um **termo
+opcional** ao score, controlado por env var:
+
+```
+HRONIR_OBJECTIVE=refine-top   # prefere pares de nível alto (refinar o topo)
+HRONIR_OBJECTIVE=hunt-worst   # prefere pares de nível baixo (caçar o pior)
+# (não setado)                # comportamento idêntico ao atual
+```
+
+```
+score += OBJECTIVE_WEIGHT * sign * (level_a + level_b)
+```
+
+- `level` = EWMA absoluta; posts sem estrelas ainda recebem 3.0 neutro (nem
+  caçados nem evitados).
+- `OBJECTIVE_WEIGHT = 0.15` é deliberadamente pequeno: **inclina empates** sem
+  dominar os termos de informação (sigma ~0.5–2, stale_bonus 3.0).
+- **Default-off** respeita o princípio conservador da RFC 0001: nada muda sem
+  opt-in explícito.
+
+Env var (e não flag) preserva o contrato não-interativo do CLI e mantém o
+sorteio dentro do fluxo `continue` sem nova plumbing de sessão.
+
+---
+
+## 6. O comando `diagnose`
+
+`npm run hronir:diagnose` — **somente leitura**, nunca muda estado. Imprime:
+
+1. Qualidade de-confundida por post (`deconf`, `raw`, `gap`, `n`), ordenada por
+   `deconf` DESC; posts com `n < MIN_APPEARANCES` marcados `(baixa-confiança)`.
+2. Viés de avaliador (`α`) ordenado.
+3. Viés de perspectiva (`π`) ordenado.
+4. Líder por perspectiva (stars EWMA dentro de cada perspectiva).
+
+Não entra no `ranking` (que continua estável e retrocompatível); é um
+diagnóstico separado pra **calibração**, não pra ordenar edição.
+
+---
+
+## 7. Compatibilidade
+
+- **Schema inalterado.** `agent_id`/`perspective_id` já existem em todo
+  `stars-v1`.
+- **Sem migração.** Tudo é derivado por leitura.
+- **`ranking` intocado.** Nenhum número existente muda. `diagnose` é aditivo.
+- **Amostragem** só muda com env var explícita; default idêntico.
+
+---
+
+## 8. Testes
+
+`node:test`, funções puras (sem tocar disco):
+
+- `_solveLinear`: sistemas 2×2 e 3×3 conhecidos (inclui troca de pivô).
+- `_computeDeconfoundedQuality`: design cruzado desbalanceado — detecta o agente
+  generoso e **encolhe** o gap espúrio entre dois posts de qualidade igual;
+  caso vazio (sem estrelas) retorna estruturas vazias.
+- `_computePerPerspectiveQuality`: baldes separados por perspectiva; ignora
+  matches sem `perspective_id`.
+
+Total da branch: **20/20 verdes** (`npm test`).
+
+---
+
+## 9. Questões em aberto
+
+1. **`DECONFOUND_RIDGE` (λ):** começa em 1.0. Calibrável contra os dados; valores
+   altos achatam tudo, baixos arriscam instabilidade em fatores esparsos.
+2. **Humor como fator:** `evaluator_mood` é texto livre PT (quase único por
+   sessão), logo **não** é um fator categórico identificável. Fica de fora do
+   modelo; `agent_id` captura o viés sistemático do avaliador, e o humor
+   residual entra em `ε`. Bucketizar humor por heurística de sentimento é
+   trabalho futuro, não desta RFC.
+3. **Objetivo no fluxo:** hoje via env var. Se virar uso recorrente, considerar
+   persistir o objetivo na sessão (`init --objective`).
+
+---
+
+## 10. Alternativas consideradas
+
+- **Modelo bayesiano hierárquico completo.** Mais rigoroso (incerteza por
+  efeito), porém pesado e com dependência de amostragem. O ridge-LSQ entrega
+  90% do valor com álgebra linear pura e determinística.
+- **Subtrair a média do avaliador/perspectiva (centragem simples).** Não
+  resolve o confundimento cruzado (um avaliador que só viu posts bons teria
+  média alta atribuída a "generosidade"). O LSQ separa os efeitos
+  simultaneamente.
+- **Flag em vez de env var pra objetivo.** Flag exigiria carregar o objetivo na
+  máquina de estados da sessão (`continue` não recebe flags hoje). Env var é
+  mais leve e reversível.
+
+---
+
+## Histórico de revisões
+
+- **r0** (2026-06-09): versão inicial + implementação (de-confounding,
+  stars-por-perspectiva, amostragem objetiva, comando `diagnose`).

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "hronir:decide": "node scripts/hronir/index.js decide",
     "hronir:ranking": "node scripts/hronir/index.js ranking",
     "hronir:worst": "node scripts/hronir/index.js worst",
+    "hronir:diagnose": "node scripts/hronir/index.js diagnose",
     "hronir:edit-worst": "node scripts/hronir/index.js edit-worst",
     "hronir:edit-commit": "node scripts/hronir/index.js edit-commit",
     "hronir:end": "node scripts/hronir/index.js end",

--- a/scripts/hronir/README.md
+++ b/scripts/hronir/README.md
@@ -49,7 +49,8 @@ Todos via npm scripts na raiz:
 | `npm run hronir:continue`                                                                                            | Avança o estado da sessão: imprime a **perspectiva sorteada** + post A; depois imprime post B; depois espera decisão                                                                                                                                                                                                                   |
 | `npm run hronir:decide -- --rate-a <1.00-5.00> --rate-b <1.00-5.00> --review-a "..." --review-b "..." --clash "..."` | Registra a decisão. Cada `--rate-*` é número 1.00–5.00 (até duas decimais, empate proibido). Cada `--review-*` e o `--clash` têm piso de 100 palavras. Vencedor é derivado: quem tem mais estrelas. Agente, perspectiva e idioma são fixos pela sessão (vêm de `init` / sorteio em `continue`). Devolve a sessão para `ready_for_next` |
 | `npm run hronir:ranking`                                                                                             | Score acumulado de todos os matches preenchidos                                                                                                                                                                                                                                                                                        |
-| `npm run hronir:worst`                                                                                               | Imprime translationKey do pior ranqueado                                                                                                                                                                                                                                                                                               |
+| `npm run hronir:worst [-- --absolute]`                                                                               | Imprime translationKey do pior ranqueado (por `ordinal`; `--absolute` usa `stars`)                                                                                                                                                                                                                                                     |
+| `npm run hronir:diagnose`                                                                                            | **Leitura pura.** Qualidade de-confundida (post vs viés de avaliador/perspectiva, ridge-LSQ), `gap` cru−de-confundido, vieses `α`/`π`, líder por perspectiva. Não muda estado. Ver RFC 0002                                                                                                                                            |
 | `npm run hronir:edit-worst`                                                                                          | Pior elegível + top 3 + defesas + crítica acumulada. Captura `git HEAD` na sessão (URL do GitHub pra versão prestes a ser substituída), injeta `replacedVersion` (marker transiente) no frontmatter dos posts, marca a sessão como `need_edit`                                                                                         |
 | `npm run hronir:edit-commit -- --msg "..."`                                                                          | Valida que cada tradução foi efetivamente alterada (UUIDv5 mudou), grava `previousVersion: { uuid, url, timestamp, msg }` no frontmatter (substitui qualquer `replacedVersion`/`editHistory` legados), fecha a sessão                                                                                                                  |
 | `npm run hronir:end -- [--skip-edit\|--force]`                                                                       | Encerra a rodada. Recusa se há matches pendentes ou edição pendente, a menos que `--force`                                                                                                                                                                                                                                             |
@@ -190,14 +191,31 @@ A ordem da tabela é por `ordinal` descendente, tie-break alfabético por `key`.
 Cada chamada de `continue` (não `init` em bloco) gera um match. Para cada par possível, calcula:
 
 ```
-score = -|predictWin(a, b) - 0.5| + sigma_a + sigma_b + stale_bonus(a) + stale_bonus(b)
+score = -|predictWin(a, b) - 0.5| + sigma_a + sigma_b + stale_bonus(a) + stale_bonus(b) + objective_bonus(a, b)
 ```
 
 - `predictWin` próximo de 0.5 → resultado mais incerto → mais informação.
 - `sigma_a + sigma_b` → preferir pares com incerteza ainda alta.
 - `stale_bonus` → `+3.0` se o post foi **editado** depois do match mais recente em que entrou; `0` caso contrário. A âncora de edição é `previousVersion.timestamp` (gravado por `edit-commit`); para posts que nunca passaram por `edit-commit`, cai no tempo do último commit git do arquivo (`gitMtime`).
+- `objective_bonus` → **opt-in, default 0**. Com `HRONIR_OBJECTIVE=refine-top` prefere pares de nível alto (estrelas); com `hunt-worst`, de nível baixo. Peso pequeno (`0.15`): inclina empates sem dominar os termos de informação.
 
 Ordena pares por score descendente (com jitter pra desempate no cold start) e pega o topo, evitando posts já usados no run atual.
+
+### Diagnose — qualidade de-confundida (RFC 0002)
+
+`npm run hronir:diagnose` é um comando de **leitura pura** (não muda estado) que separa a qualidade do post do viés do avaliador e do efeito da perspectiva, via mínimos quadrados com ridge:
+
+```
+rate = μ + q[post] + α[agent] + π[perspective] + ε
+```
+
+A estrela crua é confundida: um post pode ter média alta só porque pegou um avaliador generoso ou uma perspectiva tolerante (o sistema **sorteia perspectivas e injeta humor de propósito**). O modelo torna esses efeitos separáveis. Imprime:
+
+- **qualidade de-confundida** por post (`deconf = μ + q`), com `gap = deconf − cru`: `gap` positivo = **subnotado** (pegou plateia dura), negativo = estrela crua inflada;
+- **viés de avaliador** (`α`) e **viés de perspectiva** (`π`) — ex.: `skeptical-specialist`/`applied-thinker` são estruturalmente severos, `internet-native`/`curious-outsider` generosos;
+- **líder por perspectiva** (EWMA de estrelas dentro de cada perspectiva).
+
+O `ranking` continua intocado e retrocompatível; `diagnose` é um diagnóstico paralelo pra **calibração**, não pra ordenar edição. `DECONFOUND_RIDGE` (λ, default 1.0) é a regularização — ajustável.
 
 ### Por que MIN_APPEARANCES ainda importa com OpenSkill
 

--- a/scripts/hronir/index.js
+++ b/scripts/hronir/index.js
@@ -30,6 +30,7 @@ const {
   decide,
   ranking,
   worst,
+  diagnose,
   editWorst,
   migrate,
   doctor,
@@ -42,7 +43,7 @@ const [, , cmd, ...args] = process.argv;
 
 function usage() {
   console.error(
-    "Uso: hronir {next --agent-id <id> [init-opts]|init --agent-id <id> [--matches N] [--skip-edit] [--skip-rating] [--eval-lang <lang>] [--min-appearances N]|continue|decide --rate-a <1.00-5.00> --rate-b <1.00-5.00> --review-a <text> --review-b <text> --clash <text>|ranking|worst|edit-worst|edit-commit --msg <text>|migrate [--dry-run]|doctor|end [--skip-edit] [--force]}"
+    "Uso: hronir {next --agent-id <id> [init-opts]|init --agent-id <id> [--matches N] [--skip-edit] [--skip-rating] [--eval-lang <lang>] [--min-appearances N]|continue|decide --rate-a <1.00-5.00> --rate-b <1.00-5.00> --review-a <text> --review-b <text> --clash <text>|ranking|worst [--absolute]|diagnose|edit-worst|edit-commit --msg <text>|migrate [--dry-run]|doctor|end [--skip-edit] [--force]}"
   );
   process.exit(1);
 }
@@ -146,6 +147,9 @@ switch (cmd) {
     break;
   case "worst":
     worst({ absolute: args.includes("--absolute") });
+    break;
+  case "diagnose":
+    diagnose();
     break;
   case "edit-worst":
     editWorst();

--- a/scripts/hronir/lib/__tests__/ranking.test.js
+++ b/scripts/hronir/lib/__tests__/ranking.test.js
@@ -17,6 +17,9 @@ await mock.module("../matches.js", {
 const {
   _computeRatings,
   _computeAbsoluteQuality,
+  _computeDeconfoundedQuality,
+  _computePerPerspectiveQuality,
+  _solveLinear,
   EWMA_ALPHA,
   MIN_APPEARANCES,
 } = await import("../ranking.js");
@@ -34,6 +37,8 @@ function match(overrides) {
     bPath: "src/content/blog/post-b.md",
     aVersion: null,
     bVersion: null,
+    agentId: null,
+    perspectiveId: null,
     winner: "a",
     rateA: null,
     rateB: null,
@@ -508,5 +513,176 @@ describe("_computeAbsoluteQuality", () => {
       e,
       "EWMA should accumulate across all 3 observations"
     );
+  });
+});
+
+describe("_solveLinear", () => {
+  it("solves a known 2x2 system", () => {
+    // 2a + b = 3 ; a + 3b = 5  →  a = 0.8, b = 1.4
+    const x = _solveLinear(
+      [
+        [2, 1],
+        [1, 3],
+      ],
+      [3, 5]
+    );
+    assert.ok(Math.abs(x[0] - 0.8) < 1e-9, `a≈0.8, got ${x[0]}`);
+    assert.ok(Math.abs(x[1] - 1.4) < 1e-9, `b≈1.4, got ${x[1]}`);
+  });
+
+  it("solves a 3x3 system needing a pivot swap", () => {
+    // Zero leading pivot forces a row swap.
+    // 0a + b + c = 3 ; a + b = 3 ; b + 2c = 5  →  a=1, b=2, c=1.5? check:
+    //   row2: 1+2=3 ✓ ; row1: 2+1.5=3.5 ✗ — recompute properly below.
+    // Use a clean system: x+y+z=6, y+z=5, z=3 → z=3, y=2, x=1.
+    const x = _solveLinear(
+      [
+        [1, 1, 1],
+        [0, 1, 1],
+        [0, 0, 1],
+      ],
+      [6, 5, 3]
+    );
+    assert.ok(Math.abs(x[0] - 1) < 1e-9, `x≈1, got ${x[0]}`);
+    assert.ok(Math.abs(x[1] - 2) < 1e-9, `y≈2, got ${x[1]}`);
+    assert.ok(Math.abs(x[2] - 3) < 1e-9, `z≈3, got ${x[2]}`);
+  });
+});
+
+describe("_computeDeconfoundedQuality", () => {
+  it("detects a generous agent and corrects spurious quality gap", () => {
+    // X and Y have equal true quality (2). Agent G adds +1, Agent N adds 0.
+    // X is rated more by G, Y more by N → raw stars make X look better.
+    // De-confounding should shrink that gap and flag G > N.
+    const G = "agent-generous";
+    const N = "agent-neutral";
+    const raw = [
+      match({
+        runAt: "2024-04-01T00:00:00Z",
+        matchIndex: 1,
+        agentId: G,
+        aKey: "X",
+        aPath: "x.md",
+        rateA: 3.0,
+        bKey: "Y",
+        bPath: "y.md",
+        rateB: 3.0,
+      }),
+      match({
+        runAt: "2024-04-01T00:00:01Z",
+        matchIndex: 2,
+        agentId: G,
+        aKey: "X",
+        aPath: "x.md",
+        rateA: 3.0,
+        bKey: "F",
+        bPath: "f.md",
+        rateB: 3.0,
+      }),
+      match({
+        runAt: "2024-04-01T00:00:02Z",
+        matchIndex: 3,
+        agentId: N,
+        aKey: "X",
+        aPath: "x.md",
+        rateA: 2.0,
+        bKey: "Y",
+        bPath: "y.md",
+        rateB: 2.0,
+      }),
+      match({
+        runAt: "2024-04-01T00:00:03Z",
+        matchIndex: 4,
+        agentId: N,
+        aKey: "Y",
+        aPath: "y.md",
+        rateA: 2.0,
+        bKey: "F",
+        bPath: "f.md",
+        rateB: 2.0,
+      }),
+    ];
+
+    const { quality, agentBias } = _computeDeconfoundedQuality(raw);
+    const qx = quality.get("X");
+    const qy = quality.get("Y");
+    assert.ok(qx && qy, "X and Y present");
+
+    // Raw stars: X = (3+3+2)/3 = 2.667, Y = (3+2+2)/3 = 2.333, gap 0.333.
+    const rawGap = 2.6667 - 2.3333;
+    const deconfGap = Math.abs(qx.quality - qy.quality);
+    assert.ok(
+      deconfGap < rawGap,
+      `de-confounded gap ${deconfGap.toFixed(3)} should be < raw gap ${rawGap.toFixed(3)}`
+    );
+
+    // Generous agent should carry a higher bias than the neutral one.
+    assert.ok(
+      agentBias.get(G) > agentBias.get(N),
+      `generous agent bias ${agentBias.get(G)} should exceed neutral ${agentBias.get(N)}`
+    );
+  });
+
+  it("returns empty structures when there are no rated observations", () => {
+    const raw = [
+      match({ aKey: "a", bKey: "b", rateA: null, rateB: null, agentId: "g" }),
+    ];
+    const out = _computeDeconfoundedQuality(raw);
+    assert.equal(out.quality.size, 0, "no quality rows");
+    assert.equal(out.intercept, 0, "intercept defaults to 0");
+  });
+});
+
+describe("_computePerPerspectiveQuality", () => {
+  it("buckets stars by perspective and keeps them separate", () => {
+    const raw = [
+      match({
+        runAt: "2024-05-01T00:00:00Z",
+        matchIndex: 1,
+        perspectiveId: "skeptical-specialist",
+        aKey: "post-z",
+        aPath: "z.md",
+        rateA: 2.0,
+        bKey: "opp",
+        bPath: "o.md",
+        rateB: 1.0,
+      }),
+      match({
+        runAt: "2024-05-01T00:00:01Z",
+        matchIndex: 2,
+        perspectiveId: "curious-outsider",
+        aKey: "post-z",
+        aPath: "z.md",
+        rateA: 4.5,
+        bKey: "opp2",
+        bPath: "o2.md",
+        rateB: 3.0,
+      }),
+    ];
+
+    const result = _computePerPerspectiveQuality(raw);
+    const harsh = result.get("skeptical-specialist");
+    const gentle = result.get("curious-outsider");
+    assert.ok(harsh && gentle, "both perspective buckets exist");
+    assert.equal(harsh.get("post-z").stars, 2.0, "harsh bucket sees 2.0");
+    assert.equal(gentle.get("post-z").stars, 4.5, "gentle bucket sees 4.5");
+    assert.equal(harsh.get("post-z").n, 1);
+    assert.equal(gentle.get("post-z").n, 1);
+  });
+
+  it("skips matches without a perspective_id", () => {
+    const raw = [
+      match({
+        perspectiveId: null,
+        aKey: "p",
+        aPath: "p.md",
+        rateA: 3.0,
+        bKey: "q",
+        bPath: "q.md",
+        rateB: 2.0,
+      }),
+    ];
+    const result = _computePerPerspectiveQuality(raw);
+    assert.equal(result.size, 0, "no perspective buckets when id absent");
   });
 });

--- a/scripts/hronir/lib/commands.js
+++ b/scripts/hronir/lib/commands.js
@@ -23,6 +23,8 @@ import {
 import {
   computeRatings,
   computeAbsoluteQuality,
+  computeDeconfoundedQuality,
+  computePerPerspectiveQuality,
   getProtectedPosts,
   MIN_APPEARANCES,
 } from "./ranking.js";
@@ -56,6 +58,12 @@ function jaccard(a, b) {
   return inter / (a.size + b.size - inter);
 }
 const STALE_BONUS = 3.0;
+// Phase 3 (opt-in): objective-aware sampling. When HRONIR_OBJECTIVE is set,
+// nudge pair selection toward high-level posts (refine the top) or low-level
+// posts (hunt the worst). Default-off → identical behavior to before. The
+// weight is deliberately small so it tilts ties without overriding the
+// information terms (sigma, stale_bonus).
+const OBJECTIVE_WEIGHT = 0.15;
 const SKILLS_DIR = "scripts/hronir/skills";
 const ARCHIVE_DIR = path.join(OUT_DIR, "archive");
 const EDITS_DIR = path.join(OUT_DIR, "edits");
@@ -296,6 +304,25 @@ function generateNextMatch() {
   }
   const staleBonus = (key) => (staleByKey.get(key) ? STALE_BONUS : 0);
 
+  // Phase 3 (opt-in): objective-aware sampling. `refine-top` prefers high-level
+  // pairs, `hunt-worst` prefers low-level pairs. Level = absolute stars EWMA;
+  // posts without stars yet get a neutral 3.0 so they're neither chased nor
+  // avoided. Default (env unset) leaves the score untouched.
+  const objective = process.env.HRONIR_OBJECTIVE || "";
+  const objectiveSign =
+    objective === "refine-top" ? 1 : objective === "hunt-worst" ? -1 : 0;
+  const levelByKey = new Map();
+  if (objectiveSign !== 0) {
+    for (const [key, q] of computeAbsoluteQuality())
+      levelByKey.set(key, q.stars);
+    console.log(`(objetivo de amostragem: ${objective})`);
+  }
+  const level = (key) => levelByKey.get(key) ?? 3.0;
+  const objectiveBonus = (a, b) =>
+    objectiveSign === 0
+      ? 0
+      : OBJECTIVE_WEIGHT * objectiveSign * (level(a) + level(b));
+
   const pairs = [];
   for (let i = 0; i < eligible.length; i++) {
     for (let j = i + 1; j < eligible.length; j++) {
@@ -309,7 +336,8 @@ function generateNextMatch() {
         ra.sigma +
         rb.sigma +
         staleBonus(a.translationKey) +
-        staleBonus(b.translationKey);
+        staleBonus(b.translationKey) +
+        objectiveBonus(a.translationKey, b.translationKey);
       pairs.push({
         a,
         b,
@@ -866,6 +894,91 @@ export function worst(options = {}) {
   console.log(w.key);
   console.error(
     `(path: ${w.path}, wins: ${w.wins}/${w.appearances}, ordinal: ${w.ordinal.toFixed(3)}, mu: ${w.mu.toFixed(3)}, sigma: ${w.sigma.toFixed(3)})`
+  );
+}
+
+// Phase 3 diagnostics: de-confounded quality + evaluator/perspective biases +
+// per-perspective leaders. Read-only; never mutates state. Posts below
+// MIN_APPEARANCES are shown but flagged low-confidence.
+export function diagnose() {
+  const { quality, agentBias, perspectiveBias, intercept } =
+    computeDeconfoundedQuality();
+  const absolute = computeAbsoluteQuality();
+
+  if (quality.size === 0) {
+    console.log("Sem observações com estrelas (schema stars-v1) para modelar.");
+    nextStep("nenhum. Rode alguns matches com rate_a/rate_b primeiro.");
+    return;
+  }
+
+  // Rows sorted by de-confounded quality DESC. `gap` = de-confounded − raw
+  // EWMA: negative means the raw stars were inflated by generous evaluators or
+  // perspectives (the post got an easy crowd); positive means deflated.
+  const rows = [...quality.entries()]
+    .map(([key, q]) => {
+      const raw = absolute.get(key);
+      const rawStars = raw ? raw.stars : null;
+      return {
+        key,
+        deconf: q.quality,
+        rawStars,
+        gap: rawStars === null ? null : q.quality - rawStars,
+        n: q.n,
+      };
+    })
+    .sort((a, b) => b.deconf - a.deconf || a.key.localeCompare(b.key));
+
+  console.log(`# de-confounded quality (intercept μ=${intercept.toFixed(3)})`);
+  console.log(`rank\tkey\tdeconf\traw\tgap\tn`);
+  rows.forEach((r, i) => {
+    const conf = r.n >= MIN_APPEARANCES ? "" : "\t(baixa-confiança)";
+    const rawStr = r.rawStars === null ? "-" : r.rawStars.toFixed(2);
+    const gapStr =
+      r.gap === null ? "-" : (r.gap >= 0 ? "+" : "") + r.gap.toFixed(2);
+    console.log(
+      `${i + 1}\t${r.key}\t${r.deconf.toFixed(2)}\t${rawStr}\t${gapStr}\t${r.n}${conf}`
+    );
+  });
+
+  // Evaluator bias: who rates systematically high/low, net of which posts and
+  // perspectives they happened to draw.
+  const agents = [...agentBias.entries()].sort((a, b) => b[1] - a[1]);
+  if (agents.length > 0) {
+    console.log(`\n# evaluator bias (α — alto = avalia generoso)`);
+    for (const [id, bias] of agents) {
+      console.log(`${(bias >= 0 ? "+" : "") + bias.toFixed(3)}\t${id}`);
+    }
+  }
+
+  // Perspective bias: which reader personas are structurally harsh/generous.
+  const persps = [...perspectiveBias.entries()].sort((a, b) => b[1] - a[1]);
+  if (persps.length > 0) {
+    console.log(`\n# perspective bias (π — alto = perspectiva generosa)`);
+    for (const [id, bias] of persps) {
+      console.log(`${(bias >= 0 ? "+" : "") + bias.toFixed(3)}\t${id}`);
+    }
+  }
+
+  // Per-perspective leaders: the top post in each perspective's own stars EWMA.
+  const perPersp = computePerPerspectiveQuality();
+  if (perPersp.size > 0) {
+    console.log(`\n# líder por perspectiva (stars EWMA dentro da perspectiva)`);
+    const ids = [...perPersp.keys()].sort();
+    for (const id of ids) {
+      const inner = perPersp.get(id);
+      const top = [...inner.entries()].sort(
+        (a, b) => b[1].stars - a[1].stars || a[0].localeCompare(b[0])
+      )[0];
+      if (top) {
+        console.log(
+          `${id}\t→ ${top[0]} (${top[1].stars.toFixed(2)}, n=${top[1].n})`
+        );
+      }
+    }
+  }
+
+  nextStep(
+    "nenhum. `diagnose` é só leitura — use os vieses pra calibrar, não muda estado."
   );
 }
 

--- a/scripts/hronir/lib/ranking.js
+++ b/scripts/hronir/lib/ranking.js
@@ -5,6 +5,11 @@ export const MIN_APPEARANCES = 3;
 export const RANKING_MODEL_VERSION = 2;
 export const EWMA_ALPHA = 0.3;
 export const MARGIN_W_MIN = 0.1;
+// Ridge (L2) penalty for the de-confounding least-squares solve. Shrinks
+// factor effects toward 0, guarantees the normal-equations matrix is
+// invertible even when a factor level is sparse, and gently regularizes
+// thin evidence. Tunable; ~1.0 means a post seen 3× is shrunk ~25%.
+export const DECONFOUND_RIDGE = 1.0;
 
 // Internal: load and normalize all match data from disk.
 // Returns raw match objects with rateA/rateB fields (null for old schema).
@@ -48,6 +53,8 @@ function _loadMatchData() {
       bPath: data.post_b?.path || "",
       aVersion: data.post_a?.version ?? null,
       bVersion: data.post_b?.version ?? null,
+      agentId: data.agent_id ? String(data.agent_id) : null,
+      perspectiveId: data.perspective_id ? String(data.perspective_id) : null,
       winner,
       rateA,
       rateB,
@@ -207,6 +214,216 @@ export function _computeAbsoluteQuality(raw) {
 
 export function computeAbsoluteQuality() {
   return _computeAbsoluteQuality(_loadMatchData());
+}
+
+// Solve a symmetric positive-definite linear system A·x = b by Gaussian
+// elimination with partial pivoting. A is an array of rows (each an array);
+// b is a flat array. Returns x. A and b are mutated in place. The ridge
+// penalty added by the caller guarantees A is non-singular, but a tiny pivot
+// epsilon guards against degenerate columns just in case.
+export function _solveLinear(A, b) {
+  const n = b.length;
+  for (let col = 0; col < n; col++) {
+    // Partial pivot: find the row with the largest |value| in this column.
+    let pivot = col;
+    let best = Math.abs(A[col][col]);
+    for (let r = col + 1; r < n; r++) {
+      const v = Math.abs(A[r][col]);
+      if (v > best) {
+        best = v;
+        pivot = r;
+      }
+    }
+    if (pivot !== col) {
+      [A[col], A[pivot]] = [A[pivot], A[col]];
+      [b[col], b[pivot]] = [b[pivot], b[col]];
+    }
+    const diag = A[col][col] || 1e-9;
+    for (let r = col + 1; r < n; r++) {
+      const factor = A[r][col] / diag;
+      if (factor === 0) continue;
+      for (let c = col; c < n; c++) A[r][c] -= factor * A[col][c];
+      b[r] -= factor * b[col];
+    }
+  }
+  // Back-substitution.
+  const x = new Array(n).fill(0);
+  for (let row = n - 1; row >= 0; row--) {
+    let s = b[row];
+    for (let c = row + 1; c < n; c++) s -= A[row][c] * x[c];
+    x[row] = s / (A[row][row] || 1e-9);
+  }
+  return x;
+}
+
+// Pure function: de-confound absolute quality with a ridge least-squares model.
+// Each rated side of each clash is one observation:
+//     rate = μ + q[post] + α[agent] + π[perspective] + ε
+// Estimated by minimizing Σε² + λ(Σq² + Σα² + Σπ²) — the intercept μ is
+// unpenalized, so it absorbs the grand mean while factor effects shrink
+// toward 0 (and stay identifiable despite the dummy/intercept collinearity).
+//
+// Returns {
+//   quality: Map<key, { quality: μ+q, qDev: q, n }>,   // de-confounded level
+//   agentBias: Map<agentId, bias>,                       // α (rates high/low)
+//   perspectiveBias: Map<perspectiveId, bias>,           // π (harsh/generous)
+//   intercept: μ,
+// }
+// Posts whose rate is null (old schema) contribute no observation.
+export function _computeDeconfoundedQuality(raw, ridge = DECONFOUND_RIDGE) {
+  // Collect observations and assign dense indices per factor level.
+  const postIdx = new Map();
+  const agentIdx = new Map();
+  const perspIdx = new Map();
+  const idxFor = (map, keyName) => {
+    if (keyName == null) return -1;
+    if (!map.has(keyName)) map.set(keyName, map.size);
+    return map.get(keyName);
+  };
+
+  const obs = []; // { y, post, agent, persp }  (indices; -1 = absent)
+  const postN = new Map();
+  for (const m of raw) {
+    const add = (key, rate, path) => {
+      if (rate === null || !key) return;
+      const pi = idxFor(postIdx, key);
+      obs.push({
+        y: rate,
+        post: pi,
+        agent: idxFor(agentIdx, m.agentId),
+        persp: idxFor(perspIdx, m.perspectiveId),
+      });
+      postN.set(key, (postN.get(key) || 0) + 1);
+    };
+    add(m.aKey, m.rateA, m.aPath);
+    add(m.bKey, m.rateB, m.bPath);
+  }
+
+  const empty = {
+    quality: new Map(),
+    agentBias: new Map(),
+    perspectiveBias: new Map(),
+    intercept: 0,
+  };
+  if (obs.length === 0) return empty;
+
+  const P = postIdx.size;
+  const A = agentIdx.size;
+  const K = perspIdx.size;
+  // Parameter layout: [μ, q_0..q_{P-1}, α_0..α_{A-1}, π_0..π_{K-1}]
+  const nParams = 1 + P + A + K;
+  const qOff = 1;
+  const aOff = 1 + P;
+  const pOff = 1 + P + A;
+
+  // Build normal equations XᵀX (with ridge on the diagonal) and Xᵀy directly,
+  // without materializing the (obs × nParams) design matrix.
+  const XtX = Array.from({ length: nParams }, () => new Array(nParams).fill(0));
+  const Xty = new Array(nParams).fill(0);
+
+  for (const o of obs) {
+    const cols = [0, qOff + o.post];
+    if (o.agent >= 0) cols.push(aOff + o.agent);
+    if (o.persp >= 0) cols.push(pOff + o.persp);
+    for (const c1 of cols) {
+      Xty[c1] += o.y;
+      for (const c2 of cols) XtX[c1][c2] += 1;
+    }
+  }
+  // Ridge: penalize every coefficient except the intercept (column 0).
+  for (let c = 1; c < nParams; c++) XtX[c][c] += ridge;
+
+  const beta = _solveLinear(XtX, Xty);
+
+  const intercept = beta[0];
+  const quality = new Map();
+  for (const [key, i] of postIdx) {
+    const qDev = beta[qOff + i];
+    quality.set(key, {
+      quality: intercept + qDev,
+      qDev,
+      n: postN.get(key) || 0,
+    });
+  }
+  const agentBias = new Map();
+  for (const [id, i] of agentIdx) agentBias.set(id, beta[aOff + i]);
+  const perspectiveBias = new Map();
+  for (const [id, i] of perspIdx) perspectiveBias.set(id, beta[pOff + i]);
+
+  return { quality, agentBias, perspectiveBias, intercept };
+}
+
+export function computeDeconfoundedQuality(ridge = DECONFOUND_RIDGE) {
+  return _computeDeconfoundedQuality(_loadMatchData(), ridge);
+}
+
+// Pure function: per-(perspective, post) EWMA of stars. Mirrors
+// _computeAbsoluteQuality but buckets observations by perspective_id, so each
+// perspective gets its own absolute track. Same path-keyed reset-on-edit.
+// Returns Map<perspectiveId, Map<key, { stars, n, rawStars }>>.
+export function _computePerPerspectiveQuality(raw) {
+  const sorted = _sortMatchData(raw);
+  const byPersp = new Map(); // perspId → { ewma, count, sum, lastVersionByPath }
+
+  const bucket = (perspId) => {
+    if (!byPersp.has(perspId)) {
+      byPersp.set(perspId, {
+        ewma: new Map(),
+        count: new Map(),
+        sum: new Map(),
+        lastVersionByPath: new Map(),
+      });
+    }
+    return byPersp.get(perspId);
+  };
+
+  for (const m of sorted) {
+    if (!m.perspectiveId) continue;
+    const b = bucket(m.perspectiveId);
+
+    const resetIfEdited = (key, path, version) => {
+      if (version === null || !path) return;
+      const prev = b.lastVersionByPath.get(path);
+      if (prev !== undefined && prev !== version) {
+        b.ewma.delete(key);
+        b.count.delete(key);
+        b.sum.delete(key);
+      }
+      b.lastVersionByPath.set(path, version);
+    };
+    const applyRating = (key, rate) => {
+      if (rate === null) return;
+      b.ewma.set(
+        key,
+        b.ewma.has(key)
+          ? EWMA_ALPHA * rate + (1 - EWMA_ALPHA) * b.ewma.get(key)
+          : rate
+      );
+      b.count.set(key, (b.count.get(key) || 0) + 1);
+      b.sum.set(key, (b.sum.get(key) || 0) + rate);
+    };
+
+    resetIfEdited(m.aKey, m.aPath, m.aVersion);
+    resetIfEdited(m.bKey, m.bPath, m.bVersion);
+    applyRating(m.aKey, m.rateA);
+    applyRating(m.bKey, m.rateB);
+  }
+
+  const result = new Map();
+  for (const [perspId, b] of byPersp) {
+    const inner = new Map();
+    for (const [key, stars] of b.ewma) {
+      const n = b.count.get(key) || 0;
+      const rawStars = n > 0 ? (b.sum.get(key) || 0) / n : 0;
+      inner.set(key, { stars, n, rawStars });
+    }
+    result.set(perspId, inner);
+  }
+  return result;
+}
+
+export function computePerPerspectiveQuality() {
+  return _computePerPerspectiveQuality(_loadMatchData());
 }
 
 // Returns a Map<perspectiveId, Array<{key, ordinal, appearances, wins}>>


### PR DESCRIPTION
## O que é

Implementa a **Fase 3** esboçada no §5 da RFC 0001 — agora detalhada na **RFC 0002**. Empilhada sobre a #292 (base = `claude/friendly-archimedes-clsv9r`), então este diff mostra só o que é novo. Quando a #292 entrar no `main`, esta PR se re-aponta sozinha.

Todos os sinais vêm de campos **já gravados** nos rate files `stars-v1` (`agent_id`, `perspective_id`) + a trilha de `version` da RFC 0001. **Nada muda o `ranking` existente nem o schema.**

## Três features + um comando

**1. De-confounding por mínimos quadrados (ridge)** — `ranking.js`
A estrela crua é confundida: um post pode ter média alta só porque pegou um avaliador generoso ou perspectiva tolerante (o sistema sorteia perspectivas e injeta humor **de propósito**). O modelo separa:

```
rate = μ + q[post] + α[agent] + π[perspective] + ε
```

ajustado por ridge-LSQ (intercepto não penalizado; efeitos encolhem para 0). Solver em álgebra linear pura (`_solveLinear`, eliminação de Gauss com pivoteamento), equações normais montadas direto sem materializar a matriz de design.

**2. Stars por perspectiva** — EWMA independente por `perspective_id`, mesmo reset-on-edit keyed por `path`.

**3. Amostragem ciente do objetivo (opt-in)** — `HRONIR_OBJECTIVE=refine-top|hunt-worst` inclina a geração de pares para nível alto/baixo. **Default-off**, peso pequeno (0.15) — inclina empates sem dominar os termos de informação.

**4. `npm run hronir:diagnose`** — comando de **leitura pura** que imprime tudo isso: qualidade de-confundida (`gap = deconf − cru`), vieses `α`/`π`, líder por perspectiva.

## Resultado nos dados reais

O modelo recupera o que o design previa:

| Perspectiva            | π        | leitura                  |
| ---------------------- | -------- | ------------------------ |
| `internet-native`      | **+0.18** | tolerante                |
| `curious-outsider`     | **+0.17** | generoso                 |
| `skeptical-specialist` | **−0.03** | adversarial              |
| `applied-thinker`      | **−0.15** | o mais severo            |

E posts **subnotados** emergem (`gap` positivo): `three-hammers` (+0.70), `pierre-menard` (+0.38), `conservation-law` (+0.35) — melhores em absoluto do que as estrelas cruas sugerem.

## Testes & validação

- **20/20** `npm test` (6 novos: solver 2×2/3×3, recuperação de viés de-confundido, baldes por perspectiva).
- `prettier --check .` limpo · `hronir:doctor` 0 inconsistências.
- `diagnose` rodado contra os rate files reais (output acima).

## Decisões de design

- **Ridge** (`DECONFOUND_RIDGE=1.0`) resolve a colinearidade dummy/intercepto e encolhe fatores esparsos — ajustável.
- **Humor fica fora do modelo**: `evaluator_mood` é texto livre PT (quase único por sessão), não é fator categórico identificável; `agent_id` captura o viés sistemático, o humor residual entra em ε.
- **Env var, não flag**, pro objetivo: preserva o contrato não-interativo e evita plumbing de sessão.

Ver `docs/rfcs/0002-*.md` para o detalhamento completo.

https://claude.ai/code/session_01PDbhFtjoBF761Y2N4JSmVQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01PDbhFtjoBF761Y2N4JSmVQ)_