### PR TITLE
fix(ranking): RFC 0009 — corrige assimetria sigma no margin weighting

### DIFF
--- a/scripts/hronir/README.md
+++ b/scripts/hronir/README.md
@@ -203,7 +203,7 @@ O `edit-worst` instrui a leitura de **ambas** antes de editar e a escolher a apl
 
 ## Ranking
 
-Ranking via **OpenSkill** (modelo Weng-Lin, atualização bayesiana online de Plackett-Luce, `RANKING_MODEL_VERSION=2`). Cada par é tratado como uma partida 1v1; o delta de `mu` é escalado pela margem de estrelas `|rate_a − rate_b| / 4` — blowouts movem o ranking mais que foto-finish.
+Ranking via **OpenSkill** (modelo Weng-Lin, atualização bayesiana online de Plackett-Luce, `RANKING_MODEL_VERSION=3`). Cada par é tratado como uma partida 1v1; os deltas de `mu` **e `sigma`** são escalados pela margem de estrelas `|rate_a − rate_b| / 4` — blowouts movem o ranking mais que foto-finish, e partidas apertadas preservam mais incerteza proporcionalmente (RFC 0009).
 
 - **`mu`** — estimativa pontual da "qualidade" do post.
 - **`sigma`** — incerteza sobre `mu`. Não diz que o post é ruim — diz que ainda não sabemos.

--- a/scripts/hronir/lib/__tests__/ranking.test.js
+++ b/scripts/hronir/lib/__tests__/ranking.test.js
@@ -208,6 +208,61 @@ describe("_computeRatings", () => {
       `blowout gap (${blowoutGap.toFixed(6)}) should exceed photo-finish gap (${photoGap.toFixed(6)})`
     );
   });
+
+  // RFC 0009: monotonicity — blowout ordinal must exceed medium-margin ordinal
+  // (same win-rate, same number of matches). Fails before the sigma fix.
+  it("monotonicity: blowout ordinal exceeds medium-margin ordinal (same win-rate)", () => {
+    // Build 3 matches where every win/loss has the same outcome but different margins.
+    // Blowout: winner 5.0 vs loser 1.0 → weight = 1.0
+    // Medium:  winner 3.5 vs loser 1.5 → margin = 2/4 = 0.5 → weight = 0.55
+    const makeMatches = (rateA, rateB) =>
+      [
+        { runAt: "2024-02-01T00:00:00Z", aKey: "w", bKey: "x", winner: "a" },
+        { runAt: "2024-02-01T00:00:01Z", aKey: "w", bKey: "y", winner: "a" },
+        { runAt: "2024-02-01T00:00:02Z", aKey: "z", bKey: "w", winner: "a" },
+      ].map((m, i) =>
+        match({ ...m, runAt: `2024-02-01T00:00:0${i}Z`, rateA, rateB })
+      );
+
+    const blowoutRows = _computeRatings(makeMatches(5.0, 1.0));
+    const mediumRows = _computeRatings(makeMatches(3.5, 1.5));
+
+    const blowoutOrdinal = blowoutRows.find((r) => r.key === "w").ordinal;
+    const mediumOrdinal = mediumRows.find((r) => r.key === "w").ordinal;
+
+    assert.ok(
+      blowoutOrdinal > mediumOrdinal,
+      `blowout ordinal (${blowoutOrdinal.toFixed(4)}) should exceed medium-margin ordinal (${mediumOrdinal.toFixed(4)})`
+    );
+  });
+
+  // RFC 0009: sigma scales with weight — after equal number of matches, a post
+  // that only faced close matches must retain higher sigma than one that faced
+  // blowouts (close matches convey less information → more residual uncertainty).
+  it("sigma scales with weight: close-match sigma > blowout sigma after same matches", () => {
+    const makeMatches = (rateA, rateB) =>
+      [0, 1, 2, 3, 4].map((i) =>
+        match({
+          runAt: `2024-03-01T00:00:0${i}Z`,
+          aKey: "post",
+          bKey: `opp${i}`,
+          winner: "a",
+          rateA,
+          rateB,
+        })
+      );
+
+    const closeRows = _computeRatings(makeMatches(3.01, 3.0)); // weight ≈ 0.1
+    const blowoutRows = _computeRatings(makeMatches(5.0, 1.0)); // weight = 1.0
+
+    const closeSigma = closeRows.find((r) => r.key === "post").sigma;
+    const blowoutSigma = blowoutRows.find((r) => r.key === "post").sigma;
+
+    assert.ok(
+      closeSigma > blowoutSigma,
+      `close-match sigma (${closeSigma.toFixed(4)}) should exceed blowout sigma (${blowoutSigma.toFixed(4)})`
+    );
+  });
 });
 
 // Absolute quality tests

--- a/src/hronir/ranking.ts
+++ b/src/hronir/ranking.ts
@@ -3,7 +3,7 @@ import { listMatchFiles, readMatch, postKey } from "./matches.js";
 import type { RankRow, PerspectiveRankRow } from "./types.js";
 
 export const MIN_APPEARANCES = 3;
-export const RANKING_MODEL_VERSION = 2;
+export const RANKING_MODEL_VERSION = 3;
 export const EWMA_ALPHA = 0.3;
 export const MARGIN_W_MIN = 0.1;
 // Ridge (L2) penalty for the de-confounding least-squares solve. Shrinks
@@ -124,11 +124,11 @@ export function _computeRatings(raw: RawMatch[]): RankRow[] {
 
     ratings.set(winnerKey, {
       mu: winnerRating.mu + weight * (newWinner.mu - winnerRating.mu),
-      sigma: newWinner.sigma,
+      sigma: winnerRating.sigma + weight * (newWinner.sigma - winnerRating.sigma),
     } as ReturnType<typeof rating>);
     ratings.set(loserKey, {
       mu: loserRating.mu + weight * (newLoser.mu - loserRating.mu),
-      sigma: newLoser.sigma,
+      sigma: loserRating.sigma + weight * (newLoser.sigma - loserRating.sigma),
     } as ReturnType<typeof rating>);
     wins.set(winnerKey, (wins.get(winnerKey) || 0) + 1);
   }

--- a/src/hronir/ranking.ts
+++ b/src/hronir/ranking.ts
@@ -124,7 +124,8 @@ export function _computeRatings(raw: RawMatch[]): RankRow[] {
 
     ratings.set(winnerKey, {
       mu: winnerRating.mu + weight * (newWinner.mu - winnerRating.mu),
-      sigma: winnerRating.sigma + weight * (newWinner.sigma - winnerRating.sigma),
+      sigma:
+        winnerRating.sigma + weight * (newWinner.sigma - winnerRating.sigma),
     } as ReturnType<typeof rating>);
     ratings.set(loserKey, {
       mu: loserRating.mu + weight * (newLoser.mu - loserRating.mu),


### PR DESCRIPTION
## Resumo

Implementação da [RFC 0009](docs/rfcs/0009-correcao-assimetria-sigma.md).

Corrige o bug onde o `weight` derivado da margem de estrelas era aplicado ao `mu` mas não ao `sigma` em `_computeRatings`. A correção aplica o mesmo `weight` aos dois eixos, tornando a atualização internamente consistente.

**Mudança cirúrgica em `src/hronir/ranking.ts` (4 linhas):**

```diff
-    sigma: newWinner.sigma,
+    sigma: winnerRating.sigma + weight * (newWinner.sigma - winnerRating.sigma),
...
-    sigma: newLoser.sigma,
+    sigma: loserRating.sigma + weight * (newLoser.sigma - loserRating.sigma),
```

`RANKING_MODEL_VERSION` 2 → 3.

---

## Ranking: before vs after

**Antes** (top 15):

```
rank  key                   ordinal   W/N    stars  div
1     delphi-imperatives    13.428   10/15   4.23  +0.03
2     conservation-law      12.931   12/17   3.79  +0.24
3     pontifex-research     12.756   10/12   3.25    -
4     its-raining-truth     12.458   13/22   3.38  +0.60  ← 22 matches, mu inflado
5     pierre-menard         12.080   10/16   3.34  +0.63
6     future-father         12.024   10/16   3.28  +0.68
7     music-quando-vier-a-primavera  11.537  8/10  3.95  +0.10
8     intelligible-void     11.129   11/18   3.75  +0.24
```

**Depois** (top 15):

```
rank  key                   ordinal   W/N    stars  div
1     delphi-imperatives     9.733   10/15   4.23  +0.03
2     conservation-law       9.409   12/17   3.79  +0.24
3     music-quando-vier-a-primavera   9.324   8/10  3.95  +0.14  ↑ +4
4     pontifex-research      9.146   10/12   3.25    -
5     music-beatriz          8.876    8/10   3.87  +0.15  ↑ novo top-5
6     intelligible-void      8.035   11/18   3.75  +0.28  ↑ +2
7     pierre-menard          7.965   10/16   3.34  +0.61
8     music-eu-ia-escrever   7.867    5/5    4.37  -0.07  ↑ 100% win rate
11    its-raining-truth      7.259   13/22   3.38  +0.52  ↓ −7 (div alto, muitas partidas apertadas)
20    delegating-to-agents   6.261    9/16   4.25  -0.18  ↑ stars altas reconhecidas
```

Os posts com div alto (muitas partidas apertadas que inflavam o ordinal) caem. Posts com win rates mais decisivas sobem. O ranking de qualidade (stars) e o de ordinal convergem.

---

## Testes

21/21 verdes (`npm test`). Dois novos testes de regressão adicionados (requisito RFC 0009 §5):

- **`monotonicity`**: blowout ordinal > medium-margin ordinal com mesmo win-rate — falha antes do fix, passa depois
- **`sigma scales with weight`**: sigma de close-match > sigma de blowout após mesmo número de partidas

## Test plan

- [ ] Revisar diff (4 linhas de código + 55 linhas de teste)
- [ ] Confirmar que o re-ranking no "Depois" acima faz sentido
- [ ] `npm test` — 21/21

https://claude.ai/code/session_016kLURNjXiaqR1kDLReWuPv

---
_Generated by [Claude Code](https://claude.ai/code/session_016kLURNjXiaqR1kDLReWuPv)_