### PR TITLE
ux(tags): nuvem visual com hierarquia tipográfica melhorada

### DIFF
--- a/.routines/2026-06-12T06-12-15-tags-cloud-ux.md
+++ b/.routines/2026-06-12T06-12-15-tags-cloud-ux.md
@@ -1,0 +1,46 @@
+---
+date: 2026-06-12T06:12:15
+slug: tags-cloud-ux
+branch: claude/sleepy-pasteur-49mwc5
+status: pr-open
+issues: [247]
+pr_opened: 434
+pr_merged: 380
+---
+
+## Contexto ao chegar
+
+Main em `a02090e` (após série de hronir sessions do Jules). Backlog: 10 issues `routine` abertas, todas `priority:media` ou `baixa`. Sem `priority:alta`.
+
+PR pendente: #380 (`seo(rss): atom:link rel="self"`, Closes #244). Branch estava `dirty` (conflito em `src/generated/ranking-snapshot.json` — gerado, sem valor semântico).
+
+## O que foi feito
+
+### Merge do PR anterior (#380)
+
+Rebased `claude/sleepy-pasteur-ms7m8i` em cima de `origin/main`, pulando o commit de snapshot gerado (sem conflito funcional). CI rerun: verde em 3min. Merge com merge commit.
+
+Closes #244 — `atom:link rel="self"` nos feeds RSS EN e PT.
+
+### Fechamento de issue duplicada (#245)
+
+Issue #245 ("ux: barra de progresso de leitura") estava na fila mas já implementada: `progress#read-progress` em `src/pages/blog/[...slug].astro` com JS inline, CSS scoped e suporte a `prefers-reduced-motion`. Fechei como `completed`.
+
+Backlog voltou a 9 (abaixo de 10 efetivo após fechar #245 e #244). Mas as issues fechadas reduzem o total — contagem real de abertas segue em 9 após a run.
+
+### Issue escolhida: #247 — tags cloud visual
+
+A tags page já tinha interpolação de `font-size`, layout flex e wrap, mas faltavam:
+- `align-items: baseline` no UL (sem isso tags de tamanhos diferentes não se alinham pelo baseline tipográfico)
+- Range mais expressivo: 0.8–1.35rem → **0.85–1.5rem**
+- `.tag-count` em `0.75em` relativo ao tag (era `0.78rem` absoluto, não escalava)
+- `aria-label` em cada link (`#tag — N posts`)
+
+Aplicado em paridade EN (`src/pages/tags/index.astro`) e PT (`src/pages/pt/tags/index.astro`). Build verde.
+
+## O que fica para a próxima
+
+- Fechar #245 já feito nesta run
+- PR #this aberto; próxima run mergeia se CI verde e sem veto
+- Backlog em 9 abertas — limítrofe: se fechar mais alguma na triagem ou se a run seguinte não encontrar trabalho urgente, considerar reabastecer até 10–15
+- Issues `priority:media` restantes mais executáveis: #246 (print CSS), #248 (Memory path update), #242 (new path Law and AI)

--- a/src/pages/pt/tags/index.astro
+++ b/src/pages/pt/tags/index.astro
@@ -49,7 +49,8 @@ const itemListLd = {
       <li>
         <a
           href={`/pt/tags/${tag}/`}
-          style={`font-size: ${(0.8 + ((count - minCount) / Math.max(1, maxCount - minCount)) * 0.55).toFixed(2)}rem`}
+          style={`font-size: ${(0.85 + ((count - minCount) / Math.max(1, maxCount - minCount)) * 0.65).toFixed(2)}rem`}
+          aria-label={`#${tag} — ${count} post${count !== 1 ? 's' : ''}`}
         >
           <span class="tag-name">#{tag}</span>
           <span class="tag-count">{count}</span>
@@ -67,6 +68,7 @@ const itemListLd = {
     display: flex;
     flex-wrap: wrap;
     gap: 0.5rem;
+    align-items: baseline;
   }
   .tag-cloud li { margin: 0; }
   .tag-cloud a {
@@ -87,6 +89,6 @@ const itemListLd = {
   }
   .tag-count {
     color: var(--pico-muted-color);
-    font-size: 0.78rem;
+    font-size: 0.75em;
   }
 </style>

--- a/src/pages/tags/index.astro
+++ b/src/pages/tags/index.astro
@@ -43,7 +43,8 @@ const itemListLd = {
       <li>
         <a
           href={`/tags/${tag}/`}
-          style={`font-size: ${(0.8 + ((count - minCount) / Math.max(1, maxCount - minCount)) * 0.55).toFixed(2)}rem`}
+          style={`font-size: ${(0.85 + ((count - minCount) / Math.max(1, maxCount - minCount)) * 0.65).toFixed(2)}rem`}
+          aria-label={`#${tag} — ${count} post${count !== 1 ? 's' : ''}`}
         >
           <span class="tag-name">#{tag}</span>
           <span class="tag-count">{count}</span>
@@ -61,6 +62,7 @@ const itemListLd = {
     display: flex;
     flex-wrap: wrap;
     gap: 0.5rem;
+    align-items: baseline;
   }
   .tag-cloud li { margin: 0; }
   .tag-cloud a {
@@ -81,6 +83,6 @@ const itemListLd = {
   }
   .tag-count {
     color: var(--pico-muted-color);
-    font-size: 0.78rem;
+    font-size: 0.75em;
   }
 </style>


### PR DESCRIPTION
Closes #247

## UX

- **Range de font-size ampliado**: 0.8–1.35rem → **0.85–1.5rem** — diferença perceptível entre tags raras e dominantes
- **`align-items: baseline`** no UL: tags de tamanhos diferentes agora se alinham pelo baseline tipográfico, não pelo topo
- **`.tag-count` em `0.75em` relativo** (era `0.78rem` absoluto): o count escala proporcionalmente ao tamanho do tag, sem parecer deslocado em tags grandes
- **`aria-label` descritivo** em cada link: `#tag — N posts` — acessível por screen reader sem depender do texto visível

Paridade EN (`/tags/`) e PT (`/pt/tags/`) — ambas atualizadas.

A mudança é visual — URL a conferir no screenshot de prod da próxima run: `/tags/` e `/pt/tags/`.

---

_Rotina autônoma — janela de veto de 24h. A próxima run mergeia este PR se não houver comentário bloqueante._

_Generated by [Claude Code](https://claude.ai/code/session_01VnNid7iLa4FWvqGh2YnqTE)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01VnNid7iLa4FWvqGh2YnqTE)_