### PR TITLE
ux(print): CSS completo para impressão de ensaios

### DIFF
--- a/.routines/2026-06-13T05-00-00-print-css-ensaios.md
+++ b/.routines/2026-06-13T05-00-00-print-css-ensaios.md
@@ -1,0 +1,45 @@
+---
+date: 2026-06-13T05:00:00
+slug: print-css-ensaios
+branch: claude/sleepy-pasteur-qydwcj
+status: pr-open
+issues: [246]
+pr_opened: null
+pr_merged: 434
+---
+
+## Contexto ao chegar
+
+Run autônoma de 2026-06-13. PR #434 (`ux(tags): nuvem visual`, fecha #247) estava aberto com CI
+verde e sem reviews bloqueantes — mergeado com merge commit. Deploy estava `in_progress` no momento
+do merge; a verificação de prod fica para a próxima run (URLs: `/tags/` e `/pt/tags/`).
+
+Backlog com 7 issues `routine` abertas (abaixo do mínimo de 10). Criei 4 novas:
+- #492 — perf: lazy loading de imagens em posts (priority:media)
+- #493 — ux: indicador de seção ativa no TOC / scroll spy (priority:media)
+- #494 — seo: JSON-LD wordCount e timeRequired nos posts (priority:baixa)
+- #495 — a11y: aria-label em navegações secundárias (priority:baixa)
+
+Backlog agora em 11 issues (dentro da faixa 10–20).
+
+## O que fiz
+
+Implementei issue **#246 — ux: print CSS para ensaios**. O `global.css` já tinha um `@media print`
+básico, mas faltavam:
+
+1. `body { font-size: 11pt; max-width: 100%; }` — conforto de leitura impressa (A4/letter)
+2. `.home-rail` na lista de hidden — o aside do autor na homepage aparecia na impressão
+3. `section[aria-labelledby="webmentions-heading"]` — oculta a seção de webmentions
+4. `section[aria-labelledby="comments-heading"]` — oculta o widget Giscus
+
+O seletor de links externos `a[href^="http"]::after` já existia e está correto (não mostra URLs
+internas `/blog/xxx`, só HTTP/HTTPS absolutas). Mantido sem alteração.
+
+Build verde, `astro check` 0 errors, prettier OK.
+
+## O que ficou para a próxima run
+
+- Verificar screenshot de prod de `/tags/` e `/pt/tags/` (merge do PR #434).
+- Mergear este PR (#246) se CI verde e sem comentário bloqueante.
+- Continuar com os issues de prioridade média: #248 (reading path Memory and Funes),
+  #243 (Goodreads livros), #242 (reading path Direito e IA).

--- a/src/generated/ranking-snapshot.json
+++ b/src/generated/ranking-snapshot.json
@@ -1,393 +1,393 @@
 {
   "_meta": {
-    "generatedAt": "2026-06-12T12:22:48.544Z",
+    "generatedAt": "2026-06-13T05:06:47.638Z",
     "basis": "build",
-    "totalDuels": 1432
+    "totalDuels": 2029
   },
   "keys": {
-    "reddit-submarine-osint": {
-      "rank": 1,
-      "ordinal": 12.6795
-    },
     "pontifex-research": {
-      "rank": 2,
-      "ordinal": 12.5325
-    },
-    "music-o-telefone-da-agonia": {
-      "rank": 3,
-      "ordinal": 12.4243
-    },
-    "music-spring-loading": {
-      "rank": 4,
-      "ordinal": 11.0868
+      "rank": 1,
+      "ordinal": 18.0197
     },
     "music-beatriz": {
-      "rank": 5,
-      "ordinal": 11.0716
+      "rank": 2,
+      "ordinal": 16.6456
     },
-    "serpents-egg": {
-      "rank": 6,
-      "ordinal": 11.0649
-    },
-    "music-bibliotecario-do-infinito": {
-      "rank": 7,
-      "ordinal": 10.9935
+    "music-spring-loading": {
+      "rank": 3,
+      "ordinal": 15.7878
     },
     "delphi-imperatives": {
-      "rank": 8,
-      "ordinal": 10.93
+      "rank": 4,
+      "ordinal": 15.6927
+    },
+    "music-observer-error-moving-window-iv": {
+      "rank": 5,
+      "ordinal": 13.8644
     },
     "music-john-gospel-chapter-i-by-max-headroom": {
-      "rank": 9,
-      "ordinal": 10.2099
-    },
-    "music-meditacao-guiada-no-sertao": {
-      "rank": 10,
-      "ordinal": 10.0876
-    },
-    "music-sobre-o-rigor-na-ciencia": {
-      "rank": 11,
-      "ordinal": 9.6322
-    },
-    "crossing-interference": {
-      "rank": 12,
-      "ordinal": 9.6264
-    },
-    "music-quando-vier-a-primavera": {
-      "rank": 13,
-      "ordinal": 9.5767
-    },
-    "pierre-menard": {
-      "rank": 14,
-      "ordinal": 9.4577
-    },
-    "conservation-law": {
-      "rank": 15,
-      "ordinal": 9.4094
-    },
-    "music-trinta-de-abril": {
-      "rank": 16,
-      "ordinal": 9.3285
-    },
-    "music-crystallizing-from-the-nothing": {
-      "rank": 17,
-      "ordinal": 9.1207
-    },
-    "third-half-fourth-wall": {
-      "rank": 18,
-      "ordinal": 8.9209
-    },
-    "music-escherian-sunrise-with-godel": {
-      "rank": 19,
-      "ordinal": 8.7276
-    },
-    "music-reality-maintenance-moving-window-xii": {
-      "rank": 20,
-      "ordinal": 8.4909
+      "rank": 6,
+      "ordinal": 13.4365
     },
     "asterisk-protects": {
-      "rank": 21,
-      "ordinal": 8.2413
+      "rank": 7,
+      "ordinal": 12.7635
     },
-    "music-666": {
-      "rank": 22,
-      "ordinal": 8.1995
+    "serpents-egg": {
+      "rank": 8,
+      "ordinal": 12.5002
     },
     "music-sinal-que-se-cumpre-moving-window-ix": {
-      "rank": 23,
-      "ordinal": 8.044
+      "rank": 9,
+      "ordinal": 12.1466
     },
-    "intelligible-void": {
-      "rank": 24,
-      "ordinal": 8.0353
+    "music-borges-and-the-hyperobject-at-the-end-of-time": {
+      "rank": 10,
+      "ordinal": 12.0603
     },
-    "music-borges-e-eu": {
-      "rank": 25,
-      "ordinal": 7.6827
+    "music-meditacao-guiada-no-sertao": {
+      "rank": 11,
+      "ordinal": 11.8212
     },
-    "music-o-aleph": {
-      "rank": 26,
-      "ordinal": 7.5271
+    "reddit-submarine-osint": {
+      "rank": 12,
+      "ordinal": 11.7364
     },
-    "verne-identity-repo": {
-      "rank": 27,
-      "ordinal": 7.3334
+    "music-crystallizing-from-the-nothing": {
+      "rank": 13,
+      "ordinal": 11.6591
     },
-    "music-uma-so-cancao": {
-      "rank": 28,
-      "ordinal": 7.2895
+    "music-o-telefone-da-agonia": {
+      "rank": 14,
+      "ordinal": 11.2953
     },
-    "its-raining-truth": {
-      "rank": 29,
-      "ordinal": 7.2588
+    "music-sobre-o-rigor-na-ciencia": {
+      "rank": 15,
+      "ordinal": 11.2933
     },
-    "music-espelhos": {
-      "rank": 30,
-      "ordinal": 6.9949
+    "music-eu-ia-escrever-sobre-o-infinito-de-novo": {
+      "rank": 16,
+      "ordinal": 11.0459
     },
-    "music-xadrez": {
-      "rank": 31,
-      "ordinal": 6.9287
+    "third-half-fourth-wall": {
+      "rank": 17,
+      "ordinal": 10.7333
     },
-    "music-o-prologo": {
-      "rank": 32,
-      "ordinal": 6.8069
+    "music-clipes": {
+      "rank": 18,
+      "ordinal": 10.6784
     },
-    "future-father": {
-      "rank": 33,
-      "ordinal": 6.8028
+    "pierre-menard": {
+      "rank": 19,
+      "ordinal": 10.632
     },
-    "music-o-ritual-de-abril-anos-de-saudade": {
-      "rank": 34,
-      "ordinal": 6.7074
+    "music-bibliotecario-do-infinito": {
+      "rank": 20,
+      "ordinal": 10.4399
     },
     "music-the-ruliad-is-laughing": {
-      "rank": 35,
-      "ordinal": 6.6379
+      "rank": 21,
+      "ordinal": 10.2877
     },
     "agent-no-verbs": {
+      "rank": 22,
+      "ordinal": 9.899
+    },
+    "music-reality-maintenance-moving-window-xii": {
+      "rank": 23,
+      "ordinal": 9.4574
+    },
+    "conservation-law": {
+      "rank": 24,
+      "ordinal": 9.4094
+    },
+    "music-quando-vier-a-primavera": {
+      "rank": 25,
+      "ordinal": 9.3931
+    },
+    "future-father": {
+      "rank": 26,
+      "ordinal": 9.3123
+    },
+    "music-chegue-irmao-chegue-irma": {
+      "rank": 27,
+      "ordinal": 9.0297
+    },
+    "music-the-time": {
+      "rank": 28,
+      "ordinal": 8.9994
+    },
+    "music-escherian-sunrise-with-godel": {
+      "rank": 29,
+      "ordinal": 8.7276
+    },
+    "music-46336b97-4306-41bc-8a7b-48f0ebebbd29": {
+      "rank": 30,
+      "ordinal": 8.6591
+    },
+    "music-666": {
+      "rank": 31,
+      "ordinal": 8.6343
+    },
+    "its-raining-truth": {
+      "rank": 32,
+      "ordinal": 8.6185
+    },
+    "music-o-ritual-de-abril-anos-de-saudade": {
+      "rank": 33,
+      "ordinal": 8.536
+    },
+    "music-o-aleph": {
+      "rank": 34,
+      "ordinal": 8.4128
+    },
+    "music-trinta-de-abril": {
+      "rank": 35,
+      "ordinal": 8.1418
+    },
+    "intelligible-void": {
       "rank": 36,
-      "ordinal": 6.4799
+      "ordinal": 8.0353
     },
     "three-hammers": {
       "rank": 37,
-      "ordinal": 6.4676
+      "ordinal": 7.8
     },
-    "music-chegue-irmao-chegue-irma": {
+    "crossing-interference": {
       "rank": 38,
-      "ordinal": 6.3103
+      "ordinal": 7.7118
     },
-    "music-eu-ia-escrever-sobre-o-infinito-de-novo": {
+    "rosencrantz-coin": {
       "rank": 39,
-      "ordinal": 6.2956
-    },
-    "music-the-time": {
-      "rank": 40,
-      "ordinal": 6.2933
-    },
-    "delegating-to-agents": {
-      "rank": 41,
-      "ordinal": 6.2609
-    },
-    "music-o-verso-branquiceleste": {
-      "rank": 42,
-      "ordinal": 6.1945
-    },
-    "family-memory": {
-      "rank": 43,
-      "ordinal": 6.1679
-    },
-    "music-o-magico-e-o-fogo": {
-      "rank": 44,
-      "ordinal": 5.9196
-    },
-    "music-clipes": {
-      "rank": 45,
-      "ordinal": 5.9
-    },
-    "music-paperclip-rhapsody": {
-      "rank": 46,
-      "ordinal": 5.6749
-    },
-    "music-a-primeira-mudanca": {
-      "rank": 47,
-      "ordinal": 5.6075
-    },
-    "music-observer-error-moving-window-iv": {
-      "rank": 48,
-      "ordinal": 5.2906
-    },
-    "funes-soul": {
-      "rank": 49,
-      "ordinal": 5.0013
-    },
-    "music-46336b97-4306-41bc-8a7b-48f0ebebbd29": {
-      "rank": 50,
-      "ordinal": 4.884
-    },
-    "jules-api-harness": {
-      "rank": 51,
-      "ordinal": 4.8436
-    },
-    "music-nonada": {
-      "rank": 52,
-      "ordinal": 4.7538
-    },
-    "music-particles": {
-      "rank": 53,
-      "ordinal": 4.6815
-    },
-    "music-menino-que-voce-foi": {
-      "rank": 54,
-      "ordinal": 4.6734
-    },
-    "building-funes": {
-      "rank": 55,
-      "ordinal": 4.3846
+      "ordinal": 7.6402
     },
     "music-o-preco-da-saudade": {
-      "rank": 56,
-      "ordinal": 4.1542
+      "rank": 40,
+      "ordinal": 7.4885
     },
-    "census-not-sample": {
+    "music-a-primeira-mudanca": {
+      "rank": 41,
+      "ordinal": 7.4211
+    },
+    "music-f73c60f0-49af-45fd-a483-1d35a676dccc": {
+      "rank": 42,
+      "ordinal": 7.3915
+    },
+    "music-nonada": {
+      "rank": 43,
+      "ordinal": 7.2932
+    },
+    "music-uma-so-cancao": {
+      "rank": 44,
+      "ordinal": 7.2895
+    },
+    "music-paperclip-rhapsody": {
+      "rank": 45,
+      "ordinal": 7.1381
+    },
+    "funes-soul": {
+      "rank": 46,
+      "ordinal": 6.9353
+    },
+    "music-o-magico-e-o-fogo": {
+      "rank": 47,
+      "ordinal": 6.8288
+    },
+    "music-fourteen-words": {
+      "rank": 48,
+      "ordinal": 6.8122
+    },
+    "music-o-prologo": {
+      "rank": 49,
+      "ordinal": 6.7912
+    },
+    "music-leite-no-salao-bar": {
+      "rank": 50,
+      "ordinal": 6.6955
+    },
+    "music-borges-e-eu": {
+      "rank": 51,
+      "ordinal": 6.4576
+    },
+    "delegating-to-agents": {
+      "rank": 52,
+      "ordinal": 6.2609
+    },
+    "family-memory": {
+      "rank": 53,
+      "ordinal": 6.1679
+    },
+    "building-funes": {
+      "rank": 54,
+      "ordinal": 6.156
+    },
+    "verne-identity-repo": {
+      "rank": 55,
+      "ordinal": 6.0651
+    },
+    "music-caminho": {
+      "rank": 56,
+      "ordinal": 5.9184
+    },
+    "music-entre-rascunho-e-apagar": {
       "rank": 57,
-      "ordinal": 4.0397
+      "ordinal": 5.8245
     },
     "two-questions-out-loud": {
       "rank": 58,
-      "ordinal": 3.8318
-    },
-    "music-fourteen-words": {
-      "rank": 59,
-      "ordinal": 3.8051
-    },
-    "music-prayer-to-the-unfinished-moving-window-v": {
-      "rank": 60,
-      "ordinal": 3.7116
-    },
-    "rosencrantz-coin": {
-      "rank": 61,
-      "ordinal": 3.6722
+      "ordinal": 5.737
     },
     "music-two-cursors": {
-      "rank": 62,
-      "ordinal": 3.6321
-    },
-    "music-borges-and-the-hyperobject-at-the-end-of-time": {
-      "rank": 63,
-      "ordinal": 3.5813
-    },
-    "music-be-me-borges": {
-      "rank": 64,
-      "ordinal": 3.3607
-    },
-    "music-the-third-song-moving-window-iii": {
-      "rank": 65,
-      "ordinal": 3.3101
-    },
-    "music-leite-no-salao-bar": {
-      "rank": 66,
-      "ordinal": 3.0683
-    },
-    "music-caminho": {
-      "rank": 67,
-      "ordinal": 2.8962
-    },
-    "conceptual-document": {
-      "rank": 68,
-      "ordinal": 2.8283
-    },
-    "music-f73c60f0-49af-45fd-a483-1d35a676dccc": {
-      "rank": 69,
-      "ordinal": 2.6401
-    },
-    "music-sentido-e-referencia": {
-      "rank": 70,
-      "ordinal": 2.4463
-    },
-    "music-o-tempo": {
-      "rank": 71,
-      "ordinal": 2.1121
+      "rank": 59,
+      "ordinal": 5.6443
     },
     "social-vulnerabilities": {
-      "rank": 72,
-      "ordinal": 2.0636
+      "rank": 60,
+      "ordinal": 5.6232
     },
-    "music-stopping-by-woods-on-a-snowy-evening-by-robert-frost": {
-      "rank": 73,
-      "ordinal": 1.8671
+    "conceptual-document": {
+      "rank": 61,
+      "ordinal": 5.5281
     },
-    "music-pattern-over-stuff": {
-      "rank": 74,
-      "ordinal": 1.8189
+    "music-sentido-e-referencia": {
+      "rank": 62,
+      "ordinal": 5.0395
     },
-    "music-dd332f75-6052-4f9e-bccd-fb0303731d6e": {
-      "rank": 75,
-      "ordinal": 1.5363
-    },
-    "music-vos": {
-      "rank": 76,
-      "ordinal": 1.2404
-    },
-    "music-entre-rascunho-e-apagar": {
-      "rank": 77,
-      "ordinal": 1.2107
+    "music-o-verso-branquiceleste": {
+      "rank": 63,
+      "ordinal": 4.9018
     },
     "music-borges-and-me": {
+      "rank": 64,
+      "ordinal": 4.8726
+    },
+    "jules-api-harness": {
+      "rank": 65,
+      "ordinal": 4.8401
+    },
+    "music-espelhos": {
+      "rank": 66,
+      "ordinal": 4.7437
+    },
+    "music-xadrez": {
+      "rank": 67,
+      "ordinal": 4.5984
+    },
+    "music-particles": {
+      "rank": 68,
+      "ordinal": 4.5565
+    },
+    "music-menino-que-voce-foi": {
+      "rank": 69,
+      "ordinal": 4.0954
+    },
+    "census-not-sample": {
+      "rank": 70,
+      "ordinal": 4.0397
+    },
+    "music-mindfulness": {
+      "rank": 71,
+      "ordinal": 3.9027
+    },
+    "music-the-third-song-moving-window-iii": {
+      "rank": 72,
+      "ordinal": 3.5052
+    },
+    "music-be-me-borges": {
+      "rank": 73,
+      "ordinal": 3.3607
+    },
+    "music-vos": {
+      "rank": 74,
+      "ordinal": 3.1961
+    },
+    "music-o-tempo": {
+      "rank": 75,
+      "ordinal": 2.5805
+    },
+    "music-dd332f75-6052-4f9e-bccd-fb0303731d6e": {
+      "rank": 76,
+      "ordinal": 2.5467
+    },
+    "music-o-medo-do-louco": {
+      "rank": 77,
+      "ordinal": 2.3812
+    },
+    "pontifex-guide": {
       "rank": 78,
-      "ordinal": 1.2012
+      "ordinal": 2.2176
     },
     "travessia-project": {
       "rank": 79,
-      "ordinal": 1.0906
+      "ordinal": 1.8313
     },
-    "music-o-medo-do-louco": {
+    "music-pattern-over-stuff": {
       "rank": 80,
-      "ordinal": 1.046
-    },
-    "music-f85fb538-6f59-4751-8629-da76665fc91e": {
-      "rank": 81,
-      "ordinal": 0.8221
-    },
-    "music-primavera-carregando": {
-      "rank": 82,
-      "ordinal": 0.7288
-    },
-    "music-riobaldo-e-o-aleph": {
-      "rank": 83,
-      "ordinal": 0.4667
-    },
-    "music-veu-do-infinito": {
-      "rank": 84,
-      "ordinal": 0.438
+      "ordinal": 1.4527
     },
     "music-sussurros-binarios": {
-      "rank": 85,
-      "ordinal": 0.2998
+      "rank": 81,
+      "ordinal": 1.4515
     },
-    "inaugural-post": {
-      "rank": 86,
-      "ordinal": -0.5211
+    "music-riobaldo-e-o-aleph": {
+      "rank": 82,
+      "ordinal": 1.4099
     },
-    "pontifex-guide": {
-      "rank": 87,
-      "ordinal": -0.7798
-    },
-    "music-universal-threshold": {
-      "rank": 88,
-      "ordinal": -0.7906
-    },
-    "reclaiming-harness": {
-      "rank": 89,
-      "ordinal": -0.8599
-    },
-    "music-mindfulness": {
-      "rank": 90,
-      "ordinal": -1.6739
-    },
-    "music-151474c5-1420-4cc1-9ab5-80721f4459ed": {
-      "rank": 91,
-      "ordinal": -1.95
-    },
-    "becoming-lobsters": {
-      "rank": 92,
-      "ordinal": -1.9626
-    },
-    "music-o-regral": {
-      "rank": 93,
-      "ordinal": -2.0169
-    },
-    "music-o-sonhador-e-o-fogo": {
-      "rank": 94,
-      "ordinal": -2.5367
-    },
-    "pampa-circuit": {
-      "rank": 95,
-      "ordinal": -2.9314
+    "music-prayer-to-the-unfinished-moving-window-v": {
+      "rank": 83,
+      "ordinal": 1.241
     },
     "music-belief-engine-labyrinth-song-moving-window-viii": {
+      "rank": 84,
+      "ordinal": 0.6115
+    },
+    "music-primavera-carregando": {
+      "rank": 85,
+      "ordinal": 0.5691
+    },
+    "music-stopping-by-woods-on-a-snowy-evening-by-robert-frost": {
+      "rank": 86,
+      "ordinal": 0.4474
+    },
+    "music-veu-do-infinito": {
+      "rank": 87,
+      "ordinal": -0.0784
+    },
+    "music-o-regral": {
+      "rank": 88,
+      "ordinal": -0.1062
+    },
+    "music-universal-threshold": {
+      "rank": 89,
+      "ordinal": -0.4568
+    },
+    "becoming-lobsters": {
+      "rank": 90,
+      "ordinal": -0.6417
+    },
+    "inaugural-post": {
+      "rank": 91,
+      "ordinal": -0.7009
+    },
+    "music-f85fb538-6f59-4751-8629-da76665fc91e": {
+      "rank": 92,
+      "ordinal": -0.8167
+    },
+    "music-151474c5-1420-4cc1-9ab5-80721f4459ed": {
+      "rank": 93,
+      "ordinal": -2.1303
+    },
+    "pampa-circuit": {
+      "rank": 94,
+      "ordinal": -2.9314
+    },
+    "music-o-sonhador-e-o-fogo": {
+      "rank": 95,
+      "ordinal": -3.6233
+    },
+    "reclaiming-harness": {
       "rank": 96,
-      "ordinal": -3.8951
+      "ordinal": -4.8467
     },
     "everything-is-process": {
       "rank": 97,

--- a/src/generated/versions-selected.json
+++ b/src/generated/versions-selected.json
@@ -5,7 +5,7 @@
   },
   "_meta": {
     "schema": "selection-v1",
-    "generatedAt": "2026-06-12T12:07:08.992Z"
+    "generatedAt": "2026-06-13T05:03:53.876Z"
   },
   "151474c5-1420-4cc1-9ab5-80721f4459ed": {
     "file": "151474c5-1420-4cc1-9ab5-80721f4459ed/v-2026-06-09T20-24-29.mdx",
@@ -188,12 +188,12 @@
     "uuid": "9e3bcf3a-c10d-58e8-b3f3-3ea8b0bd5e8b"
   },
   "entre-rascunho-e-apagar": {
-    "file": "entre-rascunho-e-apagar/v-2026-06-09T20-24-29.mdx",
-    "uuid": "aead8de8-96a0-536a-bb37-3e920a287655"
+    "file": "entre-rascunho-e-apagar/v-2026-06-12T02-34-18-383.mdx",
+    "uuid": "0e26a00d-3bad-5fd3-a8d7-af9e758a2b06"
   },
   "entre-rascunho-e-apagar-en": {
-    "file": "entre-rascunho-e-apagar-en/v-2026-06-09T20-24-29.mdx",
-    "uuid": "f3618dd2-bf0b-5c77-8383-57999e72e2eb"
+    "file": "entre-rascunho-e-apagar-en/v-2026-06-12T02-34-18-383.mdx",
+    "uuid": "b2803d0d-ff60-5b67-b1c7-213e632f96fc"
   },
   "escherian-sunrise-with-godel": {
     "file": "escherian-sunrise-with-godel/v-2026-06-09T20-24-29.mdx",
@@ -232,8 +232,8 @@
     "uuid": "c7de2172-9eba-5141-bc17-c637b02311ef"
   },
   "everything-is-a-process-5-lessons-we-should-have-learned-2500-years-ago": {
-    "file": "everything-is-a-process-5-lessons-we-should-have-learned-2500-years-ago/v-2026-06-10T18-32-48.md",
-    "uuid": "e2b6de07-42c9-5dec-bb3d-272f848ca2e6"
+    "file": "everything-is-a-process-5-lessons-we-should-have-learned-2500-years-ago/v-2026-06-10T17-39-46.md",
+    "uuid": "58a61095-57cb-5851-82d1-b2e0d7793eeb"
   },
   "everything-is-eml": {
     "file": "everything-is-eml/v-2026-06-10T05-09-44.md",
@@ -324,12 +324,12 @@
     "uuid": "566e8573-ec7e-5a89-9f44-11f713d4a803"
   },
   "mindfulness": {
-    "file": "mindfulness/v-2026-06-09T20-24-29.mdx",
-    "uuid": "927c82a2-d23e-54c9-bc19-381fa38270e1"
+    "file": "mindfulness/v-2026-06-10T07-09-27.mdx",
+    "uuid": "33d2abb7-0bb9-5d64-9985-6bc2cdbb9e52"
   },
   "mindfulness-en": {
-    "file": "mindfulness-en/v-2026-06-09T20-24-29.mdx",
-    "uuid": "e2443f4a-0833-5cf3-9663-836c2942328e"
+    "file": "mindfulness-en/v-2026-06-10T07-09-27.mdx",
+    "uuid": "0587d440-f81e-5290-8e28-b7b5f5ed5038"
   },
   "moeda-rosencrantz-testando-se-os-llms-respeitam-a-probabilidade": {
     "file": "moeda-rosencrantz-testando-se-os-llms-respeitam-a-probabilidade/v-2026-06-10T05-09-44.md",
@@ -732,8 +732,8 @@
     "uuid": "c04b11e3-6337-50dc-bfa1-a910d7190710"
   },
   "tudo-e-processo": {
-    "file": "tudo-e-processo/v-2026-06-10T18-32-48.md",
-    "uuid": "7f042640-7d76-5bbd-a376-75317053ce9d"
+    "file": "tudo-e-processo/v-2026-06-10T17-39-46.md",
+    "uuid": "c19b8fbc-3d53-5b6a-9a30-14d217eedaec"
   },
   "two-cursors": {
     "file": "two-cursors/v-2026-06-09T20-24-29.mdx",
@@ -772,12 +772,12 @@
     "uuid": "fbe94cfa-7115-56fd-ba1c-7c09caa719eb"
   },
   "veu-do-infinito": {
-    "file": "veu-do-infinito/v-2026-06-09T20-24-29.mdx",
-    "uuid": "bd84afad-2193-5325-a88e-2459b5a87f8b"
+    "file": "veu-do-infinito/v-2026-06-12T09-51-17-410.mdx",
+    "uuid": "27b4fcb1-5050-59a5-ba14-9bfee44c70cc"
   },
   "veu-do-infinito-en": {
-    "file": "veu-do-infinito-en/v-2026-06-09T20-24-29.mdx",
-    "uuid": "ac725b78-6183-556a-82b2-86373633bac5"
+    "file": "veu-do-infinito-en/v-2026-06-12T09-51-17-410.mdx",
+    "uuid": "7a6c2ca5-1adf-5413-9789-9222e86673bc"
   },
   "vos": {
     "file": "vos/v-2026-06-10T02-14-41.mdx",

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -473,6 +473,10 @@ body::before {
   body::before {
     display: none;
   }
+  body {
+    font-size: 11pt;
+    max-width: 100%;
+  }
   #read-progress,
   .share-fab,
   .back-to-top,
@@ -484,7 +488,10 @@ body::before {
   .post-breadcrumb,
   .author-bio,
   .post-nav,
-  .related-posts {
+  .related-posts,
+  .home-rail,
+  section[aria-labelledby="webmentions-heading"],
+  section[aria-labelledby="comments-heading"] {
     display: none !important;
   }
   .post-grid,
@@ -494,6 +501,7 @@ body::before {
   .post-body > article {
     box-shadow: none;
   }
+  /* Show full URL after external links; skip anchor-only links. */
   a[href^="http"]::after {
     content: " (" attr(href) ")";
     font-size: 0.8em;


### PR DESCRIPTION
Closes #246

## UX

- **`body { font-size: 11pt }`** no `@media print` — tamanho de corpo confortável para A4/letter (o bloco anterior não definia font-size para impressão)
- **`body { max-width: 100% }`** — sem limitação de largura na impressão; usa toda a folha
- **`.home-rail`** adicionado à lista de elementos ocultos — o aside do autor na homepage aparecia na impressão
- **`section[aria-labelledby="webmentions-heading"]`** — oculta a seção de webmentions na impressão
- **`section[aria-labelledby="comments-heading"]`** — oculta o widget Giscus na impressão

Já existiam (mantidos): `header.container`, `footer.container`, `.toc-col`, `.toc-inline`, `.back-to-top`, `.share-fab`, `#read-progress`, `.author-bio`, `.post-nav`, `.related-posts`, `.post-breadcrumb`, `a[href^="http"]::after` (URLs externas).

A mudança é `@media print` puro — zero impacto na UI web.

---

_Rotina autônoma — janela de veto de 24h. A próxima run mergeia este PR se não houver comentário bloqueante._

_Generated by [Claude Code](https://claude.ai/code/session_015gX1jNuwstRPyWNLmccuEH)_

---
_Generated by [Claude Code](https://claude.ai/code/session_015gX1jNuwstRPyWNLmccuEH)_