### PR TITLE
perf/seo: fix 212 pagefind warnings from Astro redirect stubs

### DIFF
--- a/.routines/2026-06-09T05-10-00-pagefind-redirect-fix.md
+++ b/.routines/2026-06-09T05-10-00-pagefind-redirect-fix.md
@@ -1,0 +1,88 @@
+---
+date: 2026-06-09T05:10:00
+slug: pagefind-redirect-fix
+branch: claude/sleepy-pasteur-slc2db
+status: pr-open
+issues: [239]
+pr_opened: null
+pr_merged: 268
+---
+
+# Sessão 2026-06-09 — Pagefind: fix das 212 warnings de redirect stubs (issue #239)
+
+## Contexto ao chegar
+
+Décima-quinta sessão com esta identidade. Branch designado: `claude/sleepy-pasteur-slc2db`.
+
+Estado ao chegar:
+
+- **PR #268** (archive collapse, issue #240) — já mergeado por Franklin em 2026-06-08T06:05:42Z. Sem veto, sem review bloqueante. Verificação de produção: o WebFetch retornou versão em cache sem `<details>`, mas o código no `origin/main` confirma que os elementos `<details>/<summary>` estão corretos. Deploy OK.
+- **12 issues `routine` abertas** — backlog saudável (10–20), sem necessidade de criar ou fechar.
+- **0 PRs `routine` abertos** — nenhum PR da run anterior para mergear (já tratado acima).
+- Branch rebased sobre `origin/main` (commit `f562389`).
+
+## Trabalho executado: issue #239 — Pagefind warnings de redirect stubs
+
+### Diagnóstico real
+
+A issue descrevia os warnings como "Pagefind indexando RSS e sitemap", mas o build revelou a causa verdadeira: **212 redirect stubs** sem elemento `<html>`. Esses stubs são gerados pelo Astro em dois casos:
+
+1. Posts PT acessíveis em `/blog/<pt-slug>/` (ex: `/blog/quem-o-asterisco-protege/`) — o `[...slug].astro` chama `Astro.redirect("/pt/blog/…")` em static build, gerando um HTML mínimo sem `<html>`
+2. Redirects de URLs antigas com prefixo de data (ex: `/blog/2026-03-02-travessia/`) — gerados via `redirects` no `astro.config.mjs` a partir do `blog-redirects.json`
+
+Em ambos os casos, o Astro gera:
+```
+<!doctype html><title>Redirecting to: …</title><meta http-equiv="refresh"…><body>…</body>
+```
+Sem elemento `<html>`. Como o site usa `data-pagefind-body`, pagefind ignora corretamente essas páginas no índice, mas ainda as crawlea e emite warning para cada uma.
+
+### Solução
+
+Script `scripts/fix-redirect-html.mjs` que roda entre `astro build` e `pagefind`:
+
+1. Percorre `dist/` recursivamente procurando `.html`
+2. Detecta redirect stubs por `http-equiv="refresh"` sem `<html>`
+3. Envolve com `<html data-pagefind-ignore="">…</html>` — o redirect funciona igual (o meta refresh ainda está lá), mas pagefind pode parsear o arquivo sem warnings
+
+Build script atualizado em `package.json`:
+```
+"build": "astro build && node scripts/fix-redirect-html.mjs && pagefind --site dist"
+```
+
+### Resultado verificado
+
+```
+✔ fix-redirect-html: wrapped 212 redirect stub(s)
+Output: "dist/pagefind"
+Found a data-pagefind-body element on the site.
+↳ Ignoring pages without this tag.
+[Building search indexes]
+  Indexed 2 languages
+  Indexed 196 pages
+  Indexed 23942 words
+Finished in 0.904 seconds
+```
+
+Zero warnings de "has no `<html>` element". Build noise eliminado.
+
+**Invariantes verificados:**
+- `npm run build`: zero warnings pagefind ✓
+- `npx astro check`: 0 errors, 0 warnings ✓
+- `npx prettier --check`: All matched files use Prettier code style ✓
+- Busca EN e PT continua funcional (196 páginas indexadas, 2 línguas) ✓
+- Redirect stubs continuam funcionando (meta refresh preservado dentro do `<html>`) ✓
+
+### Arquivos alterados
+
+- `scripts/fix-redirect-html.mjs` — novo script post-build
+- `package.json` — build script atualizado
+
+## Plano para próximas sessões
+
+Por prioridade `alta` restante:
+1. **#241**: Taxonomia de tipo de documento (essay/letter/fiction) — maior escopo, envolve schema, i18n, archive UI e bulk frontmatter
+2. **#248**: Atualizar reading path "Memory and Funes" com posts 2026
+
+---
+
+_Sessão: 2026-06-09 | Branch: `claude/sleepy-pasteur-slc2db` | franklinbaldo@gmail.com_

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "check:links": "node scripts/check-links.mjs",
     "check:translations": "node scripts/check-translations.mjs",
     "dev": "astro dev",
-    "build": "astro build && pagefind --site dist",
+    "build": "astro build && node scripts/fix-redirect-html.mjs && pagefind --site dist",
     "preview": "astro preview",
     "astro": "astro",
     "format": "prettier --write .",

--- a/scripts/fix-redirect-html.mjs
+++ b/scripts/fix-redirect-html.mjs
@@ -1,0 +1,31 @@
+// Wraps Astro-generated redirect stubs with a proper <html data-pagefind-ignore>
+// element so pagefind can parse them without "has no <html> element" warnings.
+// Redirect stubs are detected by the presence of http-equiv="refresh" and the
+// absence of an <html> tag — a side-effect of Astro.redirect() in static builds.
+import { readdirSync, readFileSync, writeFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+function* walkHtml(dir) {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) yield* walkHtml(full);
+    else if (entry.name.endsWith(".html")) yield full;
+  }
+}
+
+let count = 0;
+for (const file of walkHtml("./dist")) {
+  const content = readFileSync(file, "utf-8");
+  if (
+    content.includes('http-equiv="refresh"') &&
+    !/<html[\s>]/i.test(content)
+  ) {
+    const body = content.replace(/^<!doctype html>/i, "").trimStart();
+    writeFileSync(
+      file,
+      `<!doctype html><html data-pagefind-ignore="">${body}</html>`
+    );
+    count++;
+  }
+}
+console.log(`✔ fix-redirect-html: wrapped ${count} redirect stub(s)`);


### PR DESCRIPTION
Closes #239

## perf

- Add `scripts/fix-redirect-html.mjs` — runs between `astro build` and `pagefind` in the build pipeline
- Wraps Astro-generated redirect stubs with `<html data-pagefind-ignore="">` so pagefind can parse them without emitting "has no `<html>` element" warnings
- 212 stubs fixed: PT blog posts at `/blog/<pt-slug>/` (generated by `Astro.redirect()` in `[...slug].astro`) and legacy date-prefixed URL redirects (from `blog-redirects.json`)
- Redirect behavior (meta refresh) is preserved — only the `<html>` wrapper is added
- Build noise eliminated: pagefind now runs cleanly with 0 warnings, correctly indexing 196 pages in 2 languages

## Invariantes

- `npm run build`: zero pagefind warnings ✓  
- `npx astro check`: 0 errors ✓  
- `npx prettier --check .`: clean ✓  
- Search EN and PT still functional (196 pages indexed, 2 languages) ✓

## Verificação em produção (próxima run)

Mudança é de build pipeline — sem impacto visual. Verificar que `/search/` e `/pt/search/` continuam retornando resultados.

https://claude.ai/code/session_01EPkbzEDc95DpXGYZwcJkw5

---
_Generated by [Claude Code](https://claude.ai/code/session_01EPkbzEDc95DpXGYZwcJkw5)_