### PR TITLE
ci(heartbeat): run every 15 minutes instead of hourly

### DIFF
--- a/.github/workflows/hronir-heartbeat.yml
+++ b/.github/workflows/hronir-heartbeat.yml
@@ -4,8 +4,9 @@ name: Hrönir Heartbeat
 #
 # The event-driven autopilot (hronir-autopilot.yml) only reacts when a PR
 # arrives. If a session dies without ever opening a PR — or session creation
-# failed — the conveyor would stall. This hourly cron is the safety net: it
-# makes sure at least one Hrönir session exists per hour.
+# failed — the conveyor would stall. This cron (every 15 min) is the safety
+# net: it makes sure stuck sessions are unblocked quickly and a new session
+# is spawned if none is in-flight.
 #
 # Two-phase logic:
 #   Phase 1 — Unblock: sessions in "awaiting_feedback" (stuck waiting for a
@@ -21,7 +22,7 @@ name: Hrönir Heartbeat
 
 on:
   schedule:
-    - cron: "0 * * * *" # hourly
+    - cron: "*/15 * * * *" # every 15 minutes
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Changes heartbeat cron from `0 * * * *` (hourly) to `*/15 * * * *` (every 15 min)
- Reduces max wait to unblock a stuck `awaiting_feedback` session from ~60 min to ~15 min
- Spawn recency guard (`< 3600s`) is unchanged — no change to how often new sessions are spawned

## Test plan

- [ ] Verify workflow runs on the new schedule in Actions tab after merge
- [ ] Confirm stuck sessions get nudged within 15 minutes

https://claude.ai/code/session_01YBF8py3a21LMrfToMQp3hR
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YBF8py3a21LMrfToMQp3hR)_