### PR TITLE
seo(rss): atom:link rel="self" nos feeds EN e PT

### DIFF
--- a/.routines/2026-06-11T05-30-00-rss-atom-self-link.md
+++ b/.routines/2026-06-11T05-30-00-rss-atom-self-link.md
@@ -1,0 +1,39 @@
+---
+date: 2026-06-11T05:30:00
+slug: rss-atom-self-link
+branch: claude/sleepy-pasteur-ms7m8i
+status: pr-open
+issues: [244]
+pr_opened: null
+pr_merged: null
+---
+
+## Contexto ao chegar
+
+Nenhum PR `routine` pendente de run anterior — nada a mergear. Backlog com exatamente 10 issues abertas (fronteira inferior da faixa 10–20), sem necessidade de reabastecer. Todos os PRs abertos eram `hronir` (jules) ou `rfc` — ignorados conforme protocolo.
+
+## O que foi feito
+
+Implementação da issue #244 (`priority:media`): adicionar `atom:link rel="self"` nos feeds RSS.
+
+### Mudanças entregues
+
+**`src/pages/rss.xml.js`** e **`src/pages/pt/rss.xml.js`**:
+- Adicionado `xmlns: { atom: "http://www.w3.org/2005/Atom" }` na chamada `rss()` — isso injeta `xmlns:atom="..."` no elemento raiz `<rss>`.
+- Atualizado `customData` para incluir `<atom:link href="..." rel="self" type="application/rss+xml" />` com a URL canônica de cada feed, construída a partir do `context.site` injetado pelo Astro.
+
+### Resultado em produção
+
+O XML gerado em build ficou:
+```xml
+<rss version="2.0" xmlns:content="..." xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    ...
+    <atom:link href="https://franklinbaldo.github.io/rss.xml" rel="self" type="application/rss+xml"/>
+```
+
+Ambos os feeds (EN `/rss.xml` e PT `/pt/rss.xml`) validados visualmente na saída `dist/`. Build verde, prettier verde.
+
+## O que fica para a próxima run
+
+Próximas issues `priority:media` em aberto: #245 (barra de progresso de leitura), #246 (print CSS), #247 (tags visual cloud), #248 (atualizar reading path Memory and Funes).

--- a/src/pages/pt/rss.xml.js
+++ b/src/pages/pt/rss.xml.js
@@ -35,6 +35,7 @@ export async function GET(context) {
       "Advogado e Procurador do Estado. Explorando as interseções entre metafísica do processo, agentes de IA e a arquitetura dos sistemas jurídicos.",
     site: context.site,
     items,
-    customData: "<language>pt-br</language>",
+    xmlns: { atom: "http://www.w3.org/2005/Atom" },
+    customData: `<language>pt-br</language><atom:link href="${context.site}pt/rss.xml" rel="self" type="application/rss+xml" />`,
   });
 }

--- a/src/pages/rss.xml.js
+++ b/src/pages/rss.xml.js
@@ -35,6 +35,7 @@ export async function GET(context) {
       "Lawyer and State Attorney. Exploring the intersections of process metaphysics, AI agency, and the architecture of legal systems.",
     site: context.site,
     items,
-    customData: "<language>en-us</language>",
+    xmlns: { atom: "http://www.w3.org/2005/Atom" },
+    customData: `<language>en-us</language><atom:link href="${context.site}rss.xml" rel="self" type="application/rss+xml" />`,
   });
 }


### PR DESCRIPTION
Closes #244

## SEO

- Adicionado `xmlns:atom="http://www.w3.org/2005/Atom"` no elemento raiz `<rss>` de ambos os feeds via opção `xmlns` do `@astrojs/rss`
- Adicionado `<atom:link href="..." rel="self" type="application/rss+xml" />` no `<channel>` de cada feed, com URL canônica derivada de `context.site`:
  - EN: `https://franklinbaldo.github.io/rss.xml`
  - PT: `https://franklinbaldo.github.io/pt/rss.xml`

Sem `atom:link rel="self"`, leitores de feed como Feedly e NewsBlur não conseguem construir a URL canônica do feed para re-subscription (RFC 4287).

---

_Rotina autônoma — janela de veto de 24h. A próxima run mergeia este PR se não houver comentário bloqueante._

---
_Generated by [Claude Code](https://claude.ai/code/session_01QV1qCG4XT3EN2TEHvxJ4AL)_