### PR TITLE
feat(hronir): --content-mode path-only para agentes com contexto limitado

### DIFF
--- a/scripts/hronir/index.js
+++ b/scripts/hronir/index.js
@@ -47,7 +47,7 @@ const [, , cmd, ...args] = process.argv;
 
 function usage() {
   console.error(
-    "Uso: hronir {next --agent-id <id> [init-opts]|init --agent-id <id> [--matches N] [--skip-edit] [--skip-rating] [--eval-lang <lang>] [--min-appearances N] [--pledge <text>]|continue|first-impression-a <texto>|first-impression-b <texto>|decide --after-mood <text> --rate-a <1.00-5.00> --rate-b <1.00-5.00> --review-a <text> --review-b <text> --clash <text> [--clash-append <text>] [--review-a-append <text>] [--review-b-append <text>]|ranking|worst [--absolute]|diagnose|edit-worst|edit-commit --msg <text>|migrate [--dry-run]|doctor|end [--skip-edit] [--force] [--attest <text>]|select [--dry-run]|prune [--dry-run]}"
+    "Uso: hronir {next --agent-id <id> [init-opts]|init --agent-id <id> [--matches N] [--skip-edit] [--skip-rating] [--eval-lang <lang>] [--min-appearances N] [--pledge <text>] [--content-mode inline|path-only]|continue|first-impression-a <texto>|first-impression-b <texto>|decide --after-mood <text> --rate-a <1.00-5.00> --rate-b <1.00-5.00> --review-a <text> --review-b <text> --clash <text> [--clash-append <text>] [--review-a-append <text>] [--review-b-append <text>]|ranking|worst [--absolute]|diagnose|edit-worst|edit-commit --msg <text>|migrate [--dry-run]|doctor|end [--skip-edit] [--force] [--attest <text>]|select [--dry-run]|prune [--dry-run]}"
   );
   process.exit(1);
 }
@@ -115,6 +115,11 @@ function parseInitOptions(args) {
     args.indexOf("--min-app"),
   ]);
   const pledge = readFlagValue(args, [args.indexOf("--pledge")]);
+  const contentModeRaw = readFlagValue(args, [args.indexOf("--content-mode")]);
+  const contentMode =
+    contentModeRaw === "path-only" || contentModeRaw === "inline"
+      ? contentModeRaw
+      : undefined;
   let matches = parseMatches(matchesRaw);
   if (skipRating) matches = 0;
   const minAppearances = parseMinAppearances(minAppRaw);
@@ -126,6 +131,7 @@ function parseInitOptions(args) {
     evalLang,
     minAppearances,
     pledge,
+    contentMode,
   };
 }
 

--- a/src/hronir/commands.ts
+++ b/src/hronir/commands.ts
@@ -56,6 +56,7 @@ interface InitOptions {
   minAppearances?: number;
   matches?: number;
   pledge?: string;
+  contentMode?: "inline" | "path-only";
 }
 
 interface WorstOptions {
@@ -266,6 +267,8 @@ export function init(options: InitOptions = {}) {
 
   const matchesOpt = options.matches != null ? options.matches : 10;
   const pledge = options.pledge?.trim() || null;
+  const contentMode =
+    options.contentMode === "path-only" ? "path-only" : "inline";
   const session = {
     target: matchesOpt,
     completed: 0,
@@ -277,6 +280,7 @@ export function init(options: InitOptions = {}) {
     currentMatch: null,
     minAppearances: options.minAppearances || null,
     pledge,
+    contentMode,
   };
   fs.writeFileSync(sessionPath, JSON.stringify(session, null, 2));
 
@@ -748,11 +752,13 @@ export function continueCmd() {
     const aContent = fs.readFileSync(aPath, "utf8");
     const aParsed = matter(aContent);
     const aSunoId = aParsed.data.sunoId;
+    const pathOnly = session.contentMode === "path-only";
 
     const border = "━".repeat(80);
     const aHeader = "📄 PRIMEIRO POST (A) ";
     console.log(aHeader + "━".repeat(Math.max(0, 80 - aHeader.length)));
     console.log(`Slug: ${aSlug}`);
+    console.log(`Arquivo: ${aPath}`);
     if (aSunoId) {
       console.log(`🎵 Suno Song Page: https://suno.com/song/${aSunoId}`);
       console.log(
@@ -763,8 +769,13 @@ export function continueCmd() {
       );
     }
     console.log(`${border}\n`);
-    console.log(aContent);
-    console.log(`\n${border}\n`);
+    if (!pathOnly) {
+      console.log(aContent);
+      console.log(`\n${border}\n`);
+    } else {
+      console.log(`[content-mode: path-only — leia o arquivo em: ${aPath}]`);
+      console.log(`\n${border}\n`);
+    }
 
     session.state = "waiting_impression_a";
     fs.writeFileSync(sessionPath, JSON.stringify(session, null, 2));
@@ -843,10 +854,12 @@ export function firstImpressionA(args: string[]) {
   const bContent = fs.readFileSync(bPath, "utf8");
   const bParsed = matter(bContent);
   const bSunoId = bParsed.data.sunoId;
+  const pathOnly = session.contentMode === "path-only";
 
   const bHeader = "📄 SEGUNDO POST (B) ";
   console.log(bHeader + "━".repeat(Math.max(0, 80 - bHeader.length)));
   console.log(`Slug: ${bSlug}`);
+  console.log(`Arquivo: ${bPath}`);
   if (bSunoId) {
     console.log(`🎵 Suno Song Page: https://suno.com/song/${bSunoId}`);
     console.log(
@@ -857,8 +870,13 @@ export function firstImpressionA(args: string[]) {
     );
   }
   console.log(`${border}\n`);
-  console.log(bContent);
-  console.log(`\n${border}\n`);
+  if (!pathOnly) {
+    console.log(bContent);
+    console.log(`\n${border}\n`);
+  } else {
+    console.log(`[content-mode: path-only — leia o arquivo em: ${bPath}]`);
+    console.log(`\n${border}\n`);
+  }
 
   session.state = "waiting_impression_b";
   fs.writeFileSync(sessionPath, JSON.stringify(session, null, 2));
@@ -1287,6 +1305,7 @@ export function decide(args: string[]) {
     post_b: currentMatch.post_b,
     winner,
     agent_id: agentId,
+    content_mode: session.contentMode ?? "inline",
     eval_lang: currentMatch.eval_lang || session.evalLang || "pt",
     prompt_version: PROMPT_VERSION,
     season: 1,


### PR DESCRIPTION
## O problema

Agentes com compressão de contexto (Jules, Claude em sessões longas) podem perder o conteúdo do post exibido pelo CLI numa janela anterior. Sem o conteúdo, o agente precisa ler arquivos manualmente — workaround frágil.

## A solução

Nova flag `--content-mode inline|path-only` no `hronir:init`. O agente declara o modo que melhor serve suas capacidades:

- **`inline`** (default): comportamento atual — CLI exibe o conteúdo completo do post
- **`path-only`**: CLI exibe slug + path do arquivo + URLs do Suno, e o agente lê o conteúdo via filesystem quando quiser

O modo é salvo na `session.json` e gravado no rate file como `content_mode` para rastreabilidade e análise futura de correlação com qualidade.

## Uso

```bash
npm run hronir:init -- \
  --agent-id jules \
  --matches 20 \
  --content-mode path-only \
  --pledge "..."
```

O CLI passa a mostrar:
```
📄 PRIMEIRO POST (A) ━━━━━━━━━━━━━━━━━
Slug: music-o-regral
Arquivo: src/content/blog/o-regral/v-2026-06-09T20-24-29.mdx
🎵 Suno Song Page: https://suno.com/song/6d389910-...
[content-mode: path-only — leia o arquivo em: src/content/blog/o-regral/v-2026-06-09T20-24-29.mdx]
```

## Motivação

Identificada durante sessão de dogfooding (PR #514) — o agente perdeu o conteúdo do Post A no match 3 por compressão de contexto e precisou ler arquivos manualmente.

---
_Generated by [Claude Code](https://claude.ai/code/session_012N7Qd813svgGwTAzrvmuvn)_