### PR TITLE
URLs content-addressed para versões — /blog/&lt;slug&gt;/v/&lt;uuid&gt;

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -40,6 +40,9 @@ export default defineConfig({
   integrations: [
     mdx(),
     sitemap({
+      // RFC 0003: version pages (/blog/<slug>/v/<uuid>) are noindex archives —
+      // keep them out of the sitemap.
+      filter: (page) => !/\/v\/[0-9a-f-]{8,}\/?$/i.test(page),
       serialize(item) {
         const base = "https://franklinbaldo.github.io";
 

--- a/src/components/VersionBanner.astro
+++ b/src/components/VersionBanner.astro
@@ -1,0 +1,59 @@
+---
+// RFC 0003: shown atop an archived/version page (/blog/<slug>/v/<uuid>),
+// pointing readers back to the live canonical post.
+interface Props {
+  liveHref: string;
+  date?: Date;
+  lang?: string;
+  msg?: string;
+}
+const { liveHref, date, lang, msg } = Astro.props;
+const isPt = lang === "pt";
+const dateStr = date
+  ? date.toLocaleDateString(isPt ? "pt-BR" : "en-US", {
+      year: "numeric",
+      month: "long",
+      day: "numeric",
+    })
+  : null;
+---
+
+<aside class="version-banner" role="note">
+  <p>
+    <strong>{isPt ? "Versão arquivada" : "Archived version"}</strong>{
+      dateStr && <> · <time>{dateStr}</time></>
+    }. {
+      isPt
+        ? "Esta não é a versão atual do post."
+        : "This is not the current version of the post."
+    }
+    {msg && <span class="vb-msg">“{msg}”</span>}
+  </p>
+  <p>
+    <a href={liveHref} rel="bookmark"
+      >{isPt ? "Ler a versão atual" : "Read the current version"} →</a
+    >
+  </p>
+</aside>
+
+<style>
+  .version-banner {
+    border: 1px solid var(--pico-muted-border-color);
+    border-left: 3px solid var(--pico-primary);
+    background: var(--pico-card-background-color);
+    border-radius: var(--pico-border-radius);
+    padding: 0.75rem 1rem;
+    margin: 0 0 1.5rem;
+    font-size: 0.9rem;
+  }
+  .version-banner p {
+    margin: 0;
+  }
+  .version-banner p + p {
+    margin-top: 0.4rem;
+  }
+  .vb-msg {
+    color: var(--pico-muted-color);
+    font-style: italic;
+  }
+</style>

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -1,10 +1,65 @@
 import { defineCollection, z } from "astro:content";
 import { glob } from "astro/loaders";
 
+// Shared schema for canonical posts (blog) and their non-canonical versions
+// (blogVersions). RFC 0003: a version file is a frozen copy of a canonical, so
+// it satisfies the same shape plus a few draft-lifecycle markers.
+const postSchema = ({ image }: { image: () => z.ZodTypeAny }) =>
+  z.object({
+    title: z.string(),
+    description: z.string(),
+    date: z.coerce.date(),
+    draft: z.boolean().optional(),
+    publishDate: z.coerce.date().optional(),
+    tags: z.array(z.string()).optional(),
+    heroImage: image().optional(),
+    heroImageAlt: z.string().optional(),
+    lang: z.enum(["en", "pt"]).optional(),
+    author: z.string().optional(),
+    translationKey: z.string().optional(),
+    /** RFC 0003: content UUID of the version this one superseded when it was
+     *  promoted to canonical. Lineage lives in-repo as sibling version files. */
+    supersedes: z.string().optional(),
+    /** RFC 0003 draft-lifecycle markers (set by draft-worst / draft-commit). */
+    draftCreatedAt: z.string().optional(),
+    draftCommittedAt: z.string().optional(),
+    draftMsg: z.string().optional(),
+    series: z.string().optional(),
+    seriesOrder: z.number().optional(),
+    featured: z.boolean().optional(),
+    featuredReason: z.string().optional(),
+    /** Single emoji that represents the post — used to steer the AI
+     *  prompt for the social-card QR code and as the centerpiece in
+     *  the fallback plain QR. */
+    emoji: z.string().optional(),
+    /** Legacy linked-list pointer to the immediately previous version (a
+     *  GitHub permalink). Superseded by RFC 0003 in-repo versions, but kept
+     *  for posts edited under the old flow. */
+    previousVersion: z
+      .object({
+        uuid: z.string(),
+        url: z.string().url(),
+        timestamp: z.string(),
+        msg: z.string(),
+      })
+      .optional(),
+    /** When "music", the post is a music publication with lyrics and
+     *  composer notes. Triggers the music post layout. */
+    postType: z.literal("music").optional(),
+    /** Suno song UUID — used to load audio in the global player. */
+    sunoId: z.string().optional(),
+    /** Music genres/styles for display. */
+    genre: z.array(z.string()).optional(),
+    /** Song duration in seconds. */
+    duration: z.number().optional(),
+    /** Album art URL from the Suno API (stored at stub-generation time). */
+    sunoImageUrl: z.string().url().optional(),
+  });
+
 const blog = defineCollection({
   // RFC 0003: each post lives in its own folder <slug>/, where the canonical
   // (published) version is index.md(x). Non-canonical versions are sibling
-  // files (v-<timestamp>.md) that don't match this glob → invisible to Astro.
+  // files (v-<timestamp>.md) that don't match this glob → invisible here.
   // generateId strips the trailing /index so the id stays the flat slug,
   // preserving every existing URL.
   loader: glob({
@@ -12,55 +67,19 @@ const blog = defineCollection({
     base: "./src/content/blog",
     generateId: ({ entry }) => entry.replace(/\/index\.mdx?$/, ""),
   }),
-  schema: ({ image }) =>
-    z.object({
-      title: z.string(),
-      description: z.string(),
-      date: z.coerce.date(),
-      draft: z.boolean().optional(),
-      publishDate: z.coerce.date().optional(),
-      tags: z.array(z.string()).optional(),
-      heroImage: image().optional(),
-      heroImageAlt: z.string().optional(),
-      lang: z.enum(["en", "pt"]).optional(),
-      author: z.string().optional(),
-      translationKey: z.string().optional(),
-      /** RFC 0003: content UUID of the version this one superseded when it was
-       *  promoted to canonical. Lineage lives in-repo as sibling version files. */
-      supersedes: z.string().optional(),
-      series: z.string().optional(),
-      seriesOrder: z.number().optional(),
-      featured: z.boolean().optional(),
-      featuredReason: z.string().optional(),
-      /** Single emoji that represents the post — used to steer the AI
-       *  prompt for the social-card QR code and as the centerpiece in
-       *  the fallback plain QR. */
-      emoji: z.string().optional(),
-      /** Linked-list pointer to the immediately previous version of this
-       *  post. `url` is a GitHub permalink to the file at the commit
-       *  before this edit landed; following it shows the prior version,
-       *  which itself carries its own `previousVersion` pointer (and so
-       *  on until the original commit). Set by `npm run hronir:edit-commit`. */
-      previousVersion: z
-        .object({
-          uuid: z.string(),
-          url: z.string().url(),
-          timestamp: z.string(),
-          msg: z.string(),
-        })
-        .optional(),
-      /** When "music", the post is a music publication with lyrics and
-       *  composer notes. Triggers the music post layout. */
-      postType: z.literal("music").optional(),
-      /** Suno song UUID — used to load audio in the global player. */
-      sunoId: z.string().optional(),
-      /** Music genres/styles for display. */
-      genre: z.array(z.string()).optional(),
-      /** Song duration in seconds. */
-      duration: z.number().optional(),
-      /** Album art URL from the Suno API (stored at stub-generation time). */
-      sunoImageUrl: z.string().url().optional(),
-    }),
+  schema: postSchema,
 });
 
-export const collections = { blog };
+// RFC 0003: the non-canonical versions of every post (drafts + superseded
+// canonicals). Served at /blog/<slug>/v/<uuid> (noindex, canonical → live).
+// The id keeps the folder path so the post slug = dirname(id).
+const blogVersions = defineCollection({
+  loader: glob({
+    pattern: "**/v-*.{md,mdx}",
+    base: "./src/content/blog",
+    generateId: ({ entry }) => entry.replace(/\.mdx?$/, ""),
+  }),
+  schema: postSchema,
+});
+
+export const collections = { blog, blogVersions };

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -1,10 +1,10 @@
-import { defineCollection, z } from "astro:content";
+import { defineCollection, z, type SchemaContext } from "astro:content";
 import { glob } from "astro/loaders";
 
 // Shared schema for canonical posts (blog) and their non-canonical versions
 // (blogVersions). RFC 0003: a version file is a frozen copy of a canonical, so
 // it satisfies the same shape plus a few draft-lifecycle markers.
-const postSchema = ({ image }: { image: () => z.ZodTypeAny }) =>
+const postSchema = ({ image }: SchemaContext) =>
   z.object({
     title: z.string(),
     description: z.string(),

--- a/src/layouts/PageLayout.astro
+++ b/src/layouts/PageLayout.astro
@@ -19,6 +19,11 @@ interface Props {
   translations?: Record<string, string>;
   hasMath?: boolean;
   wordCount?: number;
+  /** Override <link rel=canonical> (e.g. a version page pointing at the live
+   *  post). Defaults to the current page URL. */
+  canonicalOverride?: string;
+  /** Emit robots noindex,follow — for archive/version pages. */
+  noindex?: boolean;
 }
 
 const SITE_NAME = "Franklin Baldo";
@@ -37,6 +42,8 @@ const {
   translations = {},
   hasMath,
   wordCount,
+  canonicalOverride,
+  noindex,
 } = source;
 // Language-aware fallback description: derive lang first so PT pages without
 // an explicit description don't fall back to the English copy.
@@ -48,7 +55,7 @@ const description =
 
 const documentTitle = title.includes(SITE_NAME) ? title : `${title} | ${SITE_NAME}`;
 
-const canonical = new URL(Astro.url.pathname, Astro.site);
+const canonical = new URL(canonicalOverride ?? Astro.url.pathname, Astro.site);
 const DEFAULT_OG_IMAGE = lang === "pt" ? "/og/home-pt.png" : "/og/home.png";
 const ogImageRaw = image ?? DEFAULT_OG_IMAGE;
 const ogImage = Astro.site ? new URL(ogImageRaw, Astro.site).href : ogImageRaw;
@@ -141,7 +148,7 @@ const personLd = {
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>{documentTitle}</title>
     <meta name="description" content={description} />
-    <meta name="robots" content="max-image-preview:large, max-snippet:-1, max-video-preview:-1" />
+    <meta name="robots" content={noindex ? "noindex, follow" : "max-image-preview:large, max-snippet:-1, max-video-preview:-1"} />
     <meta name="author" content="Franklin Baldo" />
     {type === 'article' && tags?.[0] && <meta property="article:section" content={tags[0]} />}
     {type === 'article' && <link rel="author" href={Astro.site ? new URL(lang === 'pt' ? '/pt/about/' : '/about/', Astro.site).href : '/about/'} />}

--- a/src/lib/versions.mjs
+++ b/src/lib/versions.mjs
@@ -1,0 +1,45 @@
+// Bridges the site build to the Hrönir content-UUID so /blog/<slug>/v/<uuid>
+// uses the same identity as the ranking and `supersedes` (RFC 0003). RFC 0005
+// will fold the Hrönir lib into TS; until then this .mjs avoids a JS↔TS gap.
+import { existsSync } from "node:fs";
+import { getPostUuid } from "../../scripts/hronir/lib/posts.js";
+
+const BLOG_DIR = "src/content/blog";
+
+/** Slug of the post a content entry belongs to. A canonical entry id is
+ *  "<slug>"; a version entry id is "<slug>/v-<timestamp>". */
+export function slugOf(id) {
+  return id.split("/")[0];
+}
+
+/** Resolve the on-disk file for a content id, trying .md then .mdx. We derive
+ *  it from the id (always present) rather than entry.filePath, which Astro
+ *  leaves undefined on canonical entries when the sibling versions collection
+ *  is empty. Canonical id "<slug>" → <slug>/index.*; version id
+ *  "<slug>/v-<ts>" → <slug>/v-<ts>.*. */
+export function fileForId(id) {
+  const rel = id.includes("/") ? id : `${id}/index`;
+  for (const ext of [".md", ".mdx"]) {
+    const p = `${BLOG_DIR}/${rel}${ext}`;
+    if (existsSync(p)) return p;
+  }
+  return null;
+}
+
+/** Content UUID (UUIDv5 of the normalized body) for a content entry id. */
+export function uuidForId(id) {
+  const p = fileForId(id);
+  return p ? getPostUuid(p) : null;
+}
+
+/** Public URL of the live (canonical) post in the given language. */
+export function liveHref(slug, lang) {
+  return lang === "pt" ? `/pt/blog/${slug}/` : `/blog/${slug}/`;
+}
+
+/** Public URL of a specific version (content-addressed, RFC 0003). */
+export function versionHref(slug, uuid, lang) {
+  return lang === "pt"
+    ? `/pt/blog/${slug}/v/${uuid}/`
+    : `/blog/${slug}/v/${uuid}/`;
+}

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -11,6 +11,7 @@ import TableOfContents from '../../components/TableOfContents.astro';
 import RelatedPosts from '../../components/RelatedPosts.astro';
 import AuthorBio from '../../components/AuthorBio.astro';
 import { getRankByKey } from '../../lib/hronir-rank';
+import { uuidForId, versionHref } from '../../lib/versions.mjs';
 import HronirReviews from '../../components/HronirReviews.astro';
 import Comments from '../../components/Comments.astro';
 import SeriesContext from '../../components/SeriesContext.astro';
@@ -53,6 +54,22 @@ const dateOpts = { year: 'numeric', month: 'long', day: 'numeric' } as const;
 const tagsPrefix = `${urlPrefix(lang)}/tags`;
 
 const allPosts = await getCollection('blog');
+// RFC 0003: archived versions of this post, newest first → /blog/<slug>/v/<uuid>.
+const allVersions = await getCollection('blogVersions');
+const postVersions = allVersions
+  .filter((v) => v.id.split('/')[0] === post.id)
+  .map((v) => {
+    const uuid = uuidForId(v.id);
+    return uuid
+      ? {
+          href: versionHref(post.id, uuid, postLang),
+          date: v.data.draftCommittedAt ? new Date(v.data.draftCommittedAt) : v.data.date,
+          msg: v.data.draftMsg,
+        }
+      : null;
+  })
+  .filter((v) => v != null)
+  .sort((a, b) => b.date.valueOf() - a.date.valueOf());
 const sameLangPosts = allPosts
   .filter((p) => isPublished(p) && (p.data.lang ?? DEFAULT_LANG) === postLang)
   .sort((a, b) => a.data.date.valueOf() - b.data.date.valueOf());
@@ -214,6 +231,21 @@ const translationLinks = translationSiblings.map((p) => {
                 <>{i > 0 && ' · '}<a href={link.href}>{link.label}</a></>
               ))}
             </small></p>
+          )}
+          {postVersions.length > 0 && (
+            <details class="version-history">
+              <summary>{postLang === 'pt' ? `Histórico de versões (${postVersions.length})` : `Version history (${postVersions.length})`}</summary>
+              <ul>
+                {postVersions.map((v) => (
+                  <li>
+                    <a href={v.href} rel="nofollow">
+                      <time datetime={v.date.toISOString()}>{v.date.toLocaleDateString(locale, dateOpts)}</time>
+                    </a>
+                    {v.msg && <> — <span class="prev-msg">{v.msg}</span></>}
+                  </li>
+                ))}
+              </ul>
+            </details>
           )}
           {previousVersion && (
             <p><small>

--- a/src/pages/blog/[slug]/v/[uuid].astro
+++ b/src/pages/blog/[slug]/v/[uuid].astro
@@ -1,0 +1,109 @@
+---
+import { type CollectionEntry, getCollection, render } from "astro:content";
+import PageLayout from "../../../../layouts/PageLayout.astro";
+import VersionBanner from "../../../../components/VersionBanner.astro";
+import BackToTop from "../../../../components/BackToTop.astro";
+import { uuidForId, slugOf } from "../../../../lib/versions.mjs";
+
+// RFC 0003: content-addressed version pages. Every non-canonical version file
+// (drafts + superseded canonicals) gets /blog/<slug>/v/<uuid>. A UUID that is
+// *currently* the live canonical redirects to /blog/<slug> so permalinks stay
+// stable across promotion. All version pages are noindex with canonical → live.
+export async function getStaticPaths() {
+  const [versions, canon] = await Promise.all([
+    getCollection("blogVersions"),
+    getCollection("blog"),
+  ]);
+  const paths = [];
+  for (const v of versions) {
+    if ((v.data.lang ?? "en") === "pt") continue;
+    const uuid = uuidForId(v.id);
+    if (!uuid) continue; // file gone / unresolved → skip rather than crash
+    paths.push({
+      params: { slug: slugOf(v.id), uuid },
+      props: { entry: v, redirect: false },
+    });
+  }
+  for (const c of canon) {
+    if ((c.data.lang ?? "en") === "pt") continue;
+    // Only promoted canonicals need a /v/<live-uuid> permalink (their content
+    // was once a draft that may have been linked); skip the rest to avoid bloat.
+    if (!c.data.supersedes) continue;
+    const uuid = uuidForId(c.id);
+    if (!uuid) continue;
+    paths.push({
+      params: { slug: c.id, uuid },
+      props: { entry: c, redirect: true },
+    });
+  }
+  return paths;
+}
+
+type Props = { entry: CollectionEntry<"blogVersions">; redirect: boolean };
+const { entry, redirect } = Astro.props;
+const slug = slugOf(entry.id);
+const live = `/blog/${slug}/`;
+if (redirect) return Astro.redirect(live);
+
+const { title, lang, draftCommittedAt, draftMsg, date } = entry.data;
+const verDate = draftCommittedAt ? new Date(draftCommittedAt) : date;
+const { Content } = await render(entry);
+---
+
+<PageLayout
+  title={`${title} — versão arquivada`}
+  description={entry.data.description}
+  type="article"
+  lang={lang}
+  canonicalOverride={live}
+  noindex={true}
+>
+  <div class="post-grid">
+    <div class="post-body">
+      <nav aria-label="Breadcrumb" class="post-breadcrumb">
+        <ol>
+          <li><a href="/">Home</a></li>
+          <li><a href="/archive/">Archive</a></li>
+          <li><a href={live}>{title}</a></li>
+          <li aria-current="page">versão arquivada</li>
+        </ol>
+      </nav>
+
+      <VersionBanner liveHref={live} date={verDate} lang={lang} msg={draftMsg} />
+
+      <article data-pagefind-ignore lang={lang ?? "en"}>
+        <header><h1>{title}</h1></header>
+        <Content />
+      </article>
+
+      <BackToTop />
+    </div>
+  </div>
+</PageLayout>
+
+<style>
+  .post-breadcrumb {
+    margin-bottom: calc(var(--pico-spacing) * 0.75);
+  }
+  .post-breadcrumb ol {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-wrap: wrap;
+    font-size: 0.8rem;
+    color: var(--pico-muted-color);
+  }
+  .post-breadcrumb li + li::before {
+    content: " / ";
+    padding: 0 0.35em;
+    color: var(--pico-muted-color);
+  }
+  .post-breadcrumb a {
+    color: var(--pico-muted-color);
+    text-decoration: none;
+  }
+  .post-breadcrumb [aria-current="page"] {
+    color: var(--pico-color);
+  }
+</style>

--- a/src/pages/pt/blog/[...slug].astro
+++ b/src/pages/pt/blog/[...slug].astro
@@ -11,6 +11,7 @@ import TableOfContents from '../../../components/TableOfContents.astro';
 import RelatedPosts from '../../../components/RelatedPosts.astro';
 import AuthorBio from '../../../components/AuthorBio.astro';
 import { getRankByKey } from '../../../lib/hronir-rank';
+import { uuidForId, versionHref } from '../../../lib/versions.mjs';
 import Comments from '../../../components/Comments.astro';
 import SeriesContext from '../../../components/SeriesContext.astro';
 import PostActionBar from '../../../components/PostActionBar.astro';
@@ -54,6 +55,22 @@ const allPosts = await getCollection('blog');
 
 // Prev / next posts in the same language, ordered by date ascending.
 const postLang = lang ?? DEFAULT_LANG;
+// RFC 0003: archived versions of this post, newest first → /pt/blog/<slug>/v/<uuid>.
+const allVersions = await getCollection('blogVersions');
+const postVersions = allVersions
+  .filter((v) => v.id.split('/')[0] === post.id)
+  .map((v) => {
+    const uuid = uuidForId(v.id);
+    return uuid
+      ? {
+          href: versionHref(post.id, uuid, postLang),
+          date: v.data.draftCommittedAt ? new Date(v.data.draftCommittedAt) : v.data.date,
+          msg: v.data.draftMsg,
+        }
+      : null;
+  })
+  .filter((v) => v != null)
+  .sort((a, b) => b.date.valueOf() - a.date.valueOf());
 const sameLangPosts = allPosts
   .filter((p) => isPublished(p) && (p.data.lang ?? DEFAULT_LANG) === postLang)
   .sort((a, b) => a.data.date.valueOf() - b.data.date.valueOf());
@@ -215,6 +232,21 @@ const translationLinks = translationSiblings.map((p) => {
                 <>{i > 0 && ' · '}<a href={link.href}>{link.label}</a></>
               ))}
             </small></p>
+          )}
+          {postVersions.length > 0 && (
+            <details class="version-history">
+              <summary>{postLang === 'pt' ? `Histórico de versões (${postVersions.length})` : `Version history (${postVersions.length})`}</summary>
+              <ul>
+                {postVersions.map((v) => (
+                  <li>
+                    <a href={v.href} rel="nofollow">
+                      <time datetime={v.date.toISOString()}>{v.date.toLocaleDateString(locale, dateOpts)}</time>
+                    </a>
+                    {v.msg && <> — <span class="prev-msg">{v.msg}</span></>}
+                  </li>
+                ))}
+              </ul>
+            </details>
           )}
           {previousVersion && (
             <p><small>

--- a/src/pages/pt/blog/[slug]/v/[uuid].astro
+++ b/src/pages/pt/blog/[slug]/v/[uuid].astro
@@ -1,0 +1,107 @@
+---
+import { type CollectionEntry, getCollection, render } from "astro:content";
+import PageLayout from "../../../../../layouts/PageLayout.astro";
+import VersionBanner from "../../../../../components/VersionBanner.astro";
+import BackToTop from "../../../../../components/BackToTop.astro";
+import { uuidForId, slugOf } from "../../../../../lib/versions.mjs";
+
+// RFC 0003: PT mirror of the version route. Every PT version file gets
+// /pt/blog/<slug>/v/<uuid>; the live PT canonical's UUID redirects to
+// /pt/blog/<slug>. noindex with canonical → the live PT post.
+export async function getStaticPaths() {
+  const [versions, canon] = await Promise.all([
+    getCollection("blogVersions"),
+    getCollection("blog"),
+  ]);
+  const paths = [];
+  for (const v of versions) {
+    if (v.data.lang !== "pt") continue;
+    const uuid = uuidForId(v.id);
+    if (!uuid) continue; // file gone / unresolved → skip rather than crash
+    paths.push({
+      params: { slug: slugOf(v.id), uuid },
+      props: { entry: v, redirect: false },
+    });
+  }
+  for (const c of canon) {
+    if (c.data.lang !== "pt") continue;
+    // Only promoted canonicals need a /v/<live-uuid> permalink.
+    if (!c.data.supersedes) continue;
+    const uuid = uuidForId(c.id);
+    if (!uuid) continue;
+    paths.push({
+      params: { slug: c.id, uuid },
+      props: { entry: c, redirect: true },
+    });
+  }
+  return paths;
+}
+
+type Props = { entry: CollectionEntry<"blogVersions">; redirect: boolean };
+const { entry, redirect } = Astro.props;
+const slug = slugOf(entry.id);
+const live = `/pt/blog/${slug}/`;
+if (redirect) return Astro.redirect(live);
+
+const { title, draftCommittedAt, draftMsg, date } = entry.data;
+const verDate = draftCommittedAt ? new Date(draftCommittedAt) : date;
+const { Content } = await render(entry);
+---
+
+<PageLayout
+  title={`${title} — versão arquivada`}
+  description={entry.data.description}
+  type="article"
+  lang="pt"
+  canonicalOverride={live}
+  noindex={true}
+>
+  <div class="post-grid">
+    <div class="post-body">
+      <nav aria-label="Navegação" class="post-breadcrumb">
+        <ol>
+          <li><a href="/pt/">Início</a></li>
+          <li><a href="/pt/archive/">Arquivo</a></li>
+          <li><a href={live}>{title}</a></li>
+          <li aria-current="page">versão arquivada</li>
+        </ol>
+      </nav>
+
+      <VersionBanner liveHref={live} date={verDate} lang="pt" msg={draftMsg} />
+
+      <article data-pagefind-ignore lang="pt">
+        <header><h1>{title}</h1></header>
+        <Content />
+      </article>
+
+      <BackToTop />
+    </div>
+  </div>
+</PageLayout>
+
+<style>
+  .post-breadcrumb {
+    margin-bottom: calc(var(--pico-spacing) * 0.75);
+  }
+  .post-breadcrumb ol {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-wrap: wrap;
+    font-size: 0.8rem;
+    color: var(--pico-muted-color);
+  }
+  .post-breadcrumb li + li::before {
+    content: " / ";
+    padding: 0 0.35em;
+    color: var(--pico-muted-color);
+  }
+  .post-breadcrumb a {
+    color: var(--pico-muted-color);
+    text-decoration: none;
+  }
+  .post-breadcrumb [aria-current="page"] {
+    color: var(--pico-color);
+  }
+</style>


### PR DESCRIPTION
Cada versão de post (rascunhos + canônicas arquivadas, RFC 0003) passa a ter uma URL. Você decidiu o formato: **content-addressed por UUID**.

## Formato

```
/blog/<slug>/v/<uuid>          (en)
/pt/blog/<slug>/v/<uuid>       (pt)
```

O `<uuid>` é o `getPostUuid` — o **mesmo identificador interno** que o ranking e o `supersedes` já usam. Por ser content-addressed, o permalink **sobrevive a tudo** (promoção, rename, reordenação): aponta sempre pra aquele conteúdo exato.

## O que entra

- **Coleção `blogVersions`** (globa `**/v-*.{md,mdx}`) + **rotas en/pt** `/blog/<slug>/v/<uuid>`.
- **SEO:** cada página de versão leva `robots: noindex,follow` + `<link rel=canonical>` → post vivo + um **banner** "versão arquivada → ler a atual". E o **sitemap exclui** `/v/<uuid>`.
- **Estabilidade de permalink:** o UUID da canônica viva **redireciona** pra `/blog/<slug>` — mas só para canônicas **promovidas** (`supersedes` setado), pra não gerar 200+ stubs à toa.
- **Histórico no post:** rodapé "Histórico de versões / Version history" lista os `/v/<uuid>` daquele slug (substitui a UI legada de `previousVersion`, mantida como fallback).
- `PageLayout` ganhou props `canonicalOverride` + `noindex`; `src/lib/versions.mjs` faz a ponte pro `getPostUuid`.

## Robustez

Resolve o arquivo pelo **id** (não por `entry.filePath`, que o Astro deixa `undefined` em certos casos), e o `getStaticPaths` **pula entradas sem uuid** — então cache stale / arquivo removido não derruba o build. Build verde com coleção **vazia** e **com versões**.

## Verificação

`build` (vazio + com versões) · `check:hygiene/links/translations` · `hronir:doctor` 0 · golden **20/20** · `prettier --check .` (repo) — todos verdes. Testado e2e: página de versão (noindex+canonical+banner), histórico no post (en+pt), redirect do uuid vivo, sitemap sem `/v/`.

## Decisão registrada

Esquema **C (UUID)** dos três que apresentei (inteiro `/v2`, data, UUID). UUID venceu por estabilidade content-addressed; o UUID já era a identidade interna, então a URL só expõe o que já existe.

https://claude.ai/code/session_018gtV4i3vs227iqExao5VAb

---
_Generated by [Claude Code](https://claude.ai/code/session_018gtV4i3vs227iqExao5VAb)_