### PR TITLE
feat(rfc-0003): Fase 3 — promote --all e prune

### DIFF
--- a/docs/rfcs/0003-hronir-versoes-lado-a-lado-e-torneio.md
+++ b/docs/rfcs/0003-hronir-versoes-lado-a-lado-e-torneio.md
@@ -2,7 +2,7 @@
 
 |                 |                                                                                                                                                                                                                                                                                                                                                                                                        |
 | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| **Status**      | Implemented (Fases 0–2)                                                                                                                                                                                                                                                                                                                                                                                |
+| **Status**      | Implemented (Fases 0–3)                                                                                                                                                                                                                                                                                                                                                                                |
 | **Autor**       | Franklin Baldo (proposta assistida)                                                                                                                                                                                                                                                                                                                                                                    |
 | **Criado em**   | 2026-06-09                                                                                                                                                                                                                                                                                                                                                                                             |
 | **Branch / PR** | `claude/nifty-wright-z96lj3`                                                                                                                                                                                                                                                                                                                                                                           |
@@ -475,3 +475,8 @@ Merge com **merge commit** (não squash), conforme `CLAUDE.md`.
   comando `promote` (swap com `supersedes`; `supersedes` entra no schema zod).
   Aliases `edit-worst`/`edit-commit` mantidos. Verde: build, doctor, golden
   20/20, check:links/translations/hygiene.
+- **r5** (2026-06-10): **Fase 3 implementada**. `promote --all` varre todas as
+  chaves canonicais e auto-promove as que cruzaram o limiar (margem ≥0.3★,
+  n≥2 duelos). `prune [--dry-run]` remove versões que perderam para a canônica
+  por ≥0.5★ em ≥3 duelos. `npm run hronir:prune` adicionado ao `package.json`.
+  RFC 0003 status atualizado para "Implemented (Fases 0–3)".

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "hronir:draft-worst": "node --import tsx/esm scripts/hronir/index.js draft-worst",
     "hronir:draft-commit": "node --import tsx/esm scripts/hronir/index.js draft-commit",
     "hronir:promote": "node --import tsx/esm scripts/hronir/index.js promote",
+    "hronir:prune": "node --import tsx/esm scripts/hronir/index.js prune",
     "hronir:end": "node --import tsx/esm scripts/hronir/index.js end",
     "hronir:migrate": "node --import tsx/esm scripts/hronir/index.js migrate",
     "hronir:doctor": "node --import tsx/esm scripts/hronir/index.js doctor",

--- a/scripts/hronir/index.js
+++ b/scripts/hronir/index.js
@@ -37,6 +37,7 @@ const {
   end,
   editCommit,
   promote,
+  prune,
   next,
 } = await import("../../src/hronir/commands.js");
 
@@ -44,7 +45,7 @@ const [, , cmd, ...args] = process.argv;
 
 function usage() {
   console.error(
-    "Uso: hronir {next --agent-id <id> [init-opts]|init --agent-id <id> [--matches N] [--skip-edit] [--skip-rating] [--eval-lang <lang>] [--min-appearances N]|continue|decide --after-mood <text> --rate-a <1.00-5.00> --rate-b <1.00-5.00> --review-a <text> --review-b <text> --clash <text>|ranking|worst [--absolute]|diagnose|edit-worst|edit-commit --msg <text>|migrate [--dry-run]|doctor|end [--skip-edit] [--force]}"
+    "Uso: hronir {next --agent-id <id> [init-opts]|init --agent-id <id> [--matches N] [--skip-edit] [--skip-rating] [--eval-lang <lang>] [--min-appearances N]|continue|decide --after-mood <text> --rate-a <1.00-5.00> --rate-b <1.00-5.00> --review-a <text> --review-b <text> --clash <text>|ranking|worst [--absolute]|diagnose|edit-worst|edit-commit --msg <text>|migrate [--dry-run]|doctor|end [--skip-edit] [--force]|promote --draft <path>|--key <key>|--all [--force]|prune [--dry-run]}"
   );
   process.exit(1);
 }
@@ -188,6 +189,9 @@ switch (cmd) {
   }
   case "promote":
     promote(args);
+    break;
+  case "prune":
+    prune({ dryRun: args.includes("--dry-run") });
     break;
   case "migrate":
     migrate({ dryRun: args.includes("--dry-run") });

--- a/src/hronir/commands.ts
+++ b/src/hronir/commands.ts
@@ -2157,10 +2157,30 @@ export function promote(args: string[]) {
   let draftPath = null;
   let key = null;
   let force = false;
+  let all = false;
   for (let i = 0; i < args.length; i++) {
     if (args[i] === "--draft") draftPath = args[++i];
     else if (args[i] === "--key") key = args[++i];
     else if (args[i] === "--force") force = true;
+    else if (args[i] === "--all") all = true;
+  }
+
+  if (all) {
+    // Scan every canonical and attempt auto-promotion for each key.
+    const keys = new Set<string>();
+    for (const p of listPosts()) {
+      if (isCanonical(p)) keys.add(keyForPath(p));
+    }
+    let totalPromoted = 0;
+    for (const k of keys) {
+      totalPromoted += _promoteByKey(k, force);
+    }
+    nextStep(
+      totalPromoted > 0
+        ? `${totalPromoted} versão(ões) promovida(s). Revise o diff e commite.`
+        : "Nenhuma promoção: sem duelos de versão suficientes ou as canônicas já lideram."
+    );
+    return;
   }
 
   if (draftPath) {
@@ -2181,18 +2201,29 @@ export function promote(args: string[]) {
 
   if (!key) {
     console.error(
-      "Erro: informe `--draft <caminho>` (promoção explícita) ou `--key <translationKey>` (melhor versão por duelos)."
+      "Erro: informe `--draft <caminho>`, `--key <translationKey>`, ou `--all` (varre todas as chaves)."
     );
     process.exit(1);
   }
 
-  const versionRatings = computeVersionRatings();
   const translations = findTranslations(key);
   if (translations.length === 0) {
     console.error(`Erro: nenhuma canônica encontrada para a chave "${key}".`);
     process.exit(1);
   }
 
+  const promoted = _promoteByKey(key, force);
+  nextStep(
+    promoted > 0
+      ? `${promoted} versão(ões) promovida(s). Revise o diff e commite.`
+      : "Nenhuma promoção: sem duelos de versão suficientes ou a canônica já lidera. Use `--draft <caminho>` para promover manualmente."
+  );
+}
+
+// Returns the count of versions promoted for a given translationKey.
+function _promoteByKey(key: string, force: boolean): number {
+  const versionRatings = computeVersionRatings();
+  const translations = findTranslations(key);
   let promoted = 0;
   for (const t of translations) {
     const scored = listVersions(t.path)
@@ -2208,9 +2239,6 @@ export function promote(args: string[]) {
       })
       .filter((v) => v.stars !== null);
     if (scored.length === 0) {
-      console.log(
-        `[promote] ${t.lang}: sem dados de duelo de versão — pulando (use --draft).`
-      );
       continue;
     }
     const scoredRated = scored as Array<{
@@ -2222,17 +2250,13 @@ export function promote(args: string[]) {
     scoredRated.sort((a, b) => b.stars - a.stars);
     const best = scoredRated[0];
     if (best.canonical) {
-      console.log(
-        `[promote] ${t.lang}: a canônica já é a melhor versão (${best.stars.toFixed(2)}★). Nada a fazer.`
-      );
       continue;
     }
-    // Only auto-promote when the challenger clears a margin over enough duels.
     const canonicalStars = scoredRated.find((v) => v.canonical)?.stars ?? 0;
     const margin = best.stars - canonicalStars;
     if (!force && (best.n < PROMOTE_MIN_DUELS || margin < PROMOTE_MARGIN)) {
       console.log(
-        `[promote] ${t.lang}: ${best.path} lidera por +${margin.toFixed(2)}★ em ${best.n} duelo(s) — abaixo do limiar (margem ≥${PROMOTE_MARGIN}, duelos ≥${PROMOTE_MIN_DUELS}). Use --force para promover assim mesmo.`
+        `[promote] ${t.lang}: ${best.path} lidera por +${margin.toFixed(2)}★ em ${best.n} duelo(s) — abaixo do limiar (margem ≥${PROMOTE_MARGIN}, duelos ≥${PROMOTE_MIN_DUELS}).`
       );
       continue;
     }
@@ -2242,12 +2266,80 @@ export function promote(args: string[]) {
     promoteFile(best.path);
     promoted++;
   }
+  return promoted;
+}
 
-  nextStep(
-    promoted > 0
-      ? `${promoted} versão(ões) promovida(s). Revise o diff e commite.`
-      : "Nenhuma promoção: sem duelos de versão suficientes ou a canônica já lidera. Use `--draft <caminho>` para promover manualmente."
-  );
+// RFC 0003 Fase 3: prune versions that have clearly lost to the canonical.
+// A version is eligible when the canonical leads it by at least PRUNE_MARGIN
+// stars over at least PRUNE_MIN_DUELS version duels.
+const PRUNE_MARGIN = 0.5;
+const PRUNE_MIN_DUELS = 3;
+
+export function prune({ dryRun = false } = {}) {
+  const versionRatings = computeVersionRatings();
+  const toDelete: Array<{
+    path: string;
+    versionStars: number;
+    canonicalStars: number;
+    margin: number;
+    n: number;
+  }> = [];
+
+  for (const p of listPosts()) {
+    if (isCanonical(p)) continue;
+    const dir = path.dirname(p);
+    const indexMd = path.join(dir, "index.md");
+    const indexMdx = path.join(dir, "index.mdx");
+    const canonicalPath = fs.existsSync(indexMd)
+      ? indexMd
+      : fs.existsSync(indexMdx)
+        ? indexMdx
+        : null;
+    if (!canonicalPath) continue;
+
+    const versionUuid = getPostUuid(p);
+    const canonicalUuid = getPostUuid(canonicalPath);
+    if (!versionUuid || !canonicalUuid) continue;
+
+    const vr = versionRatings.get(versionUuid);
+    const cr = versionRatings.get(canonicalUuid);
+    if (!vr || !cr) continue;
+
+    const margin = cr.stars - vr.stars;
+    if (vr.n >= PRUNE_MIN_DUELS && margin >= PRUNE_MARGIN) {
+      toDelete.push({
+        path: p,
+        versionStars: vr.stars,
+        canonicalStars: cr.stars,
+        margin,
+        n: vr.n,
+      });
+    }
+  }
+
+  if (toDelete.length === 0) {
+    console.log("prune: nenhuma versão elegível para poda.");
+    return;
+  }
+
+  for (const item of toDelete) {
+    if (dryRun) {
+      console.log(
+        `[prune dry-run] ${item.path} (versão ${item.versionStars.toFixed(2)}★ vs canônica ${item.canonicalStars.toFixed(2)}★, -${item.margin.toFixed(2)}, n=${item.n})`
+      );
+    } else {
+      fs.unlinkSync(item.path);
+      console.log(
+        `[prune] removido ${item.path} (${item.versionStars.toFixed(2)}★ vs canônica ${item.canonicalStars.toFixed(2)}★, -${item.margin.toFixed(2)}, n=${item.n})`
+      );
+    }
+  }
+
+  const label = dryRun ? "dry-run" : "removida(s)";
+  console.log(`\nprune: ${toDelete.length} versão(ões) ${label}.`);
+  if (dryRun) {
+    console.log("Rode sem --dry-run para remover.");
+  }
 }
 
 function promoteFile(draftPath: string) {


### PR DESCRIPTION
## Resumo

Implementa a Fase 3 da [RFC 0003](docs/rfcs/0003-hronir-versoes-lado-a-lado-e-torneio.md) — os dois itens que faltavam após as Fases 0–2.

### `promote --all` (auto-promoção)

Varre todas as chaves canonicais e auto-promove versões que cruzaram o limiar:
- margem ≥ 0.3★ sobre a canônica
- n ≥ 2 duelos de versão registrados

Elimina a necessidade de chamar `promote --key <key>` manualmente para cada post. Internamente extrai `_promoteByKey(key, force)` como helper compartilhado entre `--key` e `--all`.

### `prune [--dry-run]` (poda de versões perdedoras)

Remove versões que claramente perderam para a canônica:
- canônica lidera por ≥ 0.5★ (PRUNE_MARGIN)
- sobre ≥ 3 duelos de versão (PRUNE_MIN_DUELS)

`--dry-run` lista as versões que seriam removidas sem deletar nada.

## Verificações

- [x] `npm run hronir:prune -- --dry-run` — executa sem erro
- [x] `npm run hronir:promote -- --all --force` — executa sem erro
- [x] `npm test` — 20/20 testes passando
- [x] `npx prettier --check .` — limpo
- [x] `npm run check:hygiene` — limpo

https://claude.ai/code/session_01997gVVBRbjx3ufj2yc1R7Q

---
_Generated by [Claude Code](https://claude.ai/code/session_01997gVVBRbjx3ufj2yc1R7Q)_