### PR TITLE
feat(ranking): RFC 0007 Fase 2 — anchors de deep-link nos cards de batalha

### DIFF
--- a/src/pages/ranking/battles/[id].astro
+++ b/src/pages/ranking/battles/[id].astro
@@ -21,7 +21,8 @@ export async function getStaticPaths() {
   const PER_PAGE = 20;
   return duels.map((duel, i) => {
     const archivePage = Math.floor(i / PER_PAGE) + 1;
-    const archiveHref = archivePage === 1 ? "/ranking/battles/" : `/ranking/battles/page/${archivePage}/`;
+    const archiveBase = archivePage === 1 ? "/ranking/battles/" : `/ranking/battles/page/${archivePage}/`;
+    const archiveHref = `${archiveBase}#${duel.id}`;
     return {
       params: { id: duel.id },
       props: {

--- a/src/pages/ranking/battles/index.astro
+++ b/src/pages/ranking/battles/index.astro
@@ -124,6 +124,7 @@ const agents = [...new Set(allDuels.map((d) => d.agentId).filter(Boolean) as str
       const searchString = [winnerName, loserName, d.perspectiveId ?? "", d.agentId ?? "", d.criterion ?? ""].join(" ").toLowerCase();
       return (
         <article
+          id={d.id}
           class="battle-card"
           data-confidence={d.confidence || "none"}
           data-season={d.season !== undefined ? String(d.season) : "none"}

--- a/src/pages/ranking/battles/page/[n].astro
+++ b/src/pages/ranking/battles/page/[n].astro
@@ -136,6 +136,7 @@ const agents = [...new Set(duels.map((d) => d.agentId).filter(Boolean) as string
       const searchString = [winnerName, loserName, d.perspectiveId ?? "", d.agentId ?? "", d.criterion ?? ""].join(" ").toLowerCase();
       return (
         <article
+          id={d.id}
           class="battle-card"
           data-confidence={d.confidence || "none"}
           data-season={d.season !== undefined ? String(d.season) : "none"}


### PR DESCRIPTION
## Summary

Phase 2 of RFC 0007 — URL state for the battles archive.

Filter query params (`?q`, `?season`, `?agent`, `?confidence`, `?perspective`) were already implemented in Phase 1. This PR adds the remaining piece:

- **Card anchors**: each `<article class="battle-card">` now has `id={d.id}` (the 8-char SHA-256 hash), enabling deep-links like `/ranking/battles/#a3f7c91b`
- **"Back to archive" anchor**: `archiveHref` in `[id].astro` now includes `#${duel.id}`, so clicking "Back to archive" from a battle detail page scrolls directly to that card in the archive

Files changed: `battles/index.astro`, `battles/page/[n].astro`, `battles/[id].astro`

## Test plan

- [ ] `/ranking/battles/#<some-id>` scrolls to the correct battle card
- [ ] From a battle detail page, "Back to archive" returns to the archive page and scrolls to the right card
- [ ] Filter query params still work (inherited from Phase 1)
- [ ] Build passes, doctor clean, prettier clean

https://claude.ai/code/session_012N7Qd813svgGwTAzrvmuvn

---
_Generated by [Claude Code](https://claude.ai/code/session_012N7Qd813svgGwTAzrvmuvn)_