### PR TITLE
RFC 0010 — Versões como pares: seleção por ranking e correções do ciclo de versões

### DIFF
--- a/docs/rfcs/0010-versoes-pares-selecao-por-ranking.md
+++ b/docs/rfcs/0010-versoes-pares-selecao-por-ranking.md
@@ -188,8 +188,9 @@ versão exibida não ficar oscilando):
    que **ambos os lados tenham rating** (corrige V2: sem rating dos dois
    lados, não há troca).
 2. Diretório novo ou sem nenhum duelo de versão: vence a versão **mais
-   recente** (timestamp do nome do arquivo). Desempate determinístico pelo
-   nome.
+   recente** (timestamp do nome do arquivo) **que passe em `isPublished`**
+   (`draft: true` e `publishDate` futuro ficam de fora — sem publicável,
+   o slug não entra no JSON). Desempate determinístico pelo nome.
 3. A seleção nunca aponta para arquivo inexistente — `hronir:doctor` valida.
 
 No Astro, a collection `blog` troca o glob `**/index.{md,mdx}` por um **loader
@@ -203,6 +204,12 @@ commits é a história das trocas de versão — mesmo padrão do
 `ranking-snapshot.json`). Conformidade com o padrão de dados persistidos do
 repo: schema `selection-v1`, script de migração preservado em
 `scripts/oneoff/`, validação no doctor.
+
+`hronir:select` é **idempotente**: antes de gravar, compara o novo mapeamento
+(`slug → file`) com o conteúdo atual do JSON ignorando `_meta.generatedAt`; se
+o mapeamento é idêntico, não escreve nada — o arquivo não é dirtied e o build
+é estritamente reprodutível. `generatedAt` só avança quando pelo menos uma
+seleção muda.
 
 ### 4.3. Um único leitor de matches (corrige V1, V6, C1)
 
@@ -357,7 +364,13 @@ Script one-off preservado em `scripts/oneoff/` (padrão do repo):
    leitor normalizado resolve paths históricos via key (que não muda), e o
    doctor trata `index.*` ausente como tolerável **apenas** em matches
    anteriores à data da migração.
-5. `npm run build` antes/depois deve produzir o mesmo conjunto de URLs
+5. Atualizar `src/lib/versions.mjs` (`fileForId`/`uuidForId`): atualmente
+   resolve IDs de entradas `blog` para `<slug>/index.{md,mdx}`; após a
+   migração, deve ler `versions-selected.json` para obter o path real da
+   versão selecionada. Sem esta atualização, `uuidForId(c.id)` retorna `null`
+   para toda entrada e os permalinks `/blog/<slug>/v/<uuid>/` perdem o redirect
+   para a versão canônica vigente (404s para URLs previamente publicadas).
+6. `npm run build` antes/depois deve produzir o mesmo conjunto de URLs
    (checado no CI da fase).
 
 Rollback: a migração é um commit de renames + um JSON; reverter o merge

--- a/docs/rfcs/0010-versoes-pares-selecao-por-ranking.md
+++ b/docs/rfcs/0010-versoes-pares-selecao-por-ranking.md
@@ -182,19 +182,18 @@ Novo comando `hronir:select` computa, por diretório, a versão exibida:
 Regra de seleção (mantém os limiares da RFC 0003 como **histerese**, para a
 versão exibida não ficar oscilando):
 
-1. A versão atualmente selecionada só perde o posto se uma rival tiver
-   `stars` maior por **margem ≥ 0.3★ com n ≥ 2 duelos de versão** — os mesmos
-   `PROMOTE_MARGIN`/`PROMOTE_MIN_DUELS` de hoje, mas agora a comparação exige
-   que **ambos os lados tenham rating** (corrige V2: sem rating dos dois
-   lados, não há troca). **Exceção:** se a versão atualmente selecionada
-   não passar em `isPublished` (foi marcada `draft: true` ou ganhou
-   `publishDate` futuro após a seleção), ela é descartada e a regra 2 é
-   aplicada imediatamente — sem esperar histerese.
-2. Diretório novo, sem seleção atual válida, ou sem nenhum duelo de versão:
-   vence a versão **mais recente** (timestamp do nome do arquivo) **que passe
-   em `isPublished`** (`draft: true` e `publishDate` futuro ficam de fora —
-   sem publicável, o slug não entra no JSON). Desempate determinístico pelo
-   nome.
+1. **Há seleção válida:** a versão atualmente selecionada é mantida, a menos
+   que uma rival tenha `stars` maior por **margem ≥ 0.3★ com n ≥ 2 duelos de
+   versão** — ambos os lados devem ter rating (corrige V2). Versões recém
+   criadas pelo `draft-worst` (sem duelos, não marcadas `draft: true`) **não
+   disparam esta regra**: a ausência de duelos nunca substitui uma seleção
+   existente. **Exceção:** se a versão selecionada não passar em `isPublished`
+   (foi marcada `draft: true` ou ganhou `publishDate` futuro pós-seleção),
+   ela é descartada e a regra 2 é aplicada imediatamente.
+2. **Sem seleção válida** (diretório estreando no JSON, ou seleção anterior
+   descartada pela exceção acima): vence a versão **mais recente por timestamp
+   de nome** que passe em `isPublished`. Sem publicável, o slug fica fora do
+   JSON. Desempate determinístico pelo nome.
 3. A seleção nunca aponta para arquivo inexistente — `hronir:doctor` valida.
 
 No Astro, a collection `blog` troca o glob `**/index.{md,mdx}` por um **loader
@@ -266,19 +265,19 @@ recente). A avaliação segue a convenção de língua do repo: review na língu
 post (`lang` do frontmatter), que agora vale por construção porque o duelo é
 sempre dentro de um diretório monolíngue.
 
-**Seleção acoplada entre traduções.** Permitir que EN e PT selecionem
-independentemente reabre a divergência de conteúdo que era o V5 original:
-o EN pode cruzar o limiar de histerese enquanto o PT acumula poucos duelos e
-fica na versão antiga — ou nunca tem versões suficientes para duelar. Para
-evitar isso, `hronir:select` trata as traduções de um mesmo `translationKey`
-como **unidade**: quando a versão selecionada muda em um diretório, o comando
-busca nos diretórios irmãos (mesmo `translationKey`) a versão com o mesmo
+**Seleção acoplada entre traduções (atômica).** Permitir que EN e PT
+selecionem independentemente reabre a divergência de conteúdo que era o V5
+original. Para evitar isso, `hronir:select` trata o grupo de traduções de um
+mesmo `translationKey` como **unidade atômica**: quando a regra 1 qualifica
+uma troca em qualquer diretório do grupo, o comando verifica se **todos** os
+diretórios irmãos que contêm versões possuem uma versão publicável com o mesmo
 `draftCreatedAt` (campo gravado pelo `draft-worst` em todas as traduções da
-mesma rodada) e a seleciona também — desde que passe em `isPublished`. Se o
-diretório irmão não tiver uma versão com o `draftCreatedAt` correspondente
-(e.g. tradução PT ainda não foi criada para esta revisão), ele mantém a seleção
-atual. Resultado: as línguas de um ensaio avançam juntas ou não avançam — sem
-divergência silenciosa.
+mesma rodada). Se algum irmão com versões não tiver a contraparte
+correspondente publicável, **nenhum** membro do grupo avança — o grupo inteiro
+fica inalterado até que a próxima rodada de `draft-worst` crie e ranqueie as
+versões em falta. Diretórios sem nenhuma versão (tradução ainda não criada)
+não fazem parte do grupo para fins de acoplamento. Resultado: as línguas de um
+ensaio **sempre avançam juntas** ou não avançam — sem divergência parcial.
 
 `prune` sobrevive, simplificado: remove versões **não-selecionadas** com
 n ≥ 3 duelos de versão e ≥ 0.5★ abaixo da selecionada — nunca a selecionada,

--- a/docs/rfcs/0010-versoes-pares-selecao-por-ranking.md
+++ b/docs/rfcs/0010-versoes-pares-selecao-por-ranking.md
@@ -18,9 +18,10 @@
 
 ## Histórico de revisões
 
-| Data       | Mudança         |
-| ---------- | --------------- |
-| 2026-06-12 | Versão inicial. |
+| Data       | Mudança                                                                                                                                                       |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 2026-06-12 | Versão inicial.                                                                                                                                               |
+| 2026-06-12 | Review (Codex + autor): seleção idempotente, fallback publicável e acoplado, acoplamento atômico com qualificação de contrapartes, endereçamento `slug@uuid`. |
 
 ---
 
@@ -214,12 +215,46 @@ o mapeamento é idêntico, não escreve nada — o arquivo não é dirtied e o b
 é estritamente reprodutível. `generatedAt` só avança quando pelo menos uma
 seleção muda.
 
-### 4.3. Um único leitor de matches (corrige V1, V6, C1)
+### 4.3. Endereçamento `slug@uuid` e um único leitor de matches (corrige V1, V6, C1)
 
-Hoje há **quatro** parsers independentes de rate file (`_loadMatchData`,
-`computePerPerspectiveRatings` inline, `hronir-rank.ts loadDuelData`,
-`latestMatchTimeByKey`) — e o guard de duelo de versão existe em só um deles.
-A RFC consolida num único normalizador em `matches.ts`:
+**Referências estáveis.** Sessões e rate files novos referenciam versões por
+`slug@uuid` — e.g. `vos@3f2a9c1e-...` — em vez de path de arquivo:
+
+- `slug` = nome da pasta = identidade da URL (estável por construção);
+- `uuid` = UUID de conteúdo (`getPostUuid`, já gravado hoje em cada match como
+  `post_a.version`) = identidade da versão, imutável porque arquivos de versão
+  são cópias congeladas.
+
+O path do arquivo deixa de ser identidade e vira **cache de resolução**: o
+leitor resolve `slug@uuid` varrendo as versões do diretório (UUIDs memoizados,
+§4.7). Isso elimina a classe inteira de problemas de path quebrado:
+
+- versão **podada** não quebra referência histórica — o `slug@uuid` continua
+  nomeando exatamente aquele conteúdo (recuperável do git); o doctor para de
+  precisar do hack `tolerableGone`;
+- a migração §6 não invalida rate files antigos (o passo 4 vira só uma regra
+  de leitura para o formato legado, não uma tolerância de erro);
+- renomear/mover arquivos de versão deixa de ser uma operação perigosa.
+
+Separador `@` (e não `#`): `#` não-quotado inicia comentário em YAML — os rate
+files são frontmatter YAML, e `vos#3f2a` seria truncado para `vos` em
+silêncio. `@` segue a convenção `pacote@versão` (npm) / `image@digest`
+(Docker) e não colide com nada nos formatos do repo.
+
+Os rate files novos gravam `post_a.ref: "slug@uuid"` (schema `stars-v2`,
+conforme o padrão de dados persistidos: schema versionado + migração + check
+no doctor); os campos legados (`path`, `key`, `version`) continuam legíveis
+pelo normalizador abaixo — rate files antigos nunca são reescritos. O
+`versions-selected.json` usa a mesma identidade (o `uuid` de cada entrada é a
+seleção; `file` é cache). A sessão (`currentMatch`) também passa a guardar
+`ref_a`/`ref_b`.
+
+**Leitor único.** Hoje há **quatro** parsers independentes de rate file
+(`_loadMatchData`, `computePerPerspectiveRatings` inline, `hronir-rank.ts
+loadDuelData`, `latestMatchTimeByKey`) — e o guard de duelo de versão existe
+em só um deles. A RFC consolida num único normalizador em `matches.ts`, que
+também é o único lugar que entende os dois formatos (`stars-v1` por
+path/key/version; `stars-v2` por `ref`):
 
 ```ts
 export type NormalizedMatch = {
@@ -270,14 +305,20 @@ selecionem independentemente reabre a divergência de conteúdo que era o V5
 original. Para evitar isso, `hronir:select` trata o grupo de traduções de um
 mesmo `translationKey` como **unidade atômica**: quando a regra 1 qualifica
 uma troca em qualquer diretório do grupo, o comando verifica se **todos** os
-diretórios irmãos que contêm versões possuem uma versão publicável com o mesmo
-`draftCreatedAt` (campo gravado pelo `draft-worst` em todas as traduções da
-mesma rodada). Se algum irmão com versões não tiver a contraparte
-correspondente publicável, **nenhum** membro do grupo avança — o grupo inteiro
-fica inalterado até que a próxima rodada de `draft-worst` crie e ranqueie as
-versões em falta. Diretórios sem nenhuma versão (tradução ainda não criada)
-não fazem parte do grupo para fins de acoplamento. Resultado: as línguas de um
-ensaio **sempre avançam juntas** ou não avançam — sem divergência parcial.
+diretórios irmãos que contêm versões possuem uma contraparte da mesma revisão
+(mesmo `draftCreatedAt`, campo gravado pelo `draft-worst` em todas as
+traduções da mesma rodada) que **também se qualifica**: publicável, com
+**n ≥ 2 duelos de versão** e `stars` **não inferiores** aos da versão
+atualmente selecionada naquele diretório. A contraparte não precisa repetir a
+margem de 0.3★ — o ônus da histerese é da língua que disparou a troca — mas
+precisa de evidência própria de não-regressão: existir não basta, senão uma
+vitória em PT publicaria um EN com zero duelos (ou pior que a seleção EN
+vigente). Se alguma contraparte não se qualificar, **nenhum** membro do grupo
+avança; para destravar rápido, o `pickVersionDuel` **prioriza** contrapartes
+sub-dueladas de revisões já qualificadas em outra língua. Diretórios sem
+nenhuma versão (tradução ainda não criada) não fazem parte do grupo para fins
+de acoplamento. Resultado: as línguas de um ensaio **sempre avançam juntas** ou
+não avançam — sem divergência parcial e sem regressão carona.
 
 O acoplamento vale também para o **fallback por seleção inválida** (exceção da
 regra 1 do §4.2): quando a seleção de um diretório é descartada por deixar de
@@ -399,10 +440,11 @@ Script one-off preservado em `scripts/oneoff/` (padrão do repo):
    1 dentro do próprio diretório, mas nunca participam de avanço acoplado
    (a regra "ausente nunca casa" impede parear versões não relacionadas).
    Validar que não são as selecionadas.
-4. Rate files antigos referenciam paths `index.*` que deixarão de existir: o
-   leitor normalizado resolve paths históricos via key (que não muda), e o
-   doctor trata `index.*` ausente como tolerável **apenas** em matches
-   anteriores à data da migração.
+4. Rate files antigos (`stars-v1`) referenciam paths `index.*` que deixarão
+   de existir: o leitor normalizado (§4.3) resolve o formato legado via
+   key + `version` (UUID), que não mudam — é regra de leitura, não tolerância
+   de erro. Rate files novos usam `ref: slug@uuid` (`stars-v2`) e são imunes a
+   renames por construção.
 5. Atualizar `src/lib/versions.mjs` (`fileForId`/`uuidForId`): atualmente
    resolve IDs de entradas `blog` para `<slug>/index.{md,mdx}`; após a
    migração, deve ler `versions-selected.json` para obter o path real da

--- a/docs/rfcs/0010-versoes-pares-selecao-por-ranking.md
+++ b/docs/rfcs/0010-versoes-pares-selecao-por-ranking.md
@@ -221,9 +221,28 @@ seleção muda.
 `slug@uuid` — e.g. `vos@3f2a9c1e-...` — em vez de path de arquivo:
 
 - `slug` = nome da pasta = identidade da URL (estável por construção);
-- `uuid` = UUID de conteúdo (`getPostUuid`, já gravado hoje em cada match como
-  `post_a.version`) = identidade da versão, imutável porque arquivos de versão
-  são cópias congeladas.
+- `uuid` = UUID de conteúdo = identidade da versão, imutável porque arquivos
+  de versão são cópias congeladas.
+
+**Definição do UUID (corrigida).** O `getPostUuid` atual hasheia **só o corpo**
+markdown — duas versões que diferem apenas no frontmatter (título, descrição)
+colidem. Não é teórico: `riobaldo-e-o-aleph/index.mdx` e
+`v-2026-06-10T12-09-24.mdx` têm hoje o mesmo UUID
+(`fd4bbbbe-…`) — pós-migração seriam duas versões-pares com a mesma ref,
+ambíguas para `computeVersionRatings`, para a seleção e para as rotas
+`/v/<uuid>`. O UUID de versão passa a ser UUIDv5 sobre o corpo normalizado
+**mais o frontmatter relevante à versão** (título, descrição, heroImage, lang
+etc.), **excluindo os campos de ciclo de vida** (`draftCreatedAt`,
+`draftCommittedAt`, `draftMsg`, `supersedes`, `previousVersion`) — para que a
+migração e o `draft-commit` possam carimbar metadados sem mudar a identidade.
+Complementos:
+
+- o doctor **proíbe** duas versões no mesmo diretório com o mesmo UUID
+  (arquivos de fato idênticos são um estado degenerado — a migração colapsa
+  duplicatas exatas como o caso `riobaldo` acima, mantendo a mais antiga);
+- o UUID legado (só-corpo), gravado nos rate files `stars-v1` como
+  `post_a.version`, continua resolvível pelo leitor normalizado; a ambiguidade
+  residual dele é limitação dos dados históricos, não do esquema novo.
 
 O path do arquivo deixa de ser identidade e vira **cache de resolução**: o
 leitor resolve `slug@uuid` varrendo as versões do diretório (UUIDs memoizados,

--- a/docs/rfcs/0010-versoes-pares-selecao-por-ranking.md
+++ b/docs/rfcs/0010-versoes-pares-selecao-por-ranking.md
@@ -186,11 +186,15 @@ versão exibida não ficar oscilando):
    `stars` maior por **margem ≥ 0.3★ com n ≥ 2 duelos de versão** — os mesmos
    `PROMOTE_MARGIN`/`PROMOTE_MIN_DUELS` de hoje, mas agora a comparação exige
    que **ambos os lados tenham rating** (corrige V2: sem rating dos dois
-   lados, não há troca).
-2. Diretório novo ou sem nenhum duelo de versão: vence a versão **mais
-   recente** (timestamp do nome do arquivo) **que passe em `isPublished`**
-   (`draft: true` e `publishDate` futuro ficam de fora — sem publicável,
-   o slug não entra no JSON). Desempate determinístico pelo nome.
+   lados, não há troca). **Exceção:** se a versão atualmente selecionada
+   não passar em `isPublished` (foi marcada `draft: true` ou ganhou
+   `publishDate` futuro após a seleção), ela é descartada e a regra 2 é
+   aplicada imediatamente — sem esperar histerese.
+2. Diretório novo, sem seleção atual válida, ou sem nenhum duelo de versão:
+   vence a versão **mais recente** (timestamp do nome do arquivo) **que passe
+   em `isPublished`** (`draft: true` e `publishDate` futuro ficam de fora —
+   sem publicável, o slug não entra no JSON). Desempate determinístico pelo
+   nome.
 3. A seleção nunca aponta para arquivo inexistente — `hronir:doctor` valida.
 
 No Astro, a collection `blog` troca o glob `**/index.{md,mdx}` por um **loader
@@ -253,7 +257,7 @@ A semântica do guard que a RFC 0003 §7 pedia ("mesma key dos dois lados
 corrompe o OpenSkill") passa a ser **estrutural**: o tipo separa os dois
 universos, e nenhum consumidor novo precisa redescobrir a regra.
 
-### 4.4. Duelos de versão para todas as línguas (corrige V5)
+### 4.4. Duelos de versão para todas as línguas e seleção acoplada (corrige V5)
 
 `pickVersionDuel` deixa de partir de `listEnglishWithKey()` e passa a iterar
 **todos os diretórios com ≥ 2 versões**, qualquer língua (PT, EN, músicas). O
@@ -261,6 +265,20 @@ desafiante é a versão não-selecionada com menos duelos (desempate: mais
 recente). A avaliação segue a convenção de língua do repo: review na língua do
 post (`lang` do frontmatter), que agora vale por construção porque o duelo é
 sempre dentro de um diretório monolíngue.
+
+**Seleção acoplada entre traduções.** Permitir que EN e PT selecionem
+independentemente reabre a divergência de conteúdo que era o V5 original:
+o EN pode cruzar o limiar de histerese enquanto o PT acumula poucos duelos e
+fica na versão antiga — ou nunca tem versões suficientes para duelar. Para
+evitar isso, `hronir:select` trata as traduções de um mesmo `translationKey`
+como **unidade**: quando a versão selecionada muda em um diretório, o comando
+busca nos diretórios irmãos (mesmo `translationKey`) a versão com o mesmo
+`draftCreatedAt` (campo gravado pelo `draft-worst` em todas as traduções da
+mesma rodada) e a seleciona também — desde que passe em `isPublished`. Se o
+diretório irmão não tiver uma versão com o `draftCreatedAt` correspondente
+(e.g. tradução PT ainda não foi criada para esta revisão), ele mantém a seleção
+atual. Resultado: as línguas de um ensaio avançam juntas ou não avançam — sem
+divergência silenciosa.
 
 `prune` sobrevive, simplificado: remove versões **não-selecionadas** com
 n ≥ 3 duelos de versão e ≥ 0.5★ abaixo da selecionada — nunca a selecionada,

--- a/docs/rfcs/0010-versoes-pares-selecao-por-ranking.md
+++ b/docs/rfcs/0010-versoes-pares-selecao-por-ranking.md
@@ -232,9 +232,13 @@ colidem. Não é teórico: `riobaldo-e-o-aleph/index.mdx` e
 ambíguas para `computeVersionRatings`, para a seleção e para as rotas
 `/v/<uuid>`. O UUID de versão passa a ser UUIDv5 sobre o corpo normalizado
 **mais o frontmatter relevante à versão** (título, descrição, heroImage, lang
-etc.), **excluindo os campos de ciclo de vida** (`draftCreatedAt`,
-`draftCommittedAt`, `draftMsg`, `supersedes`, `previousVersion`) — para que a
-migração e o `draft-commit` possam carimbar metadados sem mudar a identidade.
+etc.), **excluindo os campos de ciclo de vida e de controle de publicação**
+(`draftCreatedAt`, `draftCommittedAt`, `draftMsg`, `supersedes`,
+`previousVersion`, `draft`, `publishDate`) — para que a migração, o
+`draft-commit` e um despublicar/reagendar possam carimbar metadados sem mudar
+a identidade (alternar `draft`/`publishDate` dispara o fallback da regra 1 do
+§4.2; se isso mudasse o UUID, órfã exatamente as refs `slug@uuid` no momento em
+que o fallback roda).
 Complementos:
 
 - o doctor **proíbe** duas versões no mesmo diretório com o mesmo UUID
@@ -355,6 +359,18 @@ ficar invisível.
 n ≥ 3 duelos de versão e ≥ 0.5★ abaixo da selecionada — nunca a selecionada,
 nunca a última do diretório. Sem categoria "arquivo `-prev`": a ex-exibida é
 só mais uma versão, elegível a poda pelos mesmos critérios de todas.
+
+**Permalinks de versões podadas não viram 404.** A rota `/blog/<slug>/v/<uuid>`
+só existe enquanto o arquivo existe (a collection `blogVersions` gera rotas do
+que está em disco), então deletar o arquivo mataria um permalink já publicado —
+e a recuperabilidade via git não socorre o site estático. O `prune` registra
+cada `slug@uuid` removido num arquivo gerado e commitado
+(`src/generated/versions-pruned.json`, schema `pruned-v1`), e o build emite
+para cada entrada um **redirect** `/blog/<slug>/v/<uuid>/` → `/blog/<slug>/`
+— a mesma maquinaria dos redirects legados de
+`src/generated/blog-redirects.json`. Precisão sobre a promessa do §4.3: as
+referências **internas** (`slug@uuid` em rate files) seguem válidas após a
+poda; o permalink **público** degrada para redirect à versão viva, nunca para 404. O doctor valida que todo uuid podado está no registro.
 
 ### 4.5. Sessão robusta e idempotente (corrige S1–S6)
 

--- a/docs/rfcs/0010-versoes-pares-selecao-por-ranking.md
+++ b/docs/rfcs/0010-versoes-pares-selecao-por-ranking.md
@@ -1,0 +1,417 @@
+# RFC 0010 — Versões como pares: seleção por ranking e correções do ciclo de versões
+
+|                 |                                                                                                                                                                                                                                                                                                                                 |
+| --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Status**      | Proposed                                                                                                                                                                                                                                                                                                                        |
+| **Autor**       | Franklin Baldo (proposta assistida)                                                                                                                                                                                                                                                                                             |
+| **Criado em**   | 2026-06-12                                                                                                                                                                                                                                                                                                                      |
+| **Branch / PR** | `claude/festive-hawking-a0ccne`                                                                                                                                                                                                                                                                                                 |
+| **Depende de**  | RFC 0003 (versões lado a lado — esta RFC **substitui** o mecanismo de promoção/poda dela), RFC 0009 (margin weighting simétrico)                                                                                                                                                                                                |
+| **Afeta**       | `src/content.config.ts`, `src/content/blog/**` (migração `index.*` → `v-*`), `src/hronir/{commands,ranking,posts,matches}.ts`, `scripts/hronir/index.js`, `src/lib/hronir-rank.ts`, `src/components/RankingView.astro`, `src/pages/ranking/battles/*`, `scripts/generate-ranking-snapshot.mjs`, `src/generated/` (novo arquivo) |
+
+> Mesmo padrão das RFCs 0001/0002/0003: primeiro o documento, depois a
+> implementação incremental na mesma branch, fase a fase, cada fase verde
+> (build + testes + `prettier --check` + `hronir:doctor`) antes da próxima.
+> Merge com merge commit, nunca squash.
+
+---
+
+## Histórico de revisões
+
+| Data       | Mudança         |
+| ---------- | --------------- |
+| 2026-06-12 | Versão inicial. |
+
+---
+
+## 1. Resumo
+
+Um code review completo do sistema Hrönir (7 ângulos de busca + verificação
+individual de cada achado) confirmou **14 bugs de correção**, dos quais quatro
+estão **ativos hoje** no ciclo de versões da RFC 0003:
+
+1. Duelos de versão (mesma `key` dos dois lados) **corrompem o ranking por
+   perspectiva**: `computePerPerspectiveRatings` não tem o guard
+   `aKey === bKey` que `_computeRatings` tem (`ranking.ts:102` vs `:539`) — o
+   `ratings.set()` do perdedor sobrescreve o do vencedor, então toda vitória
+   de versão **rebaixa** o post. Há ~330 rate files de mesma key em 27 keys
+   alimentando isso agora.
+2. A auto-promoção compara o draft contra `canonicalStars ?? 0`
+   (`commands.ts:2273`). Como o UUID de versão deriva do conteúdo, **qualquer
+   edição na canônica órfã o histórico de duelos dela** — e aí qualquer draft
+   com 2 duelos promove com margem "automática" (estrelas são sempre ≥ 1).
+3. O arquivo morto `v-*-prev` que a promoção cria é contado como **draft
+   pendente** pelo `draft-worst` (`commands.ts:1406`) — post já promovido
+   nunca mais é editado — e o `pickVersionDuel` o seleciona como "draft mais
+   fresco" (sort lexical + take-last, `:350`): a ex-canônica recém-demovida
+   volta a duelar contra quem a venceu. Caso real no repo: `vos/` e `vos-en/`.
+4. `pickVersionDuel` só olha canônicas EN (`listEnglishWithKey`), mas o
+   `draft-worst` cria drafts para **todas** as traduções: ~30 drafts PT no
+   repo hoje com **zero** rate files referenciando-os. Promoção atualiza o EN
+   e deixa o PT para trás — as línguas divergem permanentemente.
+
+O diagnóstico de fundo: a RFC 0003 introduziu versões, mas manteve uma
+**canônica privilegiada** definida por convenção de nome de arquivo
+(`index.*` vs `v-*` vs `v-*-prev`), com um swap destrutivo de 3 passos na
+promoção. Cada consumidor reimplementa as convenções de nome de um jeito, e os
+bugs moram exatamente nessas costuras.
+
+Esta RFC adota o princípio oposto: **não existe versão canônica. Todas as
+versões são pares; a mais bem ranqueada é a que o site mostra.** "Publicada"
+deixa de ser identidade de arquivo e vira **resultado da seleção** — um
+mapeamento gerado (`versions-selected.json`), recomputado a partir do ranking
+e lido por um loader custom do Astro. Promoção e poda destrutivas desaparecem;
+sobra um único mecanismo: ranquear e selecionar.
+
+Além do redesenho, a RFC corrige os bugs independentes do modelo (sessão,
+`decide`, CLI, exibição de duelos, snapshot) e ataca os achados de eficiência
+e limpeza.
+
+---
+
+## 2. Inventário dos problemas confirmados
+
+Todos verificados contra o código e os dados em disco; linhas referem-se ao
+estado atual da `main`.
+
+### 2.1. Ciclo de versões (o modelo de canônica é a causa-raiz)
+
+| #   | Local                                | Defeito                                                                                                                                                  |
+| --- | ------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| V1  | `ranking.ts:539` (e `:329`, `:430`)  | `computePerPerspectiveRatings` sem guard `aKey === bKey`; update do perdedor sobrescreve o do vencedor; appearances +2 por duelo. **Ativo** (~330 files) |
+| V2  | `commands.ts:2273`                   | `canonicalStars ?? 0` + n≥2 só do desafiante → auto-promoção sem evidência após qualquer edição da canônica                                              |
+| V3  | `commands.ts:2378`                   | `promoteFile` = rename → write → unlink, não-atômico; crash no meio deixa o post **sem canônica** (some do build) ou com UUID duplicado                  |
+| V4  | `commands.ts:1406`, `:343-350`       | Arquivo `v-*-prev` conta como draft pendente (bloqueia `draft-worst` para sempre) e é escolhido como "draft mais fresco". **Ativo** (`vos`, `vos-en`)    |
+| V5  | `commands.ts:343`                    | Duelos de versão só para canônicas EN; drafts PT órfãos (nunca duelam, nunca promovem, nunca podam). **Ativo** (~30 drafts PT)                           |
+| V6  | `RankingView.astro:351`, `battles/*` | `winnerIsA = postAKey === winnerKey` é vacuamente true em duelo de versão → rates trocados, barra invertida, cards "X beat X". **Ativo**                 |
+| V7  | `commands.ts:1329` vs `:393`         | Dois mecanismos divergentes de "última edição"; `previousVersion` nunca é escrito pelo fluxo atual → cooldown e staleness discordam                      |
+
+### 2.2. Sessão e CLI
+
+| #   | Local                                    | Defeito                                                                                                                                                           |
+| --- | ---------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| S1  | `commands.ts:957-966`                    | `decide` grava o rate file **antes** do estado da sessão; retry após crash gera segundo arquivo com `run_id` novo → duelo contado em dobro                        |
+| S2  | `commands.ts:288` (+9 sites)             | `hronir_session.json` escrito com `writeFileSync` cru (sem tmp+rename); leitores com `JSON.parse` sem try/catch; `init` sobrescreve sessão em andamento sem aviso |
+| S3  | `commands.ts:835-863`                    | Parsing de flags do `decide` com `args[++i]` sem guard (ao contrário do `readFlagValue` do `index.js`)                                                            |
+| S4  | `commands.ts:946-948`                    | `--after-mood` ausente é aceito em silêncio (grava `null`); mood >250 chars é truncado em silêncio em vez de rejeitado                                            |
+| S5  | `index.js:78`, `:115`, `commands.ts:276` | `parseInt(x) \|\| 10` transforma `--matches 0` (e lixo não-numérico) em sessão de 10 partidas                                                                     |
+| S6  | `ranking.ts:31` + `commands.ts:1475`     | Post deletado mantém linha no ranking, pode virar "worst" → `editWorst` grava sessão `need_edit` com `drafts: []` → beco sem saída (`end --force`)                |
+
+### 2.3. Consumidores e dados
+
+| #   | Local                              | Defeito                                                                                                            |
+| --- | ---------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| C1  | `generate-ranking-snapshot.mjs:17` | Filtro de override **invertido** em relação ao `_loadMatchData` → `totalDuels` divergirá no primeiro override real |
+| C2  | `posts.ts:85`                      | `listEnglishWithKey` ignora `draft: true` e `publishDate` futuro → post não-publicado pode entrar no torneio       |
+
+### 2.4. Eficiência (confirmados, sem cache em lugar nenhum)
+
+| #   | Local                                 | Custo                                                                                                              |
+| --- | ------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| E1  | `ranking.ts` geral                    | Cada `compute*` relê os ~1.200 rate files; `generateNextMatch` faz 4-5 passadas completas **por partida**          |
+| E2  | `commands.ts:2193`                    | `promote --all` recomputa `computeVersionRatings()` + `findTranslations()` **por key** → ~280k leituras de arquivo |
+| E3  | `matches.ts:59` via `commands.ts:399` | `gitMtime` = um `execFileSync("git", ["log", "-1", ...])` por candidato → até ~200 subprocessos por partida        |
+
+### 2.5. Limpeza
+
+Blocos `init`/`next` do `index.js` duplicados byte a byte (~30 linhas);
+`collectDefensesForLoser`/`ForWinners` ~80 linhas copiadas e já divergidas;
+~45 linhas de código morto pré-RFC 0003 (`ARCHIVE_DIR`, `githubBlobUrl`,
+`isFileDirtyAtHead`); 18 sites de leitura/escrita inline do JSON de sessão;
+shims de backfill de `perspective_id` que não disparam mais; teste encalhado
+em `scripts/hronir/lib/__tests__/` (CLAUDE.md ainda documenta módulos lá).
+
+---
+
+## 3. Princípio de design
+
+> **Não há canônica. Toda versão é um arquivo `v-*` par das outras; o que o
+> site publica em `/blog/<slug>/` é a versão selecionada pelo ranking.** A
+> seleção é um artefato gerado e commitado (`versions-selected.json`), não um
+> nome de arquivo privilegiado. Mudar a versão exibida é mudar uma linha num
+> JSON — atômico, reversível, com diff legível — nunca um swap de arquivos.
+
+Consequências diretas:
+
+- `promote`, `promoteFile`, o arquivo `v-*-prev` e `isCanonical` **deixam de
+  existir** → V2, V3 e V4 são eliminados por construção, não corrigidos.
+- A "frescura" de uma versão é o timestamp no próprio nome do arquivo → V7
+  colapsa num mecanismo único.
+- Duelo de versão vira duelo comum entre dois arquivos do mesmo diretório,
+  para **qualquer língua** → V5 eliminado.
+- O eixo "versão" (UUID de conteúdo, já gravado em cada match como
+  `post_a.version`) finalmente vira identidade de primeira classe, como o §2.2
+  da RFC 0003 já pedia.
+
+A restrição da RFC 0003 §2.1 continua valendo — todo `.md` em
+`src/content/blog/` que casar com o glob da collection `blog` vira rota — e é
+resolvida no loader, não no filesystem (§4.2).
+
+---
+
+## 4. Desenho
+
+### 4.1. Layout de arquivos
+
+Cada post continua em sua pasta `<slug>/`, mas **sem `index.*`**:
+
+```
+src/content/blog/vos/
+  v-2026-06-08T14-02-11.mdx     ← versão (par)
+  v-2026-06-10T02-12-45.mdx     ← versão (par)
+src/generated/versions-selected.json
+```
+
+O nome `v-<timestamp>` já é o formato dos drafts atuais; a migração renomeia
+cada `index.*` para `v-<timestamp-do-último-commit-do-arquivo>.*`. O slug (e
+portanto a URL) continua sendo o nome da pasta — nada muda para o leitor.
+
+### 4.2. Seleção: `versions-selected.json` + loader custom
+
+Novo comando `hronir:select` computa, por diretório, a versão exibida:
+
+```jsonc
+// src/generated/versions-selected.json
+{
+  "_meta": { "schema": "selection-v1", "generatedAt": "..." },
+  "vos": { "file": "vos/v-2026-06-10T02-12-45.mdx", "uuid": "..." },
+  "vos-en": { "file": "vos-en/v-2026-06-10T02-02-50.mdx", "uuid": "..." }
+}
+```
+
+Regra de seleção (mantém os limiares da RFC 0003 como **histerese**, para a
+versão exibida não ficar oscilando):
+
+1. A versão atualmente selecionada só perde o posto se uma rival tiver
+   `stars` maior por **margem ≥ 0.3★ com n ≥ 2 duelos de versão** — os mesmos
+   `PROMOTE_MARGIN`/`PROMOTE_MIN_DUELS` de hoje, mas agora a comparação exige
+   que **ambos os lados tenham rating** (corrige V2: sem rating dos dois
+   lados, não há troca).
+2. Diretório novo ou sem nenhum duelo de versão: vence a versão **mais
+   recente** (timestamp do nome do arquivo). Desempate determinístico pelo
+   nome.
+3. A seleção nunca aponta para arquivo inexistente — `hronir:doctor` valida.
+
+No Astro, a collection `blog` troca o glob `**/index.{md,mdx}` por um **loader
+custom** que lê `versions-selected.json` e carrega exatamente um arquivo por
+slug (id = nome da pasta, preservando todas as URLs). A collection
+`blogVersions` (histórico em `/blog/<slug>/v/<uuid>`, noindex) passa a listar
+todas as versões **exceto** a selecionada.
+
+O arquivo é **commitado** (build reprodutível a partir do git; o diff entre
+commits é a história das trocas de versão — mesmo padrão do
+`ranking-snapshot.json`). Conformidade com o padrão de dados persistidos do
+repo: schema `selection-v1`, script de migração preservado em
+`scripts/oneoff/`, validação no doctor.
+
+### 4.3. Um único leitor de matches (corrige V1, V6, C1)
+
+Hoje há **quatro** parsers independentes de rate file (`_loadMatchData`,
+`computePerPerspectiveRatings` inline, `hronir-rank.ts loadDuelData`,
+`latestMatchTimeByKey`) — e o guard de duelo de versão existe em só um deles.
+A RFC consolida num único normalizador em `matches.ts`:
+
+```ts
+export type NormalizedMatch = {
+  aKey: string;
+  bKey: string;
+  aVersion: string | null;
+  bVersion: string | null;
+  winnerSide: "a" | "b"; // override já resolvido AQUI, uma vez só
+  isVersionDuel: boolean; // aKey === bKey
+  rateA: number | null;
+  rateB: number | null;
+  perspectiveId: string | null;
+  runAt: Date | null;
+  // ...
+};
+export function loadNormalizedMatches(): NormalizedMatch[];
+```
+
+Consumidores:
+
+- `_computeRatings` e `computePerPerspectiveRatings` (e as trilhas de
+  qualidade) filtram `!m.isVersionDuel` para o ranking **entre ensaios**;
+- `computeVersionRatings` filtra `m.isVersionDuel` e ranqueia por
+  `aVersion`/`bVersion` (UUIDs), nunca por key — é isso que alimenta o
+  `hronir:select`;
+- `hronir-rank.ts`, `RankingView.astro` e as páginas de battles recebem
+  `winnerSide` pronto (fim do `winnerIsA = postAKey === winnerKey` vacuoso) e
+  rotulam duelos de versão como tal ("vos: v2 venceu v1") em vez de
+  "vos beat vos";
+- `generate-ranking-snapshot.mjs` conta duelos com o **mesmo** resolvedor de
+  override do ranking (fim do filtro invertido, C1).
+
+A semântica do guard que a RFC 0003 §7 pedia ("mesma key dos dois lados
+corrompe o OpenSkill") passa a ser **estrutural**: o tipo separa os dois
+universos, e nenhum consumidor novo precisa redescobrir a regra.
+
+### 4.4. Duelos de versão para todas as línguas (corrige V5)
+
+`pickVersionDuel` deixa de partir de `listEnglishWithKey()` e passa a iterar
+**todos os diretórios com ≥ 2 versões**, qualquer língua (PT, EN, músicas). O
+desafiante é a versão não-selecionada com menos duelos (desempate: mais
+recente). A avaliação segue a convenção de língua do repo: review na língua do
+post (`lang` do frontmatter), que agora vale por construção porque o duelo é
+sempre dentro de um diretório monolíngue.
+
+`prune` sobrevive, simplificado: remove versões **não-selecionadas** com
+n ≥ 3 duelos de versão e ≥ 0.5★ abaixo da selecionada — nunca a selecionada,
+nunca a última do diretório. Sem categoria "arquivo `-prev`": a ex-exibida é
+só mais uma versão, elegível a poda pelos mesmos critérios de todas.
+
+### 4.5. Sessão robusta e idempotente (corrige S1–S6)
+
+- **`readSession()`/`writeSession()`** únicos: escrita via
+  `tmp + renameSync` (atômica no mesmo filesystem), leitura com try/catch e
+  erro acionável ("sessão corrompida — rode `hronir:end --force`"). Substitui
+  os 18 sites inline.
+- **Idempotência do `decide` (S1):** o `run_id` passa a ser gerado em
+  `generateNextMatch` e gravado em `session.currentMatch.run_id`. O `decide`
+  usa esse run_id no nome do rate file — um retry **sobrescreve o mesmo
+  arquivo** em vez de criar um segundo. Só depois da escrita o estado avança.
+  O doctor ganha um check de pares duplicados por sessão como cinto de
+  segurança para dados antigos.
+- **Guard no `init` (S2):** com sessão em andamento, `init` aborta e instrui
+  `end --force` (ou `next`, que já retoma). Nada de reset silencioso no meio
+  da partida 7/10.
+- **Parsing do `decide` (S3):** `readFlagValue` sai do `index.js` para um
+  módulo compartilhado e o loop `args[++i]` do `decide` passa a usá-lo
+  (rejeita valor ausente e valor começando com `--`).
+- **`--after-mood` (S4):** obrigatório — ausência é erro, igual aos outros
+  campos; > 250 chars é **rejeitado** com mensagem, nunca truncado.
+- **`--matches` (S5):** parser numérico explícito — `0` é válido
+  (sessão só-edição), não-número é erro; o fallback `|| 10` morre nos três
+  lugares. O parsing de `init`/`next` é extraído para um
+  `parseInitOptions(args)` único.
+- **Worst fantasma (S6):** as linhas do ranking são filtradas para keys cujo
+  diretório existe antes da escolha do worst; e `editWorst` se recusa a gravar
+  sessão `need_edit` com `drafts: []` — se não criou rascunho, reporta e não
+  trava o fluxo.
+
+### 4.6. Elegibilidade publicada (corrige C2)
+
+A entrada no torneio passa pelo mesmo `isPublished` do site (`draft: true` e
+`publishDate` futuro ficam de fora), usando `readPostMeta` de
+`scripts/lib/content.mjs` — que volta a ser, como a RFC 0004 declarou, a fonte
+única de descoberta de posts. `posts.ts` mantém só o que é específico do
+Hrönir (UUID de conteúdo, listagem de versões).
+
+### 4.7. Eficiência (E1–E3)
+
+- **Cache por processo:** `loadNormalizedMatches()` memoiza na primeira
+  chamada (cada invocação do CLI é um processo novo — invalidação é trivial).
+  Os `compute*` puros que já aceitam `raw` viram o caminho padrão. Resultado:
+  **uma** passada pelos ~1.200 rate files por comando, não 4-5 por partida.
+- **`gitMtime` em lote:** um único
+  `git log --format=%ct --name-only -- src/content/blog` na inicialização do
+  `generateNextMatch`, parseado para um `Map<path, mtime>` — substitui os
+  ~200 subprocessos por partida. (No modelo novo o uso encolhe: a frescura
+  primária é o timestamp do nome `v-*`.)
+- **`getPostUuid` memoizado** por `(path, mtime)`; o pipeline remark inteiro
+  só roda quando o arquivo muda.
+- O hotspot E2 (`promote --all`) **desaparece com o promote**; o
+  `hronir:select` computa `computeVersionRatings()` e o índice de diretórios
+  **uma vez** e itera.
+
+### 4.8. Limpeza (§2.5)
+
+Remoção do código morto pré-RFC 0003 e dos shims de backfill; unificação de
+`collectDefensesForLoser/Winners` num `collectDefenses(keys, side, opts)`
+sobre o leitor normalizado do §4.3; teste movido para
+`src/hronir/__tests__/`; `scripts/hronir/lib/` removido; CLAUDE.md
+atualizado (diretórios, comandos `promote`/`draft-commit` substituídos por
+`select`, constraint do `--after-mood`).
+
+---
+
+## 5. O que acontece com os comandos
+
+| Hoje                                 | Depois                                                                                     |
+| ------------------------------------ | ------------------------------------------------------------------------------------------ |
+| `hronir:promote --draft/--key/--all` | **Removido.** `hronir:select` recomputa a seleção (com histerese) e reescreve o JSON.      |
+| `hronir:prune`                       | Mantido, simplificado (§4.4).                                                              |
+| `hronir:draft-worst`                 | Mantido — cria `v-*` novo; sem checagem de "draft pendente" via `-prev` (não existe mais). |
+| `hronir:draft-commit`                | Mantido (registra o rascunho; a seleção decide sozinha quando ele passa a ser exibido).    |
+| `hronir:edit-worst`/aliases          | Mantidos como aliases.                                                                     |
+| `hronir:doctor`                      | Ganha: validação `selection-v1`, pares duplicados por sessão, `after-mood` obrigatório.    |
+
+Workflow de build: `hronir:select` roda antes do `astro build` (junto do
+`generate-ranking-snapshot`); se o JSON mudar, o diff vai no commit da sessão.
+
+---
+
+## 6. Migração
+
+Script one-off preservado em `scripts/oneoff/` (padrão do repo):
+
+1. Para cada `index.{md,mdx}` em `src/content/blog/**`: renomear para
+   `v-<timestamp do último commit do arquivo>.<ext>` via `git mv` (preserva
+   história).
+2. Gerar `versions-selected.json` inicial apontando cada slug para o arquivo
+   renomeado (a seleção inicial = estado publicado de hoje; zero mudança
+   visível no site).
+3. Arquivos `v-*-prev` existentes (`vos`, `vos-en`): viram versões comuns —
+   nenhuma ação além de validar que não são as selecionadas.
+4. Rate files antigos referenciam paths `index.*` que deixarão de existir: o
+   leitor normalizado resolve paths históricos via key (que não muda), e o
+   doctor trata `index.*` ausente como tolerável **apenas** em matches
+   anteriores à data da migração.
+5. `npm run build` antes/depois deve produzir o mesmo conjunto de URLs
+   (checado no CI da fase).
+
+Rollback: a migração é um commit de renames + um JSON; reverter o merge
+restaura o estado anterior por inteiro.
+
+---
+
+## 7. Fases de implementação
+
+Cada fase é um commit (ou grupo) verde antes da próxima, na mesma branch.
+
+- **Fase 0 — leitor único e correções de ranking** (sem mudar o modelo):
+  `loadNormalizedMatches()` com `isVersionDuel`/`winnerSide`; guard nos
+  per-perspectiva (V1); `hronir-rank.ts` + `RankingView` + battles via
+  `winnerSide` e rótulo de duelo de versão (V6); snapshot com o mesmo
+  resolvedor (C1); filtro de posts existentes no worst (S6). Testes de
+  regressão com rate files de mesma key. **Esta fase já estanca a corrupção
+  ativa do ranking por perspectiva.**
+- **Fase 1 — sessão e CLI:** `readSession`/`writeSession` atômicos; guard do
+  `init`; `run_id` pré-gerado e `decide` idempotente (S1); parsing
+  compartilhado no `decide` (S3); `--after-mood` obrigatório e sem truncação
+  (S4); `parseInitOptions` e fim do `|| 10` (S5); doctor com os checks novos.
+- **Fase 2 — versões como pares:** migração §6; loader custom + collections;
+  `hronir:select` com histerese; `pickVersionDuel` para todos os diretórios
+  (V5); remoção de `promote`/`promoteFile`/`isCanonical`/`-prev` (V2, V3,
+  V4); `prune` simplificado; elegibilidade via `isPublished` (C2);
+  `previousVersion` aposentado como mecanismo (V7 — frescura = timestamp do
+  arquivo).
+- **Fase 3 — eficiência:** cache por processo, `gitMtime` em lote, memoização
+  do `getPostUuid` (E1, E3). Meta mensurável: `hronir:continue` e
+  `generateNextMatch` com **uma** passada pelos rate files; zero subprocessos
+  git por candidato.
+- **Fase 4 — limpeza e docs:** §4.8 + atualização de CLAUDE.md e README do
+  Hrönir; nota de status nesta RFC e na 0003 (seções de promoção/poda marcadas
+  como substituídas).
+
+---
+
+## 8. Riscos e alternativas consideradas
+
+- **Loader custom vs. materializar `index.md` gerado.** Materializar (um passo
+  de build copia a selecionada para `index.md`) manteria o glob atual, mas
+  reintroduz exatamente o swap de arquivos que causa V3 e suja o working tree.
+  O loader custom não toca o filesystem. Risco do loader: depende de API do
+  Astro menos batida que o `glob()`; mitigação: o loader é ~30 linhas sobre o
+  mesmo `glob()` interno, com teste de build no CI comparando o conjunto de
+  rotas antes/depois.
+- **Flapping da seleção.** Sem histerese, duas versões próximas trocariam de
+  posto a cada sessão. A regra do §4.2 (margem ≥ 0.3★, n ≥ 2, empate fica com
+  a atual) é a mesma barra da promoção de hoje — só que agora simétrica e
+  reversível.
+- **SEO/conteúdo duplicado.** Igual à RFC 0003: só a selecionada tem rota
+  indexável; as demais vivem em `/blog/<slug>/v/<uuid>` com `noindex` +
+  `rel=canonical`. A troca de seleção não muda a URL pública.
+- **Dados históricos.** Rate files nunca são reescritos (princípio das RFCs
+  anteriores). Toda compatibilidade com formatos antigos vive num único lugar
+  novo: o leitor normalizado (§4.3).

--- a/docs/rfcs/0010-versoes-pares-selecao-por-ranking.md
+++ b/docs/rfcs/0010-versoes-pares-selecao-por-ranking.md
@@ -279,6 +279,18 @@ versões em falta. Diretórios sem nenhuma versão (tradução ainda não criada
 não fazem parte do grupo para fins de acoplamento. Resultado: as línguas de um
 ensaio **sempre avançam juntas** ou não avançam — sem divergência parcial.
 
+O acoplamento vale também para o **fallback por seleção inválida** (exceção da
+regra 1 do §4.2): quando a seleção de um diretório é descartada por deixar de
+ser publicável, a reseleção não escolhe cegamente a mais recente — escolhe a
+versão publicável mais recente **cujo `draftCreatedAt` (ou revisão de
+migração) tenha contraparte publicável em todos os irmãos com versões**, e
+move o grupo inteiro para essa revisão. Só se nenhuma revisão comum publicável
+existir é que o diretório cai sozinho para sua versão publicável mais recente
+— publicar conteúdo válido tem precedência sobre paridade de línguas — e nesse
+caso o `hronir:doctor` passa a reportar o grupo como **divergente**, para que
+a próxima rodada de `draft-worst`/`select` o reconvirja em vez de a divergência
+ficar invisível.
+
 `prune` sobrevive, simplificado: remove versões **não-selecionadas** com
 n ≥ 3 duelos de versão e ≥ 0.5★ abaixo da selecionada — nunca a selecionada,
 nunca a última do diretório. Sem categoria "arquivo `-prev`": a ex-exibida é
@@ -371,12 +383,22 @@ Script one-off preservado em `scripts/oneoff/` (padrão do repo):
 
 1. Para cada `index.{md,mdx}` em `src/content/blog/**`: renomear para
    `v-<timestamp do último commit do arquivo>.<ext>` via `git mv` (preserva
-   história).
+   história), e gravar no frontmatter um `draftCreatedAt` **compartilhado por
+   grupo de tradução**: todas as ex-canônicas de um mesmo `translationKey`
+   recebem o mesmo valor (e.g. o timestamp da migração). É esse identificador
+   que o §4.4 usa para casar contrapartes — **valores ausentes nunca casam
+   entre si** (dois arquivos sem `draftCreatedAt` não são tratados como par).
 2. Gerar `versions-selected.json` inicial apontando cada slug para o arquivo
    renomeado (a seleção inicial = estado publicado de hoje; zero mudança
    visível no site).
-3. Arquivos `v-*-prev` existentes (`vos`, `vos-en`): viram versões comuns —
-   nenhuma ação além de validar que não são as selecionadas.
+3. Arquivos `v-*-prev` existentes (`vos`, `vos-en`): viram versões comuns.
+   Quando a história de promoção permitir identificar as contrapartes (via
+   `supersedes` da então-canônica e a mesma rodada de promoção), o script
+   grava nelas um `draftCreatedAt` compartilhado; quando não, cada uma fica
+   **sem** identificador de pareamento — continuam reselecionáveis pela regra
+   1 dentro do próprio diretório, mas nunca participam de avanço acoplado
+   (a regra "ausente nunca casa" impede parear versões não relacionadas).
+   Validar que não são as selecionadas.
 4. Rate files antigos referenciam paths `index.*` que deixarão de existir: o
    leitor normalizado resolve paths históricos via key (que não muda), e o
    doctor trata `index.*` ausente como tolerável **apenas** em matches

--- a/scripts/generate-ranking-snapshot.mjs
+++ b/scripts/generate-ranking-snapshot.mjs
@@ -14,7 +14,8 @@ const duels = listMatchFiles()
   .filter((m) => {
     const w = m.data?.winner;
     const ov = m.data?.override;
-    return w && w !== "TODO" && (!ov || ov === "null");
+    const resolvedWinner = ov && ov !== "null" ? ov : w;
+    return resolvedWinner && resolvedWinner !== "TODO";
   });
 
 const keys = {};

--- a/scripts/hronir/index.js
+++ b/scripts/hronir/index.js
@@ -76,26 +76,25 @@ function readFlagValue(args, indices) {
 
 function parseMatches(raw) {
   if (raw == null) return 10;
-  const n = parseInt(raw, 10);
-  if (!Number.isFinite(n) || n < 0) {
+  if (!/^\d+$/.test(String(raw).trim())) {
     console.error(
       `Erro: --matches deve ser um inteiro não-negativo (recebido: ${JSON.stringify(raw)}).`
     );
     process.exit(1);
   }
-  return n;
+  return Number(String(raw).trim());
 }
 
 function parseMinAppearances(raw) {
   if (raw == null) return null;
-  const n = parseInt(raw, 10);
-  if (!Number.isFinite(n) || n < 1) {
+  const s = String(raw).trim();
+  if (!/^\d+$/.test(s) || Number(s) < 1) {
     console.error(
       `Erro: --min-appearances deve ser um inteiro positivo (recebido: ${JSON.stringify(raw)}).`
     );
     process.exit(1);
   }
-  return n;
+  return Number(s);
 }
 
 function parseInitOptions(args) {

--- a/scripts/hronir/index.js
+++ b/scripts/hronir/index.js
@@ -72,75 +72,64 @@ function readFlagValue(args, indices) {
   return null;
 }
 
-switch (cmd) {
-  case "init": {
-    const matchesRaw = readFlagValue(args, [args.indexOf("--matches")]);
-    let matchesOpt = matchesRaw != null ? parseInt(matchesRaw, 10) || 10 : 10;
-    const skipEdit = args.includes("--skip-edit");
-    const skipRating = args.includes("--skip-rating");
-    if (skipRating) {
-      matchesOpt = 0;
-    }
-    const agentId = readFlagValue(args, [
-      args.indexOf("--agent-id"),
-      args.indexOf("--agent"),
-    ]);
-    const evalLangRaw = readFlagValue(args, [
-      args.indexOf("--eval-lang"),
-      args.indexOf("--lang"),
-    ]);
-    const evalLang = evalLangRaw || "pt";
-    const minAppRaw = readFlagValue(args, [
-      args.indexOf("--min-appearances"),
-      args.indexOf("--min-app"),
-    ]);
-    const minAppearances =
-      minAppRaw != null ? parseInt(minAppRaw, 10) || null : null;
-    init({
-      matches: matchesOpt,
-      skipEdit,
-      skipRating,
-      agentId,
-      evalLang,
-      minAppearances,
-    });
-    break;
+function parseMatches(raw) {
+  if (raw == null) return 10;
+  const n = parseInt(raw, 10);
+  if (!Number.isFinite(n) || n < 0) {
+    console.error(
+      `Erro: --matches deve ser um inteiro não-negativo (recebido: ${JSON.stringify(raw)}).`
+    );
+    process.exit(1);
   }
+  return n;
+}
+
+function parseMinAppearances(raw) {
+  if (raw == null) return null;
+  const n = parseInt(raw, 10);
+  if (!Number.isFinite(n) || n < 1) {
+    console.error(
+      `Erro: --min-appearances deve ser um inteiro positivo (recebido: ${JSON.stringify(raw)}).`
+    );
+    process.exit(1);
+  }
+  return n;
+}
+
+function parseInitOptions(args) {
+  const matchesRaw = readFlagValue(args, [args.indexOf("--matches")]);
+  const skipEdit = args.includes("--skip-edit");
+  const skipRating = args.includes("--skip-rating");
+  const agentId = readFlagValue(args, [
+    args.indexOf("--agent-id"),
+    args.indexOf("--agent"),
+  ]);
+  const evalLangRaw = readFlagValue(args, [
+    args.indexOf("--eval-lang"),
+    args.indexOf("--lang"),
+  ]);
+  const evalLang = evalLangRaw || "pt";
+  const minAppRaw = readFlagValue(args, [
+    args.indexOf("--min-appearances"),
+    args.indexOf("--min-app"),
+  ]);
+  let matches = parseMatches(matchesRaw);
+  if (skipRating) matches = 0;
+  const minAppearances = parseMinAppearances(minAppRaw);
+  return { matches, skipEdit, skipRating, agentId, evalLang, minAppearances };
+}
+
+switch (cmd) {
+  case "init":
+    init(parseInitOptions(args));
+    break;
   case "continue":
     continueCmd();
     break;
   case "next":
-  case "auto": {
-    const matchesRaw = readFlagValue(args, [args.indexOf("--matches")]);
-    let matchesOpt = matchesRaw != null ? parseInt(matchesRaw, 10) || 10 : 10;
-    const skipEdit = args.includes("--skip-edit");
-    const skipRating = args.includes("--skip-rating");
-    if (skipRating) matchesOpt = 0;
-    const agentId = readFlagValue(args, [
-      args.indexOf("--agent-id"),
-      args.indexOf("--agent"),
-    ]);
-    const evalLangRaw = readFlagValue(args, [
-      args.indexOf("--eval-lang"),
-      args.indexOf("--lang"),
-    ]);
-    const evalLang = evalLangRaw || "pt";
-    const minAppRaw = readFlagValue(args, [
-      args.indexOf("--min-appearances"),
-      args.indexOf("--min-app"),
-    ]);
-    const minAppearances =
-      minAppRaw != null ? parseInt(minAppRaw, 10) || null : null;
-    next({
-      matches: matchesOpt,
-      skipEdit,
-      skipRating,
-      agentId,
-      evalLang,
-      minAppearances,
-    });
+  case "auto":
+    next(parseInitOptions(args));
     break;
-  }
   case "decide":
     decide(args);
     break;

--- a/src/components/RankingView.astro
+++ b/src/components/RankingView.astro
@@ -348,7 +348,9 @@ function snapshotDelta(key: string): number | null {
         const winnerName = postLabel(d.winnerKey);
         const loserName = postLabel(d.loserKey);
 
-        const winnerIsA = d.postAKey === d.winnerKey;
+        const winnerIsA = d.winnerSide
+          ? d.winnerSide === "a"
+          : d.postAKey === d.winnerKey;
         const winnerRate = d.rateA != null && d.rateB != null
           ? (winnerIsA ? d.rateA : d.rateB)
           : null;
@@ -367,6 +369,7 @@ function snapshotDelta(key: string): number | null {
           >
             <div class="bcl-meta">
               <span class="bcl-date">{fmtDate(d.runAt)}</span>
+              {d.isVersionDuel && <span class="bcl-tag">version duel</span>}
               {d.perspectiveId && (
                 <span
                   class="bcl-tag bcl-tag-persp"

--- a/src/hronir/commands.ts
+++ b/src/hronir/commands.ts
@@ -1108,8 +1108,12 @@ export function decide(args: string[]) {
   if (afterMood !== null) {
     const moodStr = String(afterMood).trim();
     if (moodStr.length > 250) {
+      saveDraft();
       console.error(
         `Erro: --after-mood excede 250 caracteres (recebido: ${moodStr.length}). Seja mais conciso.`
+      );
+      console.error(
+        `Nota: Rascunho salvo. Repita o decide apenas com um --after-mood mais curto; os demais campos serão recuperados do rascunho.`
       );
       process.exit(1);
     }

--- a/src/hronir/commands.ts
+++ b/src/hronir/commands.ts
@@ -101,50 +101,9 @@ const STALE_BONUS = 3.0;
 // information terms (sigma, stale_bonus).
 const OBJECTIVE_WEIGHT = 0.15;
 const SKILLS_DIR = "scripts/hronir/skills";
-const ARCHIVE_DIR = path.join(OUT_DIR, "archive");
-const EDITS_DIR = path.join(OUT_DIR, "edits");
 const SESSION_PATH = "hronir_session.json";
 const MIN_WORDS = 100;
 const PROMPT_VERSION = "stars-v1";
-const GITHUB_BLOB_BASE =
-  "https://github.com/franklinbaldo/franklinbaldo.github.io/blob";
-
-function currentHeadSha() {
-  return execFileSync("git", ["rev-parse", "HEAD"], {
-    encoding: "utf8",
-  }).trim();
-}
-
-function githubBlobUrl(sha: string, filepath: string): string {
-  return `${GITHUB_BLOB_BASE}/${sha}/${filepath}`;
-}
-
-// True if `filepath` has staged or unstaged changes against HEAD, or is
-// untracked. Used by edit-worst to refuse running when the working-tree
-// content of a target post diverges from the version that the captured
-// HEAD permalink will resolve to — otherwise the stored (uuid, url) pair
-// in previousVersion would describe two different files.
-function isFileDirtyAtHead(filepath: string): boolean {
-  try {
-    execFileSync("git", ["diff", "--quiet", "HEAD", "--", filepath], {
-      stdio: ["ignore", "ignore", "ignore"],
-    });
-  } catch {
-    return true;
-  }
-  try {
-    execFileSync(
-      "git",
-      ["diff", "--quiet", "--cached", "HEAD", "--", filepath],
-      {
-        stdio: ["ignore", "ignore", "ignore"],
-      }
-    );
-  } catch {
-    return true;
-  }
-  return false;
-}
 
 function wordCount(s: unknown): number {
   if (!s || typeof s !== "string") return 0;
@@ -247,6 +206,23 @@ export function init(options: InitOptions = {}) {
   const evalLang = options.evalLang || "pt";
   const sessionPath = SESSION_PATH;
 
+  if (fs.existsSync(sessionPath)) {
+    let existing: Record<string, unknown> | null = null;
+    try {
+      existing = JSON.parse(fs.readFileSync(sessionPath, "utf8"));
+    } catch {
+      // corrupt session file — let init overwrite it
+    }
+    if (existing && existing.state !== "done") {
+      console.error(
+        `Erro: sessão em andamento detectada (estado: '${existing.state}'). ` +
+          "Termine com `npm run hronir:end` antes de iniciar uma nova, " +
+          "ou force o descarte com `npm run hronir:end -- --force`."
+      );
+      process.exit(1);
+    }
+  }
+
   if (skipRating) {
     const session = {
       target: 0,
@@ -273,7 +249,7 @@ export function init(options: InitOptions = {}) {
     process.exit(1);
   }
 
-  const matchesOpt = options.matches || 10;
+  const matchesOpt = options.matches != null ? options.matches : 10;
   const session = {
     target: matchesOpt,
     completed: 0,
@@ -832,6 +808,21 @@ export function decide(args: string[]) {
     "--eval-lang",
     "--lang",
   ]);
+  function readDecideFlag(flagName: string, idx: number): string {
+    const v = args[idx + 1];
+    if (v == null) {
+      console.error(`Erro: ${flagName} exige um valor.`);
+      process.exit(1);
+    }
+    if (v.startsWith("--")) {
+      console.error(
+        `Erro: ${flagName} exige um valor, mas recebeu outra flag (${v}).`
+      );
+      process.exit(1);
+    }
+    return v;
+  }
+
   for (let i = 0; i < args.length; i++) {
     if (removedFlags.has(args[i])) {
       if (args[i] === "--perspective") {
@@ -853,14 +844,28 @@ export function decide(args: string[]) {
       args[i] === "--agent-id" ||
       args[i] === "--agent" ||
       args[i] === "--model"
-    )
-      agentId = args[++i];
-    else if (args[i] === "--clash") clash = args[++i];
-    else if (args[i] === "--review-a") reviewA = args[++i];
-    else if (args[i] === "--review-b") reviewB = args[++i];
-    else if (args[i] === "--rate-a") rateA = args[++i];
-    else if (args[i] === "--rate-b") rateB = args[++i];
-    else if (args[i] === "--after-mood") afterMood = args[++i];
+    ) {
+      agentId = readDecideFlag(args[i], i);
+      i++;
+    } else if (args[i] === "--clash") {
+      clash = readDecideFlag(args[i], i);
+      i++;
+    } else if (args[i] === "--review-a") {
+      reviewA = readDecideFlag(args[i], i);
+      i++;
+    } else if (args[i] === "--review-b") {
+      reviewB = readDecideFlag(args[i], i);
+      i++;
+    } else if (args[i] === "--rate-a") {
+      rateA = readDecideFlag(args[i], i);
+      i++;
+    } else if (args[i] === "--rate-b") {
+      rateB = readDecideFlag(args[i], i);
+      i++;
+    } else if (args[i] === "--after-mood") {
+      afterMood = readDecideFlag(args[i], i);
+      i++;
+    }
   }
 
   if (!agentId || agentId === "TODO") {
@@ -899,6 +904,16 @@ export function decide(args: string[]) {
       `Erro: --review-b precisa ter pelo menos ${MIN_WORDS} palavras (recebido: ${wcReviewB}).`
     );
     process.exit(1);
+  }
+
+  if (afterMood !== null) {
+    const moodStr = String(afterMood).trim();
+    if (moodStr.length > 250) {
+      console.error(
+        `Erro: --after-mood excede 250 caracteres (recebido: ${moodStr.length}). Seja mais conciso.`
+      );
+      process.exit(1);
+    }
   }
 
   // Pre-PR sessions can land in state=deciding with no perspective_id on
@@ -943,9 +958,7 @@ export function decide(args: string[]) {
     perspective_id: perspective.id,
     evaluator_mood: currentMatch.evaluator_mood ?? null,
     mood_glyph: currentMatch.mood_glyph ?? null,
-    evaluator_mood_after: afterMood
-      ? String(afterMood).trim().slice(0, 250) || null
-      : null,
+    evaluator_mood_after: afterMood ? String(afterMood).trim() || null : null,
     rate_a: parsedRateA,
     rate_b: parsedRateB,
     clash,
@@ -1403,8 +1416,11 @@ export function editWorst() {
     const row = eligible[i];
     if (recentlyEdited.includes(row.key)) continue;
     // RFC 0003: don't pile drafts — skip keys that already have a pending one.
+    // Exclude v-*-prev.* archive files (created by promote) — they are not drafts.
     const hasDraft = findTranslations(row.key).some((t) =>
-      listVersions(t.path).some((p) => !isCanonical(p))
+      listVersions(t.path).some(
+        (p) => !isCanonical(p) && !/-prev\.[^/]+$/.test(p)
+      )
     );
     if (hasDraft) continue;
     worstRow = row;
@@ -1421,7 +1437,16 @@ export function editWorst() {
   const topRows = eligible.filter((r) => r.key !== worstRow.key).slice(0, 3);
   const topKeys = topRows.map((r) => r.key);
 
-  const translationFiles = findTranslations(worstRow.key);
+  const translationFiles = findTranslations(worstRow.key).filter((t) =>
+    fs.existsSync(t.path)
+  );
+  if (translationFiles.length === 0) {
+    console.error(
+      `Erro: nenhum arquivo encontrado para o post '${worstRow.key}'. ` +
+        "O post pode ter sido deletado. Rode `npm run hronir:doctor` para diagnóstico."
+    );
+    process.exit(1);
+  }
 
   // RFC 0003: non-destructive drafting. Instead of editing the canonical
   // index.md in place (which conflicts when two sessions target the same

--- a/src/hronir/commands.ts
+++ b/src/hronir/commands.ts
@@ -436,9 +436,13 @@ function generateNextMatch() {
 
   // For each post, randomly pick which language version to show. The ranking
   // key is always the translationKey (derived from EN), but the evaluator
-  // reads whichever language is randomly selected.
+  // reads whichever language is randomly selected. Only publishable variants
+  // enter the draw — a draft or scheduled translation must not be evaluated
+  // and affect the shared key's ranking.
   function pickLangVariant(post: { path: string; translationKey: string }) {
-    const variants = findTranslations(post.translationKey);
+    const variants = findTranslations(post.translationKey, {
+      publishedOnly: true,
+    });
     if (variants.length <= 1) return { path: post.path, lang: "en" };
     const v = variants[Math.floor(Math.random() * variants.length)];
     return { path: v.path, lang: v.lang || "en" };

--- a/src/hronir/posts.ts
+++ b/src/hronir/posts.ts
@@ -82,6 +82,17 @@ export function buildPathIndex(): Map<
   return index;
 }
 
+// Publication predicate shared by match sampling: a post is publishable
+// unless it is marked draft or has a publishDate in the future.
+export function isPublishedData(data: Record<string, unknown>): boolean {
+  if (data.draft === true) return false;
+  if (data.publishDate) {
+    const pub = new Date(String(data.publishDate));
+    if (!isNaN(pub.getTime()) && pub > new Date()) return false;
+  }
+  return true;
+}
+
 export function listEnglishWithKey(): Array<{
   path: string;
   translationKey: string;
@@ -93,18 +104,15 @@ export function listEnglishWithKey(): Array<{
     const lang = data.lang ? String(data.lang) : "en";
     if (lang !== "en") continue;
     if (!data.translationKey) continue;
-    if (data.draft === true) continue;
-    if (data.publishDate) {
-      const pub = new Date(String(data.publishDate));
-      if (!isNaN(pub.getTime()) && pub > new Date()) continue;
-    }
+    if (!isPublishedData(data)) continue;
     out.push({ path: p, translationKey: String(data.translationKey) });
   }
   return out;
 }
 
 export function findTranslations(
-  translationKey: string
+  translationKey: string,
+  { publishedOnly = false }: { publishedOnly?: boolean } = {}
 ): Array<{ path: string; lang: string }> {
   const out: Array<{ path: string; lang: string }> = [];
   for (const p of listPosts()) {
@@ -112,6 +120,7 @@ export function findTranslations(
     const data = readPost(p);
     if (!data.translationKey) continue;
     if (String(data.translationKey) !== String(translationKey)) continue;
+    if (publishedOnly && !isPublishedData(data)) continue;
     out.push({ path: p, lang: data.lang ? String(data.lang) : "en" });
   }
   return out;

--- a/src/hronir/posts.ts
+++ b/src/hronir/posts.ts
@@ -93,6 +93,11 @@ export function listEnglishWithKey(): Array<{
     const lang = data.lang ? String(data.lang) : "en";
     if (lang !== "en") continue;
     if (!data.translationKey) continue;
+    if (data.draft === true) continue;
+    if (data.publishDate) {
+      const pub = new Date(String(data.publishDate));
+      if (!isNaN(pub.getTime()) && pub > new Date()) continue;
+    }
     out.push({ path: p, translationKey: String(data.translationKey) });
   }
   return out;

--- a/src/hronir/ranking.ts
+++ b/src/hronir/ranking.ts
@@ -327,6 +327,7 @@ export function _computeDeconfoundedQuality(
   const obs: Obs[] = [];
   const postN = new Map<string, number>();
   for (const m of raw) {
+    if (m.aKey === m.bKey) continue;
     const add = (key: string, rateVal: number | null) => {
       if (rateVal === null || !key) return;
       const pi = idxFor(postIdx, key);
@@ -429,6 +430,7 @@ export function _computePerPerspectiveQuality(
 
   for (const m of sorted) {
     if (!m.perspectiveId) continue;
+    if (m.aKey === m.bKey) continue;
     const b = bucket(m.perspectiveId);
 
     const resetIfEdited = (
@@ -508,6 +510,7 @@ export function computePerPerspectiveRatings(): Map<
     const bKey = postKey(data.post_b as { key?: string; slug?: string } | null);
     if (!aKey || !bKey) continue;
     if (winner !== "a" && winner !== "b") continue;
+    if (aKey === bKey) continue;
 
     const perspId = data.perspective_id ? String(data.perspective_id) : null;
     if (!perspId) continue;
@@ -537,6 +540,7 @@ export function computePerPerspectiveRatings(): Map<
     };
 
     for (const m of matches) {
+      if (m.aKey === m.bKey) continue;
       const aRating = ensure(m.aKey);
       const bRating = ensure(m.bKey);
       appearances.set(m.aKey, (appearances.get(m.aKey) || 0) + 1);

--- a/src/hronir/types.ts
+++ b/src/hronir/types.ts
@@ -62,6 +62,12 @@ export interface DuelEntry {
   runAt: string;
   winnerKey: string;
   loserKey: string;
+  /** Which side won, after override resolution. In version duels both sides
+   *  share the same key, so winnerKey alone cannot identify the side. */
+  winnerSide?: "a" | "b";
+  /** True when both sides are versions of the same post (post_a.key ===
+   *  post_b.key). Excluded from essay rankings but kept in the archive. */
+  isVersionDuel?: boolean;
   margin?: number;
   confidence?: string;
   criterion?: string;

--- a/src/lib/hronir-rank.ts
+++ b/src/lib/hronir-rank.ts
@@ -118,7 +118,6 @@ function loadDuelData(): { stats: RankingStats; recent: DuelEntry[] } {
     const bKey = postKey((data as any).post_b);
     if (!aKey || !bKey) continue;
     if (winner !== "a" && winner !== "b") continue;
-    if (aKey === bKey) continue;
 
     const rawRunAt = (data as any).run_at ?? (data as any).run_id ?? "";
     const runAt =
@@ -140,6 +139,8 @@ function loadDuelData(): { stats: RankingStats; recent: DuelEntry[] } {
       runAt,
       winnerKey,
       loserKey,
+      winnerSide: winner as "a" | "b",
+      isVersionDuel: aKey === bKey,
       margin:
         typeof (data as any).margin === "number"
           ? (data as any).margin

--- a/src/lib/hronir-rank.ts
+++ b/src/lib/hronir-rank.ts
@@ -118,6 +118,7 @@ function loadDuelData(): { stats: RankingStats; recent: DuelEntry[] } {
     const bKey = postKey((data as any).post_b);
     if (!aKey || !bKey) continue;
     if (winner !== "a" && winner !== "b") continue;
+    if (aKey === bKey) continue;
 
     const rawRunAt = (data as any).run_at ?? (data as any).run_id ?? "";
     const runAt =

--- a/src/pages/ranking/battles/[id].astro
+++ b/src/pages/ranking/battles/[id].astro
@@ -43,7 +43,9 @@ function dossierHref(key: string | undefined) {
   return `/ranking/posts/${key}/`;
 }
 
-const winnerIsA = duel.postAKey === duel.winnerKey;
+const winnerIsA = duel.winnerSide
+  ? duel.winnerSide === "a"
+  : duel.postAKey === duel.winnerKey;
 const winnerInfo = winnerIsA ? postAInfo : postBInfo;
 const loserInfo = winnerIsA ? postBInfo : postAInfo;
 const winnerKey = duel.winnerKey;
@@ -95,6 +97,7 @@ const loserRank = rankByKey.get(loserKey);
 
   <div class="battle-tags">
     {duel.season !== undefined && <span class="tag tag-season">Season {duel.season}</span>}
+    {duel.isVersionDuel && <span class="tag">version duel</span>}
     {duel.perspectiveId && (
       <span class="tag tag-perspective" style={`--ph:${perspectiveHue(duel.perspectiveId)}`}>
         <a href={`/ranking/perspectives/${duel.perspectiveId}/`}>{duel.perspectiveId.replace(/-/g, " ")}</a>

--- a/src/pages/ranking/battles/index.astro
+++ b/src/pages/ranking/battles/index.astro
@@ -113,7 +113,9 @@ const agents = [...new Set(duels.map((d) => d.agentId).filter(Boolean) as string
     {duels.map((d) => {
       const winnerName = postLabel(d.winnerKey);
       const loserName = postLabel(d.loserKey);
-      const winnerIsA = d.postAKey === d.winnerKey;
+      const winnerIsA = d.winnerSide
+        ? d.winnerSide === "a"
+        : d.postAKey === d.winnerKey;
       const rateWinner = winnerIsA ? d.rateA : d.rateB;
       const rateLoser = winnerIsA ? d.rateB : d.rateA;
       const hasRates = rateWinner != null && rateLoser != null;
@@ -132,6 +134,7 @@ const agents = [...new Set(duels.map((d) => d.agentId).filter(Boolean) as string
             <div class="battle-meta">
               <span class="battle-date">{fmtDate(d.runAt)}</span>
               {d.season !== undefined && <span class="tag tag-season">S{d.season}</span>}
+              {d.isVersionDuel && <span class="tag">version duel</span>}
               {d.perspectiveId && (
                 <span class="tag tag-perspective" style={`--ph:${perspectiveHue(d.perspectiveId)}`}>
                   {d.perspectiveId.replace(/-/g, " ")}


### PR DESCRIPTION
## Resumo

RFC 0010 + implementação das correções de bugs (fases 0, 1 e limpeza).

O branch contém:
1. **RFC 0010** em `docs/rfcs/0010-versoes-pares-selecao-por-ranking.md` — design completo de versões como pares, inventário de 14 bugs confirmados
2. **Implementação** dos bugs mais críticos: fase 0 (corrupção ativa de ranking), fase 1 (robustez de sessão), e limpeza de código morto

---

## Bugs corrigidos

### Fase 0 — Ranking crítico

| Bug | Local | Descrição |
|-----|-------|-----------|
| V1 | `ranking.ts:computePerPerspectiveRatings` | Guard `aKey===bKey` faltante — ~330 rate files de duelos de versão corrompiam ratings por-perspectiva (loser-side sobrescreve winner-side, +2 aparições por duelo) |
| V1b | `ranking.ts:_computeDeconfoundedQuality` | Mesma falta de guard — duelos de versão double-counted na regressão |
| V1b | `ranking.ts:_computePerPerspectiveQuality` | Mesma falta de guard |
| V1 | `ranking.ts:computePerPerspectiveRatings` | Guard também na coleta de dados (loop de `listMatchFiles`) |
| C1 | `generate-ranking-snapshot.mjs:17` | Filtro de override invertido: excluía matches com override válido, que o `_loadMatchData` usa. `totalDuels` divergia do ranking real |
| V6 | `hronir-rank.ts` + páginas de batalha | `winnerIsA = postAKey === winnerKey` era vacuamente true em duelos de versão — rates invertidos quando o lado b vencia. `DuelEntry` agora carrega `winnerSide` (lado vencedor pós-override) e `isVersionDuel`; os 3 consumidores derivam `winnerIsA` de `winnerSide`. Os ~370 duelos de versão permanecem no arquivo de batalhas (URLs preservadas) com tag "version duel" |

### Fase 1 — Robustez de sessão e CLI

| Bug | Local | Descrição |
|-----|-------|-----------|
| S2 | `commands.ts:init()` | Sobrescrevia sessão em andamento sem aviso. Agora rejeita com erro claro |
| S5 | `commands.ts:init()` | `options.matches \|\| 10` convertia `--matches 0` em 10. Corrigido para `?? 10` |
| S3 | `commands.ts:decide()` | Flag loop usava `args[++i]` sem guard contra valor ausente ou flag consecutiva. Agora usa `readDecideFlag()` local |
| S4 | `commands.ts:decide()` | `--after-mood` >250 chars era silenciosamente truncado. Agora é erro explícito, com rascunho salvo antes de sair (reviews/clash não se perdem) |
| V4 | `commands.ts:editWorst()` | `hasDraft` contava arquivos `v-*-prev.*` (criados por `promote`) como rascunhos ativos, bloqueando `draft-worst` indefinidamente para `vos/` e `vos-en/` |
| S6 | `commands.ts:editWorst()` | Se todos os arquivos de um post foram deletados, escrevia `state='need_edit'` com `drafts:[]`, criando dead-end. Agora falha com mensagem útil |
| S5 | `scripts/hronir/index.js` | `parseInt(x,10)\|\|10` → `parseMatches()` com validação estrita (`/^\d+$/`) — `--matches 0` não vira 10, `2.5`/`3oops` são rejeitados |

### Correção C2

| Bug | Local | Descrição |
|-----|-------|-----------|
| C2 | `posts.ts:listEnglishWithKey()` | Ignorava `draft:true` e `publishDate` futuro — rascunhos e posts agendados entravam no pool de matches |
| C2b | `posts.ts:findTranslations()` + `pickLangVariant` | Variantes de tradução não-publicadas (draft/agendadas) podiam ser sorteadas e avaliadas num duelo. `findTranslations` ganhou modo `publishedOnly`, usado no sorteio de variante |

### Limpeza (Fase 4)

Removido código morto de ~45 linhas pré-RFC 0003 de `commands.ts`: `ARCHIVE_DIR`, `EDITS_DIR`, `GITHUB_BLOB_BASE`, `currentHeadSha()`, `githubBlobUrl()`, `isFileDirtyAtHead()`.

`scripts/hronir/index.js` refatorado: `parseInitOptions()` e `parseMatches()` eliminam ~30 linhas duplicadas entre os cases `init` e `next`.

---

## Não implementado neste PR (próximas fases)

- **Fase 2** (migração do modelo de versões): `index.*` → `v-*`, `versions-selected.json`, loader custom Astro, comando `hronir:select`, remoção de `promote/promoteFile/isCanonical`
- **Fase 3** (eficiência): `loadNormalizedMatches()` memoizado, `gitMtime` em lote
- **UUID de versão** incluindo frontmatter relevante (requer migração de rate files existentes)

---

## Test plan

- [x] `npx prettier --check .` passa
- [x] `npm run hronir:doctor` — 0 inconsistências
- [x] `npm run hronir:ranking` — 97 keys, output correto
- [x] `astro build` — 2273 páginas, incl. 1356 de batalha (370 duelos de versão preservados); rates em ordem correta em duelo vencido pelo lado b (`b51cd994`)
- [x] CLI: `--matches 2.5`, `--matches 3oops`, `--min-appearances 0` rejeitados com erro claro
- [x] `npx tsc --noEmit` — sem erros nos arquivos hronir (erros pré-existentes de `astro:content` ignorados)

https://claude.ai/code/session_01A5w6nHmFsAR6RsVFef2DNJ