### PR TITLE
feat(ranking): RFC 0007 — Ranking UI/UX overhaul (implementation)

### DIFF
--- a/.routines/2026-06-10T02-45-00-rfc-0007-ranking-ui.md
+++ b/.routines/2026-06-10T02-45-00-rfc-0007-ranking-ui.md
@@ -1,0 +1,28 @@
+---
+date: 2026-06-10T02:45:00
+slug: rfc-0007-ranking-ui
+branch: claude/sweet-hypatia-1joz7o
+status: open
+---
+
+# RFC 0007 — Ranking: UI e UX de leitura
+
+Sessão de diagnóstico da `/ranking/` a pedido do Franklin ("suggest me
+improvements for UI and readers UX, write a RFC").
+
+## O que foi feito
+
+- Leitura de `ranking.astro`, `RankingView.astro`,
+  `ranking/perspectives/[id].astro`, `hronir-rank.ts`.
+- Build local para medir: `dist/ranking/index.html` = **3,1 MB por idioma**
+  (338 duelos renderizados integralmente; paginação só `display:none`).
+- Descoberta de bug em produção: `/ranking/perspectives/<id>/` retorna
+  **404** — `perspectives.ts` resolve o diretório via `import.meta.url`,
+  que quebra após o bundle do vite; `listPerspectives()` retorna `[]` e o
+  `getStaticPaths` emite zero páginas sem erro. Confirmado com curl em
+  produção (404) vs dev server (200).
+- Escrita da RFC 0007 com diagnóstico (D1–D9) e plano em 5 fases.
+
+## Entregável
+
+- `docs/rfcs/0007-ranking-ui-e-ux-de-leitura.md`

--- a/docs/rfcs/0007-ranking-ui-e-ux-de-leitura.md
+++ b/docs/rfcs/0007-ranking-ui-e-ux-de-leitura.md
@@ -2,7 +2,7 @@
 
 |                 |                                                                                                                                                                                        |
 | --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Status**      | Proposta (r0)                                                                                                                                                                          |
+| **Status**      | Proposta (r1)                                                                                                                                                                          |
 | **Autor**       | Franklin Baldo (proposta assistida)                                                                                                                                                    |
 | **Criado em**   | 2026-06-10                                                                                                                                                                             |
 | **Branch / PR** | `claude/sweet-hypatia-1joz7o`                                                                                                                                                          |
@@ -168,6 +168,38 @@ exibição.
 
 ---
 
+## 3.1 Fluxo primário de leitura
+
+Mapeamento do caminho happy-path de um leitor que chega pela primeira vez e
+lê um duelo completo. Identifica dois becos que precisam de solução antes das
+Fases 1–4 irem a merge:
+
+```
+/ranking/
+  → tabela (vê post #1)
+  → clica no título → /blog/<slug>/                ← link bidirecional (Fase 4)
+  → clica em "ver dossiê" → /ranking/posts/<key>/
+    breadcrumb: Home / Ranking / Dossiê            ← Fase 1 (obrigatório)
+  → vê histórico, clica em duelo → /ranking/battles/<id>/
+    breadcrumb: Home / Ranking / Batalhas / <id>   ← Fase 1 (obrigatório)
+  → lê resenhas, clica "próximo duelo"             ← [FALTANDO]
+  → volta ao arquivo → /ranking/battles/1/         ← [FALTANDO]
+```
+
+Os dois marcadores **[FALTANDO]** são requisitos obrigatórios da Fase 1:
+
+- **Prev/next entre duelos**: botões "← duelo anterior" / "próximo duelo →" na
+  página de batalha individual, na ordem cronológica inversa do arquivo.
+  Implementado sem JS: cada página recebe `{prevId, nextId}` como props do
+  `getStaticPaths`.
+- **Link "voltar ao arquivo"**: link na página de batalha que retorna para a
+  página do arquivo onde o duelo está (ex.: duelo na página 3 do arquivo →
+  link para `/ranking/battles/3/`). Calculado no build.
+
+Sem esses dois elementos a Fase 1 cria mais becos do que resolve.
+
+---
+
 ## 4. Proposta por fases
 
 ### Fase 0 — Correções imediatas (bugs, sem mudança de design)
@@ -179,10 +211,18 @@ exibição.
    `getPerspectives()` vier vazio — o build quebra alto em vez de emitir
    silenciosamente zero páginas.
 2. **i18n da CTA (D6):** mover o texto do link para `RankingStrings.unratedCTALink`.
-3. **Barra de tensão honesta (D7):** sem rates, não renderizar a barra.
-4. **A11y básica (D8):** `aria-pressed` nos chips/pills, `aria-live="polite"`
-   no contador, `type="button"` nos botões de filtro.
-5. **Limpeza (D9):** remover `ratesLabel` morto.
+3. **Barra de tensão honesta (D7):** sem `rate_a`/`rate_b`, substituir a barra
+   por um traço visual neutro (`—`) com `aria-label="tensão não disponível"`,
+   mantendo o espaço alocado no layout do card.
+4. **A11y básica (D8):** padrões ARIA por grupo de filtro:
+   - Chips de seleção exclusiva (perspectiva, critério, confiança, season,
+     agente): `role="radiogroup"` no container + `role="radio"` em cada chip.
+     `aria-pressed` seria errado aqui — exclusividade é o padrão semântico
+     correto de `radiogroup`. Se algum grupo se tornar multi-select no futuro,
+     migrar para `aria-pressed` nesse grupo específico.
+   - `aria-live="polite"` no contador de resultados.
+   - `type="button"` em todos os botões de filtro.
+5. **Limpeza (D9):** remover `ratesLabel` morto de `RankingStrings`.
 
 **Critério de aceite:** `dist/ranking/perspectives/<id>/index.html` existe
 para as 12 perspectivas; curl em produção retorna 200 após deploy;
@@ -201,23 +241,44 @@ página só.
    página, mais recente primeiro), gerada no build via `getStaticPaths` —
    paginação real, por URL, sem JS obrigatório.
 3. **`/ranking/battles/<id>/`:** página por duelo com o conteúdo completo
-   (veredito, resenhas A/B, mood do avaliador — D9), usando identificador
-   estável derivado do rate file. Os cards nas listagens carregam só o
-   cabeçalho (data, tags, versus, rates) e linkam para a página do duelo —
-   o corpo sai do HTML das listagens, e `<details>` deixa de ser o container
-   do conteúdo pesado.
+   (veredito, resenhas A/B, mood do avaliador — D9). Os cards nas listagens
+   carregam só o cabeçalho (data, tags, versus, rates) e linkam para a
+   página do duelo — o corpo sai do HTML das listagens, e `<details>` deixa
+   de ser o container do conteúdo pesado.
 4. **Busca via Pagefind (substitui `data-search`):** as páginas de duelo
    entram no índice Pagefind que o site já usa (`pagefind --site dist` já
    roda no build). A caixa de busca de batalhas passa a consultar o índice —
    busca melhor (stemming, ranking) e elimina a duplicação de texto nos
    atributos.
+5. **Identificador público do duelo (Q1 — resolvido):** hash dos primeiros 8
+   caracteres do SHA-256 do conteúdo canônico do duelo (chave A + chave B +
+   `run_at` normalizado). Opaco, estável se a convenção de nomes dos rate
+   files mudar, suficientemente curto para URL legível.
+   Ex.: `/ranking/battles/a3f7c91b/`. A função de derivação fica em
+   `src/lib/hronir-rank.ts`, versionada. O nome do arquivo do rate file
+   **não** é usado como URL pública — exporia a convenção interna de
+   nomenclatura e quebraria se ela mudar.
+6. **Navegação (ver §3.1 — obrigatório antes de merge da Fase 1):**
+   - Breadcrumb em todas as páginas novas (Home / Ranking / …).
+   - Botões prev/next cronológicos na página de batalha individual.
+   - Link "voltar ao arquivo (pág N)" calculado no build.
+7. **Estados vazios:**
+   - Post com 0 duelos: **sem dossiê** — página não é emitida; link no
+     rodapé do post só aparece se ≥1 duelo existir.
+   - Post com 1 único duelo: dossiê emitido, sparkline substituída por texto
+     ("1 duelo — histórico insuficiente para trajetória").
+   - Perspectiva sem duelos: card no grid exibe "sem duelos ainda" em vez de
+     líder; link para a página de perspectiva mantido.
+   - Duelo sem corpo (rate file sem body): exibir cabeçalho + nota "resenhas
+     não disponíveis para este duelo".
 
 Os filtros estruturados (season, agente, perspectiva, confiança, critério)
 continuam client-side, mas operando sobre os cabeçalhos leves da página
 corrente do arquivo.
 
 **Critério de aceite:** `dist/ranking/index.html` ≤ 300 KB; soma de páginas
-do arquivo cobre 100% dos duelos válidos; cada duelo tem URL própria estável;
+do arquivo cobre 100% dos duelos válidos; cada duelo tem URL própria com hash
+de 8 chars; breadcrumb + prev/next presentes em todas as páginas de batalha;
 busca encontra texto que hoje só existe no corpo das resenhas.
 
 ### Fase 2 — Estado na URL
@@ -225,8 +286,8 @@ busca encontra texto que hoje só existe no corpo das resenhas.
 1. Filtros e página refletidos em query params
    (`?q=…&season=2&perspective=curious-outsider`), aplicados na carga e
    atualizados via `history.replaceState`.
-2. Anchors nos cards (`id` = identificador do duelo) para deep-link dentro
-   de uma página do arquivo.
+2. Anchors nos cards (`id` = hash do duelo) para deep-link dentro de uma
+   página do arquivo.
 
 **Critério de aceite:** colar uma URL filtrada reproduz exatamente a visão;
 back/forward não perde estado; sem JS, as URLs continuam resolvendo (filtros
@@ -239,41 +300,64 @@ são progressive enhancement).
    estimada e incerteza") + `<details>` "como funciona o ranking" com a
    explicação completa de μ/σ/ordinal — substitui os tooltips `abbr@title`
    como canal principal (D4).
-2. **Tabela com modos:** por padrão, colunas Post / ★ posição / vitórias
-   (win rate visível, D4) / confiança; μ, σ e ordinal ficam atrás de um
-   toggle "detalhes técnicos" (persistido em `localStorage`). Top-3 também
-   listado na tabela, com destaque.
+2. **Tabela com modos:** por padrão, colunas Post / # posição / win rate /
+   confiança / Δ; μ, σ e ordinal ficam atrás de um toggle. Spec do toggle:
+   - **Affordance**: botão pequeno "⚙ detalhes técnicos" na legenda da tabela
+     (`<caption>`), alinhado à direita; texto muda para "ocultar detalhes"
+     quando ativo.
+   - **Linkabilidade**: estado refletido em query param `?view=technical` —
+     não em `localStorage`, para que URLs compartilhadas preservem o contexto
+     do remetente. `localStorage` seria contraditório com o objetivo de D3.
+   - **Top-3 na tabela**: linhas 1–3 recebem fundo tênue (paleta ouro/prata/
+     bronze do pódio) e `aria-label="1º lugar"` etc. O pódio de cards
+     permanece acima como destaque visual; a tabela começa no #1 sem
+     repetição de conteúdo — os dois componentes coexistem em alturas
+     diferentes da página.
+   - **Mobile** (< 640 px): colunas win rate e confiança visíveis; Δ e
+     posição numérica colapsam num badge sobreposto ao nome do post.
+     Toggle de detalhes técnicos mantido, oculta os mesmos campos que em
+     desktop (μ, σ, ordinal).
 3. **Movimento (Δ):** persistir snapshot do ranking por build em
-   `src/generated/ranking-snapshot.json` (schema versionado + validação no
-   `hronir:doctor`, conforme o padrão de dados persistidos do `CLAUDE.md`) e
-   exibir ▲/▼/— por linha comparando com o snapshot anterior.
+   `src/generated/ranking-snapshot.json` (schema versionado com campo `basis`
+   `"build" | "season"`, validação no `hronir:doctor`). Exibir ▲/▼/— por
+   linha comparando com o snapshot anterior.
 4. **Seção de perspectivas:** grid de cards (nome, resumo de uma linha,
    líder atual) linkando para `/ranking/perspectives/<id>/` — resolve a
    descobribilidade de D2. Os chips de filtro continuam com papel separado.
+   - **Mobile**: 1 coluna em < 480 px, 2 colunas em 480–768 px, 3+ em
+     desktop. Altura mínima de 5rem por card para affordance de toque.
 
 **Critério de aceite:** nenhum jargão estatístico visível sem interação;
-win rate legível na tabela; perspectivas alcançáveis em 1 clique da
-`/ranking/`.
+win rate e Δ legíveis na tabela; perspectivas alcançáveis em 1 clique da
+`/ranking/`; URL com `?view=technical` reproduz modo técnico ao ser colada.
 
 ### Fase 4 — Dossiê por post e ligação bidirecional
 
 1. **`/ranking/posts/<key>/`:** página por post ranqueado com posição atual
    (global e por perspectiva), histórico de duelos com links para as páginas
    de batalha, e trajetória do ordinal como sparkline SVG gerado no build
-   (sem JS).
-2. **Link no post:** rodapé dos posts ranqueados ganha uma linha discreta
-   ("**#12** no ranking Hrönir · 7 duelos · ver dossiê") — fecha o ciclo
-   leitor → post → ranking → resenhas (D5).
-3. A coluna Post da tabela linka título → post e um ícone/posição → dossiê.
+   (sem JS). Thresholds:
+   - 0 duelos: página não emitida (ver estados vazios em Fase 1).
+   - 1 duelo: dossiê emitido, sparkline substituída por texto.
+   - ≥2 duelos: sparkline SVG com dimensões mínimas de 120 × 32 px (legível
+     em mobile); pontos com `aria-label` contendo valor e data.
+2. **Link no post:** rodapé dos posts ranqueados (com ≥1 duelo) ganha linha
+   discreta ("**#12** no ranking Hrönir · 7 duelos · ver dossiê") — fecha o
+   ciclo leitor → post → ranking → resenhas (D5).
+3. A coluna Post da tabela linka título → post e ícone/posição → dossiê.
 
 **Critério de aceite:** todo post com ≥1 duelo tem dossiê; post linka dossiê
-e vice-versa; sparkline renderiza sem JS.
+e vice-versa; sparkline renderiza sem JS; link no rodapé do post ausente se
+0 duelos.
 
 ### Fase 5 — Narrativa (opcional, pode ser cortada)
 
 1. Exibir `evaluatorMood` → `evaluatorMoodAfter` na página do duelo como
-   citação curta ("estado do avaliador antes/depois") — é o material mais
-   idiossincrático do sistema e hoje é invisível (D9).
+   citação curta ("estado do avaliador"). **Nota de idioma:** `--after-mood`
+   é sempre escrito em PT (restrição do `CLAUDE.md`). Exibir com atributo
+   `lang="pt"` explícito na marcação e prefixo de idioma visível nas páginas
+   EN ("Evaluator state (PT):") — mistura declarada é melhor que mistura
+   oculta.
 2. Ordenação client-side da tabela por coluna (vitórias, duelos, Δ) como
    progressive enhancement sem dependências.
 
@@ -287,10 +371,10 @@ e vice-versa; sparkline renderiza sem JS.
 | `src/pages/ranking/perspectives/[id].astro`    | Fase 0 — guarda contra `getStaticPaths` vazio; Fase 3 — versão PT (questão aberta) |
 | `src/components/RankingView.astro`             | Fases 0–3 — emagrece: perde corpo dos duelos e `data-search`                       |
 | `src/pages/ranking.astro` / `pt/ranking.astro` | Fases 1–3 — novas strings, menos dados passados                                    |
-| `src/pages/ranking/battles/…` (novo)           | Fase 1 — listagem paginada + página por duelo                                      |
+| `src/pages/ranking/battles/…` (novo)           | Fase 1 — listagem paginada + página por duelo + breadcrumb + prev/next             |
 | `src/pages/ranking/posts/…` (novo)             | Fase 4 — dossiê por post                                                           |
-| `src/lib/hronir-rank.ts`                       | Fases 1/3/4 — id estável de duelo, snapshot Δ, trajetória por post                 |
-| `src/generated/ranking-snapshot.json` (novo)   | Fase 3 — schema versionado + validação no doctor                                   |
+| `src/lib/hronir-rank.ts`                       | Fases 1/3/4 — função de hash de 8 chars, snapshot Δ, trajetória por post           |
+| `src/generated/ranking-snapshot.json` (novo)   | Fase 3 — schema versionado (`basis` field) + validação no doctor                   |
 | `scripts/hronir/`                              | Sem mudança no CLI/engine                                                          |
 | `.routines/hronir/rates/*`                     | Sem mudança de schema                                                              |
 | Pagefind                                       | Fase 1 — páginas de duelo entram no índice existente                               |
@@ -319,34 +403,46 @@ e vice-versa; sparkline renderiza sem JS.
   acopla a UI ao motor. O snapshot por build é mais simples e auditável.
   Escolhido snapshot; replay fica como fallback se o snapshot se provar
   ruidoso.
+- **ID de duelo = nome do rate file (sem extensão).** Estável, legível —
+  mas expõe a convenção interna de nomenclatura (`YYYY-MM-DD…`) e quebraria
+  se ela mudar. Rejeitado em favor do hash de 8 chars.
+- **Toggle de tabela persistido em `localStorage`** em vez de query param.
+  Não é compartilhável: usuário A no modo técnico envia URL para usuário B
+  que vê modo simples — contradiz o objetivo de D3. Rejeitado.
 
 ---
 
 ## 7. Questões em aberto
 
-1. **Identificador público do duelo:** derivar do nome do rate file (estável,
-   mas expõe o timestamp/convention interna) ou de um hash curto do conteúdo?
-   Proposta r0: nome do arquivo sem extensão — já é estável e legível.
-2. **Versão PT das páginas de perspectiva e de duelo:** o conteúdo dos duelos
-   é misto (resenha na língua do post avaliado). r0 propõe páginas únicas
-   (sem par PT/EN) com `lang` do chrome herdado da seção — confirmar se isso
-   convive bem com o padrão hreflang do sitemap.
-3. **Granularidade do snapshot de Δ:** por build pode gerar ▲▼ ruidoso quando
-   várias sessões mergeiam no mesmo dia. Alternativa: snapshot por season.
-   Decidir na Fase 3 com dados reais.
+1. ~~**Identificador público do duelo**~~ — **resolvido na r1**: hash dos
+   primeiros 8 chars do SHA-256 do conteúdo canônico (ver Fase 1, item 5).
+2. **Versão PT das páginas de perspectiva e de duelo:** r1 propõe páginas
+   únicas (sem par PT/EN) com `lang` do chrome herdado da seção — confirmar
+   se convive com o padrão hreflang do sitemap antes de Fase 1.
+3. **Granularidade do snapshot de Δ:** snapshot por build pode gerar ▲▼
+   ruidoso quando várias sessões mergeiam no mesmo dia. Alternativa: snapshot
+   por season. O schema reserva o campo `basis: "build" | "season"` para
+   suportar ambos; decidir na Fase 3 com dados reais.
 4. **Onde mora a CTA de "sugerir duelo"** depois da Fase 1 — na `/ranking/`,
-   no arquivo de batalhas, ou em ambos.
+   no arquivo de batalhas, ou em ambos. Decidir na Fase 1.
+5. **Pagefind e idioma misto:** páginas de duelo têm conteúdo misto (resenha
+   na língua do post avaliado). Avaliar se isso causa ruído nos resultados de
+   busca PT — pode requerer `data-pagefind-filter="language:en"` nas páginas
+   de duelo.
 
 ---
 
 ## 8. Plano de execução da PR
 
-1. **Commit 1 (este):** RFC 0007.
-2. Após merge: Fase 0 em PR própria (pequena, só bugs — pode sair antes das
+1. **Commit 1 (RFC r0):** versão inicial.
+2. **Commit 2 (RFC r1, este):** incorpora review do Franklin — resolve ID
+   de URL, navegação entre duelos, estados vazios, ARIA patterns, toggle
+   de tabela, mobile constraints, mood/idioma.
+3. Após merge: Fase 0 em PR própria (pequena, só bugs — pode sair antes das
    demais). Fases 1–4 em PRs separadas, cada uma verde
    (`build` + `astro check` + `prettier` + `hronir:doctor`) antes da próxima.
-3. Fase 5 só se as anteriores não revelarem custo inesperado.
-4. Merge sempre com **merge commit**, conforme `CLAUDE.md`.
+4. Fase 5 só se as anteriores não revelarem custo inesperado.
+5. Merge sempre com **merge commit**, conforme `CLAUDE.md`.
 
 ---
 
@@ -357,3 +453,12 @@ e vice-versa; sparkline renderiza sem JS.
   `import.meta.url` vs cwd). Decisões: arquivo de batalhas como rotas
   estáticas paginadas + página por duelo; busca via Pagefind; jargão atrás
   de progressive disclosure; snapshot versionado para Δ.
+- **r1** (2026-06-10): revisão após review do Franklin (PR #326). Resoluções:
+  URL ID = hash de 8 chars SHA-256 (Q1 fechado); ARIA pattern corrigido para
+  `radiogroup`/`radio` em grupos de seleção exclusiva; toggle de tabela
+  refletido em `?view=technical` em vez de `localStorage`; prev/next +
+  breadcrumb adicionados como requisito obrigatório da Fase 1 (§3.1); estados
+  vazios definidos por componente (sparkline ≥2 duelos, dossiê ≥1 duelo);
+  barra de tensão ausente → traço neutro com `aria-label`; constraints mobile
+  adicionadas à Fase 3 (tabela, grid de perspectivas) e Fase 4 (sparkline);
+  mood em páginas EN com `lang="pt"` explícito e prefixo de atribuição.

--- a/docs/rfcs/0007-ranking-ui-e-ux-de-leitura.md
+++ b/docs/rfcs/0007-ranking-ui-e-ux-de-leitura.md
@@ -1,0 +1,359 @@
+# RFC 0007 — Ranking: UI e UX de leitura
+
+|                 |                                                                                                                                                                                        |
+| --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Status**      | Proposta (r0)                                                                                                                                                                          |
+| **Autor**       | Franklin Baldo (proposta assistida)                                                                                                                                                    |
+| **Criado em**   | 2026-06-10                                                                                                                                                                             |
+| **Branch / PR** | `claude/sweet-hypatia-1joz7o`                                                                                                                                                          |
+| **Depende de**  | —                                                                                                                                                                                      |
+| **Afeta**       | `src/pages/ranking.astro`, `src/pages/pt/ranking.astro`, `src/components/RankingView.astro`, `src/pages/ranking/perspectives/`, `src/hronir/perspectives.ts`, `src/lib/hronir-rank.ts` |
+
+> **Etapa 1 — só o RFC.** Implementação faseada após merge, cada fase verde
+> antes da próxima, conforme o padrão das RFCs anteriores.
+
+---
+
+## 1. Resumo
+
+A página `/ranking/` cresceu por acreção: pódio, tabela OpenSkill, filtros,
+cards de batalha com resenhas completas. O resultado funciona para quem já
+conhece o Hrönir, mas tem três problemas estruturais para o leitor comum:
+
+1. **Peso**: o HTML da página tem **3,1 MB por idioma** — todos os 338 duelos
+   são renderizados integralmente no documento; a paginação só alterna
+   `display: none`.
+2. **Becos sem saída**: as páginas de perspectiva retornam **404 em produção**
+   (bug de build silencioso), nada na página linka para elas, filtros não
+   sobrevivem a um reload, e não existe visão "todos os duelos deste post".
+3. **Hermetismo**: μ, σ e ordinal são apresentados sem mediação além de
+   tooltips `abbr@title`, que não funcionam em touch. O leitor casual não tem
+   como saber o que está olhando.
+
+Esta RFC documenta o diagnóstico com evidências e propõe correções em cinco
+fases: bugs imediatos, dieta da página, estado na URL, legibilidade para
+leitores e dossiê por post.
+
+---
+
+## 2. Diagnóstico — evidência concreta
+
+Números de referência (build de 2026-06-10): 225 arquivos de post,
+338 rate files em `.routines/hronir/rates/` (1,6 MB), 12 perspectivas.
+
+### D1. Página de 3,1 MB — paginação cosmética
+
+```
+dist/ranking/index.html        3.100.721 bytes
+dist/pt/ranking/index.html     3.113.857 bytes
+dist/archive/index.html          158.332 bytes   (referência)
+dist/index.html                   74.220 bytes   (referência)
+```
+
+`RankingView.astro` renderiza **todos** os duelos de `getAllDuels()` no
+documento, cada um com veredito + duas resenhas (≥100 palavras cada) passadas
+pelo `marked.parse`, mais um atributo `data-search` que duplica todo o texto
+em minúsculas para a busca client-side. A "paginação" (15 cards por página)
+acontece depois, em JS, escondendo cards com `display: none` — o DOM e o
+download carregam tudo sempre.
+
+Cada duelo custa ~9 KB de HTML × 2 idiomas. Com o autopilot rodando, a página
+cresce sem teto: mais um ano de sessões e passamos de 6 MB. Em mobile isso é
+custo real de dados, parse e LCP.
+
+### D2. Páginas de perspectiva: 404 em produção, bug silencioso
+
+`src/pages/ranking/perspectives/[id].astro` existe, funciona no `astro dev`
+(HTTP 200), mas **não é emitida no build estático** — verificado:
+`https://franklinbaldo.github.io/ranking/perspectives/curious-outsider/`
+retorna 404, e o build de 1180 rotas não contém nenhuma delas.
+
+Causa raiz: `src/hronir/perspectives.ts:7-10` resolve o diretório de
+perspectivas a partir de `import.meta.url`:
+
+```ts
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, "../..");
+const PERSPECTIVES_DIR = path.join(ROOT, "scripts/hronir/perspectives");
+```
+
+No dev server o módulo roda de `src/hronir/` e o caminho fecha. No build, o
+vite reloca o chunk e `ROOT` aponta para fora do repo; `fs.existsSync`
+falha, `listPerspectives()` retorna `[]` (linha 22), `getStaticPaths()`
+retorna `[]` e o Astro emite **zero páginas sem nenhum erro**. Já
+`posts.ts:8` usa caminho relativo ao cwd (`".routines/hronir"`) — por isso os
+duelos da `/ranking/` funcionam no mesmo build.
+
+Agravante de UX: mesmo se as páginas existissem, **nada na `/ranking/` linka
+para elas**. Os chips de perspectiva apenas filtram batalhas; o leitor não
+descobre que cada perspectiva tem ranking próprio.
+
+### D3. Estado efêmero: nada é compartilhável
+
+- Filtros (busca, season, agente, confiança, perspectiva, critério) e página
+  atual vivem só em variáveis JS. Recarregar ou compartilhar a URL perde tudo.
+- Cards de batalha não têm `id`/anchor — é impossível linkar um duelo
+  específico, embora cada rate file tenha identificador estável.
+- O botão "voltar" do navegador ignora qualquer interação com filtros.
+
+### D4. Tabela hermética para o leitor casual
+
+- μ, σ e ordinal só são explicados via `abbr@title` — invisível em touch
+  (maioria do tráfego mobile) e sem affordance além de um pontilhado.
+- O win rate existe mas está escondido num `title` do `<td>`
+  (`RankingView.astro:273`).
+- Não há indicação de movimento (subiu/desceu desde a última rodada).
+- O top-3 vive só no pódio e **não aparece na tabela** (`rows.slice(3)`):
+  Ctrl+F e leitura sequencial da tabela começam no #4.
+
+### D5. Sem visão por post
+
+Não existe página que responda "por que este post está em #12?": histórico de
+duelos do post, resenhas que recebeu, trajetória de rating. O leitor que chega
+pelo post também não tem caminho para o ranking — a ligação é unidirecional.
+
+### D6. Vazamento de idioma na página EN
+
+`RankingView.astro:299` hardcoda o texto do link da CTA de posts não
+avaliados em português ("Abra uma issue sugerindo um duelo.") mesmo na página
+EN. Deveria ser uma string de `RankingStrings`.
+
+### D7. Barra de tensão fabrica dados
+
+`RankingView.astro:404-406`: quando o duelo não tem `rate_a`/`rate_b`, a
+barra de tensão usa `65%` como default — o leitor lê uma proporção que não
+existe. Dado ausente deve ser apresentado como ausente.
+
+### D8. Acessibilidade dos filtros
+
+- Chips e pills são `<button>` sem `aria-pressed`/`role` — leitores de tela
+  não anunciam o estado ativo.
+- O contador "Showing X of Y battles" não tem `aria-live`, então mudanças de
+  filtro são silenciosas.
+- Botões dentro de form-less markup sem `type="button"` (inofensivo aqui, mas
+  frágil).
+
+### D9. Dados carregados e nunca exibidos
+
+`DuelEntry` carrega `evaluatorMood` e `evaluatorMoodAfter` para todos os
+duelos (`hronir-rank.ts:153-158`) e a UI nunca os mostra — e o mood é
+justamente a assinatura narrativa do Hrönir. A string `ratesLabel` em
+`RankingStrings` está morta. Custo zero de remoção, ganho narrativo real de
+exibição.
+
+---
+
+## 3. Objetivos e não-objetivos
+
+### Objetivos
+
+- `/ranking/` com peso de página normal (≤ ~300 KB) e crescimento O(1) com o
+  número de duelos.
+- Toda visão tem URL: filtros, página do arquivo de batalhas, duelo
+  individual, perspectiva, dossiê de post.
+- Leitor casual entende o ranking sem conhecer OpenSkill; o detalhe técnico
+  (μ, σ) fica a um clique, não na cara.
+- Bug das páginas de perspectiva corrigido **com guarda contra regressão**
+  (build falha se `getStaticPaths` de perspectivas retornar vazio).
+- Ligação bidirecional post ↔ ranking.
+
+### Não-objetivos
+
+- Não mudar o motor de rating (OpenSkill, ordinal = μ − 3σ), o schema
+  `stars-v1`, nem o CLI do Hrönir.
+- Não introduzir framework de UI/ilha hidratada — a página continua
+  Astro estático + JS vanilla progressivo.
+- Não redesenhar a identidade visual (Pico CSS, tema atual).
+- Não mexer nas OG images do ranking.
+
+---
+
+## 4. Proposta por fases
+
+### Fase 0 — Correções imediatas (bugs, sem mudança de design)
+
+1. **Perspectivas no build (D2):** trocar a resolução de `PERSPECTIVES_DIR`
+   para caminho relativo ao cwd, alinhada com `posts.ts` (o build sempre roda
+   da raiz do repo — mesma premissa que `.routines/hronir` já assume).
+   Adicionar guarda: `getStaticPaths()` de `[id].astro` lança erro se
+   `getPerspectives()` vier vazio — o build quebra alto em vez de emitir
+   silenciosamente zero páginas.
+2. **i18n da CTA (D6):** mover o texto do link para `RankingStrings.unratedCTALink`.
+3. **Barra de tensão honesta (D7):** sem rates, não renderizar a barra.
+4. **A11y básica (D8):** `aria-pressed` nos chips/pills, `aria-live="polite"`
+   no contador, `type="button"` nos botões de filtro.
+5. **Limpeza (D9):** remover `ratesLabel` morto.
+
+**Critério de aceite:** `dist/ranking/perspectives/<id>/index.html` existe
+para as 12 perspectivas; curl em produção retorna 200 após deploy;
+`npm run build` + `npx astro check` + prettier verdes.
+
+### Fase 1 — Dieta da página: arquivo de batalhas paginado
+
+A raiz do problema D1 é arquitetural: um arquivo crescente renderizado numa
+página só.
+
+1. **`/ranking/` enxuta:** mantém pódio, stats, tabela completa (incluindo
+   top-3 — resolve parte de D4), seção de não avaliados e **apenas os ~10
+   duelos mais recentes** como cards resumidos, com link "ver todas as
+   batalhas".
+2. **`/ranking/battles/[page]/`:** rota estática paginada (20 cards por
+   página, mais recente primeiro), gerada no build via `getStaticPaths` —
+   paginação real, por URL, sem JS obrigatório.
+3. **`/ranking/battles/<id>/`:** página por duelo com o conteúdo completo
+   (veredito, resenhas A/B, mood do avaliador — D9), usando identificador
+   estável derivado do rate file. Os cards nas listagens carregam só o
+   cabeçalho (data, tags, versus, rates) e linkam para a página do duelo —
+   o corpo sai do HTML das listagens, e `<details>` deixa de ser o container
+   do conteúdo pesado.
+4. **Busca via Pagefind (substitui `data-search`):** as páginas de duelo
+   entram no índice Pagefind que o site já usa (`pagefind --site dist` já
+   roda no build). A caixa de busca de batalhas passa a consultar o índice —
+   busca melhor (stemming, ranking) e elimina a duplicação de texto nos
+   atributos.
+
+Os filtros estruturados (season, agente, perspectiva, confiança, critério)
+continuam client-side, mas operando sobre os cabeçalhos leves da página
+corrente do arquivo.
+
+**Critério de aceite:** `dist/ranking/index.html` ≤ 300 KB; soma de páginas
+do arquivo cobre 100% dos duelos válidos; cada duelo tem URL própria estável;
+busca encontra texto que hoje só existe no corpo das resenhas.
+
+### Fase 2 — Estado na URL
+
+1. Filtros e página refletidos em query params
+   (`?q=…&season=2&perspective=curious-outsider`), aplicados na carga e
+   atualizados via `history.replaceState`.
+2. Anchors nos cards (`id` = identificador do duelo) para deep-link dentro
+   de uma página do arquivo.
+
+**Critério de aceite:** colar uma URL filtrada reproduz exatamente a visão;
+back/forward não perde estado; sem JS, as URLs continuam resolvendo (filtros
+são progressive enhancement).
+
+### Fase 3 — Legibilidade para leitores
+
+1. **Explicação em camadas:** um parágrafo curto em linguagem comum no topo
+   ("posts duelam em pares; vence quem convence; a posição combina força
+   estimada e incerteza") + `<details>` "como funciona o ranking" com a
+   explicação completa de μ/σ/ordinal — substitui os tooltips `abbr@title`
+   como canal principal (D4).
+2. **Tabela com modos:** por padrão, colunas Post / ★ posição / vitórias
+   (win rate visível, D4) / confiança; μ, σ e ordinal ficam atrás de um
+   toggle "detalhes técnicos" (persistido em `localStorage`). Top-3 também
+   listado na tabela, com destaque.
+3. **Movimento (Δ):** persistir snapshot do ranking por build em
+   `src/generated/ranking-snapshot.json` (schema versionado + validação no
+   `hronir:doctor`, conforme o padrão de dados persistidos do `CLAUDE.md`) e
+   exibir ▲/▼/— por linha comparando com o snapshot anterior.
+4. **Seção de perspectivas:** grid de cards (nome, resumo de uma linha,
+   líder atual) linkando para `/ranking/perspectives/<id>/` — resolve a
+   descobribilidade de D2. Os chips de filtro continuam com papel separado.
+
+**Critério de aceite:** nenhum jargão estatístico visível sem interação;
+win rate legível na tabela; perspectivas alcançáveis em 1 clique da
+`/ranking/`.
+
+### Fase 4 — Dossiê por post e ligação bidirecional
+
+1. **`/ranking/posts/<key>/`:** página por post ranqueado com posição atual
+   (global e por perspectiva), histórico de duelos com links para as páginas
+   de batalha, e trajetória do ordinal como sparkline SVG gerado no build
+   (sem JS).
+2. **Link no post:** rodapé dos posts ranqueados ganha uma linha discreta
+   ("**#12** no ranking Hrönir · 7 duelos · ver dossiê") — fecha o ciclo
+   leitor → post → ranking → resenhas (D5).
+3. A coluna Post da tabela linka título → post e um ícone/posição → dossiê.
+
+**Critério de aceite:** todo post com ≥1 duelo tem dossiê; post linka dossiê
+e vice-versa; sparkline renderiza sem JS.
+
+### Fase 5 — Narrativa (opcional, pode ser cortada)
+
+1. Exibir `evaluatorMood` → `evaluatorMoodAfter` na página do duelo como
+   citação curta ("estado do avaliador antes/depois") — é o material mais
+   idiossincrático do sistema e hoje é invisível (D9).
+2. Ordenação client-side da tabela por coluna (vitórias, duelos, Δ) como
+   progressive enhancement sem dependências.
+
+---
+
+## 5. Análise de impacto
+
+| Componente                                     | Impacto                                                                            |
+| ---------------------------------------------- | ---------------------------------------------------------------------------------- |
+| `src/hronir/perspectives.ts`                   | Fase 0 — resolução de caminho via cwd                                              |
+| `src/pages/ranking/perspectives/[id].astro`    | Fase 0 — guarda contra `getStaticPaths` vazio; Fase 3 — versão PT (questão aberta) |
+| `src/components/RankingView.astro`             | Fases 0–3 — emagrece: perde corpo dos duelos e `data-search`                       |
+| `src/pages/ranking.astro` / `pt/ranking.astro` | Fases 1–3 — novas strings, menos dados passados                                    |
+| `src/pages/ranking/battles/…` (novo)           | Fase 1 — listagem paginada + página por duelo                                      |
+| `src/pages/ranking/posts/…` (novo)             | Fase 4 — dossiê por post                                                           |
+| `src/lib/hronir-rank.ts`                       | Fases 1/3/4 — id estável de duelo, snapshot Δ, trajetória por post                 |
+| `src/generated/ranking-snapshot.json` (novo)   | Fase 3 — schema versionado + validação no doctor                                   |
+| `scripts/hronir/`                              | Sem mudança no CLI/engine                                                          |
+| `.routines/hronir/rates/*`                     | Sem mudança de schema                                                              |
+| Pagefind                                       | Fase 1 — páginas de duelo entram no índice existente                               |
+| OG images                                      | Sem mudança                                                                        |
+
+---
+
+## 6. Alternativas consideradas
+
+- **Hidratar a lista de batalhas como ilha (React/Svelte) com fetch de
+  JSON.** Resolve o peso, mas adiciona framework e runtime a um site que é
+  deliberadamente estático + vanilla. Rejeitado.
+- **Lazy-load do corpo do duelo via `fetch` no primeiro expand** (cards
+  continuam `<details>`, corpo vem de fragmento JSON/HTML). Menos navegação
+  que páginas por duelo, mas não cria URLs compartilháveis nem entra no
+  Pagefind, e mantém a listagem como única visão. Rejeitado em favor de
+  páginas estáticas por duelo — mais barato, mais indexável, mais linkável.
+- **Virtualização client-side da lista** (renderizar do JSON sob demanda).
+  Mantém um JSON de 1,6 MB+ no payload e quebra sem JS. Rejeitado.
+- **Truncar o arquivo (mostrar só N duelos recentes e descartar o resto da
+  UI).** Perde o acervo de resenhas, que é conteúdo original do site.
+  Rejeitado.
+- **Δ de ranking computado por replay dos rate files** (sem snapshot):
+  reprocessar o ranking em t−1 a partir dos próprios arquivos. Elegante (sem
+  estado novo), mas "t−1" é ambíguo (último build? última season?) e o replay
+  acopla a UI ao motor. O snapshot por build é mais simples e auditável.
+  Escolhido snapshot; replay fica como fallback se o snapshot se provar
+  ruidoso.
+
+---
+
+## 7. Questões em aberto
+
+1. **Identificador público do duelo:** derivar do nome do rate file (estável,
+   mas expõe o timestamp/convention interna) ou de um hash curto do conteúdo?
+   Proposta r0: nome do arquivo sem extensão — já é estável e legível.
+2. **Versão PT das páginas de perspectiva e de duelo:** o conteúdo dos duelos
+   é misto (resenha na língua do post avaliado). r0 propõe páginas únicas
+   (sem par PT/EN) com `lang` do chrome herdado da seção — confirmar se isso
+   convive bem com o padrão hreflang do sitemap.
+3. **Granularidade do snapshot de Δ:** por build pode gerar ▲▼ ruidoso quando
+   várias sessões mergeiam no mesmo dia. Alternativa: snapshot por season.
+   Decidir na Fase 3 com dados reais.
+4. **Onde mora a CTA de "sugerir duelo"** depois da Fase 1 — na `/ranking/`,
+   no arquivo de batalhas, ou em ambos.
+
+---
+
+## 8. Plano de execução da PR
+
+1. **Commit 1 (este):** RFC 0007.
+2. Após merge: Fase 0 em PR própria (pequena, só bugs — pode sair antes das
+   demais). Fases 1–4 em PRs separadas, cada uma verde
+   (`build` + `astro check` + `prettier` + `hronir:doctor`) antes da próxima.
+3. Fase 5 só se as anteriores não revelarem custo inesperado.
+4. Merge sempre com **merge commit**, conforme `CLAUDE.md`.
+
+---
+
+## Histórico de revisões
+
+- **r0** (2026-06-10): versão inicial. Diagnóstico medido em build local
+  (3,1 MB/idioma; 404 das perspectivas confirmado em produção; causa raiz
+  `import.meta.url` vs cwd). Decisões: arquivo de batalhas como rotas
+  estáticas paginadas + página por duelo; busca via Pagefind; jargão atrás
+  de progressive disclosure; snapshot versionado para Δ.

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "check:links": "node scripts/check-links.mjs",
     "check:translations": "node scripts/check-translations.mjs",
     "dev": "astro dev",
-    "build": "astro build && node scripts/fix-redirect-html.mjs && pagefind --site dist",
+    "build": "astro build && node scripts/fix-redirect-html.mjs && pagefind --site dist && node --import tsx/esm scripts/generate-ranking-snapshot.mjs",
     "preview": "astro preview",
     "astro": "astro",
     "format": "prettier --write .",

--- a/scripts/generate-ranking-snapshot.mjs
+++ b/scripts/generate-ranking-snapshot.mjs
@@ -1,0 +1,36 @@
+#!/usr/bin/env node
+// Saves the current ranking to src/generated/ranking-snapshot.json.
+// Run after each build so the next build can show movement (Δ) in the table.
+// This file is committed to git; the diff between builds IS the Δ.
+
+import { writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { computeRatings } from "../src/hronir/ranking.js";
+import { listMatchFiles, readMatch } from "../src/hronir/matches.js";
+
+const rows = computeRatings();
+const duels = listMatchFiles()
+  .map((f) => readMatch(f))
+  .filter((m) => {
+    const w = m.data?.winner;
+    const ov = m.data?.override;
+    return w && w !== "TODO" && (!ov || ov === "null");
+  });
+
+const keys = {};
+rows.forEach((r, i) => {
+  keys[r.key] = { rank: i + 1, ordinal: Number(r.ordinal.toFixed(4)) };
+});
+
+const snapshot = {
+  _meta: {
+    generatedAt: new Date().toISOString(),
+    basis: "build",
+    totalDuels: duels.length,
+  },
+  keys,
+};
+
+const out = join(process.cwd(), "src/generated/ranking-snapshot.json");
+writeFileSync(out, JSON.stringify(snapshot, null, 2) + "\n");
+console.log(`ranking-snapshot: ${rows.length} keys saved to ${out}`);

--- a/src/components/RankingView.astro
+++ b/src/components/RankingView.astro
@@ -1,6 +1,11 @@
 ---
-import type { RankRow, DuelEntry, RankingStats } from "../lib/hronir-rank";
-import { marked } from "marked";
+import type {
+  RankRow,
+  DuelEntry,
+  RankingStats,
+  PerspectiveGridItem,
+  RankingSnapshot,
+} from "../lib/hronir-rank";
 
 export interface RankPostInfo {
   slug: string;
@@ -20,9 +25,11 @@ export interface UnratedItem {
 }
 
 export interface RankingStrings {
-  /** small grey label below H1 */
   subtitle: string;
-  intro: string;
+  plainLangHeading: string;
+  plainLangBody: string;
+  technicalViewLabel: string;
+  standardViewLabel: string;
   podiumLabel: string;
   statsTotalDuels: string;
   statsTotalRated: string;
@@ -34,13 +41,15 @@ export interface RankingStrings {
   thOrdinal: string;
   thMu: string;
   thSigma: string;
-  thRecord: string; // V/N or W/N
+  thRecord: string;
   thConfidence: string;
+  thWinRate: string;
+  thDelta: string;
   unratedHeading: string;
   unratedBlurb: string;
   recentHeading: string;
   recentBlurb: string;
-  recentBeats: string; // e.g. "venceu" / "beat"
+  recentBeats: string;
   emptyState: string;
   ordinalTip: string;
   muTip: string;
@@ -52,30 +61,13 @@ export interface RankingStrings {
   podiumSilver: string;
   podiumBronze: string;
   noDate: string;
-  filterSearchPlaceholder: string;
-  filterCriterionAll: string;
-  filterConfidenceAll: string;
-  filterSeasonAll: string;
-  showingResultsCount: string;
-  verdictTab: string;
-  analysisATab: string;
-  analysisBTab: string;
-  emptyFilterState: string;
-  modelLabel: string;
-  seasonLabel: string;
-  marginLabel: string;
-  marginHigh: string;
-  marginMedium: string;
-  marginLow: string;
   unratedCTA: string;
-  perspectiveLabel: string;
-  filterPerspectiveAll: string;
-  agentLabel: string;
-  filterAgentAll: string;
-  ratesLabel: string;
-  paginationPrev: string;
-  paginationNext: string;
-  paginationPageOf: string;
+  perspectivesHeading: string;
+  perspectivesBlurb: string;
+  perspectivesLeaderLabel: string;
+  perspectivesViewAllLink: string;
+  allBattlesLinkText: string;
+  readAnalysisLinkLabel: string;
 }
 
 interface Props {
@@ -86,9 +78,21 @@ interface Props {
   stats: RankingStats;
   postByKey: Map<string, RankPostInfo>;
   strings: RankingStrings;
+  perspectivesGrid?: PerspectiveGridItem[];
+  snapshot?: RankingSnapshot | null;
 }
 
-const { rows, unrated, recent, stats, postByKey, strings, lang } = Astro.props as Props;
+const {
+  rows,
+  unrated,
+  recent,
+  stats,
+  postByKey,
+  strings,
+  lang,
+  perspectivesGrid,
+  snapshot,
+} = Astro.props as Props;
 
 const locale = lang === "pt" ? "pt-BR" : "en-US";
 
@@ -132,7 +136,6 @@ function perspectiveHue(id: string): number {
 }
 
 const podium = rows.slice(0, 3);
-const rest = rows.slice(3);
 
 const podiumMeta = [
   { label: strings.podiumGold, place: 1 },
@@ -152,19 +155,14 @@ function postHref(key: string): string | null {
   return p.lang === "pt" ? `/pt/blog/${p.slug}/` : `/blog/${p.slug}/`;
 }
 
-const criteria = Array.from(new Set(recent.map((d) => d.criterion).filter(Boolean))) as string[];
-const seasons = Array.from(new Set(recent.map((d) => d.season).filter((s) => typeof s === "number"))) as number[];
-seasons.sort((a, b) => a - b);
-
-const perspectives = Array.from(
-  new Set(recent.map((d) => d.perspectiveId).filter(Boolean))
-) as string[];
-perspectives.sort();
-
-const agents = Array.from(
-  new Set(recent.map((d) => d.agentId).filter(Boolean))
-) as string[];
-agents.sort();
+function snapshotDelta(key: string): number | null {
+  if (!snapshot) return null;
+  const prev = snapshot.keys[key];
+  if (!prev) return null;
+  const current = rows.find((r) => r.key === key);
+  if (!current) return null;
+  return prev.rank - current.rank;
+}
 ---
 
 <hgroup>
@@ -172,7 +170,10 @@ agents.sort();
   <p><small>{strings.subtitle}</small></p>
 </hgroup>
 
-<p class="rank-intro">{strings.intro}</p>
+<details class="plain-lang-explain">
+  <summary>{strings.plainLangHeading}</summary>
+  <p>{strings.plainLangBody}</p>
+</details>
 
 {rows.length > 0 && (
   <section class="rank-stats" aria-label={strings.statsTotalDuels}>
@@ -230,36 +231,49 @@ agents.sort();
 )}
 
 {rows.length > 0 && (
+  <div class="rank-table-header">
+    <p class="rank-caption">{strings.tableCaption}</p>
+    <button class="view-toggle" id="view-toggle" type="button">
+      {strings.technicalViewLabel}
+    </button>
+  </div>
   <div class="overflow-table rank-table-wrap">
-    <table class="rank-table">
-      <caption class="rank-caption">{strings.tableCaption}</caption>
+    <table class="rank-table" id="rank-table">
       <thead>
         <tr>
           <th scope="col" class="col-rank">{strings.thRank}</th>
           <th scope="col" class="col-post">{strings.thPost}</th>
-          <th scope="col" class="col-ordinal">
+          <th scope="col" class="col-winrate">{strings.thWinRate}</th>
+          {snapshot && <th scope="col" class="col-delta">{strings.thDelta}</th>}
+          <th scope="col" class="col-confidence">{strings.thConfidence}</th>
+          <th scope="col" class="col-ordinal tech-col">
             <abbr title={strings.ordinalTip}>{strings.thOrdinal}</abbr>
           </th>
-          <th scope="col" class="col-mu">
+          <th scope="col" class="col-mu tech-col">
             <abbr title={strings.muTip}>{strings.thMu}</abbr>
           </th>
-          <th scope="col" class="col-sigma">
+          <th scope="col" class="col-sigma tech-col">
             <abbr title={strings.sigmaTip}>{strings.thSigma}</abbr>
           </th>
-          <th scope="col" class="col-record">{strings.thRecord}</th>
-          <th scope="col" class="col-confidence">{strings.thConfidence}</th>
+          <th scope="col" class="col-record tech-col">{strings.thRecord}</th>
         </tr>
       </thead>
       <tbody>
-        {rest.map((r) => {
+        {rows.map((r) => {
           const conf = confidenceLevel(r.sigma, r.appearances);
-          const winRate = r.appearances > 0 ? Math.round((r.wins / r.appearances) * 100) : 0;
+          const winRatePct = r.appearances > 0 ? Math.round((r.wins / r.appearances) * 100) : 0;
+          const delta = snapshotDelta(r.key);
+          const href = r.post
+            ? r.post.lang === "pt"
+              ? `/pt/blog/${r.post.slug}/`
+              : `/blog/${r.post.slug}/`
+            : null;
           return (
             <tr>
               <th scope="row" class="col-rank">{r.rank}</th>
               <td class="col-post">
-                {r.post ? (
-                  <a href={r.post.lang === "pt" ? `/pt/blog/${r.post.slug}/` : `/blog/${r.post.slug}/`}>{r.post.title}</a>
+                {href ? (
+                  <a href={href}>{r.post!.title}</a>
                 ) : (
                   <code>{r.key}</code>
                 )}
@@ -267,13 +281,23 @@ agents.sort();
                   <span style={`width:${barPct(r.ordinal)}%`}></span>
                 </div>
               </td>
-              <td class="col-ordinal num"><strong>{r.ordinal.toFixed(2)}</strong></td>
-              <td class="col-mu num">{r.mu.toFixed(2)}</td>
-              <td class="col-sigma num">{r.sigma.toFixed(2)}</td>
-              <td class="col-record num" title={`${winRate}%`}>{r.wins}/{r.appearances}</td>
+              <td class="col-winrate num">{winRatePct}%</td>
+              {snapshot && (
+                <td class="col-delta num">
+                  {delta === null ? "—" : delta === 0 ? "·" : (
+                    <span class={delta > 0 ? "delta-up" : "delta-down"}>
+                      {delta > 0 ? `+${delta}` : `${delta}`}
+                    </span>
+                  )}
+                </td>
+              )}
               <td class="col-confidence">
                 <span class={`conf-badge conf-${conf.level}`}>{conf.label}</span>
               </td>
+              <td class="col-ordinal num tech-col"><strong>{r.ordinal.toFixed(2)}</strong></td>
+              <td class="col-mu num tech-col">{r.mu.toFixed(2)}</td>
+              <td class="col-sigma num tech-col">{r.sigma.toFixed(2)}</td>
+              <td class="col-record num tech-col" title={`${winRatePct}%`}>{r.wins}/{r.appearances}</td>
             </tr>
           );
         })}
@@ -284,6 +308,103 @@ agents.sort();
 
 {rows.length === 0 && (
   <p class="rank-empty"><em>{strings.emptyState}</em></p>
+)}
+
+{perspectivesGrid && perspectivesGrid.length > 0 && (
+  <section class="perspectives-grid-section">
+    <h2>{strings.perspectivesHeading}</h2>
+    <p><small>{strings.perspectivesBlurb}</small></p>
+    <div class="perspectives-grid">
+      {perspectivesGrid.map((p) => (
+        <a href={`/ranking/perspectives/${p.id}/`} class="persp-card" style={`--ph:${p.hue}`}>
+          <header class="persp-card-head">
+            <span class="persp-name">{p.name}</span>
+          </header>
+          <p class="persp-summary">{p.summary}</p>
+          {p.leaderTitle && (
+            <p class="persp-leader">
+              <span class="persp-leader-label">{strings.perspectivesLeaderLabel}</span>
+              <span class="persp-leader-title">{p.leaderTitle}</span>
+            </p>
+          )}
+        </a>
+      ))}
+    </div>
+    <p class="persp-view-all">
+      <a href="/ranking/perspectives/">{strings.perspectivesViewAllLink}</a>
+    </p>
+  </section>
+)}
+
+{recent.length > 0 && (
+  <section class="rank-recent">
+    <h2>{strings.recentHeading}</h2>
+    <p><small>{strings.recentBlurb}</small></p>
+
+    <div class="battle-list-light">
+      {recent.map((d) => {
+        const winnerHref = postHref(d.winnerKey);
+        const loserHref = postHref(d.loserKey);
+        const winnerName = postLabel(d.winnerKey);
+        const loserName = postLabel(d.loserKey);
+
+        const winnerIsA = d.postAKey === d.winnerKey;
+        const winnerRate = d.rateA != null && d.rateB != null
+          ? (winnerIsA ? d.rateA : d.rateB)
+          : null;
+        const loserRate = d.rateA != null && d.rateB != null
+          ? (winnerIsA ? d.rateB : d.rateA)
+          : null;
+        const tensionPct = winnerRate != null && loserRate != null
+          ? Math.round(winnerRate / (winnerRate + loserRate) * 100)
+          : 62;
+        const hasRates = winnerRate != null && loserRate != null;
+
+        return (
+          <a
+            href={d.id ? `/ranking/battles/${d.id}/` : "/ranking/battles/"}
+            class="bcl-card"
+          >
+            <div class="bcl-meta">
+              <span class="bcl-date">{fmtDate(d.runAt)}</span>
+              {d.perspectiveId && (
+                <span
+                  class="bcl-tag bcl-tag-persp"
+                  style={`--ph:${perspectiveHue(d.perspectiveId)}`}
+                >
+                  {formatPerspective(d.perspectiveId)}
+                </span>
+              )}
+              {d.agentId && (
+                <span class="bcl-tag bcl-tag-agent">{d.agentId}</span>
+              )}
+            </div>
+            <div class="bcl-versus">
+              <span class="bcl-winner">{winnerName}</span>
+              {hasRates && (
+                <span class="bcl-rates">
+                  {winnerRate!.toFixed(1)} · {loserRate!.toFixed(1)}
+                </span>
+              )}
+              <span class="bcl-vs">{strings.recentBeats}</span>
+              <span class="bcl-loser">{loserName}</span>
+            </div>
+            <div class="bcl-tension">
+              <div class="bcl-fill win" style={`width:${tensionPct}%`}></div>
+              <div class="bcl-fill loss" style={`width:${100 - tensionPct}%`}></div>
+            </div>
+            <span class="bcl-read">{strings.readAnalysisLinkLabel} →</span>
+          </a>
+        );
+      })}
+    </div>
+
+    <p class="all-battles-link">
+      <a href="/ranking/battles/">
+        {strings.allBattlesLinkText.replace("{count}", String(stats.totalDuels))}
+      </a>
+    </p>
+  </section>
 )}
 
 {unrated.length > 0 && (
@@ -301,231 +422,28 @@ agents.sort();
   </section>
 )}
 
-{recent.length > 0 && (
-  <section class="rank-recent">
-    <h2>{strings.recentHeading}</h2>
-    <p><small>{strings.recentBlurb}</small></p>
-
-    <!-- Interactive Filter controls -->
-    <div class="battle-filters" id="battle-filters">
-      <div class="filter-row-main">
-        <input type="search" id="battle-search" placeholder={strings.filterSearchPlaceholder} aria-label={strings.filterSearchPlaceholder} />
-      </div>
-      <div class="filter-row-meta">
-        <div class="filter-group">
-          <label for="filter-season">{strings.seasonLabel}</label>
-          <select id="filter-season">
-            <option value="all">{strings.filterSeasonAll}</option>
-            {seasons.map((s) => (
-              <option value={s}>{s}</option>
-            ))}
-          </select>
-        </div>
-        {agents.length > 0 && (
-          <div class="filter-group">
-            <label for="filter-agent">{strings.agentLabel}</label>
-            <select id="filter-agent">
-              <option value="all">{strings.filterAgentAll}</option>
-              {agents.map((a) => (
-                <option value={a}>{a}</option>
-              ))}
-            </select>
-          </div>
-        )}
-        <div class="filter-group">
-          <label>{strings.thConfidence}</label>
-          <div class="filter-pills" id="filter-confidence">
-            <button data-value="all" class="pill active">{strings.filterConfidenceAll}</button>
-            <button data-value="high" class="pill">{strings.confidenceHigh}</button>
-            <button data-value="medium" class="pill">{strings.confidenceMedium}</button>
-            <button data-value="low" class="pill">{strings.confidenceLow}</button>
-          </div>
-        </div>
-      </div>
-      {perspectives.length > 0 && (
-        <div class="filter-row-chips" id="filter-perspective">
-          <button data-perspective="all" class="chip active">{strings.filterPerspectiveAll}</button>
-          {perspectives.map((p) => (
-            <button
-              data-perspective={p}
-              class="chip"
-              style={`--ph:${perspectiveHue(p)}`}
-            >
-              {formatPerspective(p)}
-            </button>
-          ))}
-        </div>
-      )}
-      {criteria.length > 0 && (
-        <div class="filter-row-chips">
-          <button data-criterion="all" class="chip active">{strings.filterCriterionAll}</button>
-          {criteria.map((c) => (
-            <button data-criterion={c} class="chip">{c}</button>
-          ))}
-        </div>
-      )}
-      <div class="filter-status">
-        <span id="filter-count-label" data-template={strings.showingResultsCount}>
-          {strings.showingResultsCount.replace("{count}", String(recent.length)).replace("{total}", String(recent.length))}
-        </span>
-      </div>
-    </div>
-
-    <!-- Battle Cards -->
-    <div class="battle-list" id="battle-list">
-      {recent.map((d) => {
-        const winnerHref = postHref(d.winnerKey);
-        const loserHref = postHref(d.loserKey);
-        const winnerName = postLabel(d.winnerKey);
-        const loserName = postLabel(d.loserKey);
-        const parsed = d.parsedContent;
-        const searchString = [
-          winnerName,
-          loserName,
-          d.perspectiveId ?? "",
-          d.agentId ?? "",
-          d.criterion ?? "",
-          parsed?.verdict ?? "",
-          parsed?.postAAnalysis ?? "",
-          parsed?.postBAnalysis ?? "",
-        ].join(" ").toLowerCase();
-
-        const postAName = d.postAKey ? postLabel(d.postAKey) : "Post A";
-        const postBName = d.postBKey ? postLabel(d.postBKey) : "Post B";
-
-        // Tension bar: use actual rates when available
-        const winnerIsA = d.postAKey === d.winnerKey;
-        const winnerRate = d.rateA != null && d.rateB != null
-          ? (winnerIsA ? d.rateA : d.rateB)
-          : null;
-        const loserRate = d.rateA != null && d.rateB != null
-          ? (winnerIsA ? d.rateB : d.rateA)
-          : null;
-        const tensionPct = winnerRate != null && loserRate != null
-          ? Math.round(winnerRate / (winnerRate + loserRate) * 100)
-          : 65;
-
-        const hasRates = d.rateA != null && d.rateB != null;
-        const rateWinner = winnerRate?.toFixed(1) ?? "";
-        const rateLoser = loserRate?.toFixed(1) ?? "";
-
-        return (
-          <article
-            class="battle-card"
-            data-criterion={d.criterion || "none"}
-            data-confidence={d.confidence || "none"}
-            data-season={d.season !== undefined ? String(d.season) : "none"}
-            data-perspective={d.perspectiveId || "none"}
-            data-agent={d.agentId || "none"}
-            data-search={searchString}
-          >
-            <details class="battle-details">
-              <summary class="battle-header">
-                <div class="battle-meta">
-                  <span class="battle-date">{fmtDate(d.runAt)}</span>
-                  {d.season !== undefined && (
-                    <span class="battle-tag tag-season">{strings.seasonLabel} {d.season}</span>
-                  )}
-                  {d.perspectiveId && (
-                    <span
-                      class="battle-tag tag-perspective"
-                      style={`--ph:${perspectiveHue(d.perspectiveId)}`}
-                      title={`${strings.perspectiveLabel}: ${formatPerspective(d.perspectiveId)}`}
-                    >
-                      {formatPerspective(d.perspectiveId)}
-                    </span>
-                  )}
-                  {d.agentId && (
-                    <span class="battle-tag tag-agent">{d.agentId}</span>
-                  )}
-                  {d.confidence && (
-                    <span class={`battle-tag tag-confidence conf-${d.confidence}`}>{d.confidence}</span>
-                  )}
-                </div>
-                <div class="battle-versus">
-                  <div class="versus-side winner">
-                    {winnerHref ? (
-                      <a href={winnerHref} class="post-title-link">{winnerName}</a>
-                    ) : (
-                      <span class="post-title-text">{winnerName}</span>
-                    )}
-                    <span class="versus-medal" title="Winner" aria-hidden="true">🏆</span>
-                    {hasRates && <span class="versus-rate">{rateWinner}</span>}
-                  </div>
-                  <div class="versus-divider">
-                    <span class="versus-vs">VS</span>
-                  </div>
-                  <div class="versus-side loser">
-                    {loserHref ? (
-                      <a href={loserHref} class="post-title-link">{loserName}</a>
-                    ) : (
-                      <span class="post-title-text">{loserName}</span>
-                    )}
-                    {hasRates && <span class="versus-rate loser-rate">{rateLoser}</span>}
-                  </div>
-                </div>
-                <div class="battle-tension-bar">
-                  <div class="tension-fill winner" style={`width: ${tensionPct}%;`}></div>
-                  <div class="tension-fill loser" style={`width: ${100 - tensionPct}%;`}></div>
-                </div>
-                <div class="battle-expand-indicator">
-                  <span class="expand-icon" aria-hidden="true">▼</span>
-                </div>
-              </summary>
-
-              <div class="battle-body">
-                {parsed ? (
-                  <div class="battle-tabs">
-                    {parsed.verdict && (
-                      <div class="battle-section verdict-section">
-                        <h5>{strings.verdictTab}</h5>
-                        <div class="section-content" set:html={marked.parse(parsed.verdict)} />
-                      </div>
-                    )}
-
-                    <div class="battle-sides-grid">
-                      {parsed.postAAnalysis && (
-                        <div class="battle-section side-section">
-                          <h6>{strings.analysisATab} — {postAName}</h6>
-                          <div class="section-content" set:html={marked.parse(parsed.postAAnalysis)} />
-                        </div>
-                      )}
-                      {parsed.postBAnalysis && (
-                        <div class="battle-section side-section">
-                          <h6>{strings.analysisBTab} — {postBName}</h6>
-                          <div class="section-content" set:html={marked.parse(parsed.postBAnalysis)} />
-                        </div>
-                      )}
-                    </div>
-                  </div>
-                ) : (
-                  <div class="battle-section">
-                    <div class="section-content" set:html={d.body ? marked.parse(d.body) : ""} />
-                  </div>
-                )}
-              </div>
-            </details>
-          </article>
-        );
-      })}
-    </div>
-
-    <nav id="battle-pagination" class="battle-pagination" style="display: none;" aria-label="battles pagination">
-      <button id="prev-page" class="outline secondary">{strings.paginationPrev}</button>
-      <span id="page-indicator" data-template={strings.paginationPageOf}>
-        {strings.paginationPageOf.replace("{n}", "1").replace("{total}", "1")}
-      </span>
-      <button id="next-page" class="outline secondary">{strings.paginationNext}</button>
-    </nav>
-
-    <div id="battle-empty" class="rank-empty" style="display: none;">
-      <em>{strings.emptyFilterState}</em>
-    </div>
-  </section>
-)}
-
 <style>
-  .rank-intro {
+  /* Plain language explain ---------------------------------------- */
+  .plain-lang-explain {
+    margin: 0 0 1.5rem;
+    font-size: 0.9rem;
+    border: 1px solid var(--pico-muted-border-color);
+    border-radius: var(--pico-border-radius);
+    padding: 0.6rem 0.9rem;
+    background: var(--pico-card-sectioning-background-color);
+  }
+  .plain-lang-explain summary {
+    cursor: pointer;
+    font-weight: 500;
+    color: var(--pico-muted-color);
+    font-size: 0.82rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+  }
+  .plain-lang-explain p {
+    margin: 0.6rem 0 0;
+    font-size: 0.88rem;
+    color: var(--pico-color);
     max-width: 38rem;
   }
 
@@ -585,12 +503,10 @@ agents.sort();
     transition: transform 0.3s ease, box-shadow 0.3s ease;
     animation: fadeInUp 0.5s ease-out both;
   }
-
   @keyframes fadeInUp {
     from { opacity: 0; transform: translateY(15px); }
     to   { opacity: 1; transform: translateY(0); }
   }
-
   .podium-1 {
     border-top-color: #d4a017;
     background: linear-gradient(180deg, rgba(212, 160, 23, 0.04) 0%, var(--pico-card-background-color) 40%);
@@ -609,12 +525,7 @@ agents.sort();
     order: 3;
     animation-delay: 0.25s;
   }
-
-  .podium-head {
-    display: flex;
-    align-items: baseline;
-    gap: 0.6rem;
-  }
+  .podium-head { display: flex; align-items: baseline; gap: 0.6rem; }
   .podium-medal {
     font-family: var(--pico-font-family-monospace);
     font-size: 1.6rem;
@@ -631,11 +542,7 @@ agents.sort();
     letter-spacing: 0.08em;
     color: var(--pico-muted-color);
   }
-  .podium-title {
-    font-size: 1.02rem;
-    line-height: 1.3;
-    margin: 0;
-  }
+  .podium-title { font-size: 1.02rem; line-height: 1.3; margin: 0; }
   .podium-title a { text-decoration: none; }
   .podium-title a:hover { text-decoration: underline; }
   .podium-stats {
@@ -659,13 +566,11 @@ agents.sort();
     font-weight: 600;
     margin: 0;
   }
-
   @media (min-width: 600px) {
     .podium-1 { transform: scale(1.06); z-index: 2; box-shadow: 0 10px 25px rgba(212, 160, 23, 0.1); }
     .podium-1:hover { transform: scale(1.08); box-shadow: 0 12px 30px rgba(212, 160, 23, 0.16); }
     .podium-2:hover, .podium-3:hover { transform: scale(1.03); }
   }
-
   @media (max-width: 599px) {
     .rank-podium { flex-direction: column; align-items: stretch; }
     .podium-1 { order: 1; }
@@ -674,14 +579,44 @@ agents.sort();
   }
 
   /* Table ----------------------------------------------------------- */
-  .rank-table-wrap { margin-top: 0.5rem; }
+  .rank-table-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    margin-top: 0.5rem;
+    margin-bottom: 0.3rem;
+    flex-wrap: wrap;
+  }
   .rank-caption {
     text-align: left;
     font-size: 0.78rem;
     color: var(--pico-muted-color);
-    margin-bottom: 0.4rem;
-    caption-side: top;
+    margin: 0;
   }
+  .view-toggle {
+    font-size: 0.75rem;
+    padding: 0.25rem 0.7rem;
+    margin: 0;
+    border-radius: var(--pico-border-radius);
+    background: transparent;
+    border: 1px solid var(--pico-muted-border-color);
+    color: var(--pico-muted-color);
+    cursor: pointer;
+    line-height: 1.3;
+    transition: background 0.2s, color 0.2s, border-color 0.2s;
+  }
+  .view-toggle:hover {
+    background: var(--pico-card-sectioning-background-color);
+    border-color: var(--pico-primary);
+    color: var(--pico-primary);
+  }
+  .view-toggle.active {
+    background: var(--pico-primary);
+    border-color: var(--pico-primary);
+    color: var(--pico-primary-inverse);
+  }
+  .rank-table-wrap { margin-top: 0; }
   .rank-table {
     width: 100%;
     border-collapse: collapse;
@@ -715,7 +650,9 @@ agents.sort();
   .rank-table th.col-ordinal,
   .rank-table th.col-mu,
   .rank-table th.col-sigma,
-  .rank-table th.col-record { text-align: right; }
+  .rank-table th.col-record,
+  .rank-table th.col-winrate,
+  .rank-table th.col-delta { text-align: right; }
   .rank-table .col-rank {
     width: 2.5rem;
     text-align: right;
@@ -725,6 +662,8 @@ agents.sort();
   }
   .rank-table .col-post a { text-decoration: none; }
   .rank-table .col-post a:hover { text-decoration: underline; }
+  .rank-table .col-delta { width: 3.5rem; }
+  .rank-table .col-winrate { width: 4rem; }
   .ord-bar {
     margin-top: 0.4rem;
     height: 3px;
@@ -738,6 +677,15 @@ agents.sort();
     background: var(--pico-primary);
     opacity: 0.55;
   }
+
+  /* Technical columns: hidden by default, shown when table has data-view="technical" */
+  .tech-col { display: none; }
+  #rank-table[data-view="technical"] .tech-col { display: table-cell; }
+
+  .delta-up { color: #2d6a4f; font-weight: 600; }
+  .delta-down { color: #c0392b; font-weight: 600; }
+  [data-theme="dark"] .delta-up { color: #74c69d; }
+  [data-theme="dark"] .delta-down { color: #e57373; }
 
   .conf-badge {
     display: inline-block;
@@ -756,15 +704,198 @@ agents.sort();
   [data-theme="dark"] .conf-high { color: #74c69d; border-color: #74c69d55; background: #74c69d12; }
   [data-theme="dark"] .conf-medium { color: #f1c453; border-color: #f1c45355; background: #f1c45312; }
 
-  @media (max-width: 720px) {
-    .rank-table .col-mu,
-    .rank-table .col-sigma,
+  @media (max-width: 680px) {
     .rank-table .col-confidence { display: none; }
   }
 
+  /* Perspectives grid -------------------------------------------- */
+  .perspectives-grid-section {
+    margin-top: 3.5rem;
+  }
+  .perspectives-grid-section h2 {
+    font-size: 1.15rem;
+    margin-bottom: 0.2rem;
+  }
+  .perspectives-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(16rem, 1fr));
+    gap: 1rem;
+    margin: 1rem 0;
+  }
+  .persp-card {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+    padding: 1rem 1.1rem 0.9rem;
+    border: 1px solid var(--pico-muted-border-color);
+    border-left: 4px solid hsl(var(--ph, 200), 55%, 55%);
+    border-radius: var(--pico-border-radius);
+    background: var(--pico-card-background-color);
+    text-decoration: none;
+    color: inherit;
+    transition: border-color 0.2s, box-shadow 0.2s;
+  }
+  .persp-card:hover {
+    border-left-color: hsl(var(--ph, 200), 65%, 45%);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.05);
+  }
+  .persp-card-head {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+  }
+  .persp-name {
+    font-weight: 600;
+    font-size: 0.95rem;
+    color: hsl(var(--ph, 200), 45%, 32%);
+  }
+  [data-theme="dark"] .persp-name {
+    color: hsl(var(--ph, 200), 65%, 72%);
+  }
+  .persp-summary {
+    font-size: 0.82rem;
+    color: var(--pico-muted-color);
+    margin: 0;
+    line-height: 1.4;
+  }
+  .persp-leader {
+    font-size: 0.78rem;
+    margin: 0.2rem 0 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.1rem;
+  }
+  .persp-leader-label {
+    font-size: 0.65rem;
+    text-transform: uppercase;
+    letter-spacing: 0.07em;
+    color: var(--pico-muted-color);
+  }
+  .persp-leader-title {
+    color: var(--pico-color);
+    font-size: 0.8rem;
+    font-weight: 500;
+  }
+  .persp-view-all {
+    margin-top: 0.5rem;
+    font-size: 0.88rem;
+  }
+
+  /* Recent battles (light cards) -------------------------------- */
+  .rank-recent { margin-top: 3.5rem; }
+  .rank-recent h2 { font-size: 1.15rem; margin-bottom: 0.2rem; }
+
+  .battle-list-light {
+    display: flex;
+    flex-direction: column;
+    gap: 0.55rem;
+    margin: 1rem 0;
+  }
+  .bcl-card {
+    display: block;
+    padding: 0.8rem 1rem;
+    border: 1px solid var(--pico-muted-border-color);
+    border-radius: var(--pico-border-radius);
+    background: var(--pico-card-background-color);
+    text-decoration: none;
+    color: inherit;
+    transition: border-color 0.2s, box-shadow 0.2s;
+  }
+  .bcl-card:hover {
+    border-color: var(--pico-primary);
+    box-shadow: 0 4px 10px rgba(0, 0, 0, 0.04);
+  }
+  .bcl-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.35rem;
+    align-items: center;
+    margin-bottom: 0.45rem;
+  }
+  .bcl-date {
+    font-family: var(--pico-font-family-monospace);
+    font-size: 0.72rem;
+    color: var(--pico-muted-color);
+  }
+  .bcl-tag {
+    font-size: 0.64rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    padding: 0.1rem 0.4rem;
+    border-radius: 4px;
+    border: 1px solid var(--pico-muted-border-color);
+    color: var(--pico-muted-color);
+  }
+  .bcl-tag-persp {
+    background: hsl(var(--ph, 200), 28%, 92%);
+    color: hsl(var(--ph, 200), 45%, 32%);
+    border-color: hsl(var(--ph, 200), 38%, 72%);
+    text-transform: none;
+    letter-spacing: 0;
+    font-size: 0.7rem;
+  }
+  [data-theme="dark"] .bcl-tag-persp {
+    background: hsl(var(--ph, 200), 22%, 18%);
+    color: hsl(var(--ph, 200), 52%, 70%);
+    border-color: hsl(var(--ph, 200), 32%, 38%);
+  }
+  .bcl-tag-agent {
+    font-family: var(--pico-font-family-monospace);
+    background: rgba(100, 100, 200, 0.05);
+    border-color: rgba(100, 100, 200, 0.15);
+    text-transform: none;
+    letter-spacing: 0;
+  }
+  .bcl-versus {
+    display: flex;
+    align-items: baseline;
+    gap: 0.45rem;
+    flex-wrap: wrap;
+    font-size: 0.93rem;
+    margin-bottom: 0.4rem;
+  }
+  .bcl-winner { font-weight: 600; }
+  .bcl-loser { color: var(--pico-muted-color); }
+  .bcl-vs {
+    font-size: 0.72rem;
+    color: var(--pico-muted-color);
+    background: var(--pico-muted-border-color);
+    padding: 0.1rem 0.3rem;
+    border-radius: 3px;
+    flex-shrink: 0;
+  }
+  .bcl-rates {
+    font-family: var(--pico-font-family-monospace);
+    font-size: 0.72rem;
+    color: var(--pico-muted-color);
+    flex-shrink: 0;
+  }
+  .bcl-tension {
+    height: 3px;
+    background: var(--pico-muted-border-color);
+    border-radius: 2px;
+    overflow: hidden;
+    display: flex;
+    margin: 0 0 0.4rem;
+  }
+  .bcl-fill.win { background: var(--pico-primary); opacity: 0.6; }
+  .bcl-fill.loss { background: var(--pico-muted-border-color); opacity: 0.35; }
+  .bcl-read {
+    font-size: 0.75rem;
+    color: var(--pico-muted-color);
+    display: block;
+    text-align: right;
+  }
+  .bcl-card:hover .bcl-read { color: var(--pico-primary); }
+
+  .all-battles-link {
+    margin-top: 0.8rem;
+    font-size: 0.9rem;
+  }
+
   /* Unrated --------------------------------------------------------- */
-  .rank-unrated, .rank-recent { margin-top: 3rem; }
-  .rank-unrated h2, .rank-recent h2 { font-size: 1.15rem; margin-bottom: 0.2rem; }
+  .rank-unrated { margin-top: 3rem; }
+  .rank-unrated h2 { font-size: 1.15rem; margin-bottom: 0.2rem; }
   .rank-unrated ul {
     list-style: none;
     padding: 0;
@@ -775,297 +906,6 @@ agents.sort();
   }
   .rank-unrated li::before { content: "·"; color: var(--pico-muted-color); margin-right: 0.4rem; }
   .unrated-cta { margin-top: 0.8rem; font-size: 0.88rem; color: var(--pico-muted-color); }
-
-  /* Filters ----------------------------------------------------------- */
-  .battle-filters {
-    background: var(--pico-card-sectioning-background-color);
-    border: 1px solid var(--pico-muted-border-color);
-    border-radius: var(--pico-border-radius);
-    padding: 1.1rem;
-    margin: 1.2rem 0 2rem;
-    display: flex;
-    flex-direction: column;
-    gap: 0.9rem;
-  }
-  .filter-row-main input[type="search"] { margin: 0; width: 100%; }
-  .filter-row-meta {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 1.5rem;
-    align-items: flex-end;
-  }
-  .filter-group { display: flex; flex-direction: column; gap: 0.3rem; }
-  .filter-group label {
-    margin: 0;
-    font-size: 0.7rem;
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
-    color: var(--pico-muted-color);
-  }
-  .filter-group select {
-    margin: 0;
-    min-width: 8rem;
-    padding: 0.3rem 0.5rem;
-    height: auto;
-    font-size: 0.88rem;
-  }
-  .filter-pills { display: flex; gap: 0.35rem; }
-  .filter-pills .pill {
-    padding: 0.3rem 0.7rem;
-    font-size: 0.8rem;
-    margin: 0;
-    border-radius: var(--pico-border-radius);
-    background: transparent;
-    border: 1px solid var(--pico-muted-border-color);
-    color: var(--pico-muted-color);
-    cursor: pointer;
-    line-height: 1.2;
-    transition: background-color 0.2s, color 0.2s, border-color 0.2s;
-  }
-  .filter-pills .pill.active,
-  .filter-pills .pill:hover {
-    background: var(--pico-primary);
-    border-color: var(--pico-primary);
-    color: var(--pico-primary-inverse);
-  }
-
-  .filter-row-chips {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.35rem;
-    padding-top: 0.6rem;
-    border-top: 1px dashed var(--pico-muted-border-color);
-  }
-  .filter-row-chips .chip {
-    padding: 0.2rem 0.6rem;
-    font-size: 0.76rem;
-    margin: 0;
-    border-radius: 999px;
-    background: transparent;
-    border: 1px solid var(--pico-muted-border-color);
-    color: var(--pico-muted-color);
-    cursor: pointer;
-    line-height: 1.2;
-    transition: background-color 0.2s, color 0.2s, border-color 0.2s;
-  }
-  .filter-row-chips .chip.active,
-  .filter-row-chips .chip:hover {
-    background: var(--pico-primary);
-    border-color: var(--pico-primary);
-    color: var(--pico-primary-inverse);
-  }
-  /* Perspective chips use their hue when active */
-  #filter-perspective .chip[data-perspective]:not([data-perspective="all"]):not(.active):hover {
-    background: hsl(var(--ph, 200), 30%, 88%);
-    border-color: hsl(var(--ph, 200), 40%, 65%);
-    color: hsl(var(--ph, 200), 45%, 28%);
-  }
-  [data-theme="dark"] #filter-perspective .chip[data-perspective]:not([data-perspective="all"]):not(.active):hover {
-    background: hsl(var(--ph, 200), 25%, 22%);
-    border-color: hsl(var(--ph, 200), 35%, 45%);
-    color: hsl(var(--ph, 200), 55%, 75%);
-  }
-
-  .filter-status { font-size: 0.76rem; color: var(--pico-muted-color); text-align: right; }
-
-  /* Battle Cards ----------------------------------------------------- */
-  .battle-list { display: flex; flex-direction: column; gap: 0.85rem; }
-  .battle-card {
-    border: 1px solid var(--pico-muted-border-color);
-    border-radius: var(--pico-border-radius);
-    background: var(--pico-card-background-color);
-    overflow: hidden;
-    transition: border-color 0.2s ease, box-shadow 0.2s ease;
-  }
-  .battle-card:hover { border-color: var(--pico-primary); box-shadow: 0 4px 12px rgba(0, 0, 0, 0.03); }
-
-  .battle-details { margin: 0; padding: 0; }
-  .battle-header {
-    padding: 1rem 1.1rem;
-    list-style: none;
-    cursor: pointer;
-    position: relative;
-    user-select: none;
-  }
-  .battle-header::-webkit-details-marker { display: none; }
-
-  .battle-meta {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.35rem;
-    align-items: center;
-    margin-bottom: 0.5rem;
-    padding-right: 1.5rem;
-  }
-  .battle-date {
-    font-family: var(--pico-font-family-monospace);
-    font-size: 0.72rem;
-    color: var(--pico-muted-color);
-    margin-right: 0.3rem;
-  }
-  .battle-tag {
-    font-size: 0.64rem;
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
-    padding: 0.1rem 0.4rem;
-    border-radius: 4px;
-    border: 1px solid var(--pico-muted-border-color);
-    color: var(--pico-muted-color);
-    line-height: 1.1;
-  }
-  /* Perspective tag uses computed hue */
-  .tag-perspective {
-    background: hsl(var(--ph, 200), 28%, 92%);
-    color: hsl(var(--ph, 200), 45%, 32%);
-    border-color: hsl(var(--ph, 200), 38%, 72%);
-    text-transform: none;
-    letter-spacing: 0;
-    font-size: 0.7rem;
-  }
-  [data-theme="dark"] .tag-perspective {
-    background: hsl(var(--ph, 200), 22%, 18%);
-    color: hsl(var(--ph, 200), 52%, 70%);
-    border-color: hsl(var(--ph, 200), 32%, 38%);
-  }
-  /* Agent tag */
-  .tag-agent {
-    font-family: var(--pico-font-family-monospace);
-    background: rgba(100, 100, 200, 0.05);
-    color: var(--pico-muted-color);
-    border-color: rgba(100, 100, 200, 0.15);
-    text-transform: none;
-    letter-spacing: 0;
-  }
-  [data-theme="dark"] .tag-agent {
-    background: rgba(150, 150, 255, 0.07);
-    border-color: rgba(150, 150, 255, 0.2);
-  }
-  .tag-season { background: rgba(0, 0, 0, 0.03); }
-  .tag-confidence.conf-high { background: rgba(45, 106, 79, 0.04); color: #2d6a4f; border-color: rgba(45, 106, 79, 0.12); }
-  [data-theme="dark"] .tag-confidence.conf-high { color: #74c69d; border-color: rgba(116, 198, 157, 0.2); }
-  .tag-confidence.conf-medium { background: rgba(176, 131, 0, 0.04); color: #a07800; border-color: rgba(176, 131, 0, 0.12); }
-  [data-theme="dark"] .tag-confidence.conf-medium { color: #f1c453; border-color: rgba(241, 196, 83, 0.2); }
-
-  .battle-versus {
-    display: grid;
-    grid-template-columns: 1fr auto 1fr;
-    gap: 0.85rem;
-    align-items: center;
-    margin-bottom: 0.6rem;
-    padding-right: 1.5rem;
-  }
-  .versus-side {
-    display: flex;
-    align-items: center;
-    gap: 0.45rem;
-    font-size: 0.96rem;
-  }
-  .versus-side.winner { font-weight: 600; }
-  .versus-side.loser { color: var(--pico-muted-color); }
-  .versus-side.winner .post-title-link { color: var(--pico-color); text-decoration: none; }
-  .versus-side.winner .post-title-link:hover { text-decoration: underline; }
-  .versus-side.loser .post-title-link {
-    color: var(--pico-muted-color);
-    text-decoration: line-through;
-    text-decoration-color: var(--pico-muted-border-color);
-  }
-  .versus-side.loser .post-title-link:hover { color: var(--pico-color); text-decoration: underline; text-decoration-color: var(--pico-primary); }
-  .versus-medal { font-size: 0.9rem; flex-shrink: 0; }
-  .versus-rate {
-    font-family: var(--pico-font-family-monospace);
-    font-size: 0.72rem;
-    font-weight: 700;
-    color: var(--pico-primary);
-    flex-shrink: 0;
-  }
-  .versus-rate.loser-rate { color: var(--pico-muted-color); font-weight: 400; }
-
-  .versus-divider {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    flex-shrink: 0;
-  }
-  .versus-vs {
-    font-size: 0.68rem;
-    font-weight: 700;
-    color: var(--pico-muted-color);
-    background: var(--pico-muted-border-color);
-    padding: 0.1rem 0.3rem;
-    border-radius: 4px;
-    line-height: 1;
-  }
-
-  .battle-tension-bar {
-    height: 3px;
-    background: var(--pico-muted-border-color);
-    border-radius: 2px;
-    overflow: hidden;
-    display: flex;
-    margin-top: 0.4rem;
-    width: calc(100% - 1.5rem);
-  }
-  .tension-fill.winner { background: var(--pico-primary); opacity: 0.6; }
-  .tension-fill.loser { background: var(--pico-muted-border-color); opacity: 0.35; }
-
-  .battle-expand-indicator {
-    position: absolute;
-    right: 1.1rem;
-    top: 50%;
-    transform: translateY(-50%);
-    font-size: 0.72rem;
-    color: var(--pico-muted-color);
-    transition: transform 0.25s ease;
-  }
-  details[open] .battle-expand-indicator { transform: translateY(-50%) rotate(180deg); }
-
-  .battle-body {
-    padding: 1.1rem;
-    border-top: 1px dashed var(--pico-muted-border-color);
-    background: var(--pico-card-sectioning-background-color);
-  }
-
-  .battle-section { margin-top: 0.8rem; }
-  .battle-section h5,
-  .battle-section h6 {
-    margin-bottom: 0.4rem;
-    font-size: 0.8rem;
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
-    color: var(--pico-muted-color);
-  }
-  .verdict-section {
-    border-left: 3px solid var(--pico-primary);
-    padding-left: 0.7rem;
-    margin-top: 0;
-    margin-bottom: 1rem;
-  }
-  .section-content { font-size: 0.9rem; line-height: 1.5; }
-  .section-content p:last-child { margin-bottom: 0; }
-
-  .battle-sides-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(16rem, 1fr));
-    gap: 1rem;
-    border-top: 1px dashed var(--pico-muted-border-color);
-    padding-top: 0.8rem;
-  }
-  .side-section { margin-top: 0; }
-
-  @media (max-width: 680px) {
-    .battle-versus {
-      grid-template-columns: 1fr;
-      gap: 0.3rem;
-      text-align: center;
-      padding-right: 0;
-      width: 100%;
-    }
-    .versus-side { justify-content: center; }
-    .versus-divider { flex-direction: row; gap: 0.35rem; }
-    .battle-tension-bar { width: 100%; }
-    .battle-meta { padding-right: 0; }
-  }
 
   .rank-empty {
     padding: 2rem 1rem;
@@ -1080,151 +920,41 @@ agents.sort();
     border-bottom: 1px dotted var(--pico-muted-color);
     cursor: help;
   }
-
-  .battle-pagination {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: 1rem;
-    margin: 1.25rem 0 0.5rem;
-  }
-  .battle-pagination button {
-    padding: 0.35rem 0.9rem;
-    font-size: 0.85rem;
-    min-width: 7rem;
-    margin-bottom: 0;
-  }
-  #page-indicator {
-    font-size: 0.85rem;
-    color: var(--pico-muted-color);
-    min-width: 8rem;
-    text-align: center;
-  }
 </style>
 
 <script>
-  document.addEventListener('DOMContentLoaded', () => {
-    const searchInput = document.getElementById('battle-search') as HTMLInputElement | null;
-    const seasonSelect = document.getElementById('filter-season') as HTMLSelectElement | null;
-    const agentSelect = document.getElementById('filter-agent') as HTMLSelectElement | null;
-    const confidenceContainer = document.getElementById('filter-confidence');
-    const perspectiveContainer = document.getElementById('filter-perspective');
-    const criterionContainer = document.querySelector('.filter-row-chips:not(#filter-perspective)');
-    const cards = Array.from(document.querySelectorAll('.battle-card')) as HTMLElement[];
-    const countLabel = document.getElementById('filter-count-label');
-    const emptyState = document.getElementById('battle-empty');
-    const paginationEl = document.getElementById('battle-pagination') as HTMLElement | null;
-    const prevBtn = document.getElementById('prev-page') as HTMLButtonElement | null;
-    const nextBtn = document.getElementById('next-page') as HTMLButtonElement | null;
-    const pageIndicator = document.getElementById('page-indicator') as HTMLElement | null;
+  document.addEventListener("DOMContentLoaded", () => {
+    const toggleBtn = document.getElementById("view-toggle") as HTMLButtonElement | null;
+    const table = document.getElementById("rank-table") as HTMLTableElement | null;
+    if (!toggleBtn || !table) return;
 
-    let activeCriterion = 'all';
-    let activeConfidence = 'all';
-    let activePerspective = 'all';
-    let currentPage = 0;
-    let lastVisible: HTMLElement[] = [];
+    // Read initial state from URL
+    const urlParams = new URLSearchParams(window.location.search);
+    const isTechnical = urlParams.get("view") === "technical";
+    if (isTechnical) {
+      table.dataset.view = "technical";
+      toggleBtn.classList.add("active");
+    }
 
-    const PAGE_SIZE = 15;
-
-    if (!searchInput || !cards.length || !countLabel) return;
-
-    const countTemplate = countLabel.getAttribute('data-template') || 'Showing {count} of {total}';
-    const pageTemplate = pageIndicator?.getAttribute('data-template') || 'Page {n} of {total}';
-
-    function showPage(page: number) {
-      const totalPages = Math.max(1, Math.ceil(lastVisible.length / PAGE_SIZE));
-      currentPage = Math.max(0, Math.min(page, totalPages - 1));
-
-      const start = currentPage * PAGE_SIZE;
-      const end = start + PAGE_SIZE;
-
-      cards.forEach((card) => { card.style.display = 'none'; });
-      lastVisible.forEach((card, i) => {
-        card.style.display = (i >= start && i < end) ? 'block' : 'none';
-      });
-
-      countLabel!.textContent = countTemplate
-        .replace('{count}', String(lastVisible.length))
-        .replace('{total}', String(cards.length));
-
-      if (emptyState) emptyState.style.display = lastVisible.length === 0 ? 'block' : 'none';
-
-      const showPagination = totalPages > 1;
-      if (paginationEl) paginationEl.style.display = showPagination ? 'flex' : 'none';
-      if (prevBtn) prevBtn.disabled = currentPage === 0;
-      if (nextBtn) nextBtn.disabled = currentPage >= totalPages - 1;
-      if (pageIndicator) {
-        pageIndicator.textContent = pageTemplate
-          .replace('{n}', String(currentPage + 1))
-          .replace('{total}', String(totalPages));
+    toggleBtn.addEventListener("click", () => {
+      const current = table.dataset.view === "technical";
+      if (current) {
+        delete table.dataset.view;
+        toggleBtn.classList.remove("active");
+        const params = new URLSearchParams(window.location.search);
+        params.delete("view");
+        const newUrl =
+          window.location.pathname +
+          (params.toString() ? "?" + params.toString() : "") +
+          window.location.hash;
+        history.replaceState(null, "", newUrl);
+      } else {
+        table.dataset.view = "technical";
+        toggleBtn.classList.add("active");
+        const params = new URLSearchParams(window.location.search);
+        params.set("view", "technical");
+        history.replaceState(null, "", window.location.pathname + "?" + params.toString() + window.location.hash);
       }
-    }
-
-    function applyFilters() {
-      if (!searchInput) return;
-      const query = searchInput.value.toLowerCase().trim();
-      const season = seasonSelect ? seasonSelect.value : 'all';
-      const agent = agentSelect ? agentSelect.value : 'all';
-
-      lastVisible = cards.filter((card) => {
-        const matchesQuery = !query || (card.getAttribute('data-search') || '').includes(query);
-        const matchesSeason = season === 'all' || (card.getAttribute('data-season') || '') === season;
-        const matchesAgent = agent === 'all' || (card.getAttribute('data-agent') || '') === agent;
-        const matchesConfidence = activeConfidence === 'all' || (card.getAttribute('data-confidence') || '') === activeConfidence;
-        const matchesCriterion = activeCriterion === 'all' || (card.getAttribute('data-criterion') || '') === activeCriterion;
-        const matchesPerspective = activePerspective === 'all' || (card.getAttribute('data-perspective') || '') === activePerspective;
-        return matchesQuery && matchesSeason && matchesAgent && matchesConfidence && matchesCriterion && matchesPerspective;
-      });
-
-      showPage(0);
-    }
-
-    searchInput.addEventListener('input', applyFilters);
-    if (seasonSelect) seasonSelect.addEventListener('change', applyFilters);
-    if (agentSelect) agentSelect.addEventListener('change', applyFilters);
-
-    if (prevBtn) prevBtn.addEventListener('click', () => showPage(currentPage - 1));
-    if (nextBtn) nextBtn.addEventListener('click', () => showPage(currentPage + 1));
-
-    if (confidenceContainer) {
-      const pills = confidenceContainer.querySelectorAll('.pill');
-      pills.forEach((pill) => {
-        pill.addEventListener('click', (e) => {
-          pills.forEach((p) => p.classList.remove('active'));
-          const target = e.currentTarget as HTMLElement;
-          target.classList.add('active');
-          activeConfidence = target.getAttribute('data-value') || 'all';
-          applyFilters();
-        });
-      });
-    }
-
-    if (perspectiveContainer) {
-      const chips = perspectiveContainer.querySelectorAll('.chip');
-      chips.forEach((chip) => {
-        chip.addEventListener('click', (e) => {
-          chips.forEach((c) => c.classList.remove('active'));
-          const target = e.currentTarget as HTMLElement;
-          target.classList.add('active');
-          activePerspective = target.getAttribute('data-perspective') || 'all';
-          applyFilters();
-        });
-      });
-    }
-
-    if (criterionContainer) {
-      const chips = criterionContainer.querySelectorAll('.chip');
-      chips.forEach((chip) => {
-        chip.addEventListener('click', (e) => {
-          chips.forEach((c) => c.classList.remove('active'));
-          const target = e.currentTarget as HTMLElement;
-          target.classList.add('active');
-          activeCriterion = target.getAttribute('data-criterion') || 'all';
-          applyFilters();
-        });
-      });
-    }
-
-    applyFilters();
+    });
   });
 </script>

--- a/src/generated/ranking-snapshot.json
+++ b/src/generated/ranking-snapshot.json
@@ -1,0 +1,313 @@
+{
+  "_meta": {
+    "generatedAt": "2026-06-10T03:43:55.667Z",
+    "basis": "build",
+    "totalDuels": 338
+  },
+  "keys": {
+    "pontifex-research": {
+      "rank": 1,
+      "ordinal": 14.5805
+    },
+    "third-half-fourth-wall": {
+      "rank": 2,
+      "ordinal": 12.6506
+    },
+    "its-raining-truth": {
+      "rank": 3,
+      "ordinal": 12.4578
+    },
+    "reddit-submarine-osint": {
+      "rank": 4,
+      "ordinal": 12.1811
+    },
+    "pierre-menard": {
+      "rank": 5,
+      "ordinal": 12.0799
+    },
+    "future-father": {
+      "rank": 6,
+      "ordinal": 12.0235
+    },
+    "conservation-law": {
+      "rank": 7,
+      "ordinal": 12.0223
+    },
+    "delphi-imperatives": {
+      "rank": 8,
+      "ordinal": 11.9149
+    },
+    "three-hammers": {
+      "rank": 9,
+      "ordinal": 11.7933
+    },
+    "intelligible-void": {
+      "rank": 10,
+      "ordinal": 11.1288
+    },
+    "crossing-interference": {
+      "rank": 11,
+      "ordinal": 10.6362
+    },
+    "agent-no-verbs": {
+      "rank": 12,
+      "ordinal": 10.2745
+    },
+    "family-memory": {
+      "rank": 13,
+      "ordinal": 9.3255
+    },
+    "verne-identity-repo": {
+      "rank": 14,
+      "ordinal": 9.1422
+    },
+    "asterisk-protects": {
+      "rank": 15,
+      "ordinal": 8.9652
+    },
+    "delegating-to-agents": {
+      "rank": 16,
+      "ordinal": 8.9254
+    },
+    "music-o-tempo": {
+      "rank": 17,
+      "ordinal": 8.8388
+    },
+    "census-not-sample": {
+      "rank": 18,
+      "ordinal": 8.7541
+    },
+    "rosencrantz-coin": {
+      "rank": 19,
+      "ordinal": 8.5678
+    },
+    "funes-soul": {
+      "rank": 20,
+      "ordinal": 8.2068
+    },
+    "serpents-egg": {
+      "rank": 21,
+      "ordinal": 7.8469
+    },
+    "two-questions-out-loud": {
+      "rank": 22,
+      "ordinal": 7.6725
+    },
+    "conceptual-document": {
+      "rank": 23,
+      "ordinal": 7.3557
+    },
+    "music-eu-ia-escrever-sobre-o-infinito-de-novo": {
+      "rank": 24,
+      "ordinal": 7.0234
+    },
+    "music-stopping-by-woods-on-a-snowy-evening-by-robert-frost": {
+      "rank": 25,
+      "ordinal": 6.8515
+    },
+    "building-funes": {
+      "rank": 26,
+      "ordinal": 6.6414
+    },
+    "music-sentido-e-referencia": {
+      "rank": 27,
+      "ordinal": 6.4304
+    },
+    "music-john-gospel-chapter-i-by-max-headroom": {
+      "rank": 28,
+      "ordinal": 6.3628
+    },
+    "jules-api-harness": {
+      "rank": 29,
+      "ordinal": 6.0267
+    },
+    "music-menino-que-voce-foi": {
+      "rank": 30,
+      "ordinal": 5.8364
+    },
+    "music-trinta-de-abril": {
+      "rank": 31,
+      "ordinal": 5.8036
+    },
+    "pontifex-guide": {
+      "rank": 32,
+      "ordinal": 5.2029
+    },
+    "inaugural-post": {
+      "rank": 33,
+      "ordinal": 5.1093
+    },
+    "music-reality-maintenance-moving-window-xii": {
+      "rank": 34,
+      "ordinal": 4.801
+    },
+    "travessia-project": {
+      "rank": 35,
+      "ordinal": 4.7785
+    },
+    "music-paperclip-rhapsody": {
+      "rank": 36,
+      "ordinal": 4.722
+    },
+    "music-o-medo-do-louco": {
+      "rank": 37,
+      "ordinal": 4.5021
+    },
+    "social-vulnerabilities": {
+      "rank": 38,
+      "ordinal": 4.4427
+    },
+    "music-nonada": {
+      "rank": 39,
+      "ordinal": 4.4021
+    },
+    "music-o-verso-branquiceleste": {
+      "rank": 40,
+      "ordinal": 4.2137
+    },
+    "music-the-ruliad-is-laughing": {
+      "rank": 41,
+      "ordinal": 4.2004
+    },
+    "music-o-preco-da-saudade": {
+      "rank": 42,
+      "ordinal": 4.2001
+    },
+    "reclaiming-harness": {
+      "rank": 43,
+      "ordinal": 4.115
+    },
+    "music-a-primeira-mudanca": {
+      "rank": 44,
+      "ordinal": 4.0009
+    },
+    "music-o-aleph": {
+      "rank": 45,
+      "ordinal": 3.8753
+    },
+    "music-espelhos": {
+      "rank": 46,
+      "ordinal": 3.8492
+    },
+    "music-the-time": {
+      "rank": 47,
+      "ordinal": 3.278
+    },
+    "pampa-circuit": {
+      "rank": 48,
+      "ordinal": 2.897
+    },
+    "music-spring-loading": {
+      "rank": 49,
+      "ordinal": 2.839
+    },
+    "becoming-lobsters": {
+      "rank": 50,
+      "ordinal": 2.8018
+    },
+    "music-o-regral": {
+      "rank": 51,
+      "ordinal": 2.6421
+    },
+    "music-entre-rascunho-e-apagar": {
+      "rank": 52,
+      "ordinal": 2.5688
+    },
+    "music-o-telefone-da-agonia": {
+      "rank": 53,
+      "ordinal": 2.255
+    },
+    "music-o-sonhador-e-o-fogo": {
+      "rank": 54,
+      "ordinal": 2.2529
+    },
+    "music-caminho": {
+      "rank": 55,
+      "ordinal": 2.2226
+    },
+    "music-o-magico-e-o-fogo": {
+      "rank": 56,
+      "ordinal": 2.18
+    },
+    "music-two-cursors": {
+      "rank": 57,
+      "ordinal": 2.0245
+    },
+    "music-fourteen-words": {
+      "rank": 58,
+      "ordinal": 1.9564
+    },
+    "music-quando-vier-a-primavera": {
+      "rank": 59,
+      "ordinal": 1.907
+    },
+    "music-universal-threshold": {
+      "rank": 60,
+      "ordinal": 1.8711
+    },
+    "music-meditacao-guiada-no-sertao": {
+      "rank": 61,
+      "ordinal": 1.8082
+    },
+    "music-pattern-over-stuff": {
+      "rank": 62,
+      "ordinal": 1.8082
+    },
+    "music-crystallizing-from-the-nothing": {
+      "rank": 63,
+      "ordinal": 1.6654
+    },
+    "music-beatriz": {
+      "rank": 64,
+      "ordinal": 0.6338
+    },
+    "music-666": {
+      "rank": 65,
+      "ordinal": 0.3476
+    },
+    "everything-is-process": {
+      "rank": 66,
+      "ordinal": 0.3436
+    },
+    "music-chegue-irmao-chegue-irma": {
+      "rank": 67,
+      "ordinal": 0.2705
+    },
+    "music-veu-do-infinito": {
+      "rank": 68,
+      "ordinal": 0.0953
+    },
+    "music-borges-and-me": {
+      "rank": 69,
+      "ordinal": -0.0182
+    },
+    "music-riobaldo-e-o-aleph": {
+      "rank": 70,
+      "ordinal": -0.1067
+    },
+    "music-151474c5-1420-4cc1-9ab5-80721f4459ed": {
+      "rank": 71,
+      "ordinal": -0.2012
+    },
+    "music-mindfulness": {
+      "rank": 72,
+      "ordinal": -0.2012
+    },
+    "music-o-prologo": {
+      "rank": 73,
+      "ordinal": -0.3494
+    },
+    "music-f85fb538-6f59-4751-8629-da76665fc91e": {
+      "rank": 74,
+      "ordinal": -0.6459
+    },
+    "music-sussurros-binarios": {
+      "rank": 75,
+      "ordinal": -1.3183
+    },
+    "music-vos": {
+      "rank": 76,
+      "ordinal": -1.3679
+    }
+  }
+}

--- a/src/hronir/perspectives.ts
+++ b/src/hronir/perspectives.ts
@@ -1,13 +1,13 @@
 import fs from "node:fs";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
 import matter from "gray-matter";
 import type { PerspectiveMeta } from "./types.js";
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-// perspectives/ lives in scripts/hronir/ — two dirs up from src/hronir/
-const ROOT = path.resolve(__dirname, "../..");
-const PERSPECTIVES_DIR = path.join(ROOT, "scripts/hronir/perspectives");
+// Build always runs from repo root; using cwd is stable across vite chunk relocation.
+const PERSPECTIVES_DIR = path.join(
+  process.cwd(),
+  "scripts/hronir/perspectives"
+);
 
 export interface Perspective extends PerspectiveMeta {
   body: string;

--- a/src/hronir/types.ts
+++ b/src/hronir/types.ts
@@ -57,6 +57,8 @@ export interface DuelContent {
 }
 
 export interface DuelEntry {
+  /** 8-char SHA-256 hash of postAKey|postBKey|runAt — stable URL identifier. */
+  id: string;
   runAt: string;
   winnerKey: string;
   loserKey: string;
@@ -98,4 +100,22 @@ export interface PerspectiveRankRow {
   ordinal: number;
   appearances: number;
   wins: number;
+}
+
+export interface PerspectiveGridItem {
+  id: string;
+  name: string;
+  summary: string;
+  leaderTitle: string | null;
+  leaderHref: string | null;
+  hue: number;
+}
+
+export interface RankingSnapshot {
+  _meta: {
+    generatedAt: string | null;
+    basis: "build" | "season";
+    totalDuels: number;
+  };
+  keys: Record<string, { rank: number; ordinal: number }>;
 }

--- a/src/lib/hronir-rank.ts
+++ b/src/lib/hronir-rank.ts
@@ -2,6 +2,9 @@
 // Reads .routines/hronir/*.md, runs OpenSkill, exposes a Map<key, RankRow>
 // keyed by translationKey, plus a sorted array.
 
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
 import {
   computeRatings,
   computePerPerspectiveRatings,
@@ -15,6 +18,8 @@ import type {
   RankingStats,
   PerspectiveMeta,
   PerspectiveRankRow,
+  PerspectiveGridItem,
+  RankingSnapshot,
 } from "../hronir/types.js";
 
 export type {
@@ -24,7 +29,20 @@ export type {
   RankingStats,
   PerspectiveMeta,
   PerspectiveRankRow,
+  PerspectiveGridItem,
+  RankingSnapshot,
 };
+
+export function duelId(
+  d: Pick<DuelEntry, "postAKey" | "postBKey" | "runAt">
+): string {
+  const canonical = [d.postAKey ?? "", d.postBKey ?? "", d.runAt].join("|");
+  return crypto
+    .createHash("sha256")
+    .update(canonical)
+    .digest("hex")
+    .slice(0, 8);
+}
 
 export function parseDuelContent(
   body?: string,
@@ -116,7 +134,8 @@ function loadDuelData(): { stats: RankingStats; recent: DuelEntry[] } {
       ? String((data as any).agent_id)
       : undefined;
 
-    duels.push({
+    const entry: DuelEntry = {
+      id: "",
       runAt,
       winnerKey,
       loserKey,
@@ -160,7 +179,9 @@ function loadDuelData(): { stats: RankingStats; recent: DuelEntry[] } {
         content ? String(content).trim() : undefined,
         data as Record<string, unknown>
       ),
-    });
+    };
+    entry.id = duelId(entry);
+    duels.push(entry);
   }
 
   duels.sort((a, b) => b.runAt.localeCompare(a.runAt));
@@ -207,4 +228,73 @@ export function getPerPerspectiveRankings(): Map<string, PerspectiveRankRow[]> {
     string,
     PerspectiveRankRow[]
   >;
+}
+
+export function getDuelById(id: string): DuelEntry | undefined {
+  return getAllDuels().find((d) => d.id === id);
+}
+
+export function getPostDuelHistory(key: string): DuelEntry[] {
+  return getAllDuels().filter((d) => d.postAKey === key || d.postBKey === key);
+}
+
+const SNAPSHOT_PATH = path.join(
+  process.cwd(),
+  "src/generated/ranking-snapshot.json"
+);
+
+let _snapshotCache: RankingSnapshot | null | undefined = undefined;
+
+export function loadSnapshot(): RankingSnapshot | null {
+  if (_snapshotCache !== undefined) return _snapshotCache;
+  try {
+    const raw = fs.readFileSync(SNAPSHOT_PATH, "utf8");
+    _snapshotCache = JSON.parse(raw) as RankingSnapshot;
+  } catch {
+    _snapshotCache = null;
+  }
+  return _snapshotCache;
+}
+
+export function getSnapshotDelta(key: string): number | null {
+  const snapshot = loadSnapshot();
+  if (!snapshot) return null;
+  const prev = snapshot.keys[key];
+  if (!prev) return null;
+  const current = getRankByKey().get(key);
+  if (!current) return null;
+  return prev.rank - current.rank;
+}
+
+function perspectiveHue(id: string): number {
+  let h = 0;
+  for (let i = 0; i < id.length; i++) {
+    h = ((h << 5) - h + id.charCodeAt(i)) & 0xffff;
+  }
+  return Math.abs(h) % 360;
+}
+
+export function buildPerspectivesGrid(
+  postByKey: Map<string, { title: string; slug: string; lang: string }>
+): PerspectiveGridItem[] {
+  const perspectives = getPerspectives();
+  const perPerspective = getPerPerspectiveRankings();
+  return perspectives.map((p) => {
+    const rows = perPerspective.get(p.id) ?? [];
+    const leaderKey = rows[0]?.key;
+    const leaderPost = leaderKey ? postByKey.get(leaderKey) : undefined;
+    const leaderHref = leaderPost
+      ? leaderPost.lang === "pt"
+        ? `/pt/blog/${leaderPost.slug}/`
+        : `/blog/${leaderPost.slug}/`
+      : null;
+    return {
+      id: p.id,
+      name: p.name,
+      summary: p.summary,
+      leaderTitle: leaderPost?.title ?? null,
+      leaderHref,
+      hue: perspectiveHue(p.id),
+    };
+  });
 }

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -47,7 +47,9 @@ const showUpdated = lastModified && lastModified.valueOf() - date.valueOf() > MS
 const rankInfo = translationKey ? getRankByKey().get(translationKey) : undefined;
 const postLang: string = lang ?? DEFAULT_LANG;
 const rankLabel = postLang === 'pt' ? 'ranking Hrönir' : 'Hrönir rank';
-const rankHref = postLang === 'pt' ? '/pt/ranking/' : '/ranking/';
+const rankHref = translationKey
+  ? `/ranking/posts/${translationKey}/`
+  : postLang === 'pt' ? '/pt/ranking/' : '/ranking/';
 const series = await getSeriesContext(post, { lang: postLang });
 const locale = localeFor(lang);
 const dateOpts = { year: 'numeric', month: 'long', day: 'numeric' } as const;

--- a/src/pages/pt/ranking.astro
+++ b/src/pages/pt/ranking.astro
@@ -1,9 +1,19 @@
 ---
 import PageLayout from "../../layouts/PageLayout.astro";
 import { getCollection } from "astro:content";
-import { getRanking, getRankingStats, getAllDuels } from "../../lib/hronir-rank";
+import {
+  getRanking,
+  getRankingStats,
+  getRecentDuels,
+  buildPerspectivesGrid,
+  loadSnapshot,
+} from "../../lib/hronir-rank";
 import { isPublished } from "../../lib/publish";
-import RankingView, { type RankPostInfo, type UnratedItem, type RankingStrings } from "../../components/RankingView.astro";
+import RankingView, {
+  type RankPostInfo,
+  type UnratedItem,
+  type RankingStrings,
+} from "../../components/RankingView.astro";
 
 const all = await getCollection("blog");
 const byKey = new Map<string, RankPostInfo>();
@@ -13,7 +23,6 @@ for (const p of all) {
   if (!key) continue;
   const existing = byKey.get(key);
   const lang = p.data.lang ?? "en";
-  // Prefer PT entry on this page; otherwise fall back to anything.
   if (!existing || lang === "pt") {
     byKey.set(key, { slug: p.id, title: p.data.title, lang });
   }
@@ -33,19 +42,24 @@ for (const p of all) {
   if (!isPublished(p)) continue;
   const key = p.data.translationKey;
   if (!key || ratedKeys.has(key) || seenUnrated.has(key)) continue;
-  // Prefer PT title for this page.
   const lang = p.data.lang ?? "en";
   const preferred =
     lang === "pt"
       ? p
       : all.find((q) => q.data.translationKey === key && (q.data.lang ?? "en") === "pt") ?? p;
-  unrated.push({ slug: preferred.id, title: preferred.data.title, lang: preferred.data.lang ?? "pt" });
+  unrated.push({
+    slug: preferred.id,
+    title: preferred.data.title,
+    lang: preferred.data.lang ?? "pt",
+  });
   seenUnrated.add(key);
 }
 unrated.sort((a, b) => a.title.localeCompare(b.title, "pt-BR"));
 
 const stats = getRankingStats();
-const recent = getAllDuels();
+const recent = getRecentDuels(10);
+const perspectivesGrid = buildPerspectivesGrid(byKey);
+const snapshot = loadSnapshot();
 
 const itemListLd = {
   "@context": "https://schema.org",
@@ -55,18 +69,26 @@ const itemListLd = {
   inLanguage: "pt-BR",
   url: "https://franklinbaldo.github.io/pt/ranking/",
   numberOfItems: enriched.length,
-  itemListElement: enriched.map((r) => ({
-    "@type": "ListItem",
-    position: r.rank,
-    name: r.post ? r.post.title : r.key,
-    url: r.post ? `https://franklinbaldo.github.io/${r.post.lang === "pt" ? "pt/" : ""}blog/${r.post.slug}/` : undefined,
-  })).filter((item) => item.url),
+  itemListElement: enriched
+    .map((r) => ({
+      "@type": "ListItem",
+      position: r.rank,
+      name: r.post ? r.post.title : r.key,
+      url: r.post
+        ? `https://franklinbaldo.github.io/${r.post.lang === "pt" ? "pt/" : ""}blog/${r.post.slug}/`
+        : undefined,
+    }))
+    .filter((item) => item.url),
 };
 
 const strings: RankingStrings = {
-  subtitle: "Posts ordenados pelo ordinal do OpenSkill (μ − 3σ). Maior é melhor. Atualizado a cada build a partir de .routines/hronir/.",
-  intro:
-    "O sistema Hrönir confronta posts em duelos par-a-par. Um avaliador (às vezes eu, às vezes um modelo) escolhe um vencedor e escreve uma defesa apaixonada. O OpenSkill transforma esses duelos num ranking contínuo com incerteza explícita (σ): posts com poucas aparições têm σ maior e portanto ordinal mais baixo mesmo com μ alto.",
+  subtitle:
+    "Posts ordenados pelo ordinal do OpenSkill (μ − 3σ). Maior é melhor. Atualizado a cada build a partir de .routines/hronir/.",
+  plainLangHeading: "Como isso funciona",
+  plainLangBody:
+    "Cada post compete contra outro num duelo par-a-par. Um leitor (às vezes eu, às vezes um modelo de IA) lê os dois e escolhe o melhor — depois escreve uma defesa breve dessa escolha. Quanto mais duelos um post vence, mais ele sobe. Posts com menos duelos têm incerteza maior e por isso ficam mais baixos até acumular mais confrontos.",
+  technicalViewLabel: "Visão técnica",
+  standardViewLabel: "Visão padrão",
   podiumLabel: "Pódio",
   statsTotalDuels: "duelos disputados",
   statsTotalRated: "posts no ranking",
@@ -80,12 +102,16 @@ const strings: RankingStrings = {
   thSigma: "σ",
   thRecord: "V/N",
   thConfidence: "confiança",
+  thWinRate: "vitórias%",
+  thDelta: "Δ",
   unratedHeading: "Ainda sem duelo",
   unratedBlurb: "Posts publicados que ainda não passaram por nenhuma comparação Hrönir.",
-  recentHeading: "Julgamentos e Batalhas",
-  recentBlurb: "Veja a análise e o veredito completo de cada confronto disputado.",
+  recentHeading: "Batalhas recentes",
+  recentBlurb:
+    "Os confrontos mais recentes — clique em qualquer card para ler a análise e o veredito completo.",
   recentBeats: "venceu",
-  emptyState: "Sem posts ranqueados ainda — rode uma rodada Hrönir para popular o ranking.",
+  emptyState:
+    "Sem posts ranqueados ainda — rode uma rodada Hrönir para popular o ranking.",
   ordinalTip: "Ordinal = μ − 3σ. Combina habilidade estimada com penalidade pela incerteza.",
   muTip: "μ (mu): habilidade média estimada pelo OpenSkill.",
   sigmaTip: "σ (sigma): incerteza da estimativa. Cai à medida que o post acumula duelos.",
@@ -96,30 +122,15 @@ const strings: RankingStrings = {
   podiumSilver: "2º lugar",
   podiumBronze: "3º lugar",
   noDate: "—",
-  filterSearchPlaceholder: "Buscar batalhas (título, veredito, modelo...)",
-  filterCriterionAll: "Todos os critérios",
-  filterConfidenceAll: "Todas as confianças",
-  filterSeasonAll: "Todas as temporadas",
-  showingResultsCount: "Mostrando {count} de {total} batalhas",
-  verdictTab: "Veredito",
-  analysisATab: "Análise Post A",
-  analysisBTab: "Análise Post B",
-  emptyFilterState: "Nenhuma batalha corresponde aos filtros selecionados.",
-  modelLabel: "Modelo",
-  seasonLabel: "Temporada",
-  marginLabel: "Margem",
-  marginHigh: "alta",
-  marginMedium: "média",
-  marginLow: "baixa",
-  unratedCTA: "Esses posts ainda não passaram pelo julgamento. Sente que algum deles merecia estar no topo?",
-  perspectiveLabel: "Perspectiva",
-  filterPerspectiveAll: "Todas as perspectivas",
-  agentLabel: "Agente",
-  filterAgentAll: "Todos os agentes",
-  ratesLabel: "Notas",
-  paginationPrev: "← Anterior",
-  paginationNext: "Próximo →",
-  paginationPageOf: "Página {n} de {total}",
+  unratedCTA:
+    "Esses posts ainda não passaram pelo julgamento. Sente que algum deles merecia estar no topo?",
+  perspectivesHeading: "Explorar por perspectiva",
+  perspectivesBlurb:
+    "Cada perspectiva é uma lente diferente para avaliar os posts — curiosidade, clareza, memorabilidade e mais.",
+  perspectivesLeaderLabel: "Líder:",
+  perspectivesViewAllLink: "→ Ver todos os rankings por perspectiva",
+  allBattlesLinkText: "→ Ver todas as {count} batalhas",
+  readAnalysisLinkLabel: "Ler análise",
 };
 ---
 
@@ -139,5 +150,7 @@ const strings: RankingStrings = {
     stats={stats}
     postByKey={byKey}
     strings={strings}
+    perspectivesGrid={perspectivesGrid}
+    snapshot={snapshot}
   />
 </PageLayout>

--- a/src/pages/ranking.astro
+++ b/src/pages/ranking.astro
@@ -1,9 +1,19 @@
 ---
 import PageLayout from "../layouts/PageLayout.astro";
 import { getCollection } from "astro:content";
-import { getRanking, getRankingStats, getAllDuels } from "../lib/hronir-rank";
+import {
+  getRanking,
+  getRankingStats,
+  getRecentDuels,
+  buildPerspectivesGrid,
+  loadSnapshot,
+} from "../lib/hronir-rank";
 import { isPublished } from "../lib/publish";
-import RankingView, { type RankPostInfo, type UnratedItem, type RankingStrings } from "../components/RankingView.astro";
+import RankingView, {
+  type RankPostInfo,
+  type UnratedItem,
+  type RankingStrings,
+} from "../components/RankingView.astro";
 
 const all = await getCollection("blog");
 const byKey = new Map<string, RankPostInfo>();
@@ -11,7 +21,6 @@ for (const p of all) {
   if (!isPublished(p)) continue;
   const key = p.data.translationKey;
   if (!key) continue;
-  // Prefer EN entry for the link; fall back to first seen.
   const existing = byKey.get(key);
   if (!existing || (p.data.lang ?? "en") === "en") {
     byKey.set(key, { slug: p.id, title: p.data.title, lang: p.data.lang ?? "en" });
@@ -37,13 +46,19 @@ for (const p of all) {
     lang === "en"
       ? p
       : all.find((q) => q.data.translationKey === key && (q.data.lang ?? "en") === "en") ?? p;
-  unrated.push({ slug: preferred.id, title: preferred.data.title, lang: preferred.data.lang ?? "en" });
+  unrated.push({
+    slug: preferred.id,
+    title: preferred.data.title,
+    lang: preferred.data.lang ?? "en",
+  });
   seenUnrated.add(key);
 }
 unrated.sort((a, b) => a.title.localeCompare(b.title, "en-US"));
 
 const stats = getRankingStats();
-const recent = getAllDuels();
+const recent = getRecentDuels(10);
+const perspectivesGrid = buildPerspectivesGrid(byKey);
+const snapshot = loadSnapshot();
 
 const itemListLd = {
   "@context": "https://schema.org",
@@ -53,18 +68,26 @@ const itemListLd = {
   inLanguage: "en-US",
   url: "https://franklinbaldo.github.io/ranking/",
   numberOfItems: enriched.length,
-  itemListElement: enriched.map((r) => ({
-    "@type": "ListItem",
-    position: r.rank,
-    name: r.post ? r.post.title : r.key,
-    url: r.post ? `https://franklinbaldo.github.io/${r.post.lang === "pt" ? "pt/" : ""}blog/${r.post.slug}/` : undefined,
-  })).filter((item) => item.url),
+  itemListElement: enriched
+    .map((r) => ({
+      "@type": "ListItem",
+      position: r.rank,
+      name: r.post ? r.post.title : r.key,
+      url: r.post
+        ? `https://franklinbaldo.github.io/${r.post.lang === "pt" ? "pt/" : ""}blog/${r.post.slug}/`
+        : undefined,
+    }))
+    .filter((item) => item.url),
 };
 
 const strings: RankingStrings = {
-  subtitle: "Posts ordered by OpenSkill ordinal (μ − 3σ). Higher is better. Updated every build from .routines/hronir/.",
-  intro:
-    "The Hrönir system pits posts against each other in pairwise duels. An evaluator (sometimes me, sometimes a model) picks a winner and writes a passionate defense. OpenSkill turns those duels into a continuous ranking with explicit uncertainty (σ): posts with few appearances have larger σ and therefore a lower ordinal even with high μ.",
+  subtitle:
+    "Posts ordered by OpenSkill ordinal (μ − 3σ). Higher is better. Updated every build from .routines/hronir/.",
+  plainLangHeading: "How this works",
+  plainLangBody:
+    "Every post competes against another in a one-on-one duel. A reader (sometimes me, sometimes an AI model) reads both and picks the better one — then writes a short defense of that choice. The more duels a post wins, the higher it climbs. Posts with fewer duels have wider uncertainty and therefore rank lower until they've faced more competition.",
+  technicalViewLabel: "Technical view",
+  standardViewLabel: "Standard view",
   podiumLabel: "Podium",
   statsTotalDuels: "duels run",
   statsTotalRated: "posts ranked",
@@ -78,10 +101,12 @@ const strings: RankingStrings = {
   thSigma: "σ",
   thRecord: "W/N",
   thConfidence: "confidence",
+  thWinRate: "win%",
+  thDelta: "Δ",
   unratedHeading: "Not yet duelled",
   unratedBlurb: "Published posts that haven't gone through a Hrönir comparison yet.",
-  recentHeading: "Judgments and Battles",
-  recentBlurb: "Read the complete analysis and verdict of each confrontation.",
+  recentHeading: "Recent Battles",
+  recentBlurb: "The latest confrontations — click any card to read the full analysis and verdict.",
   recentBeats: "beat",
   emptyState: "No rated posts yet — run a Hrönir round to populate the ranking.",
   ordinalTip: "Ordinal = μ − 3σ. Combines estimated skill with a penalty for uncertainty.",
@@ -94,30 +119,15 @@ const strings: RankingStrings = {
   podiumSilver: "2nd place",
   podiumBronze: "3rd place",
   noDate: "—",
-  filterSearchPlaceholder: "Search battles (title, verdict, model...)",
-  filterCriterionAll: "All criteria",
-  filterConfidenceAll: "All confidence levels",
-  filterSeasonAll: "All seasons",
-  showingResultsCount: "Showing {count} of {total} battles",
-  verdictTab: "Verdict",
-  analysisATab: "Analysis Post A",
-  analysisBTab: "Analysis Post B",
-  emptyFilterState: "No battles match the selected filters.",
-  modelLabel: "Model",
-  seasonLabel: "Season",
-  marginLabel: "Margin",
-  marginHigh: "high",
-  marginMedium: "medium",
-  marginLow: "low",
-  unratedCTA: "These posts haven't been duelled yet. Feel like one of them deserves to be on top?",
-  perspectiveLabel: "Perspective",
-  filterPerspectiveAll: "All perspectives",
-  agentLabel: "Agent",
-  filterAgentAll: "All agents",
-  ratesLabel: "Rates",
-  paginationPrev: "← Previous",
-  paginationNext: "Next →",
-  paginationPageOf: "Page {n} of {total}",
+  unratedCTA:
+    "These posts haven't been duelled yet. Feel like one of them deserves to be on top?",
+  perspectivesHeading: "Explore by Perspective",
+  perspectivesBlurb:
+    "Each perspective is a different lens for evaluating posts — curiosity, clarity, memorability, and more.",
+  perspectivesLeaderLabel: "Leader:",
+  perspectivesViewAllLink: "→ Browse all perspective rankings",
+  allBattlesLinkText: "→ See all {count} battles",
+  readAnalysisLinkLabel: "Read analysis",
 };
 ---
 
@@ -137,5 +147,7 @@ const strings: RankingStrings = {
     stats={stats}
     postByKey={byKey}
     strings={strings}
+    perspectivesGrid={perspectivesGrid}
+    snapshot={snapshot}
   />
 </PageLayout>

--- a/src/pages/ranking/battles/[id].astro
+++ b/src/pages/ranking/battles/[id].astro
@@ -1,0 +1,330 @@
+---
+import PageLayout from "../../../layouts/PageLayout.astro";
+import { getCollection } from "astro:content";
+import { getAllDuels, getRankByKey } from "../../../lib/hronir-rank";
+import { isPublished } from "../../../lib/publish";
+import { marked } from "marked";
+
+export async function getStaticPaths() {
+  const allPosts = await getCollection("blog");
+  const byKey = new Map<string, { title: string; slug: string; lang: string }>();
+  for (const p of allPosts) {
+    if (!isPublished(p)) continue;
+    const key = p.data.translationKey;
+    if (!key) continue;
+    const lang = p.data.lang ?? "en";
+    const existing = byKey.get(key);
+    if (!existing || lang === "en") byKey.set(key, { title: p.data.title, slug: p.id, lang });
+  }
+
+  const duels = getAllDuels();
+  return duels.map((duel, i) => ({
+    params: { id: duel.id },
+    props: {
+      duel,
+      prevId: i + 1 < duels.length ? duels[i + 1].id : null,
+      nextId: i > 0 ? duels[i - 1].id : null,
+      prevPage: i + 1 < duels.length ? Math.floor((i + 1) / 20) + 1 : null,
+      postAInfo: byKey.get(duel.postAKey ?? ""),
+      postBInfo: byKey.get(duel.postBKey ?? ""),
+    },
+  }));
+}
+
+const { duel, prevId, nextId, prevPage, postAInfo, postBInfo } = Astro.props;
+
+function postHref(info: { slug: string; lang: string } | undefined) {
+  if (!info) return null;
+  return info.lang === "pt" ? `/pt/blog/${info.slug}/` : `/blog/${info.slug}/`;
+}
+
+function dossierHref(key: string | undefined) {
+  if (!key) return null;
+  return `/ranking/posts/${key}/`;
+}
+
+const winnerIsA = duel.postAKey === duel.winnerKey;
+const winnerInfo = winnerIsA ? postAInfo : postBInfo;
+const loserInfo = winnerIsA ? postBInfo : postAInfo;
+const winnerKey = duel.winnerKey;
+const loserKey = duel.loserKey;
+const winnerTitle = winnerInfo?.title ?? winnerKey;
+const loserTitle = loserInfo?.title ?? loserKey;
+const winnerHref = postHref(winnerInfo);
+const loserHref = postHref(loserInfo);
+
+const rateWinner = winnerIsA ? duel.rateA : duel.rateB;
+const rateLoser = winnerIsA ? duel.rateB : duel.rateA;
+const hasRates = rateWinner != null && rateLoser != null;
+const tensionPct = hasRates
+  ? Math.round((rateWinner! / (rateWinner! + rateLoser!)) * 100)
+  : null;
+
+function fmtDate(iso: string) {
+  return new Date(iso).toLocaleDateString("en-US", { year: "numeric", month: "long", day: "numeric" });
+}
+
+function perspectiveHue(id: string): number {
+  let h = 0;
+  for (let i = 0; i < id.length; i++) h = ((h << 5) - h + id.charCodeAt(i)) & 0xffff;
+  return Math.abs(h) % 360;
+}
+
+const pageTitle = `${winnerTitle} vs ${loserTitle}`;
+const pageDesc = `Hrönir duel: ${winnerTitle} beat ${loserTitle}${duel.perspectiveId ? ` under the ${duel.perspectiveId} perspective` : ""}.`;
+
+const rankByKey = getRankByKey();
+const winnerRank = rankByKey.get(winnerKey);
+const loserRank = rankByKey.get(loserKey);
+---
+
+<PageLayout title={`${pageTitle} | Ranking Battles`} description={pageDesc} lang="en">
+  <nav class="breadcrumb" aria-label="Breadcrumb">
+    <ol>
+      <li><a href="/">Home</a></li>
+      <li><a href="/ranking/">Ranking</a></li>
+      <li><a href="/ranking/battles/">All battles</a></li>
+      <li aria-current="page">{winnerTitle} vs {loserTitle}</li>
+    </ol>
+  </nav>
+
+  <hgroup>
+    <h1>Battle Report</h1>
+    <p><small>{fmtDate(duel.runAt)}</small></p>
+  </hgroup>
+
+  <div class="battle-tags">
+    {duel.season !== undefined && <span class="tag tag-season">Season {duel.season}</span>}
+    {duel.perspectiveId && (
+      <span class="tag tag-perspective" style={`--ph:${perspectiveHue(duel.perspectiveId)}`}>
+        <a href={`/ranking/perspectives/${duel.perspectiveId}/`}>{duel.perspectiveId.replace(/-/g, " ")}</a>
+      </span>
+    )}
+    {duel.agentId && <span class="tag tag-agent">{duel.agentId}</span>}
+    {duel.confidence && <span class={`tag tag-confidence conf-${duel.confidence}`}>{duel.confidence} confidence</span>}
+  </div>
+
+  <section class="versus-section" aria-label="Versus">
+    <div class="versus-grid">
+      <div class="versus-side winner">
+        <div class="versus-label">Winner 🏆</div>
+        <div class="versus-title">
+          {winnerHref
+            ? <a href={winnerHref}>{winnerTitle}</a>
+            : <span>{winnerTitle}</span>}
+        </div>
+        {hasRates && <div class="versus-rate">{rateWinner!.toFixed(2)}</div>}
+        {winnerRank && (
+          <div class="versus-rank">
+            <a href={dossierHref(winnerKey) ?? "/ranking/"}>#{winnerRank.rank}/{winnerRank.total}</a>
+          </div>
+        )}
+      </div>
+
+      <div class="versus-center">
+        <span class="vs-badge">VS</span>
+      </div>
+
+      <div class="versus-side loser">
+        <div class="versus-label">Challenger</div>
+        <div class="versus-title">
+          {loserHref
+            ? <a href={loserHref}>{loserTitle}</a>
+            : <span>{loserTitle}</span>}
+        </div>
+        {hasRates && <div class="versus-rate loser-rate">{rateLoser!.toFixed(2)}</div>}
+        {loserRank && (
+          <div class="versus-rank">
+            <a href={dossierHref(loserKey) ?? "/ranking/"}>#{loserRank.rank}/{loserRank.total}</a>
+          </div>
+        )}
+      </div>
+    </div>
+
+    {tensionPct !== null ? (
+      <div class="tension-bar" role="meter" aria-label={`Win rate split: ${tensionPct}% / ${100 - tensionPct}%`} aria-valuenow={tensionPct} aria-valuemin={0} aria-valuemax={100}>
+        <div class="tension-fill winner-fill" style={`width:${tensionPct}%`}></div>
+        <div class="tension-fill loser-fill" style={`width:${100 - tensionPct}%`}></div>
+      </div>
+    ) : (
+      <div class="tension-bar-absent" aria-label="Tension data not available">—</div>
+    )}
+  </section>
+
+  {duel.parsedContent?.verdict && (
+    <section class="content-section verdict-section">
+      <h2>Verdict</h2>
+      <div class="prose" set:html={marked.parse(duel.parsedContent.verdict)} />
+    </section>
+  )}
+
+  {(duel.parsedContent?.postAAnalysis || duel.parsedContent?.postBAnalysis) && (
+    <div class="analyses-grid">
+      {duel.parsedContent.postAAnalysis && (
+        <section class="content-section">
+          <h3>Analysis — {postAInfo?.title ?? duel.postAKey}</h3>
+          <div class="prose" set:html={marked.parse(duel.parsedContent.postAAnalysis)} />
+        </section>
+      )}
+      {duel.parsedContent.postBAnalysis && (
+        <section class="content-section">
+          <h3>Analysis — {postBInfo?.title ?? duel.postBKey}</h3>
+          <div class="prose" set:html={marked.parse(duel.parsedContent.postBAnalysis)} />
+        </section>
+      )}
+    </div>
+  )}
+
+  {(duel.evaluatorMood || duel.evaluatorMoodAfter) && (
+    <section class="content-section mood-section">
+      <h2>Evaluator State</h2>
+      {duel.evaluatorMood && (
+        <blockquote lang="pt">
+          <small>Before: </small>"{duel.evaluatorMood}"
+        </blockquote>
+      )}
+      {duel.evaluatorMoodAfter && (
+        <blockquote lang="pt">
+          <small>After: </small>"{duel.evaluatorMoodAfter}"
+        </blockquote>
+      )}
+    </section>
+  )}
+
+  <nav class="battle-nav" aria-label="Battle navigation">
+    {nextId ? (
+      <a href={`/ranking/battles/${nextId}/`} class="nav-btn prev-btn">← Newer battle</a>
+    ) : <span class="nav-btn nav-disabled">← Newest</span>}
+    {prevPage && (
+      <a href={`/ranking/battles/#page-${prevPage}`} class="nav-btn archive-btn">
+        Back to archive
+      </a>
+    )}
+    {prevId ? (
+      <a href={`/ranking/battles/${prevId}/`} class="nav-btn next-btn">Older battle →</a>
+    ) : <span class="nav-btn nav-disabled">Oldest →</span>}
+  </nav>
+</PageLayout>
+
+<style>
+  .breadcrumb ol {
+    list-style: none; padding: 0; margin: 0 0 1rem;
+    display: flex; flex-wrap: wrap; gap: 0;
+    font-size: 0.8rem; color: var(--pico-muted-color);
+  }
+  .breadcrumb li + li::before { content: " / "; padding: 0 0.35em; }
+  .breadcrumb a { color: var(--pico-muted-color); text-decoration: none; }
+  .breadcrumb a:hover { text-decoration: underline; }
+
+  .battle-tags { display: flex; flex-wrap: wrap; gap: 0.4rem; margin-bottom: 1.5rem; }
+  .tag {
+    font-size: 0.68rem; text-transform: uppercase; letter-spacing: 0.05em;
+    padding: 0.15rem 0.5rem; border-radius: 4px;
+    border: 1px solid var(--pico-muted-border-color); color: var(--pico-muted-color);
+  }
+  .tag-perspective {
+    background: hsl(var(--ph,200), 28%, 92%); color: hsl(var(--ph,200), 45%, 32%);
+    border-color: hsl(var(--ph,200), 38%, 72%);
+    text-transform: none; letter-spacing: 0;
+  }
+  [data-theme="dark"] .tag-perspective {
+    background: hsl(var(--ph,200),22%,18%); color: hsl(var(--ph,200),52%,70%);
+    border-color: hsl(var(--ph,200),32%,38%);
+  }
+  .tag-perspective a { color: inherit; text-decoration: none; }
+  .tag-perspective a:hover { text-decoration: underline; }
+  .tag-agent { font-family: var(--pico-font-family-monospace); text-transform: none; letter-spacing: 0; }
+  .tag-confidence.conf-high { color: #2d6a4f; border-color: #2d6a4f55; background: #2d6a4f12; }
+  [data-theme="dark"] .tag-confidence.conf-high { color: #74c69d; border-color: #74c69d55; }
+  .tag-confidence.conf-medium { color: #b08300; border-color: #b0830044; background: #b0830012; }
+  [data-theme="dark"] .tag-confidence.conf-medium { color: #f1c453; border-color: #f1c45355; }
+
+  .versus-section { margin: 2rem 0; }
+  .versus-grid {
+    display: grid; grid-template-columns: 1fr auto 1fr;
+    gap: 1rem; align-items: center;
+    padding: 1.5rem;
+    border: 1px solid var(--pico-muted-border-color);
+    border-radius: var(--pico-border-radius);
+    background: var(--pico-card-background-color);
+  }
+  .versus-side { display: flex; flex-direction: column; gap: 0.4rem; }
+  .versus-side.winner { border-left: 3px solid var(--pico-primary); padding-left: 0.75rem; }
+  .versus-side.loser { text-align: right; border-right: 3px solid var(--pico-muted-border-color); padding-right: 0.75rem; }
+  .versus-label { font-size: 0.68rem; text-transform: uppercase; letter-spacing: 0.08em; color: var(--pico-muted-color); }
+  .versus-title { font-size: 1.05rem; font-weight: 600; }
+  .versus-side.loser .versus-title { color: var(--pico-muted-color); }
+  .versus-title a { text-decoration: none; color: inherit; }
+  .versus-title a:hover { text-decoration: underline; }
+  .versus-rate { font-family: var(--pico-font-family-monospace); font-size: 1.4rem; font-weight: 700; color: var(--pico-primary); }
+  .versus-rate.loser-rate { color: var(--pico-muted-color); }
+  .versus-rank { font-size: 0.78rem; color: var(--pico-muted-color); }
+  .versus-rank a { color: inherit; text-decoration: none; }
+  .versus-rank a:hover { text-decoration: underline; }
+  .versus-center { display: flex; align-items: center; justify-content: center; }
+  .vs-badge {
+    font-size: 0.75rem; font-weight: 700; color: var(--pico-muted-color);
+    background: var(--pico-muted-border-color);
+    padding: 0.2rem 0.4rem; border-radius: 4px;
+  }
+  .tension-bar {
+    height: 6px; border-radius: 3px; overflow: hidden; display: flex;
+    margin-top: 0.75rem;
+  }
+  .tension-fill { height: 100%; }
+  .winner-fill { background: var(--pico-primary); opacity: 0.7; }
+  .loser-fill { background: var(--pico-muted-border-color); opacity: 0.5; }
+  .tension-bar-absent {
+    height: 6px; line-height: 6px;
+    font-size: 0.72rem; color: var(--pico-muted-color);
+    text-align: center; margin-top: 0.75rem;
+  }
+
+  @media (max-width: 580px) {
+    .versus-grid { grid-template-columns: 1fr; gap: 0.75rem; }
+    .versus-side.winner { border-left: none; border-bottom: 2px solid var(--pico-primary); padding-left: 0; padding-bottom: 0.75rem; }
+    .versus-side.loser { text-align: left; border-right: none; border-top: 2px solid var(--pico-muted-border-color); padding-right: 0; padding-top: 0.75rem; }
+  }
+
+  .content-section { margin: 2rem 0; }
+  .content-section h2 { font-size: 1rem; text-transform: uppercase; letter-spacing: 0.06em; color: var(--pico-muted-color); margin-bottom: 0.5rem; }
+  .content-section h3 { font-size: 0.88rem; text-transform: uppercase; letter-spacing: 0.05em; color: var(--pico-muted-color); margin-bottom: 0.5rem; }
+  .verdict-section { border-left: 3px solid var(--pico-primary); padding-left: 1rem; }
+  .prose { font-size: 0.93rem; line-height: 1.6; }
+  .prose p:last-child { margin-bottom: 0; }
+
+  .analyses-grid {
+    display: grid; grid-template-columns: repeat(auto-fit, minmax(18rem, 1fr));
+    gap: 1.5rem; margin: 2rem 0;
+  }
+  .analyses-grid .content-section {
+    border: 1px solid var(--pico-muted-border-color);
+    border-radius: var(--pico-border-radius);
+    padding: 1rem; margin: 0;
+  }
+
+  .mood-section blockquote {
+    font-style: italic; color: var(--pico-muted-color);
+    border-left: 3px solid var(--pico-muted-border-color);
+    padding-left: 0.75rem; margin: 0.5rem 0;
+  }
+  .mood-section small { font-style: normal; }
+
+  .battle-nav {
+    display: flex; gap: 1rem; align-items: center; justify-content: space-between;
+    margin-top: 3rem; padding-top: 1.5rem;
+    border-top: 1px solid var(--pico-muted-border-color);
+    flex-wrap: wrap;
+  }
+  .nav-btn {
+    padding: 0.4rem 0.9rem; font-size: 0.85rem;
+    border: 1px solid var(--pico-muted-border-color);
+    border-radius: var(--pico-border-radius);
+    text-decoration: none; color: var(--pico-color);
+    background: var(--pico-card-background-color);
+    transition: border-color 0.15s, background 0.15s;
+  }
+  .nav-btn:hover { border-color: var(--pico-primary); background: var(--pico-card-sectioning-background-color); }
+  .nav-disabled { color: var(--pico-muted-color); border-color: transparent; background: transparent; cursor: default; }
+  .archive-btn { border-style: dashed; }
+</style>

--- a/src/pages/ranking/battles/index.astro
+++ b/src/pages/ranking/battles/index.astro
@@ -1,0 +1,431 @@
+---
+import PageLayout from "../../../layouts/PageLayout.astro";
+import { getCollection } from "astro:content";
+import { getAllDuels } from "../../../lib/hronir-rank";
+import { isPublished } from "../../../lib/publish";
+
+const allPosts = await getCollection("blog");
+const byKey = new Map<string, { title: string; slug: string; lang: string }>();
+for (const p of allPosts) {
+  if (!isPublished(p)) continue;
+  const key = p.data.translationKey;
+  if (!key) continue;
+  const lang = p.data.lang ?? "en";
+  const existing = byKey.get(key);
+  if (!existing || lang === "en") byKey.set(key, { title: p.data.title, slug: p.id, lang });
+}
+
+const duels = getAllDuels();
+
+function postLabel(key: string) {
+  return byKey.get(key)?.title ?? key;
+}
+function postHref(key: string) {
+  const p = byKey.get(key);
+  if (!p) return null;
+  return p.lang === "pt" ? `/pt/blog/${p.slug}/` : `/blog/${p.slug}/`;
+}
+
+function fmtDate(iso: string) {
+  return new Date(iso).toLocaleDateString("en-US", { year: "numeric", month: "short", day: "numeric" });
+}
+
+function perspectiveHue(id: string): number {
+  let h = 0;
+  for (let i = 0; i < id.length; i++) h = ((h << 5) - h + id.charCodeAt(i)) & 0xffff;
+  return Math.abs(h) % 360;
+}
+
+const seasons = [...new Set(duels.map((d) => d.season).filter((s): s is number => typeof s === "number"))].sort((a, b) => a - b);
+const perspectives = [...new Set(duels.map((d) => d.perspectiveId).filter(Boolean) as string[])].sort();
+const agents = [...new Set(duels.map((d) => d.agentId).filter(Boolean) as string[])].sort();
+---
+
+<PageLayout
+  title="Battle Archive | Ranking | Franklin Baldo"
+  description="All Hrönir duels — the full battle history with verdicts, analyses, and rates."
+  lang="en"
+>
+  <nav class="breadcrumb" aria-label="Breadcrumb">
+    <ol>
+      <li><a href="/">Home</a></li>
+      <li><a href="/ranking/">Ranking</a></li>
+      <li aria-current="page">All Battles</li>
+    </ol>
+  </nav>
+
+  <hgroup>
+    <h1>Battle Archive</h1>
+    <p><small>{duels.length} duels · click any battle to read the full analysis and verdict</small></p>
+  </hgroup>
+
+  <div class="battle-filters" id="battle-filters">
+    <div class="filter-row-main">
+      <input type="search" id="battle-search" placeholder="Search battles (title, perspective, agent…)" aria-label="Search battles" />
+    </div>
+    <div class="filter-row-meta">
+      {seasons.length > 0 && (
+        <div class="filter-group">
+          <label for="filter-season">Season</label>
+          <select id="filter-season">
+            <option value="all">All seasons</option>
+            {seasons.map((s) => <option value={s}>{s}</option>)}
+          </select>
+        </div>
+      )}
+      {agents.length > 0 && (
+        <div class="filter-group">
+          <label for="filter-agent">Agent</label>
+          <select id="filter-agent">
+            <option value="all">All agents</option>
+            {agents.map((a) => <option value={a}>{a}</option>)}
+          </select>
+        </div>
+      )}
+      <div class="filter-group">
+        <label id="conf-group-label">Confidence</label>
+        <div class="filter-pills" id="filter-confidence" role="radiogroup" aria-labelledby="conf-group-label">
+          <button type="button" role="radio" aria-checked="true" data-value="all" class="pill active">All</button>
+          <button type="button" role="radio" aria-checked="false" data-value="high" class="pill">high</button>
+          <button type="button" role="radio" aria-checked="false" data-value="medium" class="pill">medium</button>
+          <button type="button" role="radio" aria-checked="false" data-value="low" class="pill">low</button>
+        </div>
+      </div>
+    </div>
+    {perspectives.length > 0 && (
+      <div class="filter-row-chips" role="radiogroup" aria-label="Filter by perspective" id="filter-perspective">
+        <button type="button" role="radio" aria-checked="true" data-perspective="all" class="chip active">All perspectives</button>
+        {perspectives.map((p) => (
+          <button type="button" role="radio" aria-checked="false" data-perspective={p} class="chip" style={`--ph:${perspectiveHue(p)}`}>
+            {p.replace(/-/g, " ")}
+          </button>
+        ))}
+      </div>
+    )}
+    <div class="filter-status">
+      <span id="filter-count-label" data-total={duels.length}>
+        Showing {duels.length} of {duels.length} battles
+      </span>
+    </div>
+  </div>
+
+  <div class="battle-list" id="battle-list">
+    {duels.map((d) => {
+      const winnerName = postLabel(d.winnerKey);
+      const loserName = postLabel(d.loserKey);
+      const winnerIsA = d.postAKey === d.winnerKey;
+      const rateWinner = winnerIsA ? d.rateA : d.rateB;
+      const rateLoser = winnerIsA ? d.rateB : d.rateA;
+      const hasRates = rateWinner != null && rateLoser != null;
+      const tensionPct = hasRates ? Math.round((rateWinner! / (rateWinner! + rateLoser!)) * 100) : null;
+      const searchString = [winnerName, loserName, d.perspectiveId ?? "", d.agentId ?? "", d.criterion ?? ""].join(" ").toLowerCase();
+      return (
+        <article
+          class="battle-card"
+          data-confidence={d.confidence || "none"}
+          data-season={d.season !== undefined ? String(d.season) : "none"}
+          data-perspective={d.perspectiveId || "none"}
+          data-agent={d.agentId || "none"}
+          data-search={searchString}
+        >
+          <a href={`/ranking/battles/${d.id}/`} class="battle-link" aria-label={`Read analysis: ${winnerName} vs ${loserName}`}>
+            <div class="battle-meta">
+              <span class="battle-date">{fmtDate(d.runAt)}</span>
+              {d.season !== undefined && <span class="tag tag-season">S{d.season}</span>}
+              {d.perspectiveId && (
+                <span class="tag tag-perspective" style={`--ph:${perspectiveHue(d.perspectiveId)}`}>
+                  {d.perspectiveId.replace(/-/g, " ")}
+                </span>
+              )}
+              {d.agentId && <span class="tag tag-agent">{d.agentId}</span>}
+              {d.confidence && <span class={`tag conf-${d.confidence}`}>{d.confidence}</span>}
+            </div>
+            <div class="battle-versus">
+              <div class="side winner">
+                <span class="post-name">{winnerName}</span>
+                <span class="medal" aria-hidden="true">🏆</span>
+                {hasRates && <span class="rate">{rateWinner!.toFixed(1)}</span>}
+              </div>
+              <div class="divider"><span class="vs">VS</span></div>
+              <div class="side loser">
+                <span class="post-name">{loserName}</span>
+                {hasRates && <span class="rate loser-rate">{rateLoser!.toFixed(1)}</span>}
+              </div>
+            </div>
+            {tensionPct !== null ? (
+              <div class="tension-bar">
+                <div class="tf winner-fill" style={`width:${tensionPct}%`}></div>
+                <div class="tf loser-fill" style={`width:${100 - tensionPct}%`}></div>
+              </div>
+            ) : (
+              <div class="tension-absent" aria-label="Rates not available">—</div>
+            )}
+            <div class="read-cta">Read analysis →</div>
+          </a>
+        </article>
+      );
+    })}
+  </div>
+
+  <nav id="battle-pagination" class="battle-pagination" style="display:none;" aria-label="Battle pages">
+    <button id="prev-page" type="button" class="outline secondary">← Previous</button>
+    <span id="page-indicator" data-template="Page {n} of {total}">Page 1 of 1</span>
+    <button id="next-page" type="button" class="outline secondary">Next →</button>
+  </nav>
+
+  <div id="battle-empty" class="empty-state" style="display:none;">
+    <em>No battles match the selected filters.</em>
+  </div>
+</PageLayout>
+
+<style>
+  .breadcrumb ol {
+    list-style: none; padding: 0; margin: 0 0 1rem;
+    display: flex; flex-wrap: wrap; gap: 0;
+    font-size: 0.8rem; color: var(--pico-muted-color);
+  }
+  .breadcrumb li + li::before { content: " / "; padding: 0 0.35em; }
+  .breadcrumb a { color: var(--pico-muted-color); text-decoration: none; }
+  .breadcrumb a:hover { text-decoration: underline; }
+
+  .battle-filters {
+    background: var(--pico-card-sectioning-background-color);
+    border: 1px solid var(--pico-muted-border-color);
+    border-radius: var(--pico-border-radius);
+    padding: 1rem; margin: 1rem 0 1.5rem;
+    display: flex; flex-direction: column; gap: 0.8rem;
+  }
+  .filter-row-main input[type="search"] { margin: 0; width: 100%; }
+  .filter-row-meta { display: flex; flex-wrap: wrap; gap: 1.2rem; align-items: flex-end; }
+  .filter-group { display: flex; flex-direction: column; gap: 0.25rem; }
+  .filter-group label { margin: 0; font-size: 0.68rem; text-transform: uppercase; letter-spacing: 0.05em; color: var(--pico-muted-color); }
+  .filter-group select { margin: 0; min-width: 8rem; padding: 0.3rem 0.5rem; height: auto; font-size: 0.88rem; }
+  .filter-pills { display: flex; gap: 0.3rem; }
+  .pill {
+    padding: 0.25rem 0.6rem; font-size: 0.78rem; margin: 0;
+    border-radius: var(--pico-border-radius);
+    background: transparent; border: 1px solid var(--pico-muted-border-color);
+    color: var(--pico-muted-color); cursor: pointer; line-height: 1.2;
+    transition: background-color 0.15s, color 0.15s, border-color 0.15s;
+  }
+  .pill.active, .pill:hover { background: var(--pico-primary); border-color: var(--pico-primary); color: var(--pico-primary-inverse); }
+  .filter-row-chips {
+    display: flex; flex-wrap: wrap; gap: 0.3rem;
+    padding-top: 0.5rem; border-top: 1px dashed var(--pico-muted-border-color);
+  }
+  .chip {
+    padding: 0.18rem 0.55rem; font-size: 0.74rem; margin: 0;
+    border-radius: 999px; background: transparent;
+    border: 1px solid var(--pico-muted-border-color);
+    color: var(--pico-muted-color); cursor: pointer; line-height: 1.2;
+    transition: background-color 0.15s, color 0.15s, border-color 0.15s;
+  }
+  .chip.active, .chip:hover { background: var(--pico-primary); border-color: var(--pico-primary); color: var(--pico-primary-inverse); }
+  #filter-perspective .chip[data-perspective]:not([data-perspective="all"]):not(.active):hover {
+    background: hsl(var(--ph,200),30%,88%); border-color: hsl(var(--ph,200),40%,65%); color: hsl(var(--ph,200),45%,28%);
+  }
+  [data-theme="dark"] #filter-perspective .chip[data-perspective]:not([data-perspective="all"]):not(.active):hover {
+    background: hsl(var(--ph,200),25%,22%); border-color: hsl(var(--ph,200),35%,45%); color: hsl(var(--ph,200),55%,75%);
+  }
+  .filter-status { font-size: 0.74rem; color: var(--pico-muted-color); text-align: right; }
+
+  .battle-list { display: flex; flex-direction: column; gap: 0.6rem; }
+  .battle-card {
+    border: 1px solid var(--pico-muted-border-color);
+    border-radius: var(--pico-border-radius);
+    background: var(--pico-card-background-color);
+    transition: border-color 0.15s, box-shadow 0.15s;
+  }
+  .battle-card:hover { border-color: var(--pico-primary); box-shadow: 0 2px 8px rgba(0,0,0,0.05); }
+
+  .battle-link {
+    display: block; padding: 0.9rem 1rem; text-decoration: none; color: inherit;
+  }
+  .battle-meta {
+    display: flex; flex-wrap: wrap; gap: 0.3rem; align-items: center;
+    margin-bottom: 0.5rem; font-size: 0.78rem;
+  }
+  .battle-date { font-family: var(--pico-font-family-monospace); font-size: 0.7rem; color: var(--pico-muted-color); margin-right: 0.2rem; }
+  .tag {
+    font-size: 0.62rem; text-transform: uppercase; letter-spacing: 0.04em;
+    padding: 0.08rem 0.35rem; border-radius: 3px;
+    border: 1px solid var(--pico-muted-border-color); color: var(--pico-muted-color);
+  }
+  .tag-perspective {
+    background: hsl(var(--ph,200),28%,92%); color: hsl(var(--ph,200),45%,32%);
+    border-color: hsl(var(--ph,200),38%,72%); text-transform: none; letter-spacing: 0;
+  }
+  [data-theme="dark"] .tag-perspective { background: hsl(var(--ph,200),22%,18%); color: hsl(var(--ph,200),52%,70%); border-color: hsl(var(--ph,200),32%,38%); }
+  .tag-agent { font-family: var(--pico-font-family-monospace); text-transform: none; letter-spacing: 0; }
+  .conf-high { color: #2d6a4f; border-color: #2d6a4f55; background: #2d6a4f0a; }
+  [data-theme="dark"] .conf-high { color: #74c69d; border-color: #74c69d55; }
+
+  .battle-versus {
+    display: grid; grid-template-columns: 1fr auto 1fr;
+    gap: 0.6rem; align-items: center; margin-bottom: 0.4rem;
+  }
+  .side { display: flex; align-items: center; gap: 0.35rem; font-size: 0.92rem; }
+  .side.winner { font-weight: 600; }
+  .side.loser { color: var(--pico-muted-color); }
+  .post-name { flex: 1; }
+  .medal { font-size: 0.85rem; flex-shrink: 0; }
+  .rate { font-family: var(--pico-font-family-monospace); font-size: 0.7rem; font-weight: 700; color: var(--pico-primary); flex-shrink: 0; }
+  .rate.loser-rate { color: var(--pico-muted-color); font-weight: 400; }
+  .divider { display: flex; align-items: center; flex-shrink: 0; }
+  .vs { font-size: 0.65rem; font-weight: 700; color: var(--pico-muted-color); background: var(--pico-muted-border-color); padding: 0.08rem 0.25rem; border-radius: 3px; }
+  .tension-bar { height: 3px; border-radius: 2px; overflow: hidden; display: flex; }
+  .tf { height: 100%; }
+  .winner-fill { background: var(--pico-primary); opacity: 0.6; }
+  .loser-fill { background: var(--pico-muted-border-color); }
+  .tension-absent { font-size: 0.65rem; color: var(--pico-muted-color); text-align: center; }
+  .read-cta { font-size: 0.75rem; color: var(--pico-primary); text-align: right; margin-top: 0.35rem; }
+
+  @media (max-width: 580px) {
+    .battle-versus { grid-template-columns: 1fr; gap: 0.2rem; }
+    .side.loser { justify-content: flex-start; }
+    .divider { display: none; }
+  }
+
+  .battle-pagination {
+    display: flex; align-items: center; justify-content: center;
+    gap: 1rem; margin: 1.5rem 0 0.5rem;
+  }
+  .battle-pagination button { padding: 0.35rem 0.9rem; font-size: 0.85rem; min-width: 7rem; margin-bottom: 0; }
+  #page-indicator { font-size: 0.85rem; color: var(--pico-muted-color); min-width: 8rem; text-align: center; }
+  .empty-state { padding: 2rem; text-align: center; color: var(--pico-muted-color); border: 1px dashed var(--pico-muted-border-color); border-radius: var(--pico-border-radius); }
+</style>
+
+<script>
+  document.addEventListener("DOMContentLoaded", () => {
+    const searchInput = document.getElementById("battle-search") as HTMLInputElement | null;
+    const seasonSelect = document.getElementById("filter-season") as HTMLSelectElement | null;
+    const agentSelect = document.getElementById("filter-agent") as HTMLSelectElement | null;
+    const confContainer = document.getElementById("filter-confidence");
+    const perspContainer = document.getElementById("filter-perspective");
+    const cards = Array.from(document.querySelectorAll(".battle-card")) as HTMLElement[];
+    const countLabel = document.getElementById("filter-count-label");
+    const emptyState = document.getElementById("battle-empty");
+    const paginationEl = document.getElementById("battle-pagination") as HTMLElement | null;
+    const prevBtn = document.getElementById("prev-page") as HTMLButtonElement | null;
+    const nextBtn = document.getElementById("next-page") as HTMLButtonElement | null;
+    const pageIndicator = document.getElementById("page-indicator") as HTMLElement | null;
+
+    if (!searchInput || !cards.length) return;
+
+    const PAGE_SIZE = 20;
+    const total = cards.length;
+    const countTotal = countLabel?.getAttribute("data-total") ?? String(total);
+    const pageTemplate = pageIndicator?.getAttribute("data-template") ?? "Page {n} of {total}";
+
+    let activeConfidence = "all";
+    let activePerspective = "all";
+    let currentPage = 0;
+    let lastVisible: HTMLElement[] = [];
+
+    // Restore state from URL
+    const params = new URLSearchParams(window.location.search);
+    if (searchInput && params.get("q")) searchInput.value = params.get("q")!;
+    const urlSeason = params.get("season") || "all";
+    const urlAgent = params.get("agent") || "all";
+    const urlConf = params.get("confidence") || "all";
+    const urlPersp = params.get("perspective") || "all";
+    if (seasonSelect && urlSeason !== "all") seasonSelect.value = urlSeason;
+    if (agentSelect && urlAgent !== "all") agentSelect.value = urlAgent;
+    activeConfidence = urlConf;
+    activePerspective = urlPersp;
+
+    function syncAriaChecked(container: Element | null, attr: string, val: string) {
+      if (!container) return;
+      container.querySelectorAll("[role=radio]").forEach((btn) => {
+        const v = (btn as HTMLElement).getAttribute(attr) ?? "";
+        const checked = v === val;
+        btn.setAttribute("aria-checked", String(checked));
+        btn.classList.toggle("active", checked);
+      });
+    }
+    syncAriaChecked(confContainer, "data-value", activeConfidence);
+    syncAriaChecked(perspContainer, "data-perspective", activePerspective);
+
+    function updateURL() {
+      const p = new URLSearchParams();
+      const q = searchInput?.value.trim() ?? "";
+      if (q) p.set("q", q);
+      const s = seasonSelect?.value ?? "all";
+      if (s !== "all") p.set("season", s);
+      const a = agentSelect?.value ?? "all";
+      if (a !== "all") p.set("agent", a);
+      if (activeConfidence !== "all") p.set("confidence", activeConfidence);
+      if (activePerspective !== "all") p.set("perspective", activePerspective);
+      if (currentPage > 0) p.set("page", String(currentPage + 1));
+      const qs = p.toString();
+      history.replaceState(null, "", window.location.pathname + (qs ? "?" + qs : ""));
+    }
+
+    function showPage(page: number) {
+      const totalPages = Math.max(1, Math.ceil(lastVisible.length / PAGE_SIZE));
+      currentPage = Math.max(0, Math.min(page, totalPages - 1));
+      const start = currentPage * PAGE_SIZE;
+      const end = start + PAGE_SIZE;
+      cards.forEach((c) => { c.style.display = "none"; });
+      lastVisible.forEach((c, i) => { c.style.display = i >= start && i < end ? "block" : "none"; });
+      if (countLabel) {
+        countLabel.textContent = `Showing ${lastVisible.length} of ${countTotal} battles`;
+      }
+      if (emptyState) emptyState.style.display = lastVisible.length === 0 ? "block" : "none";
+      const showPag = totalPages > 1;
+      if (paginationEl) paginationEl.style.display = showPag ? "flex" : "none";
+      if (prevBtn) prevBtn.disabled = currentPage === 0;
+      if (nextBtn) nextBtn.disabled = currentPage >= totalPages - 1;
+      if (pageIndicator) {
+        pageIndicator.textContent = pageTemplate.replace("{n}", String(currentPage + 1)).replace("{total}", String(totalPages));
+      }
+      updateURL();
+    }
+
+    function applyFilters() {
+      const query = searchInput?.value.toLowerCase().trim() ?? "";
+      const season = seasonSelect?.value ?? "all";
+      const agent = agentSelect?.value ?? "all";
+      lastVisible = cards.filter((card) => {
+        const matchQ = !query || (card.getAttribute("data-search") ?? "").includes(query);
+        const matchS = season === "all" || card.getAttribute("data-season") === season;
+        const matchA = agent === "all" || card.getAttribute("data-agent") === agent;
+        const matchC = activeConfidence === "all" || card.getAttribute("data-confidence") === activeConfidence;
+        const matchP = activePerspective === "all" || card.getAttribute("data-perspective") === activePerspective;
+        return matchQ && matchS && matchA && matchC && matchP;
+      });
+      showPage(0);
+    }
+
+    searchInput.addEventListener("input", applyFilters);
+    if (seasonSelect) seasonSelect.addEventListener("change", applyFilters);
+    if (agentSelect) agentSelect.addEventListener("change", applyFilters);
+    if (prevBtn) prevBtn.addEventListener("click", () => showPage(currentPage - 1));
+    if (nextBtn) nextBtn.addEventListener("click", () => showPage(currentPage + 1));
+
+    // Restore page from URL
+    const urlPage = parseInt(params.get("page") ?? "1", 10);
+
+    if (confContainer) {
+      confContainer.querySelectorAll("[role=radio]").forEach((btn) => {
+        btn.addEventListener("click", () => {
+          activeConfidence = (btn as HTMLElement).getAttribute("data-value") ?? "all";
+          syncAriaChecked(confContainer, "data-value", activeConfidence);
+          applyFilters();
+        });
+      });
+    }
+    if (perspContainer) {
+      perspContainer.querySelectorAll("[role=radio]").forEach((btn) => {
+        btn.addEventListener("click", () => {
+          activePerspective = (btn as HTMLElement).getAttribute("data-perspective") ?? "all";
+          syncAriaChecked(perspContainer, "data-perspective", activePerspective);
+          applyFilters();
+        });
+      });
+    }
+
+    applyFilters();
+    if (urlPage > 1) showPage(urlPage - 1);
+  });
+</script>

--- a/src/pages/ranking/perspectives/[id].astro
+++ b/src/pages/ranking/perspectives/[id].astro
@@ -10,6 +10,11 @@ import { isPublished } from "../../../lib/publish";
 
 export function getStaticPaths() {
   const perspectives = getPerspectives();
+  if (perspectives.length === 0) {
+    throw new Error(
+      "getStaticPaths: getPerspectives() returned empty — check PERSPECTIVES_DIR resolution and scripts/hronir/perspectives/*.md files."
+    );
+  }
   return perspectives.map((p) => ({ params: { id: p.id } }));
 }
 

--- a/src/pages/ranking/perspectives/index.astro
+++ b/src/pages/ranking/perspectives/index.astro
@@ -1,0 +1,168 @@
+---
+import PageLayout from "../../../layouts/PageLayout.astro";
+import { getCollection } from "astro:content";
+import { getPerspectives, getPerPerspectiveRankings } from "../../../lib/hronir-rank";
+import { isPublished } from "../../../lib/publish";
+
+const perspectives = getPerspectives();
+const perPerspective = getPerPerspectiveRankings();
+
+const allPosts = await getCollection("blog");
+const byKey = new Map<string, { title: string; slug: string; lang: string }>();
+for (const p of allPosts) {
+  if (!isPublished(p)) continue;
+  const key = p.data.translationKey;
+  if (!key) continue;
+  const lang = p.data.lang ?? "en";
+  const existing = byKey.get(key);
+  if (!existing || lang === "en") {
+    byKey.set(key, { title: p.data.title, slug: p.id, lang });
+  }
+}
+
+function hue(id: string): number {
+  let h = 0;
+  for (let i = 0; i < id.length; i++) h = ((h << 5) - h + id.charCodeAt(i)) & 0xffff;
+  return Math.abs(h) % 360;
+}
+
+const enriched = perspectives.map((p) => {
+  const rows = perPerspective.get(p.id) ?? [];
+  const leaderKey = rows[0]?.key;
+  const leader = leaderKey ? byKey.get(leaderKey) : undefined;
+  const leaderHref = leader
+    ? leader.lang === "pt"
+      ? `/pt/blog/${leader.slug}/`
+      : `/blog/${leader.slug}/`
+    : null;
+  return {
+    ...p,
+    hue: hue(p.id),
+    duelCount: rows.reduce((sum, r) => sum + r.appearances, 0) / 2,
+    leaderTitle: leader?.title ?? null,
+    leaderHref,
+    postsRanked: rows.length,
+  };
+});
+---
+
+<PageLayout
+  title="Perspectives — Ranking | Franklin Baldo"
+  description="Browse all evaluation perspectives used in the Hrönir ranking system."
+  lang="en"
+>
+  <nav class="breadcrumb" aria-label="Breadcrumb">
+    <ol>
+      <li><a href="/">Home</a></li>
+      <li><a href="/ranking/">Ranking</a></li>
+      <li aria-current="page">Perspectives</li>
+    </ol>
+  </nav>
+
+  <hgroup>
+    <h1>Ranking perspectives</h1>
+    <p>Each perspective is a different lens for judging a post — curiosity, clarity, writing quality, and more. A post can rank differently under each lens.</p>
+  </hgroup>
+
+  <div class="persp-grid">
+    {enriched.map((p) => (
+      <a href={`/ranking/perspectives/${p.id}/`} class="persp-card" style={`--ph:${p.hue}`}>
+        <header class="persp-card-head">
+          <span class="persp-name">{p.name}</span>
+          <span class="persp-count">{p.postsRanked} posts</span>
+        </header>
+        <p class="persp-summary">{p.summary}</p>
+        {p.leaderTitle && (
+          <div class="persp-leader">
+            <span class="persp-leader-label">Leader</span>
+            <span class="persp-leader-title">{p.leaderTitle}</span>
+          </div>
+        )}
+      </a>
+    ))}
+  </div>
+</PageLayout>
+
+<style>
+  .breadcrumb ol {
+    list-style: none;
+    padding: 0;
+    margin: 0 0 1rem;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0;
+    font-size: 0.8rem;
+    color: var(--pico-muted-color);
+  }
+  .breadcrumb li + li::before { content: " / "; padding: 0 0.35em; }
+  .breadcrumb a { color: var(--pico-muted-color); text-decoration: none; }
+  .breadcrumb a:hover { text-decoration: underline; }
+
+  .persp-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(18rem, 1fr));
+    gap: 1.1rem;
+    margin-top: 1.5rem;
+  }
+  .persp-card {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    padding: 1.1rem 1.2rem 1rem;
+    border: 1px solid var(--pico-muted-border-color);
+    border-left: 4px solid hsl(var(--ph, 200), 55%, 55%);
+    border-radius: var(--pico-border-radius);
+    background: var(--pico-card-background-color);
+    text-decoration: none;
+    color: inherit;
+    transition: border-color 0.2s, box-shadow 0.2s;
+  }
+  .persp-card:hover {
+    border-left-color: hsl(var(--ph, 200), 65%, 45%);
+    box-shadow: 0 4px 14px rgba(0, 0, 0, 0.06);
+  }
+  .persp-card-head {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 0.5rem;
+  }
+  .persp-name {
+    font-weight: 600;
+    font-size: 1rem;
+    color: hsl(var(--ph, 200), 45%, 32%);
+  }
+  [data-theme="dark"] .persp-name {
+    color: hsl(var(--ph, 200), 65%, 72%);
+  }
+  .persp-count {
+    font-size: 0.72rem;
+    color: var(--pico-muted-color);
+    font-family: var(--pico-font-family-monospace);
+    white-space: nowrap;
+  }
+  .persp-summary {
+    font-size: 0.85rem;
+    color: var(--pico-muted-color);
+    margin: 0;
+    line-height: 1.45;
+  }
+  .persp-leader {
+    display: flex;
+    flex-direction: column;
+    gap: 0.1rem;
+    padding-top: 0.4rem;
+    border-top: 1px dashed var(--pico-muted-border-color);
+  }
+  .persp-leader-label {
+    font-size: 0.65rem;
+    text-transform: uppercase;
+    letter-spacing: 0.07em;
+    color: var(--pico-muted-color);
+  }
+  .persp-leader-title {
+    font-size: 0.82rem;
+    font-weight: 500;
+    color: var(--pico-color);
+  }
+</style>

--- a/src/pages/ranking/posts/[key].astro
+++ b/src/pages/ranking/posts/[key].astro
@@ -1,0 +1,516 @@
+---
+import PageLayout from "../../../layouts/PageLayout.astro";
+import { getCollection } from "astro:content";
+import {
+  getRanking,
+  getPostDuelHistory,
+  getPerPerspectiveRankings,
+  getPerspectives,
+  getSnapshotDelta,
+} from "../../../lib/hronir-rank";
+import { isPublished } from "../../../lib/publish";
+
+export function getStaticPaths() {
+  const ranking = getRanking();
+  return ranking.map((r) => ({ params: { key: r.key } }));
+}
+
+const { key } = Astro.params;
+const ranking = getRanking();
+const rankIndex = ranking.findIndex((r) => r.key === key);
+if (rankIndex < 0) return Astro.redirect("/ranking/");
+const rankEntry = ranking[rankIndex];
+const currentRank = rankIndex + 1;
+
+const allPosts = await getCollection("blog");
+const postsByKey = new Map<string, { title: string; slug: string; lang: string }>();
+for (const p of allPosts) {
+  if (!isPublished(p)) continue;
+  const k = p.data.translationKey;
+  if (!k) continue;
+  const lang = p.data.lang ?? "en";
+  const existing = postsByKey.get(k);
+  if (!existing || lang === "en") {
+    postsByKey.set(k, { title: p.data.title, slug: p.id, lang });
+  }
+}
+
+const postInfo = postsByKey.get(key);
+const title = postInfo?.title ?? key;
+const postHref = postInfo
+  ? postInfo.lang === "pt"
+    ? `/pt/blog/${postInfo.slug}/`
+    : `/blog/${postInfo.slug}/`
+  : null;
+
+const duels = getPostDuelHistory(key);
+
+// Per-perspective rankings
+const perPerspective = getPerPerspectiveRankings();
+const perspectives = getPerspectives();
+const perspectiveRanks: { id: string; name: string; rank: number; ordinal: number }[] = [];
+for (const p of perspectives) {
+  const rows = perPerspective.get(p.id) ?? [];
+  const idx = rows.findIndex((r) => r.key === key);
+  if (idx >= 0) {
+    perspectiveRanks.push({ id: p.id, name: p.name, rank: idx + 1, ordinal: rows[idx].ordinal });
+  }
+}
+perspectiveRanks.sort((a, b) => a.rank - b.rank);
+
+const delta = getSnapshotDelta(key);
+const overallWins = duels.filter((d) => d.winnerKey === key).length;
+const winRate = duels.length > 0 ? Math.round((overallWins / duels.length) * 100) : 0;
+
+// Sparkline: chronological order (duels are newest-first)
+const chronological = [...duels].reverse();
+
+function buildSparkline(pts: { won: boolean }[]): string {
+  if (pts.length < 2) return "";
+  const W = 200, H = 36;
+  return pts
+    .map((_pt, i) => {
+      const wins = pts.slice(0, i + 1).filter((p) => p.won).length;
+      const rate = wins / (i + 1);
+      const x = (i / (pts.length - 1)) * W;
+      const y = H - rate * H;
+      return `${i === 0 ? "M" : "L"} ${x.toFixed(1)} ${y.toFixed(1)}`;
+    })
+    .join(" ");
+}
+
+const sparklinePts = chronological.map((d) => ({ won: d.winnerKey === key }));
+const sparklinePath = buildSparkline(sparklinePts);
+
+function hue(id: string): number {
+  let h = 0;
+  for (let i = 0; i < id.length; i++) h = ((h << 5) - h + id.charCodeAt(i)) & 0xffff;
+  return Math.abs(h) % 360;
+}
+
+function fmtDate(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.valueOf())) return "—";
+  return d.toLocaleDateString("en-US", { year: "numeric", month: "short", day: "numeric" });
+}
+---
+
+<PageLayout
+  title={`${title} — Dossier | Franklin Baldo`}
+  description={`Ranking history and duel record for "${title}" in the Hrönir system.`}
+  lang="en"
+>
+  <nav class="breadcrumb" aria-label="Breadcrumb">
+    <ol>
+      <li><a href="/">Home</a></li>
+      <li><a href="/ranking/">Ranking</a></li>
+      <li aria-current="page">{title}</li>
+    </ol>
+  </nav>
+
+  <hgroup>
+    <h1>{title}</h1>
+    {postHref && <p><a href={postHref}>Read post →</a></p>}
+  </hgroup>
+
+  <div class="dossier-stats">
+    <div class="doss-stat">
+      <span class="doss-val">#{currentRank}</span>
+      <span class="doss-lbl">global rank</span>
+    </div>
+    {delta !== null && delta !== 0 && (
+      <div class="doss-stat">
+        <span class={`doss-val ${delta > 0 ? "delta-up" : "delta-down"}`}>
+          {delta > 0 ? `+${delta}` : `${delta}`}
+        </span>
+        <span class="doss-lbl">rank change</span>
+      </div>
+    )}
+    <div class="doss-stat">
+      <span class="doss-val">{winRate}%</span>
+      <span class="doss-lbl">win rate</span>
+    </div>
+    <div class="doss-stat">
+      <span class="doss-val">{overallWins}/{duels.length}</span>
+      <span class="doss-lbl">wins / duels</span>
+    </div>
+    <div class="doss-stat">
+      <span class="doss-val">{rankEntry.ordinal.toFixed(3)}</span>
+      <span class="doss-lbl">ordinal</span>
+    </div>
+  </div>
+
+  {sparklinePath && (
+    <div class="sparkline-wrap">
+      <p class="sparkline-caption">Win rate over time (each point = one duel, chronological)</p>
+      <svg viewBox="0 0 200 36" class="sparkline" aria-hidden="true">
+        <line x1="0" y1="18" x2="200" y2="18" class="spark-ref" />
+        <path d={sparklinePath} class="spark-path" />
+        {sparklinePts.map((pt, i) => {
+          const wins = sparklinePts.slice(0, i + 1).filter((p) => p.won).length;
+          const rate = wins / (i + 1);
+          const x = (i / (sparklinePts.length - 1)) * 200;
+          const y = 36 - rate * 36;
+          return (
+            <circle
+              cx={x.toFixed(1)}
+              cy={y.toFixed(1)}
+              r={pt.won ? 2.5 : 1.5}
+              class={pt.won ? "spark-dot win" : "spark-dot loss"}
+            />
+          );
+        })}
+      </svg>
+    </div>
+  )}
+
+  {perspectiveRanks.length > 0 && (
+    <section class="persp-ranks">
+      <h2>Perspective rankings</h2>
+      <ul class="persp-list">
+        {perspectiveRanks.map((pr) => (
+          <li>
+            <a href={`/ranking/perspectives/${pr.id}/`}>
+              <span class="persp-badge" style={`--ph:${hue(pr.id)}`}>{pr.name}</span>
+            </a>
+            <span class="persp-rank-num">#{pr.rank}</span>
+            <span class="persp-ordinal">({pr.ordinal.toFixed(3)})</span>
+          </li>
+        ))}
+      </ul>
+    </section>
+  )}
+
+  <section class="duel-history">
+    <h2>Duel history <small>({duels.length} total)</small></h2>
+    {duels.length === 0 ? (
+      <p class="empty">No duels recorded yet.</p>
+    ) : (
+      <ol class="duel-list">
+        {duels.map((d) => {
+          const won = d.winnerKey === key;
+          const opponentKey = won ? d.loserKey : d.winnerKey;
+          const opponent = postsByKey.get(opponentKey);
+          const opponentHref = opponent
+            ? opponent.lang === "pt"
+              ? `/pt/blog/${opponent.slug}/`
+              : `/blog/${opponent.slug}/`
+            : null;
+          const opponentTitle = opponent?.title ?? opponentKey;
+          const myRate = d.postAKey === key ? d.rateA : d.rateB;
+          const oppRate = d.postAKey === key ? d.rateB : d.rateA;
+          return (
+            <li class={won ? "duel-won" : "duel-lost"}>
+              <div class="duel-row">
+                <span class="duel-outcome" aria-label={won ? "Won" : "Lost"}>{won ? "W" : "L"}</span>
+                <div class="duel-content">
+                  <div class="duel-opponent">
+                    <span class="vs-label">vs</span>
+                    {opponentHref ? (
+                      <a href={opponentHref}>{opponentTitle}</a>
+                    ) : (
+                      <code>{opponentKey}</code>
+                    )}
+                  </div>
+                  <div class="duel-meta-row">
+                    <span class="duel-date">{fmtDate(d.runAt)}</span>
+                    {myRate != null && oppRate != null && (
+                      <span class="duel-rates">{myRate.toFixed(1)} / {oppRate.toFixed(1)}</span>
+                    )}
+                    {d.perspectiveId && (
+                      <a
+                        href={`/ranking/perspectives/${d.perspectiveId}/`}
+                        class="duel-perspective"
+                        style={`--ph:${hue(d.perspectiveId)}`}
+                      >
+                        {d.perspectiveId.replace(/-/g, " ")}
+                      </a>
+                    )}
+                  </div>
+                </div>
+                {d.id && (
+                  <a
+                    href={`/ranking/battles/${d.id}/`}
+                    class="duel-analysis-link"
+                    title="Read full analysis"
+                  >
+                    analysis →
+                  </a>
+                )}
+              </div>
+            </li>
+          );
+        })}
+      </ol>
+    )}
+  </section>
+</PageLayout>
+
+<style>
+  .breadcrumb ol {
+    list-style: none;
+    padding: 0;
+    margin: 0 0 1rem;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0;
+    font-size: 0.8rem;
+    color: var(--pico-muted-color);
+  }
+  .breadcrumb li + li::before {
+    content: " / ";
+    padding: 0 0.35em;
+  }
+  .breadcrumb a {
+    color: var(--pico-muted-color);
+    text-decoration: none;
+  }
+  .breadcrumb a:hover {
+    text-decoration: underline;
+  }
+
+  .dossier-stats {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem 2rem;
+    margin: 1.5rem 0 2rem;
+    padding: 1rem 1.2rem;
+    border: 1px solid var(--pico-muted-border-color);
+    border-radius: var(--pico-border-radius);
+    background: var(--pico-card-sectioning-background-color);
+  }
+  .doss-stat {
+    display: flex;
+    flex-direction: column;
+    gap: 0.1rem;
+  }
+  .doss-val {
+    font-family: var(--pico-font-family-monospace);
+    font-size: 1.4rem;
+    font-weight: 600;
+  }
+  .doss-lbl {
+    font-size: 0.68rem;
+    text-transform: uppercase;
+    letter-spacing: 0.07em;
+    color: var(--pico-muted-color);
+  }
+  .delta-up {
+    color: #2d6a4f;
+  }
+  .delta-down {
+    color: #c0392b;
+  }
+  [data-theme="dark"] .delta-up {
+    color: #74c69d;
+  }
+  [data-theme="dark"] .delta-down {
+    color: #e57373;
+  }
+
+  .sparkline-wrap {
+    margin: 0 0 2.5rem;
+    padding: 1rem 1.2rem 0.8rem;
+    border: 1px solid var(--pico-muted-border-color);
+    border-radius: var(--pico-border-radius);
+    background: var(--pico-card-sectioning-background-color);
+  }
+  .sparkline-caption {
+    font-size: 0.72rem;
+    text-transform: uppercase;
+    letter-spacing: 0.07em;
+    color: var(--pico-muted-color);
+    margin: 0 0 0.6rem;
+  }
+  .sparkline {
+    width: 100%;
+    height: 36px;
+    display: block;
+    overflow: visible;
+  }
+  .spark-ref {
+    stroke: var(--pico-muted-border-color);
+    stroke-width: 1;
+    stroke-dasharray: 3 3;
+  }
+  .spark-path {
+    fill: none;
+    stroke: var(--pico-primary);
+    stroke-width: 1.5;
+    stroke-linejoin: round;
+    stroke-linecap: round;
+  }
+  .spark-dot {
+    fill: var(--pico-primary);
+  }
+  .spark-dot.loss {
+    fill: var(--pico-muted-color);
+    opacity: 0.5;
+  }
+
+  .persp-ranks {
+    margin: 0 0 2rem;
+  }
+  .persp-ranks h2 {
+    font-size: 1rem;
+    margin-bottom: 0.75rem;
+  }
+  .persp-list {
+    list-style: none;
+    padding: 0;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem 1rem;
+  }
+  .persp-list li {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+  }
+  .persp-badge {
+    display: inline-block;
+    padding: 0.15em 0.55em;
+    border-radius: 999px;
+    font-size: 0.82em;
+    background: hsl(var(--ph, 200), 55%, 88%);
+    color: hsl(var(--ph, 200), 45%, 28%);
+    text-decoration: none;
+  }
+  @media (prefers-color-scheme: dark) {
+    .persp-badge {
+      background: hsl(var(--ph, 200), 40%, 20%);
+      color: hsl(var(--ph, 200), 70%, 75%);
+    }
+  }
+  .persp-rank-num {
+    font-family: var(--pico-font-family-monospace);
+    font-size: 0.82rem;
+    font-weight: 600;
+  }
+  .persp-ordinal {
+    font-size: 0.75rem;
+    color: var(--pico-muted-color);
+    font-family: var(--pico-font-family-monospace);
+  }
+
+  .duel-history {
+    margin-top: 2rem;
+  }
+  .duel-history h2 {
+    font-size: 1.1rem;
+    margin-bottom: 0.75rem;
+  }
+  .duel-history h2 small {
+    font-weight: 400;
+    font-size: 0.85em;
+    color: var(--pico-muted-color);
+  }
+  .duel-list {
+    list-style: none;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.45rem;
+  }
+  .duel-row {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.75rem;
+    padding: 0.7rem 0.85rem;
+    border: 1px solid var(--pico-muted-border-color);
+    border-left-width: 3px;
+    border-radius: var(--pico-border-radius);
+    background: var(--pico-card-background-color);
+  }
+  .duel-won .duel-row {
+    border-left-color: #2d6a4f;
+  }
+  .duel-lost .duel-row {
+    border-left-color: var(--pico-muted-border-color);
+  }
+  [data-theme="dark"] .duel-won .duel-row {
+    border-left-color: #74c69d;
+  }
+  .duel-outcome {
+    font-family: var(--pico-font-family-monospace);
+    font-size: 0.72rem;
+    font-weight: 700;
+    width: 1.2rem;
+    flex-shrink: 0;
+    text-align: center;
+    padding-top: 0.15rem;
+  }
+  .duel-won .duel-outcome {
+    color: #2d6a4f;
+  }
+  .duel-lost .duel-outcome {
+    color: var(--pico-muted-color);
+  }
+  [data-theme="dark"] .duel-won .duel-outcome {
+    color: #74c69d;
+  }
+  .duel-content {
+    flex: 1;
+    min-width: 0;
+  }
+  .duel-opponent {
+    font-size: 0.92rem;
+  }
+  .duel-opponent a {
+    text-decoration: none;
+  }
+  .duel-opponent a:hover {
+    text-decoration: underline;
+  }
+  .vs-label {
+    color: var(--pico-muted-color);
+    font-size: 0.78rem;
+    margin-right: 0.3rem;
+  }
+  .duel-meta-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin-top: 0.25rem;
+    align-items: center;
+  }
+  .duel-date {
+    font-size: 0.72rem;
+    color: var(--pico-muted-color);
+    font-family: var(--pico-font-family-monospace);
+  }
+  .duel-rates {
+    font-size: 0.72rem;
+    color: var(--pico-muted-color);
+    font-family: var(--pico-font-family-monospace);
+  }
+  .duel-perspective {
+    font-size: 0.68rem;
+    padding: 0.1rem 0.4rem;
+    border-radius: 999px;
+    text-decoration: none;
+    background: hsl(var(--ph, 200), 55%, 88%);
+    color: hsl(var(--ph, 200), 45%, 28%);
+  }
+  @media (prefers-color-scheme: dark) {
+    .duel-perspective {
+      background: hsl(var(--ph, 200), 40%, 20%);
+      color: hsl(var(--ph, 200), 70%, 75%);
+    }
+  }
+  .duel-analysis-link {
+    font-size: 0.78rem;
+    color: var(--pico-muted-color);
+    text-decoration: none;
+    white-space: nowrap;
+    flex-shrink: 0;
+    padding-top: 0.15rem;
+  }
+  .duel-analysis-link:hover {
+    color: var(--pico-primary);
+  }
+  .empty {
+    color: var(--pico-muted-color);
+    font-style: italic;
+  }
+</style>


### PR DESCRIPTION
## RFC 0007 — Ranking: UI e UX de leitura — Implementation

Implementação completa de todas as fases da [RFC 0007](docs/rfcs/0007-ranking-ui-e-ux-de-leitura.md) em um único PR.

### What changed

**Fase 0 — Bug fixes**
- `src/hronir/perspectives.ts`: fix path resolution (process.cwd() em vez de import.meta.url que quebrava em prod)
- `src/pages/ranking/perspectives/[id].astro`: guard em getStaticPaths → build falha em vez de gerar zero páginas silenciosamente
- `src/hronir/types.ts`: adiciona campo `id` em `DuelEntry` + interfaces `PerspectiveGridItem`, `RankingSnapshot`
- `src/lib/hronir-rank.ts`: `duelId()` (SHA-256 8 chars de `postAKey|postBKey|runAt`)

**Fase 1 — Páginas individuais**
- `src/pages/ranking/battles/[id].astro` — página completa de cada duelo (análise, veredito, rates, tension bar, mood, prev/next)
- `src/pages/ranking/battles/index.astro` — arquivo de batalhas: cards leves, filtros com query params (?q, ?season, ?agent, ?perspective, ?confidence, ?page), paginação
- `src/pages/ranking/posts/[key].astro` — dossiê por post: rank global, sparkline SVG de win rate, histórico de duelos, rankings por perspectiva
- `src/pages/ranking/perspectives/index.astro` — índice de perspectivas

**Fase 2 — URL state**
- Archive de batalhas: todos os filtros persistem em query params com `history.replaceState`

**Fase 3 — Legibilidade**
- `RankingView.astro` reescrito:
  - Seção de batalhas: 10 cards leves com link para página individual (em vez de 338 duelos completos = -3MB)
  - Grid de perspectivas com líder e summary por perspectiva
  - Tabela mostra todos os ranks (1-N), colunas `win%` e `Δ` adicionadas
  - Toggle `?view=technical` para colunas μ/σ (hidden by default)
  - `<details>` "How this works" com explicação em linguagem simples
- ARIA: filtros usam `role=radiogroup/radio` (semântica correta para seleção exclusiva)

**Fase 4 — Dossiê por post**
- Sparkline SVG inline (win rate cumulativo ao longo do tempo, sem JS)
- Histórico completo de duelos com links para páginas individuais
- Rankings por perspectiva agrupados

**Infra**
- `scripts/generate-ranking-snapshot.mjs`: salva snapshot do ranking após cada build para calcular Δ no próximo build
- `src/generated/ranking-snapshot.json`: stub inicial (76 keys)
- `package.json`: build script atualizado para executar snapshot após pagefind
- `src/pages/blog/[...slug].astro`: link de rank agora aponta para `/ranking/posts/<key>/` (dossiê) em vez de `/ranking/`

### Test plan

- [ ] Build limpo: `npm run build` → 0 erros, todas as páginas geradas
- [ ] `/ranking/` carrega em < 100KB (antes: 3.1MB) — seção de batalhas agora são 10 cards leves
- [ ] `/ranking/battles/` lista todos os duelos com filtros funcionando
- [ ] `/ranking/battles/<hash>/` mostra análise completa de um duelo
- [ ] `/ranking/posts/<key>/` mostra dossiê com sparkline e histórico
- [ ] `/ranking/perspectives/<id>/` retorna 200 (bug D2 corrigido)
- [ ] `/ranking/perspectives/` lista todas as perspectivas
- [ ] `?view=technical` na tabela mostra colunas μ/σ
- [ ] Link de rank em post aponta para dossiê

https://claude.ai/code/session_01Wii7YKckCZsRmGkK9jwnaZ