### PR TITLE
docs(hronir): instrui o Jules a operar com autonomia total no autopilot

### DIFF
--- a/.github/hronir-session-prompt.md
+++ b/.github/hronir-session-prompt.md
@@ -3,6 +3,27 @@ Run a complete Hrönir rating session for this blog and open a PR with the resul
 **For the full operating manual** (session flow, decision constraints, mood, reviews,
 clash format) see [`CLAUDE.md`](../CLAUDE.md) in the repo root.
 
+## This session is fully autonomous — never ask the user anything
+
+There is no human watching this session. **Never** ask the user a question,
+request clarification, wait for approval, or pause for input of any kind —
+a question stalls the session forever and the conveyor with it.
+
+Everything you need to know is discoverable from the Hrönir system itself:
+
+- `CLAUDE.md` is the complete operating manual.
+- After every command, the CLI prints the **NEXT STEP** — follow it literally.
+- The perspective banner, the initial mood, and the random glyph are all shown
+  to you by `hronir:continue`; nothing about them needs to be asked.
+- `npm run hronir:doctor` tells you whether your rate files are valid, and its
+  error messages say exactly what to fix.
+- If a command fails, read its output, fix the cause, and retry. If a match is
+  unrecoverable after honest retries, finish the remaining matches and open the
+  PR with what you completed — a partial PR beats a stalled session.
+
+When in doubt, the answer is always: run the next Hrönir command and read what
+it prints — never ask.
+
 ## Autopilot-specific constraints
 
 These are the only differences from a manual session:


### PR DESCRIPTION
## Resumo

A sessão do Jules spawnada pelo autopilot (GHA → `spawn-session.sh` → `.github/hronir-session-prompt.md`) não tem humano observando, mas o prompt não dizia isso. Esta PR adiciona uma seção explícita ao prompt:

- **Nunca** perguntar nada ao usuário, pedir aprovação ou esperar input — uma pergunta trava a sessão e a esteira inteira.
- Tudo que a sessão precisa saber é descobrível pelo próprio sistema Hrönir: `CLAUDE.md` é o manual, o CLI imprime o **NEXT STEP** a cada comando, o banner mostra perspectiva/mood/glyph, e o `hronir:doctor` aponta exatamente o que corrigir.
- Em caso de falha: ler o output, corrigir e tentar de novo; se um match for irrecuperável, terminar os demais e abrir a PR com o que foi completado em vez de travar.

## Mudanças

- `.github/hronir-session-prompt.md`: nova seção "This session is fully autonomous — never ask the user anything".

https://claude.ai/code/session_01JmXpY5esBxXvcPbrumfpBG

---
_Generated by [Claude Code](https://claude.ai/code/session_01JmXpY5esBxXvcPbrumfpBG)_