### PR TITLE
docs(rfc): RFC 0003 r6 + fix: paths Windows nos rate files do pool

### DIFF
--- a/.routines/hronir/rates/2026-06-10T02-08-48_music-sussurros-binarios_x_music-sussurros-binarios.md
+++ b/.routines/hronir/rates/2026-06-10T02-08-48_music-sussurros-binarios_x_music-sussurros-binarios.md
@@ -4,12 +4,12 @@ run_at: '2026-06-10T02:08:48Z'
 match_index: 1
 post_a:
   key: music-sussurros-binarios
-  path: src\content\blog\sussurros-binarios-en\index.mdx
+  path: src/content/blog/sussurros-binarios-en/index.mdx
   display_lang: en
   version: 267aaacf-c59d-549d-a76e-7438b0cfb299
 post_b:
   key: music-sussurros-binarios
-  path: src\content\blog\sussurros-binarios-en\v-2026-06-10T00-16-09.mdx
+  path: src/content/blog/sussurros-binarios-en/v-2026-06-10T00-16-09.mdx
   display_lang: en
   version: 267aaacf-c59d-549d-a76e-7438b0cfb299
 winner: a

--- a/.routines/hronir/rates/2026-06-10T02-09-55_music-pattern-over-stuff_x_music-151474c5-1420-4cc1-9ab5-80721f4459ed.md
+++ b/.routines/hronir/rates/2026-06-10T02-09-55_music-pattern-over-stuff_x_music-151474c5-1420-4cc1-9ab5-80721f4459ed.md
@@ -4,12 +4,12 @@ run_at: '2026-06-10T02:09:55Z'
 match_index: 2
 post_a:
   key: music-pattern-over-stuff
-  path: src\content\blog\pattern-over-stuff\index.mdx
+  path: src/content/blog/pattern-over-stuff/index.mdx
   display_lang: pt
   version: 6bf933f2-770a-5b49-ba6e-aadc44032534
 post_b:
   key: music-151474c5-1420-4cc1-9ab5-80721f4459ed
-  path: src\content\blog\151474c5-1420-4cc1-9ab5-80721f4459ed\index.mdx
+  path: src/content/blog/151474c5-1420-4cc1-9ab5-80721f4459ed/index.mdx
   display_lang: pt
   version: d11c938f-def6-51ed-9f91-1ce7bbc7a317
 winner: a

--- a/.routines/hronir/rates/2026-06-10T02-11-04_music-fourteen-words_x_music-o-prologo.md
+++ b/.routines/hronir/rates/2026-06-10T02-11-04_music-fourteen-words_x_music-o-prologo.md
@@ -4,12 +4,12 @@ run_at: '2026-06-10T02:11:04Z'
 match_index: 3
 post_a:
   key: music-fourteen-words
-  path: src\content\blog\fourteen-words\index.mdx
+  path: src/content/blog/fourteen-words/index.mdx
   display_lang: pt
   version: 000574f0-2a07-5606-bb76-371c2aa939b2
 post_b:
   key: music-o-prologo
-  path: src\content\blog\o-prologo\index.mdx
+  path: src/content/blog/o-prologo/index.mdx
   display_lang: pt
   version: c60ff045-f64a-54e9-9aa9-7f1edac71952
 winner: a

--- a/.routines/hronir/rates/2026-06-10T02-12-03_music-mindfulness_x_music-meditacao-guiada-no-sertao.md
+++ b/.routines/hronir/rates/2026-06-10T02-12-03_music-mindfulness_x_music-meditacao-guiada-no-sertao.md
@@ -4,12 +4,12 @@ run_at: '2026-06-10T02:12:03Z'
 match_index: 4
 post_a:
   key: music-mindfulness
-  path: src\content\blog\mindfulness-en\index.mdx
+  path: src/content/blog/mindfulness-en/index.mdx
   display_lang: en
   version: 8f049910-7849-587c-88d3-8c7a74e79ac2
 post_b:
   key: music-meditacao-guiada-no-sertao
-  path: src\content\blog\meditacao-guiada-no-sertao-en\index.mdx
+  path: src/content/blog/meditacao-guiada-no-sertao-en/index.mdx
   display_lang: en
   version: b241c85c-a3b5-55ad-bb4f-354d8c916ab9
 winner: b

--- a/.routines/hronir/rates/2026-06-10T02-13-09_music-o-sonhador-e-o-fogo_x_music-f85fb538-6f59-4751-8629-da76665fc91e.md
+++ b/.routines/hronir/rates/2026-06-10T02-13-09_music-o-sonhador-e-o-fogo_x_music-f85fb538-6f59-4751-8629-da76665fc91e.md
@@ -4,12 +4,12 @@ run_at: '2026-06-10T02:13:09Z'
 match_index: 5
 post_a:
   key: music-o-sonhador-e-o-fogo
-  path: src\content\blog\o-sonhador-e-o-fogo\index.mdx
+  path: src/content/blog/o-sonhador-e-o-fogo/index.mdx
   display_lang: pt
   version: c666f8ee-d927-512f-b85c-bfdce5aa2979
 post_b:
   key: music-f85fb538-6f59-4751-8629-da76665fc91e
-  path: src\content\blog\f85fb538-6f59-4751-8629-da76665fc91e\index.mdx
+  path: src/content/blog/f85fb538-6f59-4751-8629-da76665fc91e/index.mdx
   display_lang: pt
   version: a99c0ea7-0df8-52f8-b092-d5d309e0ca52
 winner: a

--- a/docs/rfcs/0003-hronir-versoes-lado-a-lado-e-torneio.md
+++ b/docs/rfcs/0003-hronir-versoes-lado-a-lado-e-torneio.md
@@ -420,7 +420,18 @@ fundação travada por testes.
    `promote` grava o equivalente ou se a UI passa a ler `supersedes`.
 7. **`promote` e o `migrate`:** com `version` autoritativo (§7), resta confirmar a
    tolerância `path`×`version` no `doctor` e se vale um modo de "reescrever paths"
-   no `migrate` após promoções.
+   no `migrate` após promoções. _Resolvido na PR #321:_ o `doctor` tolera path
+   `v-*` ausente quando o lado tem UUID de versão e a pasta do post existe
+   (promote renomeia o rascunho; prune remove o arquivo); reescrever paths no
+   `migrate` foi dispensado — o path gravado é registro histórico fiel.
+8. **Promoção × sincronia bilíngue (descoberto na primeira promoção real,
+   PR #321):** a trilha por-versão é por-língua, mas o `check:translations`
+   exige que o par PT/EN evolua **junto** no mesmo PR. Quando só um lado
+   acumula duelos suficientes (o sorteio é independente por língua), o
+   `promote --all` promove um lado e quebra o CI. Workaround atual: promover o
+   espelho manualmente via `promote --draft` (os rascunhos nascem em par pelo
+   `draft-worst`). Fix candidato: `promote` tratar o par como unidade — quando
+   qualquer língua cruza o limiar, promover os espelhos do mesmo round juntos.
 
 ---
 
@@ -480,3 +491,11 @@ Merge com **merge commit** (não squash), conforme `CLAUDE.md`.
   n≥2 duelos). `prune [--dry-run]` remove versões que perderam para a canônica
   por ≥0.5★ em ≥3 duelos. `npm run hronir:prune` adicionado ao `package.json`.
   RFC 0003 status atualizado para "Implemented (Fases 0–3)".
+- **r6** (2026-06-10): erratum pós **primeira promoção real** (PR #321,
+  `music-vos`: rascunho EN venceu por +1.63★ em 3 duelos). Dois achados de
+  produção: (a) o `doctor` exigia que `post_a/b.path` existissem, mas
+  promote/prune apagam o path gravado — tolerância do §7 implementada (QA 7
+  resolvida); (b) **gap novo**: promoção por-língua × `check:translations`,
+  que exige o par PT/EN evoluindo junto — registrado como QA 8, com fix
+  candidato (promover espelhos do mesmo round como unidade). Workaround
+  aplicado na #321: `promote --draft` do espelho PT.

--- a/src/hronir/matches.ts
+++ b/src/hronir/matches.ts
@@ -26,6 +26,17 @@ export function readMatch(filePath: string): {
 } {
   const raw = fs.readFileSync(filePath, "utf8");
   const parsed = matter(raw);
+  // Rate files written on Windows carry backslash separators in
+  // post_a/b.path; normalize to POSIX so existsSync and key lookups work
+  // on Linux CI. decide() re-persists via writeMatch, so files self-heal.
+  for (const sideName of ["post_a", "post_b"]) {
+    const side = (parsed.data as Record<string, unknown>)[sideName] as
+      | { path?: unknown }
+      | undefined;
+    if (side && typeof side.path === "string") {
+      side.path = side.path.replace(/\\/g, "/");
+    }
+  }
   return { ...parsed, filePath };
 }
 


### PR DESCRIPTION
## Resumo

Começou como erratum de docs; o CI revelou um bug de dados na main que este PR também corrige.

### docs: RFC 0003 r6 — erratum da primeira promoção real

Documenta os dois achados de produção da PR #321 (`music-vos`):

- **QA 7 resolvida**: o `doctor` tolera path `v-*` ausente pós-promote/prune (path informacional, version autoritativo, §7).
- **QA 8 nova**: gap entre promoção por-língua e o `check:translations` (par PT/EN deve evoluir junto). Workaround na #321: `promote --draft` do espelho. Fix candidato registrado: promover espelhos do mesmo round como unidade.

### fix: separadores Windows nos paths dos rate files

Sessões do pool (`claude-sonnet-4-6`) rodando em Windows gravaram `post_a/b.path` com barra invertida (`src\content\blog\...`) em 5 rate files de hoje — `fs.existsSync` falha no CI Linux e o `doctor` acusava 10 inconsistências. Correção em duas pontas:

- **dados**: os 5 rate files normalizados para POSIX
- **leitura**: `readMatch` normaliza `\` → `/` em `post_a/b.path`; como o `decide()` re-persiste via `writeMatch`, arquivos futuros escritos em Windows se auto-corrigem

## Verificações

- [x] `npm run hronir:doctor` — 0 inconsistências (era 10 no CI)
- [x] `npm test` — 20/20
- [x] `npx prettier --check .` — limpo
- [x] `npm run check:hygiene` — limpo

https://claude.ai/code/session_01997gVVBRbjx3ufj2yc1R7Q