### PR TITLE
feat: ranking UX + hronir docs (content-mode, version duels, technical view default, perspective tabs)

### DIFF
--- a/.github/hronir-session-prompt.md
+++ b/.github/hronir-session-prompt.md
@@ -60,17 +60,24 @@ e as convenções do repo (língua, commits, PR). Não pule esta etapa.
 Instale os pacotes do projeto antes de qualquer outro comando.
 
 **Passo 3 — Inicializar a sessão**
-Inicialize com `--agent-id jules`, `--matches 20` e `--pledge` com uma declaração
-em primeira pessoa afirmando que você vai ler cada post inteiramente e escrever
-análise genuína sem usar automação. Exemplo:
+Inicialize com `--agent-id jules`, `--matches 20`, `--content-mode path-only` e
+`--pledge` com uma declaração em primeira pessoa afirmando que você vai ler cada
+post inteiramente e escrever análise genuína sem usar automação. Exemplo:
 
 ```
 npm run hronir:init -- \
   --agent-id jules \
   --matches 20 \
   --skip-edit \
+  --content-mode path-only \
   --pledge "Eu, Jules, me comprometo a ler cada post integralmente e a escrever análise genuína em todos os campos, sem recorrer a scripts, geradores de texto ou qualquer automação para preencher review-a, review-b, clash ou qualquer outro campo desta sessão."
 ```
+
+Use `--content-mode path-only` porque suas sessões são longas (20 matches) e sujeitas
+a compressão de contexto. Neste modo, o CLI exibe o slug e o **caminho do arquivo**
+em vez do conteúdo completo — leia o arquivo diretamente com sua ferramenta de leitura
+de arquivos antes de registrar a primeira impressão. Isso garante que você sempre tem
+o conteúdo disponível, independentemente do estado da janela de contexto.
 
 Leia o output com atenção — ele mostra a perspectiva, o mood inicial e a instrução
 de próximo passo.
@@ -79,9 +86,16 @@ de próximo passo.
 Cada match é uma unidade indivisível: ler Post A + ler Post B + decidir.
 Para cada match, execute em sequência sem interrupção:
 
-1. Avance o estado para revelar o Post A. Leia o conteúdo completo. Anote o slug.
-2. Avance para revelar o Post B. Leia o conteúdo completo. Leia o glifo Unicode
-   e o campo de mood que o CLI exibe — faça isso antes de escrever qualquer coisa.
+1. Avance o estado para revelar o Post A. O CLI exibe o slug e o **caminho do
+   arquivo** (`Arquivo: src/content/blog/...`). Leia o arquivo inteiro com sua
+   ferramenta de leitura antes de registrar qualquer impressão.
+   - **Duelos de versão:** Quando o CLI indicar "DUELO DE VERSÃO", Post A é a
+     versão atualmente selecionada (canônica) e Post B é a versão desafiante
+     (rascunho criado numa sessão anterior). Avalie qual versão serve melhor o
+     leitor — não qual é mais recente.
+2. Avance para revelar o Post B. Leia o arquivo indicado pelo CLI. Leia também o
+   glifo Unicode e o campo de mood exibidos — faça isso antes de escrever qualquer
+   coisa.
 3. Interprete o glifo subjetivamente, combine com o mood inicial e com o que os
    dois posts evocaram. Esse estado interno é o `--after-mood` (≤250 chars,
    primeira pessoa PT, sobre seu estado — não sobre os posts). Depois atribua

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,9 @@ npm run hronir:init -- --agent-id <your-model-id> --matches 10 --skip-edit
 - `--agent-id` is **required** — use a stable identifier like `claude-opus-4-8` or `franklin`
 - `--matches` defaults to 10
 - `--skip-edit` skips the post-editing phase; use it for pure rating sessions
+- `--content-mode inline|path-only` — controls how post content is delivered:
+  - `inline` (default): CLI prints the full post content in its output
+  - `path-only`: CLI prints only the slug, file path, and Suno URLs; the agent reads the file directly. Recommended for agents with long sessions or context compression (e.g. Jules with 20 matches). The chosen mode is saved in `session.json` and recorded in each rate file as `content_mode`.
 
 ### 2. Loop: read → first-impression-a → first-impression-b → decide
 

--- a/docs/rfcs/0007-ranking-ui-e-ux-de-leitura.md
+++ b/docs/rfcs/0007-ranking-ui-e-ux-de-leitura.md
@@ -1,12 +1,12 @@
 # RFC 0007 — Ranking: UI e UX de leitura
 
-|                 |                                                                                                                                                                                                                            |
-| --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Status**      | Parcialmente implementado (r2) — Fases 0/3-parcial via PR #504/517; Fases 1–2, 4–6 em proposta                                                                                                                            |
-| **Autor**       | Franklin Baldo (proposta assistida)                                                                                                                                                                                        |
-| **Criado em**   | 2026-06-10                                                                                                                                                                                                                 |
-| **Branch / PR** | `claude/sweet-hypatia-1joz7o`                                                                                                                                                                                              |
-| **Depende de**  | —                                                                                                                                                                                                                          |
+|                 |                                                                                                                                                                                                                               |
+| --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Status**      | Parcialmente implementado (r2) — Fases 0/3-parcial via PR #504/517; Fases 1–2, 4–6 em proposta                                                                                                                                |
+| **Autor**       | Franklin Baldo (proposta assistida)                                                                                                                                                                                           |
+| **Criado em**   | 2026-06-10                                                                                                                                                                                                                    |
+| **Branch / PR** | `claude/sweet-hypatia-1joz7o`                                                                                                                                                                                                 |
+| **Depende de**  | —                                                                                                                                                                                                                             |
 | **Afeta**       | `src/pages/ranking.astro`, `src/pages/pt/ranking.astro`, `src/components/RankingView.astro`, `src/pages/ranking/perspectives/`, `src/hronir/perspectives.ts`, `src/lib/hronir-rank.ts`, `src/generated/ranking-snapshot.json` |
 
 > **Etapa 1 — só o RFC.** Implementação faseada após merge, cada fase verde
@@ -445,10 +445,11 @@ e confiança — o Elo ficaria redundante sem o contexto técnico.
 
 Na visão técnica, a ordem das colunas é:
 
-| Pos | Post | Elo | μ | σ | Ordinal | W/N | Confiança | Δ |
-|-----|------|-----|---|---|---------|-----|-----------|---|
+| Pos | Post | Elo | μ   | σ   | Ordinal | W/N | Confiança | Δ   |
+| --- | ---- | --- | --- | --- | ------- | --- | --------- | --- |
 
 Racional da posição:
+
 - **Elo antes de μ/σ** porque é mais legível — serve de âncora intuitiva
   antes de mergulhar nos parâmetros Bayesianos.
 - **Cor relativa ao 1000:** Elo > 1000 recebe `color: var(--pico-color-green)`,
@@ -505,21 +506,21 @@ fase.
 
 ## 5. Análise de impacto
 
-| Componente                                          | Impacto                                                                                         |
-| --------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
-| `src/hronir/perspectives.ts`                        | Fase 0 — resolução de caminho via cwd                                                           |
-| `src/pages/ranking/perspectives/[id].astro`         | Fase 0 — guarda contra `getStaticPaths` vazio; Fase 3 — versão PT (questão aberta)              |
-| `src/components/RankingView.astro`                  | Fases 0–3 — emagrece; Fase 6 — coluna Elo na visão técnica                                     |
-| `src/pages/ranking.astro` / `pt/ranking.astro`      | Fases 1–3 — novas strings, menos dados passados                                                 |
-| `src/pages/ranking/battles/…` (novo)                | Fase 1 — listagem paginada + página por duelo + breadcrumb + prev/next                          |
-| `src/pages/ranking/posts/…` (novo)                  | Fase 4 — dossiê por post; Fase 6 — linha Elo com pico                                          |
-| `src/lib/hronir-rank.ts`                            | Fases 1/3/4 — função de hash de 8 chars, snapshot Δ, trajetória por post                       |
-| `src/generated/ranking-snapshot.json`               | Fase 3 — schema `snapshot-v1` com `basis`; Fase 6 — schema `snapshot-v2` com `elo`/`eloPeak`   |
-| `scripts/generate-ranking-snapshot.mjs`             | Fase 6 — cálculo cronológico do Elo (K=32, start=1000) na mesma passada do OpenSkill           |
-| `scripts/hronir/`                                   | Sem mudança no CLI/engine                                                                       |
-| `.routines/hronir/rates/*`                          | Sem mudança de schema                                                                           |
-| Pagefind                                            | Fase 1 — páginas de duelo entram no índice existente                                            |
-| OG images                                          | Sem mudança                                                                                     |
+| Componente                                     | Impacto                                                                                      |
+| ---------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| `src/hronir/perspectives.ts`                   | Fase 0 — resolução de caminho via cwd                                                        |
+| `src/pages/ranking/perspectives/[id].astro`    | Fase 0 — guarda contra `getStaticPaths` vazio; Fase 3 — versão PT (questão aberta)           |
+| `src/components/RankingView.astro`             | Fases 0–3 — emagrece; Fase 6 — coluna Elo na visão técnica                                   |
+| `src/pages/ranking.astro` / `pt/ranking.astro` | Fases 1–3 — novas strings, menos dados passados                                              |
+| `src/pages/ranking/battles/…` (novo)           | Fase 1 — listagem paginada + página por duelo + breadcrumb + prev/next                       |
+| `src/pages/ranking/posts/…` (novo)             | Fase 4 — dossiê por post; Fase 6 — linha Elo com pico                                        |
+| `src/lib/hronir-rank.ts`                       | Fases 1/3/4 — função de hash de 8 chars, snapshot Δ, trajetória por post                     |
+| `src/generated/ranking-snapshot.json`          | Fase 3 — schema `snapshot-v1` com `basis`; Fase 6 — schema `snapshot-v2` com `elo`/`eloPeak` |
+| `scripts/generate-ranking-snapshot.mjs`        | Fase 6 — cálculo cronológico do Elo (K=32, start=1000) na mesma passada do OpenSkill         |
+| `scripts/hronir/`                              | Sem mudança no CLI/engine                                                                    |
+| `.routines/hronir/rates/*`                     | Sem mudança de schema                                                                        |
+| Pagefind                                       | Fase 1 — páginas de duelo entram no índice existente                                         |
+| OG images                                      | Sem mudança                                                                                  |
 
 ---
 

--- a/docs/rfcs/0007-ranking-ui-e-ux-de-leitura.md
+++ b/docs/rfcs/0007-ranking-ui-e-ux-de-leitura.md
@@ -1,13 +1,13 @@
 # RFC 0007 — Ranking: UI e UX de leitura
 
-|                 |                                                                                                                                                                                        |
-| --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Status**      | Proposta (r1)                                                                                                                                                                          |
-| **Autor**       | Franklin Baldo (proposta assistida)                                                                                                                                                    |
-| **Criado em**   | 2026-06-10                                                                                                                                                                             |
-| **Branch / PR** | `claude/sweet-hypatia-1joz7o`                                                                                                                                                          |
-| **Depende de**  | —                                                                                                                                                                                      |
-| **Afeta**       | `src/pages/ranking.astro`, `src/pages/pt/ranking.astro`, `src/components/RankingView.astro`, `src/pages/ranking/perspectives/`, `src/hronir/perspectives.ts`, `src/lib/hronir-rank.ts` |
+|                 |                                                                                                                                                                                                                            |
+| --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Status**      | Parcialmente implementado (r2) — Fases 0/3-parcial via PR #504/517; Fases 1–2, 4–6 em proposta                                                                                                                            |
+| **Autor**       | Franklin Baldo (proposta assistida)                                                                                                                                                                                        |
+| **Criado em**   | 2026-06-10                                                                                                                                                                                                                 |
+| **Branch / PR** | `claude/sweet-hypatia-1joz7o`                                                                                                                                                                                              |
+| **Depende de**  | —                                                                                                                                                                                                                          |
+| **Afeta**       | `src/pages/ranking.astro`, `src/pages/pt/ranking.astro`, `src/components/RankingView.astro`, `src/pages/ranking/perspectives/`, `src/hronir/perspectives.ts`, `src/lib/hronir-rank.ts`, `src/generated/ranking-snapshot.json` |
 
 > **Etapa 1 — só o RFC.** Implementação faseada após merge, cada fase verde
 > antes da próxima, conforme o padrão das RFCs anteriores.
@@ -361,24 +361,165 @@ e vice-versa; sparkline renderiza sem JS; link no rodapé do post ausente se
 2. Ordenação client-side da tabela por coluna (vitórias, duelos, Δ) como
    progressive enhancement sem dependências.
 
+### Fase 6 — Elo como pontuação complementar
+
+O OpenSkill é o motor de ranking — é o que determina a posição de cada post.
+Mas μ − 3σ não é legível para quem não conhece o sistema Bayesiano: o leitor
+casual vê `2.31` e não tem referência. O Elo resolve isso: parte de 1000,
+sobe e desce com vitórias e derrotas, e qualquer pessoa que já jogou xadrez
+ou conhece a classificação do FIFA entende intuitivamente o que `1243`
+significa.
+
+Esta fase adiciona o Elo como **pontuação complementar** na visão técnica —
+o OpenSkill continua como chave de ordenação; o Elo é uma segunda lente sobre
+os mesmos dados.
+
+#### 6.1 Especificação do cálculo
+
+O Elo do Hrönir segue a fórmula padrão (FIDE, sem modificações):
+
+```
+expected_A = 1 / (1 + 10^((elo_B − elo_A) / 400))
+new_elo_A  = elo_A + K × (actual_A − expected_A)
+```
+
+- **Ponto de partida:** 1000 para todos os posts.
+- **K = 32** (constante única; não há divisão por nível, pois todos os posts
+  estão sempre "em desenvolvimento").
+- **`actual`:** 1.0 para vitória, 0.0 para derrota. **Empates não são
+  possíveis no Hrönir** (restrição `--rate-a ≠ --rate-b` do CLI).
+- **Ordem de processamento:** rate files ordenados por `run_at` crescente
+  (cronológico). Posts estreantes num duelo entram com Elo 1000 naquele
+  ponto da linha do tempo.
+- **Duelos de versão:** usam o Elo da versão específica (identificada por
+  `post_a.version`/`post_b.version`), não o Elo da key genérica. O Elo da
+  key no ranking é o Elo da versão atualmente selecionada.
+- **Perspectivas:** o Elo global acumula todos os duelos; o Elo por
+  perspectiva acumula apenas os duelos dessa perspectiva (análogo ao
+  OpenSkill por perspectiva).
+
+O cálculo é **determinístico e reprodutível**: dado o conjunto de rate files
+e sua ordem cronológica, o Elo de qualquer post em qualquer ponto do tempo
+é único. Isso o torna auditável — ao contrário do μ/σ do OpenSkill (que
+depende do número de aparições e da variância do oponente), o Elo pode ser
+recalculado à mão duelo a duelo.
+
+#### 6.2 Onde persiste
+
+O Elo é adicionado ao `ranking-snapshot.json` (schema já versionado, Fase 3):
+
+```jsonc
+// src/generated/ranking-snapshot.json (schema estendido)
+{
+  "_meta": { "schema": "snapshot-v2", "generatedAt": "..." },
+  "global": [
+    {
+      "key": "vos",
+      "mu": 3.21,
+      "sigma": 0.42,
+      "ordinal": 1.95,
+      "wins": 14,
+      "total": 18,
+      "elo": 1187          // ← novo campo
+    }
+    // ...
+  ]
+}
+```
+
+Versão do schema: `snapshot-v1` → `snapshot-v2`. O `hronir:doctor` valida
+que todo post com `ordinal` também tem `elo`. O script
+`scripts/generate-ranking-snapshot.mjs` computa o Elo após processar os
+rate files na mesma passada que já calcula o OpenSkill.
+
+Não há arquivo separado para o Elo: o snapshot já é o artefato commitado que
+serve de base para o build. Adicionar o campo ao mesmo JSON mantém os dois
+ratings sincronizados e elimina a necessidade de leitura de dois arquivos no
+build do Astro.
+
+#### 6.3 Apresentação na tabela
+
+O Elo aparece **apenas na visão técnica** (o `?view=technical` / botão
+"Standard view" da Fase 3). Na visão padrão o leitor vê posição, win rate,
+e confiança — o Elo ficaria redundante sem o contexto técnico.
+
+Na visão técnica, a ordem das colunas é:
+
+| Pos | Post | Elo | μ | σ | Ordinal | W/N | Confiança | Δ |
+|-----|------|-----|---|---|---------|-----|-----------|---|
+
+Racional da posição:
+- **Elo antes de μ/σ** porque é mais legível — serve de âncora intuitiva
+  antes de mergulhar nos parâmetros Bayesianos.
+- **Cor relativa ao 1000:** Elo > 1000 recebe `color: var(--pico-color-green)`,
+  Elo < 1000 recebe `color: var(--pico-color-red)`, Elo = 1000 fica neutro.
+  Sem gradiente contínuo — threshold único e legível.
+- **Tooltip com tendência:** `title="Elo atual: 1187 (+143 desde 1000)"` —
+  mostra quanto o post subiu ou desceu desde o ponto de partida, sem precisar
+  de coluna extra para o delta.
+- **Mobile (< 640 px):** coluna Elo incluída no collapse da visão técnica
+  (mesmas colunas que μ/σ ocultam). A visão padrão em mobile não muda.
+
+O Elo **não é usado para ordenar** a tabela — a ordenação continua por
+`ordinal` (μ − 3σ). A razão: o ordinal penaliza incerteza, tornando posts
+bem-testados mais estáveis no ranking. O Elo puro sem suavização pode
+inflar posts que venceram oponentes fracos no início, quando todos estavam
+em 1000. As duas métricas coexistem, cada uma com seu papel.
+
+#### 6.4 Apresentação no dossiê do post (Fase 4)
+
+A página `/ranking/posts/<key>/` recebe uma linha nova no bloco de stats:
+
+```
+Elo: 1187   (+187 desde o início · pico: 1204)
+```
+
+Pico = Elo máximo registrado em qualquer ponto da linha do tempo. Para isso,
+o `generate-ranking-snapshot.mjs` registra também `eloPeak` e `eloStart`
+(sempre 1000; o campo existe para tornar o diff legível).
+
+#### 6.5 Trajetória de Elo (opcional, vinculada à Fase 4)
+
+Se a sparkline da Fase 4 for implementada para `ordinal`, pode ser
+estendida para Elo como segunda linha no mesmo SVG — duas linhas normalizadas
+ao range do post:
+
+- Linha sólida: ordinal (chave primária de ranking)
+- Linha tracejada: Elo normalizado
+
+Implementar apenas se a sparkline SVG da Fase 4 existir; não bloqueia esta
+fase.
+
+#### 6.6 Critério de aceite
+
+- `generate-ranking-snapshot.mjs` calcula Elo cronologicamente e escreve
+  `elo` em cada entrada de `global` e de cada perspectiva.
+- `hronir:doctor` valida campo `elo` presente e numérico para todo post
+  ranqueado; schema `snapshot-v2` declarado no `_meta`.
+- Visão técnica da `/ranking/` exibe coluna Elo com cor relativa ao 1000
+  e tooltip com delta desde o início.
+- Visão padrão não exibe coluna Elo.
+- `npm run build` + `npx astro check` + `npx prettier --check .` verdes.
+
 ---
 
 ## 5. Análise de impacto
 
-| Componente                                     | Impacto                                                                            |
-| ---------------------------------------------- | ---------------------------------------------------------------------------------- |
-| `src/hronir/perspectives.ts`                   | Fase 0 — resolução de caminho via cwd                                              |
-| `src/pages/ranking/perspectives/[id].astro`    | Fase 0 — guarda contra `getStaticPaths` vazio; Fase 3 — versão PT (questão aberta) |
-| `src/components/RankingView.astro`             | Fases 0–3 — emagrece: perde corpo dos duelos e `data-search`                       |
-| `src/pages/ranking.astro` / `pt/ranking.astro` | Fases 1–3 — novas strings, menos dados passados                                    |
-| `src/pages/ranking/battles/…` (novo)           | Fase 1 — listagem paginada + página por duelo + breadcrumb + prev/next             |
-| `src/pages/ranking/posts/…` (novo)             | Fase 4 — dossiê por post                                                           |
-| `src/lib/hronir-rank.ts`                       | Fases 1/3/4 — função de hash de 8 chars, snapshot Δ, trajetória por post           |
-| `src/generated/ranking-snapshot.json` (novo)   | Fase 3 — schema versionado (`basis` field) + validação no doctor                   |
-| `scripts/hronir/`                              | Sem mudança no CLI/engine                                                          |
-| `.routines/hronir/rates/*`                     | Sem mudança de schema                                                              |
-| Pagefind                                       | Fase 1 — páginas de duelo entram no índice existente                               |
-| OG images                                      | Sem mudança                                                                        |
+| Componente                                          | Impacto                                                                                         |
+| --------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| `src/hronir/perspectives.ts`                        | Fase 0 — resolução de caminho via cwd                                                           |
+| `src/pages/ranking/perspectives/[id].astro`         | Fase 0 — guarda contra `getStaticPaths` vazio; Fase 3 — versão PT (questão aberta)              |
+| `src/components/RankingView.astro`                  | Fases 0–3 — emagrece; Fase 6 — coluna Elo na visão técnica                                     |
+| `src/pages/ranking.astro` / `pt/ranking.astro`      | Fases 1–3 — novas strings, menos dados passados                                                 |
+| `src/pages/ranking/battles/…` (novo)                | Fase 1 — listagem paginada + página por duelo + breadcrumb + prev/next                          |
+| `src/pages/ranking/posts/…` (novo)                  | Fase 4 — dossiê por post; Fase 6 — linha Elo com pico                                          |
+| `src/lib/hronir-rank.ts`                            | Fases 1/3/4 — função de hash de 8 chars, snapshot Δ, trajetória por post                       |
+| `src/generated/ranking-snapshot.json`               | Fase 3 — schema `snapshot-v1` com `basis`; Fase 6 — schema `snapshot-v2` com `elo`/`eloPeak`   |
+| `scripts/generate-ranking-snapshot.mjs`             | Fase 6 — cálculo cronológico do Elo (K=32, start=1000) na mesma passada do OpenSkill           |
+| `scripts/hronir/`                                   | Sem mudança no CLI/engine                                                                       |
+| `.routines/hronir/rates/*`                          | Sem mudança de schema                                                                           |
+| Pagefind                                            | Fase 1 — páginas de duelo entram no índice existente                                            |
+| OG images                                          | Sem mudança                                                                                     |
 
 ---
 
@@ -462,3 +603,11 @@ e vice-versa; sparkline renderiza sem JS; link no rodapé do post ausente se
   barra de tensão ausente → traço neutro com `aria-label`; constraints mobile
   adicionadas à Fase 3 (tabela, grid de perspectivas) e Fase 4 (sparkline);
   mood em páginas EN com `lang="pt"` explícito e prefixo de atribuição.
+- **r2** (2026-06-13): incorpora Elo como pontuação complementar (Fase 6).
+  Adicionados: especificação do cálculo (K=32, start=1000, ordem cronológica
+  por `run_at`, duelos de versão por `post_a.version`); esquema de persistência
+  `snapshot-v2` com campos `elo` e `eloPeak`; apresentação como coluna na
+  visão técnica (cor relativa a 1000, tooltip com delta, sem reordenação —
+  ordinal continua chave de sort); linha de Elo no dossiê da Fase 4 com pico;
+  sparkline de duas linhas opcional. Status atualizado para refletir Fases 0/3
+  parcialmente implementadas via PR #504/517.

--- a/src/components/RankingView.astro
+++ b/src/components/RankingView.astro
@@ -230,11 +230,28 @@ function snapshotDelta(key: string): number | null {
   </section>
 )}
 
+{perspectivesGrid && perspectivesGrid.length > 0 && (
+  <nav class="persp-tabs" aria-label={strings.perspectivesHeading}>
+    <a href={lang === "pt" ? "/pt/ranking/" : "/ranking/"} class="persp-tab persp-tab-all">
+      All
+    </a>
+    {perspectivesGrid.map((p) => (
+      <a
+        href={`/ranking/perspectives/${p.id}/`}
+        class="persp-tab"
+        style={`--ph:${p.hue}`}
+      >
+        {p.name}
+      </a>
+    ))}
+  </nav>
+)}
+
 {rows.length > 0 && (
   <div class="rank-table-header">
     <p class="rank-caption">{strings.tableCaption}</p>
     <button class="view-toggle" id="view-toggle" type="button">
-      {strings.technicalViewLabel}
+      {strings.standardViewLabel}
     </button>
   </div>
   <div class="overflow-table rank-table-wrap">
@@ -310,31 +327,6 @@ function snapshotDelta(key: string): number | null {
   <p class="rank-empty"><em>{strings.emptyState}</em></p>
 )}
 
-{perspectivesGrid && perspectivesGrid.length > 0 && (
-  <section class="perspectives-grid-section">
-    <h2>{strings.perspectivesHeading}</h2>
-    <p><small>{strings.perspectivesBlurb}</small></p>
-    <div class="perspectives-grid">
-      {perspectivesGrid.map((p) => (
-        <a href={`/ranking/perspectives/${p.id}/`} class="persp-card" style={`--ph:${p.hue}`}>
-          <header class="persp-card-head">
-            <span class="persp-name">{p.name}</span>
-          </header>
-          <p class="persp-summary">{p.summary}</p>
-          {p.leaderTitle && (
-            <p class="persp-leader">
-              <span class="persp-leader-label">{strings.perspectivesLeaderLabel}</span>
-              <span class="persp-leader-title">{p.leaderTitle}</span>
-            </p>
-          )}
-        </a>
-      ))}
-    </div>
-    <p class="persp-view-all">
-      <a href="/ranking/perspectives/">{strings.perspectivesViewAllLink}</a>
-    </p>
-  </section>
-)}
 
 {recent.length > 0 && (
   <section class="rank-recent">
@@ -681,9 +673,9 @@ function snapshotDelta(key: string): number | null {
     opacity: 0.55;
   }
 
-  /* Technical columns: hidden by default, shown when table has data-view="technical" */
-  .tech-col { display: none; }
-  #rank-table[data-view="technical"] .tech-col { display: table-cell; }
+  /* Technical columns: visible by default, hidden when table has data-view="standard" */
+  .tech-col { display: table-cell; }
+  #rank-table[data-view="standard"] .tech-col { display: none; }
 
   .delta-up { color: #2d6a4f; font-weight: 600; }
   .delta-down { color: #c0392b; font-weight: 600; }
@@ -711,77 +703,43 @@ function snapshotDelta(key: string): number | null {
     .rank-table .col-confidence { display: none; }
   }
 
-  /* Perspectives grid -------------------------------------------- */
-  .perspectives-grid-section {
-    margin-top: 3.5rem;
-  }
-  .perspectives-grid-section h2 {
-    font-size: 1.15rem;
-    margin-bottom: 0.2rem;
-  }
-  .perspectives-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(16rem, 1fr));
-    gap: 1rem;
-    margin: 1rem 0;
-  }
-  .persp-card {
+  /* Perspective tabs -------------------------------------------- */
+  .persp-tabs {
     display: flex;
-    flex-direction: column;
+    flex-wrap: wrap;
     gap: 0.4rem;
-    padding: 1rem 1.1rem 0.9rem;
+    margin: 0 0 1.5rem;
+  }
+  .persp-tab {
+    font-size: 0.75rem;
+    padding: 0.3rem 0.8rem;
+    border-radius: 999px;
     border: 1px solid var(--pico-muted-border-color);
-    border-left: 4px solid hsl(var(--ph, 200), 55%, 55%);
-    border-radius: var(--pico-border-radius);
-    background: var(--pico-card-background-color);
+    color: var(--pico-muted-color);
     text-decoration: none;
-    color: inherit;
-    transition: border-color 0.2s, box-shadow 0.2s;
+    background: transparent;
+    transition: border-color 0.2s, color 0.2s, background 0.2s;
+    white-space: nowrap;
   }
-  .persp-card:hover {
-    border-left-color: hsl(var(--ph, 200), 65%, 45%);
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.05);
-  }
-  .persp-card-head {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-  }
-  .persp-name {
-    font-weight: 600;
-    font-size: 0.95rem;
+  .persp-tab:hover {
+    border-color: hsl(var(--ph, 200), 55%, 55%);
     color: hsl(var(--ph, 200), 45%, 32%);
+    background: hsl(var(--ph, 200), 55%, 96%);
+    text-decoration: none;
   }
-  [data-theme="dark"] .persp-name {
-    color: hsl(var(--ph, 200), 65%, 72%);
-  }
-  .persp-summary {
-    font-size: 0.82rem;
-    color: var(--pico-muted-color);
-    margin: 0;
-    line-height: 1.4;
-  }
-  .persp-leader {
-    font-size: 0.78rem;
-    margin: 0.2rem 0 0;
-    display: flex;
-    flex-direction: column;
-    gap: 0.1rem;
-  }
-  .persp-leader-label {
-    font-size: 0.65rem;
-    text-transform: uppercase;
-    letter-spacing: 0.07em;
-    color: var(--pico-muted-color);
-  }
-  .persp-leader-title {
-    color: var(--pico-color);
-    font-size: 0.8rem;
+  .persp-tab-all {
     font-weight: 500;
+    color: var(--pico-color);
+    border-color: var(--pico-color);
   }
-  .persp-view-all {
-    margin-top: 0.5rem;
-    font-size: 0.88rem;
+  .persp-tab-all:hover {
+    background: var(--pico-card-sectioning-background-color);
+    color: var(--pico-color);
+    border-color: var(--pico-color);
+  }
+  [data-theme="dark"] .persp-tab:hover {
+    color: hsl(var(--ph, 200), 65%, 72%);
+    background: hsl(var(--ph, 200), 30%, 15%);
   }
 
   /* Recent battles (light cards) -------------------------------- */
@@ -934,17 +892,18 @@ function snapshotDelta(key: string): number | null {
     if (toggleBtn.dataset.hasListener) return;
     toggleBtn.dataset.hasListener = "true";
 
-    // Read initial state from URL
+    // Technical view is the default. URL param "view=standard" switches to simplified.
     const urlParams = new URLSearchParams(window.location.search);
-    const isTechnical = urlParams.get("view") === "technical";
-    if (isTechnical) {
-      table.dataset.view = "technical";
+    const isStandard = urlParams.get("view") === "standard";
+    if (isStandard) {
+      table.dataset.view = "standard";
       toggleBtn.classList.add("active");
     }
 
     toggleBtn.addEventListener("click", () => {
-      const current = table.dataset.view === "technical";
+      const current = table.dataset.view === "standard";
       if (current) {
+        // Switch back to technical (default)
         delete table.dataset.view;
         toggleBtn.classList.remove("active");
         const params = new URLSearchParams(window.location.search);
@@ -955,10 +914,11 @@ function snapshotDelta(key: string): number | null {
           window.location.hash;
         history.replaceState(null, "", newUrl);
       } else {
-        table.dataset.view = "technical";
+        // Switch to standard (simplified)
+        table.dataset.view = "standard";
         toggleBtn.classList.add("active");
         const params = new URLSearchParams(window.location.search);
-        params.set("view", "technical");
+        params.set("view", "standard");
         history.replaceState(null, "", window.location.pathname + "?" + params.toString() + window.location.hash);
       }
     });

--- a/src/generated/ranking-snapshot.json
+++ b/src/generated/ranking-snapshot.json
@@ -1,397 +1,397 @@
 {
   "_meta": {
-    "generatedAt": "2026-06-13T05:06:47.638Z",
+    "generatedAt": "2026-06-13T14:36:47.772Z",
     "basis": "build",
-    "totalDuels": 2029
+    "totalDuels": 669
   },
   "keys": {
-    "pontifex-research": {
+    "music-trinta-de-abril": {
       "rank": 1,
-      "ordinal": 18.0197
+      "ordinal": 10.6499
     },
-    "music-beatriz": {
+    "pontifex-research": {
       "rank": 2,
-      "ordinal": 16.6456
-    },
-    "music-spring-loading": {
-      "rank": 3,
-      "ordinal": 15.7878
+      "ordinal": 10.3277
     },
     "delphi-imperatives": {
+      "rank": 3,
+      "ordinal": 9.8385
+    },
+    "conservation-law": {
       "rank": 4,
-      "ordinal": 15.6927
+      "ordinal": 8.3206
     },
-    "music-observer-error-moving-window-iv": {
+    "pierre-menard": {
       "rank": 5,
-      "ordinal": 13.8644
+      "ordinal": 8.3179
     },
-    "music-john-gospel-chapter-i-by-max-headroom": {
+    "future-father": {
       "rank": 6,
-      "ordinal": 13.4365
+      "ordinal": 8.0682
     },
-    "asterisk-protects": {
+    "intelligible-void": {
       "rank": 7,
-      "ordinal": 12.7635
+      "ordinal": 8.0353
     },
-    "serpents-egg": {
+    "family-memory": {
       "rank": 8,
-      "ordinal": 12.5002
+      "ordinal": 7.9805
     },
-    "music-sinal-que-se-cumpre-moving-window-ix": {
+    "three-hammers": {
       "rank": 9,
-      "ordinal": 12.1466
+      "ordinal": 7.5508
     },
-    "music-borges-and-the-hyperobject-at-the-end-of-time": {
+    "crossing-interference": {
       "rank": 10,
-      "ordinal": 12.0603
+      "ordinal": 7.4549
     },
-    "music-meditacao-guiada-no-sertao": {
+    "music-crystallizing-from-the-nothing": {
       "rank": 11,
-      "ordinal": 11.8212
+      "ordinal": 7.4421
     },
     "reddit-submarine-osint": {
       "rank": 12,
-      "ordinal": 11.7364
-    },
-    "music-crystallizing-from-the-nothing": {
-      "rank": 13,
-      "ordinal": 11.6591
-    },
-    "music-o-telefone-da-agonia": {
-      "rank": 14,
-      "ordinal": 11.2953
-    },
-    "music-sobre-o-rigor-na-ciencia": {
-      "rank": 15,
-      "ordinal": 11.2933
-    },
-    "music-eu-ia-escrever-sobre-o-infinito-de-novo": {
-      "rank": 16,
-      "ordinal": 11.0459
-    },
-    "third-half-fourth-wall": {
-      "rank": 17,
-      "ordinal": 10.7333
-    },
-    "music-clipes": {
-      "rank": 18,
-      "ordinal": 10.6784
-    },
-    "pierre-menard": {
-      "rank": 19,
-      "ordinal": 10.632
-    },
-    "music-bibliotecario-do-infinito": {
-      "rank": 20,
-      "ordinal": 10.4399
-    },
-    "music-the-ruliad-is-laughing": {
-      "rank": 21,
-      "ordinal": 10.2877
-    },
-    "agent-no-verbs": {
-      "rank": 22,
-      "ordinal": 9.899
-    },
-    "music-reality-maintenance-moving-window-xii": {
-      "rank": 23,
-      "ordinal": 9.4574
-    },
-    "conservation-law": {
-      "rank": 24,
-      "ordinal": 9.4094
+      "ordinal": 7.2988
     },
     "music-quando-vier-a-primavera": {
-      "rank": 25,
-      "ordinal": 9.3931
-    },
-    "future-father": {
-      "rank": 26,
-      "ordinal": 9.3123
-    },
-    "music-chegue-irmao-chegue-irma": {
-      "rank": 27,
-      "ordinal": 9.0297
-    },
-    "music-the-time": {
-      "rank": 28,
-      "ordinal": 8.9994
-    },
-    "music-escherian-sunrise-with-godel": {
-      "rank": 29,
-      "ordinal": 8.7276
-    },
-    "music-46336b97-4306-41bc-8a7b-48f0ebebbd29": {
-      "rank": 30,
-      "ordinal": 8.6591
-    },
-    "music-666": {
-      "rank": 31,
-      "ordinal": 8.6343
-    },
-    "its-raining-truth": {
-      "rank": 32,
-      "ordinal": 8.6185
-    },
-    "music-o-ritual-de-abril-anos-de-saudade": {
-      "rank": 33,
-      "ordinal": 8.536
-    },
-    "music-o-aleph": {
-      "rank": 34,
-      "ordinal": 8.4128
-    },
-    "music-trinta-de-abril": {
-      "rank": 35,
-      "ordinal": 8.1418
-    },
-    "intelligible-void": {
-      "rank": 36,
-      "ordinal": 8.0353
-    },
-    "three-hammers": {
-      "rank": 37,
-      "ordinal": 7.8
-    },
-    "crossing-interference": {
-      "rank": 38,
-      "ordinal": 7.7118
-    },
-    "rosencrantz-coin": {
-      "rank": 39,
-      "ordinal": 7.6402
-    },
-    "music-o-preco-da-saudade": {
-      "rank": 40,
-      "ordinal": 7.4885
-    },
-    "music-a-primeira-mudanca": {
-      "rank": 41,
-      "ordinal": 7.4211
-    },
-    "music-f73c60f0-49af-45fd-a483-1d35a676dccc": {
-      "rank": 42,
-      "ordinal": 7.3915
-    },
-    "music-nonada": {
-      "rank": 43,
-      "ordinal": 7.2932
-    },
-    "music-uma-so-cancao": {
-      "rank": 44,
-      "ordinal": 7.2895
-    },
-    "music-paperclip-rhapsody": {
-      "rank": 45,
-      "ordinal": 7.1381
-    },
-    "funes-soul": {
-      "rank": 46,
-      "ordinal": 6.9353
-    },
-    "music-o-magico-e-o-fogo": {
-      "rank": 47,
-      "ordinal": 6.8288
-    },
-    "music-fourteen-words": {
-      "rank": 48,
-      "ordinal": 6.8122
-    },
-    "music-o-prologo": {
-      "rank": 49,
-      "ordinal": 6.7912
-    },
-    "music-leite-no-salao-bar": {
-      "rank": 50,
-      "ordinal": 6.6955
-    },
-    "music-borges-e-eu": {
-      "rank": 51,
-      "ordinal": 6.4576
-    },
-    "delegating-to-agents": {
-      "rank": 52,
-      "ordinal": 6.2609
-    },
-    "family-memory": {
-      "rank": 53,
-      "ordinal": 6.1679
-    },
-    "building-funes": {
-      "rank": 54,
-      "ordinal": 6.156
-    },
-    "verne-identity-repo": {
-      "rank": 55,
-      "ordinal": 6.0651
-    },
-    "music-caminho": {
-      "rank": 56,
-      "ordinal": 5.9184
-    },
-    "music-entre-rascunho-e-apagar": {
-      "rank": 57,
-      "ordinal": 5.8245
-    },
-    "two-questions-out-loud": {
-      "rank": 58,
-      "ordinal": 5.737
-    },
-    "music-two-cursors": {
-      "rank": 59,
-      "ordinal": 5.6443
-    },
-    "social-vulnerabilities": {
-      "rank": 60,
-      "ordinal": 5.6232
-    },
-    "conceptual-document": {
-      "rank": 61,
-      "ordinal": 5.5281
-    },
-    "music-sentido-e-referencia": {
-      "rank": 62,
-      "ordinal": 5.0395
-    },
-    "music-o-verso-branquiceleste": {
-      "rank": 63,
-      "ordinal": 4.9018
-    },
-    "music-borges-and-me": {
-      "rank": 64,
-      "ordinal": 4.8726
-    },
-    "jules-api-harness": {
-      "rank": 65,
-      "ordinal": 4.8401
-    },
-    "music-espelhos": {
-      "rank": 66,
-      "ordinal": 4.7437
-    },
-    "music-xadrez": {
-      "rank": 67,
-      "ordinal": 4.5984
-    },
-    "music-particles": {
-      "rank": 68,
-      "ordinal": 4.5565
-    },
-    "music-menino-que-voce-foi": {
-      "rank": 69,
-      "ordinal": 4.0954
-    },
-    "census-not-sample": {
-      "rank": 70,
-      "ordinal": 4.0397
-    },
-    "music-mindfulness": {
-      "rank": 71,
-      "ordinal": 3.9027
-    },
-    "music-the-third-song-moving-window-iii": {
-      "rank": 72,
-      "ordinal": 3.5052
-    },
-    "music-be-me-borges": {
-      "rank": 73,
-      "ordinal": 3.3607
-    },
-    "music-vos": {
-      "rank": 74,
-      "ordinal": 3.1961
-    },
-    "music-o-tempo": {
-      "rank": 75,
-      "ordinal": 2.5805
-    },
-    "music-dd332f75-6052-4f9e-bccd-fb0303731d6e": {
-      "rank": 76,
-      "ordinal": 2.5467
-    },
-    "music-o-medo-do-louco": {
-      "rank": 77,
-      "ordinal": 2.3812
-    },
-    "pontifex-guide": {
-      "rank": 78,
-      "ordinal": 2.2176
-    },
-    "travessia-project": {
-      "rank": 79,
-      "ordinal": 1.8313
+      "rank": 13,
+      "ordinal": 7.1819
     },
     "music-pattern-over-stuff": {
-      "rank": 80,
-      "ordinal": 1.4527
+      "rank": 14,
+      "ordinal": 6.8954
     },
-    "music-sussurros-binarios": {
-      "rank": 81,
-      "ordinal": 1.4515
+    "third-half-fourth-wall": {
+      "rank": 15,
+      "ordinal": 6.8903
+    },
+    "music-john-gospel-chapter-i-by-max-headroom": {
+      "rank": 16,
+      "ordinal": 6.8621
+    },
+    "two-questions-out-loud": {
+      "rank": 17,
+      "ordinal": 6.6186
+    },
+    "music-eu-ia-escrever-sobre-o-infinito-de-novo": {
+      "rank": 18,
+      "ordinal": 6.4843
+    },
+    "serpents-egg": {
+      "rank": 19,
+      "ordinal": 5.9154
+    },
+    "music-spring-loading": {
+      "rank": 20,
+      "ordinal": 5.7519
+    },
+    "verne-identity-repo": {
+      "rank": 21,
+      "ordinal": 5.3529
+    },
+    "music-borges-and-me": {
+      "rank": 22,
+      "ordinal": 5.1651
+    },
+    "music-666": {
+      "rank": 23,
+      "ordinal": 5.1123
+    },
+    "delegating-to-agents": {
+      "rank": 24,
+      "ordinal": 5.0009
+    },
+    "its-raining-truth": {
+      "rank": 25,
+      "ordinal": 4.9931
+    },
+    "music-nonada": {
+      "rank": 26,
+      "ordinal": 4.9111
+    },
+    "agent-no-verbs": {
+      "rank": 27,
+      "ordinal": 4.8228
+    },
+    "music-46336b97-4306-41bc-8a7b-48f0ebebbd29": {
+      "rank": 28,
+      "ordinal": 4.5792
+    },
+    "music-beatriz": {
+      "rank": 29,
+      "ordinal": 4.5327
+    },
+    "social-vulnerabilities": {
+      "rank": 30,
+      "ordinal": 4.4597
+    },
+    "music-reality-maintenance-moving-window-xii": {
+      "rank": 31,
+      "ordinal": 4.3707
+    },
+    "music-a-primeira-mudanca": {
+      "rank": 32,
+      "ordinal": 4.2915
+    },
+    "asterisk-protects": {
+      "rank": 33,
+      "ordinal": 4.206
+    },
+    "music-fourteen-words": {
+      "rank": 34,
+      "ordinal": 4.1711
+    },
+    "music-sobre-o-rigor-na-ciencia": {
+      "rank": 35,
+      "ordinal": 4.1366
+    },
+    "census-not-sample": {
+      "rank": 36,
+      "ordinal": 4.0397
+    },
+    "music-be-me-borges": {
+      "rank": 37,
+      "ordinal": 3.9682
+    },
+    "music-o-ritual-de-abril-anos-de-saudade": {
+      "rank": 38,
+      "ordinal": 3.8648
+    },
+    "conceptual-document": {
+      "rank": 39,
+      "ordinal": 3.8103
+    },
+    "music-o-aleph": {
+      "rank": 40,
+      "ordinal": 3.7515
+    },
+    "funes-soul": {
+      "rank": 41,
+      "ordinal": 3.644
+    },
+    "music-sentido-e-referencia": {
+      "rank": 42,
+      "ordinal": 3.4737
+    },
+    "music-the-ruliad-is-laughing": {
+      "rank": 43,
+      "ordinal": 3.1934
+    },
+    "music-o-tempo": {
+      "rank": 44,
+      "ordinal": 3.167
+    },
+    "music-o-preco-da-saudade": {
+      "rank": 45,
+      "ordinal": 3.0718
+    },
+    "music-meditacao-guiada-no-sertao": {
+      "rank": 46,
+      "ordinal": 2.8939
+    },
+    "music-particles": {
+      "rank": 47,
+      "ordinal": 2.7387
+    },
+    "music-o-prologo": {
+      "rank": 48,
+      "ordinal": 2.6913
+    },
+    "jules-api-harness": {
+      "rank": 49,
+      "ordinal": 2.5939
+    },
+    "music-vos": {
+      "rank": 50,
+      "ordinal": 2.4831
     },
     "music-riobaldo-e-o-aleph": {
-      "rank": 82,
-      "ordinal": 1.4099
+      "rank": 51,
+      "ordinal": 2.4151
     },
-    "music-prayer-to-the-unfinished-moving-window-v": {
-      "rank": 83,
-      "ordinal": 1.241
+    "music-o-magico-e-o-fogo": {
+      "rank": 52,
+      "ordinal": 2.3189
     },
-    "music-belief-engine-labyrinth-song-moving-window-viii": {
-      "rank": 84,
-      "ordinal": 0.6115
-    },
-    "music-primavera-carregando": {
-      "rank": 85,
-      "ordinal": 0.5691
-    },
-    "music-stopping-by-woods-on-a-snowy-evening-by-robert-frost": {
-      "rank": 86,
-      "ordinal": 0.4474
-    },
-    "music-veu-do-infinito": {
-      "rank": 87,
-      "ordinal": -0.0784
-    },
-    "music-o-regral": {
-      "rank": 88,
-      "ordinal": -0.1062
-    },
-    "music-universal-threshold": {
-      "rank": 89,
-      "ordinal": -0.4568
-    },
-    "becoming-lobsters": {
-      "rank": 90,
-      "ordinal": -0.6417
-    },
-    "inaugural-post": {
-      "rank": 91,
-      "ordinal": -0.7009
+    "music-o-telefone-da-agonia": {
+      "rank": 53,
+      "ordinal": 2.0679
     },
     "music-f85fb538-6f59-4751-8629-da76665fc91e": {
-      "rank": 92,
-      "ordinal": -0.8167
+      "rank": 54,
+      "ordinal": 1.9335
+    },
+    "music-caminho": {
+      "rank": 55,
+      "ordinal": 1.9067
+    },
+    "music-espelhos": {
+      "rank": 56,
+      "ordinal": 1.6893
+    },
+    "reclaiming-harness": {
+      "rank": 57,
+      "ordinal": 1.6396
+    },
+    "music-xadrez": {
+      "rank": 58,
+      "ordinal": 1.5933
+    },
+    "rosencrantz-coin": {
+      "rank": 59,
+      "ordinal": 1.5921
+    },
+    "music-chegue-irmao-chegue-irma": {
+      "rank": 60,
+      "ordinal": 1.5367
+    },
+    "music-escherian-sunrise-with-godel": {
+      "rank": 61,
+      "ordinal": 1.5132
+    },
+    "music-two-cursors": {
+      "rank": 62,
+      "ordinal": 1.2643
+    },
+    "music-primavera-carregando": {
+      "rank": 63,
+      "ordinal": 1.2619
+    },
+    "pontifex-guide": {
+      "rank": 64,
+      "ordinal": 1.1745
+    },
+    "music-entre-rascunho-e-apagar": {
+      "rank": 65,
+      "ordinal": 1.0994
+    },
+    "music-belief-engine-labyrinth-song-moving-window-viii": {
+      "rank": 66,
+      "ordinal": 0.9252
     },
     "music-151474c5-1420-4cc1-9ab5-80721f4459ed": {
+      "rank": 67,
+      "ordinal": 0.7922
+    },
+    "music-veu-do-infinito": {
+      "rank": 68,
+      "ordinal": 0.7839
+    },
+    "music-the-third-song-moving-window-iii": {
+      "rank": 69,
+      "ordinal": 0.7674
+    },
+    "music-observer-error-moving-window-iv": {
+      "rank": 70,
+      "ordinal": 0.7671
+    },
+    "music-borges-and-the-hyperobject-at-the-end-of-time": {
+      "rank": 71,
+      "ordinal": 0.7088
+    },
+    "music-borges-e-eu": {
+      "rank": 72,
+      "ordinal": 0.6752
+    },
+    "music-o-medo-do-louco": {
+      "rank": 73,
+      "ordinal": 0.6016
+    },
+    "music-sinal-que-se-cumpre-moving-window-ix": {
+      "rank": 74,
+      "ordinal": 0.5552
+    },
+    "music-paperclip-rhapsody": {
+      "rank": 75,
+      "ordinal": 0.5083
+    },
+    "music-leite-no-salao-bar": {
+      "rank": 76,
+      "ordinal": 0.4296
+    },
+    "music-dd332f75-6052-4f9e-bccd-fb0303731d6e": {
+      "rank": 77,
+      "ordinal": 0.2668
+    },
+    "music-f73c60f0-49af-45fd-a483-1d35a676dccc": {
+      "rank": 78,
+      "ordinal": 0.1946
+    },
+    "music-uma-so-cancao": {
+      "rank": 79,
+      "ordinal": -0.1273
+    },
+    "music-o-verso-branquiceleste": {
+      "rank": 80,
+      "ordinal": -0.1902
+    },
+    "inaugural-post": {
+      "rank": 81,
+      "ordinal": -0.4861
+    },
+    "building-funes": {
+      "rank": 82,
+      "ordinal": -0.7922
+    },
+    "music-bibliotecario-do-infinito": {
+      "rank": 83,
+      "ordinal": -1.1821
+    },
+    "music-o-regral": {
+      "rank": 84,
+      "ordinal": -1.2211
+    },
+    "travessia-project": {
+      "rank": 85,
+      "ordinal": -1.2596
+    },
+    "music-clipes": {
+      "rank": 86,
+      "ordinal": -1.3496
+    },
+    "becoming-lobsters": {
+      "rank": 87,
+      "ordinal": -1.402
+    },
+    "music-the-time": {
+      "rank": 88,
+      "ordinal": -1.4524
+    },
+    "music-o-sonhador-e-o-fogo": {
+      "rank": 89,
+      "ordinal": -1.6132
+    },
+    "music-mindfulness": {
+      "rank": 90,
+      "ordinal": -1.683
+    },
+    "music-prayer-to-the-unfinished-moving-window-v": {
+      "rank": 91,
+      "ordinal": -1.8003
+    },
+    "music-stopping-by-woods-on-a-snowy-evening-by-robert-frost": {
+      "rank": 92,
+      "ordinal": -1.9318
+    },
+    "music-universal-threshold": {
       "rank": 93,
-      "ordinal": -2.1303
+      "ordinal": -2.0167
     },
     "pampa-circuit": {
       "rank": 94,
-      "ordinal": -2.9314
+      "ordinal": -2.9115
     },
-    "music-o-sonhador-e-o-fogo": {
+    "music-menino-que-voce-foi": {
       "rank": 95,
-      "ordinal": -3.6233
+      "ordinal": -3.4633
     },
-    "reclaiming-harness": {
+    "music-sussurros-binarios": {
       "rank": 96,
-      "ordinal": -4.8467
+      "ordinal": -3.5864
     },
     "everything-is-process": {
       "rank": 97,
-      "ordinal": -5.615
+      "ordinal": -5.0993
     }
   }
 }


### PR DESCRIPTION
## Mudanças

### `RankingView.astro` — UX do ranking

**Technical view como padrão**
- Antes: tabela mostrava só `#`, `POST`, `WIN%`, `Δ`, `CONFIDENCE` por default
- Depois: `ORDINAL`, `μ`, `σ`, `W/N` visíveis por default — o botão agora troca para "Standard view"
- URL param muda de `?view=technical` para `?view=standard`

**Perspectivas como tabs no topo**
- Remove a grade de cards de perspectivas do fundo da página
- Adiciona barra compacta de pills/tabs logo antes da tabela de ranking
- Tab "All" leva ao ranking geral; cada perspectiva leva a `/ranking/perspectives/<id>/`

### `.github/hronir-session-prompt.md` + `CLAUDE.md` — Docs

- Jules usa `--content-mode path-only` por default (sessões longas, compressão de contexto)
- Instrução explícita sobre duelos de versão: Post A = selecionada, Post B = desafiante
- `CLAUDE.md` documenta `--content-mode inline|path-only`

### `docs/rfcs/0007-ranking-ui-e-ux-de-leitura.md` — RFC 0007 r2

Revisão r2 adiciona **Fase 6: Elo como pontuação complementar**:
- Especificação do cálculo: K=32, start=1000, ordem cronológica por `run_at`, duelos de versão por `post_a.version`
- Persistência: campo `elo` + `eloPeak` no `ranking-snapshot.json` como schema `snapshot-v2`
- Apresentação: coluna na visão técnica com cor relativa a 1000 e tooltip de delta; ordenação continua por ordinal (OpenSkill); linha de Elo com pico no dossiê da Fase 4
- Sparkline de duas linhas (ordinal + Elo normalizado) opcional vinculada à Fase 4

## Motivação

UX review da página `/ranking/`: technical view deveria ser o default para o público do blog; perspectivas como filter tabs no topo melhoram descoberta. Docs fecham o ciclo do dogfooding (PR #514, #515). RFC 0007 r2 adiciona Elo como pontuação complementar legível ao lado do OpenSkill.