### PR TITLE
Follow-ups da RFC 0003 — cooldown de rascunho + auto-promoção com limiar

### DIFF
--- a/scripts/hronir/README.md
+++ b/scripts/hronir/README.md
@@ -79,9 +79,11 @@ init
              └─> continue  # gera match 2, imprime post A
                  ...
                  └─> continue  # após N matches, sessão entra em 'need_edit'
-                     └─> edit-worst   # mostra pior post + contexto, captura HEAD, marca posts
-                         └─> [edição manual em todas as traduções]
-                             └─> edit-commit --msg "..."  # grava previousVersion
+                     └─> draft-worst  # cria <slug>/v-<ts>.md (cópia da canônica); index.md intocada
+                         └─> [edição manual dos RASCUNHOS em todas as traduções]
+                             └─> draft-commit --msg "..."  # valida UUID novo, registra o competidor
+                                 └─> [duelos de versão no sampling decidem]
+                                     └─> promote --key <key>  # vencedora vira index.md (swap)
 ```
 
 A máquina de estados está em `hronir_session.json`: `ready_for_next → reading_a → reading_b → deciding → ready_for_next → … → need_edit → (sessão fechada)`.

--- a/scripts/hronir/lib/commands.js
+++ b/scripts/hronir/lib/commands.js
@@ -294,6 +294,12 @@ function randomMoodGlyph() {
 // sibling draft, so it's a no-op until draft-worst creates one.
 const VERSION_DUEL_PROB = 0.34;
 
+// RFC 0003 follow-up: auto-promotion threshold. `promote --key` only swaps a
+// challenger in when it leads the canonical by at least PROMOTE_MARGIN stars
+// over at least PROMOTE_MIN_DUELS version duels. `--force` bypasses both.
+const PROMOTE_MARGIN = 0.3;
+const PROMOTE_MIN_DUELS = 2;
+
 // Find an eligible canonical that has at least one sibling draft (v-*) and
 // return the duel sides (canonical vs the freshest draft) for that (key, lang).
 function pickVersionDuel(eligible) {
@@ -1283,14 +1289,17 @@ function getRecentlyEditedKeys(limit = 2) {
     const data = readPost(p);
     if (!data.translationKey) continue;
     let latest = 0;
-    const prev = data.previousVersion;
-    if (prev?.timestamp) {
-      latest = Date.parse(String(prev.timestamp)) || 0;
-    } else if (Array.isArray(data.editHistory)) {
-      for (const entry of data.editHistory) {
-        const t = entry?.timestamp ? Date.parse(String(entry.timestamp)) : 0;
-        if (t > latest) latest = t;
-      }
+    const consider = (ts) => {
+      const t = ts ? Date.parse(String(ts)) || 0 : 0;
+      if (t > latest) latest = t;
+    };
+    consider(data.previousVersion?.timestamp);
+    // RFC 0003: a recent draft (or one just promoted) also puts the key on
+    // cooldown, so draft-worst doesn't re-draft the same post every round.
+    consider(data.draftCommittedAt);
+    consider(data.draftCreatedAt);
+    if (Array.isArray(data.editHistory)) {
+      for (const entry of data.editHistory) consider(entry?.timestamp);
     }
     if (!latest) continue;
     const key = String(data.translationKey);
@@ -1352,10 +1361,14 @@ export function editWorst() {
   let worstRow = null;
   for (let i = eligible.length - 1; i >= 0; i--) {
     const row = eligible[i];
-    if (!recentlyEdited.includes(row.key)) {
-      worstRow = row;
-      break;
-    }
+    if (recentlyEdited.includes(row.key)) continue;
+    // RFC 0003: don't pile drafts — skip keys that already have a pending one.
+    const hasDraft = findTranslations(row.key).some((t) =>
+      listVersions(t.path).some((p) => !isCanonical(p))
+    );
+    if (hasDraft) continue;
+    worstRow = row;
+    break;
   }
 
   if (!worstRow) {
@@ -2093,9 +2106,11 @@ export function editCommit(msg) {
 export function promote(args) {
   let draftPath = null;
   let key = null;
+  let force = false;
   for (let i = 0; i < args.length; i++) {
     if (args[i] === "--draft") draftPath = args[++i];
     else if (args[i] === "--key") key = args[++i];
+    else if (args[i] === "--force") force = true;
   }
 
   if (draftPath) {
@@ -2133,7 +2148,12 @@ export function promote(args) {
     const scored = listVersions(t.path)
       .map((p) => {
         const vr = versionRatings.get(getPostUuid(p));
-        return { path: p, stars: vr ? vr.stars : null, n: vr ? vr.n : 0 };
+        return {
+          path: p,
+          canonical: isCanonical(p),
+          stars: vr ? vr.stars : null,
+          n: vr ? vr.n : 0,
+        };
       })
       .filter((v) => v.stars !== null);
     if (scored.length === 0) {
@@ -2144,14 +2164,23 @@ export function promote(args) {
     }
     scored.sort((a, b) => b.stars - a.stars);
     const best = scored[0];
-    if (isCanonical(best.path)) {
+    if (best.canonical) {
       console.log(
         `[promote] ${t.lang}: a canônica já é a melhor versão (${best.stars.toFixed(2)}★). Nada a fazer.`
       );
       continue;
     }
+    // Only auto-promote when the challenger clears a margin over enough duels.
+    const canonicalStars = scored.find((v) => v.canonical)?.stars ?? 0;
+    const margin = best.stars - canonicalStars;
+    if (!force && (best.n < PROMOTE_MIN_DUELS || margin < PROMOTE_MARGIN)) {
+      console.log(
+        `[promote] ${t.lang}: ${best.path} lidera por +${margin.toFixed(2)}★ em ${best.n} duelo(s) — abaixo do limiar (margem ≥${PROMOTE_MARGIN}, duelos ≥${PROMOTE_MIN_DUELS}). Use --force para promover assim mesmo.`
+      );
+      continue;
+    }
     console.log(
-      `[promote] ${t.lang}: promovendo ${best.path} (${best.stars.toFixed(2)}★, n=${best.n}).`
+      `[promote] ${t.lang}: promovendo ${best.path} (${best.stars.toFixed(2)}★ vs canônica ${canonicalStars.toFixed(2)}★, +${margin.toFixed(2)}, n=${best.n}).`
     );
     promoteFile(best.path);
     promoted++;


### PR DESCRIPTION
Refinamentos pós-merge da **RFC 0003** (#306, já na `main`). Dois ajustes de comportamento no Hrönir + uma atualização de doc.

## 1. Cooldown ciente de rascunhos
- `getRecentlyEditedKeys` agora também considera `draftCommittedAt`/`draftCreatedAt` — uma versão recém-draftada (ou recém-promovida) entra em cooldown, então o `draft-worst` não re-mira o mesmo post rodada após rodada.
- `draft-worst` **pula keys que já têm um rascunho pendente** (um `v-*` não-canônico já existe) — evita empilhar rascunhos do mesmo post.

## 2. Auto-promoção com limiar
- `promote --key` antes promovia a melhor versão sem exigir nada. Agora só troca a canônica quando o desafiante **lidera por ≥ `PROMOTE_MARGIN` (0.30★) em ≥ `PROMOTE_MIN_DUELS` (2) duelos de versão**.
- `--force` ignora o limiar (promoção explícita continua via `promote --draft <path>`).

## 3. README
- Diagrama de **Fluxo** atualizado para `draft-worst → draft-commit → duelos de versão → promote`. (O note de topo do README, vindo do #306, já marcava o fluxo novo e as seções legadas.)

## Verificação
`golden tests` **20/20** · `hronir:doctor` 0 · `ranking` ✓ · `prettier --check .` (repo) ✓. Testado: `promote --key` sem duelos pula corretamente (“sem dados de duelo”); o limiar barra promoção sem margem/volume; cleanup limpo.

## Deixado de fora (de propósito — decisão sua)
- **Publicar histórico de versões** em URLs versionadas (`/blog/<slug>/v/<uuid>`) + **UI de `supersedes`** (RFC §11.4/§11.6). Isso publica conteúdo e é uma decisão de produto/SEO — não quis construir unilateralmente. Se quiser, eu faço numa PR dedicada com a rota + `rel=canonical`.

https://claude.ai/code/session_018gtV4i3vs227iqExao5VAb

---
_Generated by [Claude Code](https://claude.ai/code/session_018gtV4i3vs227iqExao5VAb)_