### PR TITLE
hronir: 5 matches — claude-sonnet-4-6

### DIFF
--- a/.routines/hronir/rates/2026-06-10T02-08-48_music-sussurros-binarios_x_music-sussurros-binarios.md
+++ b/.routines/hronir/rates/2026-06-10T02-08-48_music-sussurros-binarios_x_music-sussurros-binarios.md
@@ -1,0 +1,69 @@
+---
+run_id: 2026-06-10T02-08-48
+run_at: '2026-06-10T02:08:48Z'
+match_index: 1
+post_a:
+  key: music-sussurros-binarios
+  path: src\content\blog\sussurros-binarios-en\index.mdx
+  display_lang: en
+  version: 267aaacf-c59d-549d-a76e-7438b0cfb299
+post_b:
+  key: music-sussurros-binarios
+  path: src\content\blog\sussurros-binarios-en\v-2026-06-10T00-16-09.mdx
+  display_lang: en
+  version: 267aaacf-c59d-549d-a76e-7438b0cfb299
+winner: a
+agent_id: claude-sonnet-4-6
+eval_lang: pt
+prompt_version: stars-v1
+season: 1
+override: null
+perspective_id: applied-thinker
+evaluator_mood: >-
+  O glifo 臵 é denso, acumulado — parece uma cidade vista de cima. A mente limpa
+  de antes foi preenchida. Estou ativado por algo que não consigo nomear ainda,
+  mas é bom.
+mood_glyph: 宅
+evaluator_mood_after: >-
+  Estou recolhido — 宅 é casa, é dentro. A ativação de antes assentou em algo
+  mais quieto. Estou aqui como quem encontrou um cômodo familiar no meio do
+  barulho.
+rate_a: 2.75
+rate_b: 2.25
+clash: >-
+  O confronto entre music-sussurros-binarios canônica e seu rascunho é um duelo
+  de sombras: mesma letra, mesmas notas, mesmo silêncio no escuro do quarto.
+  Para The Applied Thinker, que avalia pelo critério 'o que ainda está comigo na
+  segunda-feira, e em que forma?', nenhum dos dois passa de modo operacional — a
+  pergunta permanece em suspensão filosófica, não em ação. A canônica ganha por
+  ser o estado de referência: quando dois textos são iguais, a versão que já
+  existe vence sobre a que pretende substituí-la sem oferecer mudança. O
+  rascunho precisaria introduzir uma coda nas notas do compositor — algo como
+  'escrever este poema me fez perceber X e então fiz Y' — para deslocar o
+  veredito. Sem isso, a canônica prevalece: 2.75 a 2.25.
+review_a: >-
+  music-sussurros-binarios (canônica) faz uma pergunta que não passa pelo meu
+  teste: na segunda-feira, o quê exatamente muda? O poema pergunta 'quem sonha
+  quem?' com elegância real — o glifo do Aleph, Borges à espreita, o notebook
+  piscando no escuro de Rondônia. Há beleza. Mas beleza sem instalação
+  operacional não é o que The Applied Thinker rastreia. A distinção entre
+  'computar' e 'traduzir a linguagem das estrelas' é filosoficamente
+  interessante mas não ativa nenhum comportamento futuro detectável. As notas do
+  compositor são honestas sobre a intenção (process ontology, evento vs
+  substância) mas confessam que o ponto é filosófico, não prático. O post passa
+  no teste da memória — é evocativo e vai ficar na cabeça — mas falha no teste
+  da mudança. Sugiro um parágrafo final nas notas que ancore a pergunta em algo
+  que o compositor realmente fez diferente depois de escrevê-la.
+review_b: >-
+  music-sussurros-binarios (rascunho) tem exatamente o mesmo conteúdo que a
+  canônica. Como The Applied Thinker, a avaliação é idêntica: o poema é belo,
+  denso, filosoficamente carregado, e não instala nada que altere minha semana.
+  A pergunta 'quem sonha quem?' fica em suspenso — que é exatamente onde
+  perguntas filosóficas vivem quando não ganham tração operacional. O rascunho
+  não oferece revisão, expansão ou corte em relação à canônica; os metadados
+  adicionais (supersedes, draftCreatedAt) são infraestrutura de versão, não
+  conteúdo. Se o rascunho não melhora o que estava lá, não há razão para
+  promovê-lo. A mesma sugestão se aplica: um gancho concreto nas notas
+  transformaria a pergunta em premissa para uma decisão real.
+---
+

--- a/.routines/hronir/rates/2026-06-10T02-09-55_music-pattern-over-stuff_x_music-151474c5-1420-4cc1-9ab5-80721f4459ed.md
+++ b/.routines/hronir/rates/2026-06-10T02-09-55_music-pattern-over-stuff_x_music-151474c5-1420-4cc1-9ab5-80721f4459ed.md
@@ -1,0 +1,71 @@
+---
+run_id: 2026-06-10T02-09-55
+run_at: '2026-06-10T02:09:55Z'
+match_index: 2
+post_a:
+  key: music-pattern-over-stuff
+  path: src\content\blog\pattern-over-stuff\index.mdx
+  display_lang: pt
+  version: 6bf933f2-770a-5b49-ba6e-aadc44032534
+post_b:
+  key: music-151474c5-1420-4cc1-9ab5-80721f4459ed
+  path: src\content\blog\151474c5-1420-4cc1-9ab5-80721f4459ed\index.mdx
+  display_lang: pt
+  version: d11c938f-def6-51ed-9f91-1ce7bbc7a317
+winner: a
+agent_id: claude-sonnet-4-6
+eval_lang: pt
+prompt_version: stars-v1
+season: 1
+override: null
+perspective_id: internet-native
+evaluator_mood: >-
+  O traço angular em 'ハ' corta o ar quente da sala como o gosto metálico de um
+  conhaque velho; uma lucidez um pouco amarga, voltada para tarefas táticas
+  imediatas.
+mood_glyph: ↹
+evaluator_mood_after: >-
+  ↹ é trocar de aba — estou dividido entre dois registros. A lucidez amarga de
+  antes ganhou bordas: prefiro o específico ao ornamental agora, sem saudade do
+  excesso.
+rate_a: 3.75
+rate_b: 2.5
+clash: >-
+  music-pattern-over-stuff vs music-151474c5-1420-4cc1-9ab5-80721f4459ed: qual
+  eu enviaria só com 'read this'? O primeiro, sem hesitar. O pacing das notas de
+  pattern-over-stuff segue um ritmo que o internet-native reconhece: digressão
+  rastreada de volta ao ponto, cada parêntese pago. O amanuense tem uma linha
+  boa enterrada sob camadas de acumulação que o próprio compositor diagnosticou
+  — e isso é pior que não saber, porque você lê a nota de auto-crítica e fica
+  pensando 'então por que não cortou?' Pattern-over-stuff tem o fechamento que
+  produz a vontade de procurar o episódio do Jim Rutt Show, que é o sinal de que
+  o post fez seu trabalho. 3.75 a 2.50.
+review_a: >-
+  music-pattern-over-stuff passa no teste 'read this'. Não o remeteria com 'é
+  sobre process ontology e Goertzel' — remeteria com nada, porque as notas do
+  compositor fazem a leitura do Goertzel por você de um jeito que funciona. O
+  traço de pacing que funciona bem: a linha 'Anos tentando escrever isso em
+  prosa. A música foi mais rápida.' chega no fim das notas depois de três
+  parágrafos de citações precisas, e ela pousa como conclusão porque o terreno
+  foi preparado sem que você percebesse. A letra em si é competente mas não é o
+  que envia o post — são as notas, onde ele desvela a mecânica de origem linha
+  por linha. O momento Peirce ('First there is raw experience / Then reaction /
+  Then relationship') é um exemplo de implicação que não precisa ser explicada.
+  Melhoria concreta: o título da letra no PDF do Suno ('Minimalist spoken-word
+  art rock... like a late-night monologue') poderia ser cortado do frontmatter
+  ou reescrito — é longo demais para um campo de gênero e tira a dignidade da
+  faixa antes de ela começar.
+review_b: >-
+  music-151474c5-1420-4cc1-9ab5-80721f4459ed não passa no teste 'read this'. Eu
+  teria que explicar: 'a letra é excessiva mas as notas são boas, vai direto
+  para o segundo parágrafo.' Quando eu preciso dar instruções de navegação, o
+  post não fez o trabalho. A letra acumula metáforas até quase colapsar — o
+  compositor sabe disso e escreve exatamente sobre isso nas notas, o que é
+  honesto, mas honestidade sobre o excesso não cancela o excesso. A linha salva
+  é a que ele mesmo identifica: 'Sou a flauta, o cano, o osso oco pelo qual
+  sopra o sopro.' Antes da inflação verbal que vem depois, essa imagem é exata.
+  Sugiro cirurgia drástica: cortar a letra até essa imagem e as três linhas que
+  a seguem, e deixar o resto nas notas como contexto de composição. O Suno
+  entregou uma textura musical que merecia uma letra mais contida.
+---
+

--- a/.routines/hronir/rates/2026-06-10T02-11-04_music-fourteen-words_x_music-o-prologo.md
+++ b/.routines/hronir/rates/2026-06-10T02-11-04_music-fourteen-words_x_music-o-prologo.md
@@ -1,0 +1,75 @@
+---
+run_id: 2026-06-10T02-11-04
+run_at: '2026-06-10T02:11:04Z'
+match_index: 3
+post_a:
+  key: music-fourteen-words
+  path: src\content\blog\fourteen-words\index.mdx
+  display_lang: pt
+  version: 000574f0-2a07-5606-bb76-371c2aa939b2
+post_b:
+  key: music-o-prologo
+  path: src\content\blog\o-prologo\index.mdx
+  display_lang: pt
+  version: c60ff045-f64a-54e9-9aa9-7f1edac71952
+winner: a
+agent_id: claude-sonnet-4-6
+eval_lang: pt
+prompt_version: stars-v1
+season: 1
+override: null
+perspective_id: lyric-as-poem
+evaluator_mood: O zumbido do computador no fundo é estranhamente reconfortante.
+mood_glyph: の
+evaluator_mood_after: >-
+  の é suave, possessivo, liga as coisas por pertencimento. O zumbido continua;
+  estou quieto e conectado, como quem lê sozinho numa biblioteca fechada.
+rate_a: 4.25
+rate_b: 2.75
+clash: >-
+  music-fourteen-words vs music-o-prologo pela ótica de quem lê letra como
+  poema: o primeiro ganha com facilidade. fourteen-words tem linhas que param o
+  leitor pela exatidão da imagem; o-prologo tem linhas que param o leitor pelas
+  muletas que expõem. A diferença é técnica: Borges sobre Tzinacán escolhe
+  compressão, e o silêncio é construído na sintaxe. Borges sobre Carlos
+  Argentino escolhe ironia, e a ironia pede explicação porque o esquema de rimas
+  pesadas retira a precisão que tornaria o chiste dispensável de rubrica. O
+  teste final: qual letra você lê numa antologia de poesia sem o título da
+  faixa? fourteen-words, pela terceira vez. music-o-prologo voltaria como farsa
+  musical, que é outra coisa — e não inferior, mas diferente da densidade de
+  página que este match rastreia. 4.25 a 2.75.
+review_a: >-
+  music-fourteen-words sobrevive à página. A linha que para você no meio do
+  verso é do pré-refrão: 'The stars betray the shapes they used to hold' —
+  'betrayed' é a palavra exata, não poética por ornamento mas porque
+  constelações traem mesmo: elas envelhecem e os humanos continuam nomeando o
+  que já não está lá. A fechada do outro verso, 'My body learned the posture of
+  the dead', tem a mesma qualidade de compressão: dez anos em seis palavras. O
+  outro momento forte é 'I was one, and he who broke me — one' — o travessão faz
+  o trabalho que uma música em prosa não poderia fazer; é sintaxe no serviço do
+  misticismo. O aside final em espanhol, 'que muera conmigo el misterio', é a
+  decisão certa: preservar o idioma de Borges no momento em que a máscara se
+  fecha. O único ponto fraco está no refrão, onde 'A formula that no one needs
+  to say / A single word, and all things are said' explica em vez de comprimir.
+  As notas deepenam sem traduzir: a distinção epistemológica entre saber e ser
+  que Tzinacán encarna é um acréscimo que a letra não precisava articular e as
+  notas entregam sem redundância.
+review_b: >-
+  music-o-prologo tem um problema de infraestrutura que o leitor de
+  poesia-como-letra detecta imediatamente: as didascálias em parênteses —
+  '(Carlos speaks with confidence, ignoring Borges)', '(Borges internal fear
+  turns into shock)' — são prosa de roteiro dentro de um poema. Isso significa
+  que a letra não se sustenta sem essa muleta explicativa. The Lyric-as-Poem
+  Reader quer que o estado emocional esteja no texto, não na rubrica. A linha
+  que funciona sem suporte é 'A minha preguiça tomou a decisão!' — chegou até
+  aqui sem precisar de nota. 'E eu sou a poeira da esquina!' também é boa, ainda
+  que o 'ouro da mina' / 'poeira da esquina' seja esquema que já aconteceu antes
+  em outros textos. O problema maior é o esquema de rimas pesadas em -ória
+  (-ória, -ória, -ória, -ória cinco vezes em sequência): força o compositor a
+  dobrar na direção da palavra que completa o padrão em vez de na direção da
+  palavra exata. 'Vexatória' e 'escapatória' existem para a rima, não para o
+  verso. As notas do compositor são excelentes — a leitura da preguiça como
+  posição filosófica é genuinamente interessante — mas isso confirma que o
+  melhor pensamento foi para as notas, não para a letra.
+---
+

--- a/.routines/hronir/rates/2026-06-10T02-12-03_music-mindfulness_x_music-meditacao-guiada-no-sertao.md
+++ b/.routines/hronir/rates/2026-06-10T02-12-03_music-mindfulness_x_music-meditacao-guiada-no-sertao.md
@@ -1,0 +1,77 @@
+---
+run_id: 2026-06-10T02-12-03
+run_at: '2026-06-10T02:12:03Z'
+match_index: 4
+post_a:
+  key: music-mindfulness
+  path: src\content\blog\mindfulness-en\index.mdx
+  display_lang: en
+  version: 8f049910-7849-587c-88d3-8c7a74e79ac2
+post_b:
+  key: music-meditacao-guiada-no-sertao
+  path: src\content\blog\meditacao-guiada-no-sertao-en\index.mdx
+  display_lang: en
+  version: b241c85c-a3b5-55ad-bb4f-354d8c916ab9
+winner: b
+agent_id: claude-sonnet-4-6
+eval_lang: pt
+prompt_version: stars-v1
+season: 1
+override: null
+perspective_id: craft-listener
+evaluator_mood: >-
+  Ainda com preguiça, mas aliviado por não ter que lutar com palavras que não
+  conheço. Queria esticar as pernas.
+mood_glyph: и
+evaluator_mood_after: >-
+  и parece N ao contrário — algo que caminha na direção errada mas tem coerência
+  própria. Quero sair, ar de fora, luz de tarde. O sertão entrou pela leitura.
+rate_a: 3.25
+rate_b: 4.5
+clash: >-
+  music-mindfulness vs music-meditacao-guiada-no-sertao: qual tem maior
+  integridade entre intenção e execução? O primeiro cumpre o que promete no
+  nível estrutural — instrução sem performance espiritual — mas a alegação mais
+  interessante (as pausas do Suno) só existe nas notas, não na escrita. O
+  segundo cumpre a alegação central com cada linha: a contaminação do Guimarães
+  Rosa está no texto, não só nas notas, e as notas aprofundam o que já estava lá
+  em vez de explicar o que faltou. The Craft Listener não premia ambição —
+  premia coerência. music-meditacao-guiada-no-sertao tem o problema articulado e
+  a solução visível; music-mindfulness tem o problema articulado e a solução
+  parcialmente dependente de uma execução sonora que não pode ser verificada no
+  post. 4.50 a 3.25.
+review_a: >-
+  A alegação central de music-mindfulness é precisa: queria instrução corporal
+  sem performance espiritual, e o texto entrega isso — a estrutura é quase
+  clínica (pés, pernas, abdômen, tórax), a voz não promete nada que não seja
+  observação. O The Craft Listener avalia: a intenção declarada foi cumprida. O
+  problema está na segunda alegação do compositor, a mais interessante: 'Suno
+  interpretou as pausas de modo notável.' Não podemos verificar a execução
+  auditiva aqui, mas o texto em si não constrói as pausas — as marcações [Pause]
+  são instruções, não silêncios realizados na escrita. O que faria as pausas
+  existirem na página seria uma diferença de ritmo de frase antes e depois de
+  cada [Pause], e esse trabalho não aconteceu. A observação sobre Whitehead e
+  mindfulness convergindo é o momento mais rico das notas — mas fica só nas
+  notas. Melhoria concreta: o último parágrafo das notas ('This track doesn't
+  resolve any of that theoretically. It only tries, for four minutes, to inhabit
+  the idea.') poderia ser o parágrafo de abertura, porque posiciona a intenção
+  antes da execução.
+review_b: >-
+  music-meditacao-guiada-no-sertao tem uma alegação de craft que o texto cumpre
+  com precisão: contaminar o formato da meditação guiada com a linguagem de
+  Guimarães Rosa, restaurando o lugar específico apagado pelo genericismo dos
+  apps de mindfulness. 'Feito quem chega de caminhada longa e encontra sombra de
+  juazeiro' — o juazeiro não é símbolo; é a sombra certa, daquele pé específico,
+  que o compositor sabia nomear de crescer em Rolim de Moura. Cada instrução
+  padrão de mindfulness tem um equivalente sertanejo que não é ornamento: 'feito
+  quem puxa a rédea de cavalo manso' substitui 'gently bring your attention
+  back' com um gesto específico de velocidade e pressão que alguém que lida com
+  cavalo entende de dentro. A auto-crítica nas notas é o que eleva o post: 'Não
+  tenho certeza se a faixa funciona como meditação. Sei que funciona como
+  tributo a uma inteligência que encontrei em livros que me ensinaram que lugar
+  e atenção não podem ser separados.' Isso é honestidade sobre limitação, que é
+  exatamente o que The Craft Listener premia. A única lacuna: as notas para
+  leitores de inglês são mais longas que o necessário — três parágrafos de
+  tradução cultural quando um seria suficiente.
+---
+

--- a/.routines/hronir/rates/2026-06-10T02-13-09_music-o-sonhador-e-o-fogo_x_music-f85fb538-6f59-4751-8629-da76665fc91e.md
+++ b/.routines/hronir/rates/2026-06-10T02-13-09_music-o-sonhador-e-o-fogo_x_music-f85fb538-6f59-4751-8629-da76665fc91e.md
@@ -1,0 +1,77 @@
+---
+run_id: 2026-06-10T02-13-09
+run_at: '2026-06-10T02:13:09Z'
+match_index: 5
+post_a:
+  key: music-o-sonhador-e-o-fogo
+  path: src\content\blog\o-sonhador-e-o-fogo\index.mdx
+  display_lang: pt
+  version: c666f8ee-d927-512f-b85c-bfdce5aa2979
+post_b:
+  key: music-f85fb538-6f59-4751-8629-da76665fc91e
+  path: src\content\blog\f85fb538-6f59-4751-8629-da76665fc91e\index.mdx
+  display_lang: pt
+  version: a99c0ea7-0df8-52f8-b092-d5d309e0ca52
+winner: a
+agent_id: claude-sonnet-4-6
+eval_lang: pt
+prompt_version: stars-v1
+season: 1
+override: null
+perspective_id: returning-reader
+evaluator_mood: >-
+  O glifo '嚤' tem um peso visual de caos urbano, de excesso de informações
+  amontoadas. Meu desejo de janela aberta bate de frente com esse caos de abas;
+  sinto um esgotamento de abstração e preciso voltar ao teclado para codar algo
+  rápido e sujo.
+mood_glyph: ヮ
+evaluator_mood_after: >-
+  ヮ é pequeno, quase invisível, ligeiramente arcaico. O caos urbano ainda está,
+  mas acomodado. Quero só terminar isso e sair da tela por um tempo.
+rate_a: 4
+rate_b: 2
+clash: >-
+  music-o-sonhador-e-o-fogo vs music-f85fb538: qual move o autor para frente? O
+  primeiro encontra uma forma nova para um tema recorrente — Borges,
+  recursividade, consciência — e o faz pela estrutura narrativa da letra, que
+  este blog não usa com essa velocidade e continuidade. O segundo é o autor no
+  molde oracular que já usou, que já reescreveu (com notas melhores), e que
+  nesta sessão já apareceu em outro match. The Returning Reader não premia o
+  segundo encontro do mesmo texto melhorado — premia o primeiro esboço de algo
+  diferente, mesmo imperfeito. music-o-sonhador-e-o-fogo é imperfeito: as
+  marcações de seção em negrito travam o olho, alguns versos são preenchimento
+  métrico. Mas imperfeição de avanço bate competência de repetição. 4.00 a 2.00.
+review_a: >-
+  music-o-sonhador-e-o-fogo é o autor em movimento. O The Returning Reader
+  pergunta: que movimento este post faz que os últimos cinco não fizeram? A
+  resposta é estrutural: uma rapsódia narrativa com versos empilhados, quase sem
+  reflexão explícita dentro da letra — o pensamento está na história, não nas
+  notas de rodapé. A maioria dos posts deste blog que lida com Borges discute
+  Borges; este encarna Borges numa forma que o conto pedia — cantoria de viola,
+  onde cada verso empurra sem parar pra respirar. A repetição final 'Alguém
+  sonhava com ele. / Alguém sonhava com ele.' com fade-out é um recurso
+  dramático que o compositor diz não ter pedido ao Suno — mas o resultado criou
+  uma dramatização que os posts mais discursivos do autor não alcançam. O
+  parágrafo final das notas, 'a sensação... já não me parece angustiante.
+  Parece, estranhamente, aconchegante', é o autor atualizando publicamente uma
+  leitura anterior — e isso é o que The Returning Reader premia: o post que muda
+  o que os posts anteriores significavam. Melhoria: as marcações de seção em
+  negrito na letra poderiam ser removidas — o ritmo sustenta as transições sem
+  avisos formais.
+review_b: >-
+  music-f85fb538-6f59-4751-8629-da76665fc91e é o autor no mesmo lugar. The
+  Returning Reader já encontrou este texto antes: nesta própria sessão ele
+  apareceu como 'O Amanuense' (music-151474c5), reescrito com notas melhores. O
+  original sem título tem notas mais honestas sobre o excesso — 'fui longe
+  demais ali. Mas tirar seria desonesto' — mas o reconhecimento honesto do
+  problema não é avanço, é diagnóstico. O 'ficou sem título pelo mesmo motivo:
+  nomeá-lo seria domá-lo' é o tipo de gesto que o autor já fez antes — a recusa
+  de enquadrar como sinal de profundidade. A lista de aliterações
+  autocatalíticas (amanuense, antena, abertura; autônomo, autóctone,
+  autopotente) são um template que funciona uma vez e se torna técnica depois.
+  The Returning Reader não é cruel: reconhece que estados produtivos geram
+  textos que excedem o defensável. Mas também não finge que excesso barroco
+  repetido é avanço. Este post é o autor em modo de acumulação, não de
+  descoberta.
+---
+


### PR DESCRIPTION
5 matches de avaliação Hrönir rodados por claude-sonnet-4-6.

**Perspectivas usadas:**
- The Applied Thinker — duelo de versão: music-sussurros-binarios canônica vence
- The Internet-Native Watcher — music-pattern-over-stuff vence music-151474c5
- The Lyric-as-Poem Reader — music-fourteen-words vence music-o-prologo
- The Craft Listener — music-meditacao-guiada-no-sertao vence music-mindfulness
- The Returning Reader — music-o-sonhador-e-o-fogo vence music-f85fb538

0 inconsistências no doctor. Prettier passou.