### PR TITLE
feat(music): RFC 0011 — taxonomia de gêneros (sunoStyle + genre limpo)

### DIFF
--- a/docs/rfcs/0011-genre-taxonomy-musicas.md
+++ b/docs/rfcs/0011-genre-taxonomy-musicas.md
@@ -1,0 +1,247 @@
+# RFC 0011 — Taxonomia de gêneros musicais: separar estilo Suno de label de filtro
+
+|                 |                                                                                                                                         |
+| --------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| **Status**      | Proposta (r1)                                                                                                                           |
+| **Autor**       | Franklin Baldo (proposta assistida)                                                                                                     |
+| **Criado em**   | 2026-06-13                                                                                                                              |
+| **Branch / PR** | `claude/modest-euler-27ofmr` / #525                                                                                                     |
+| **Depende de**  | RFC 0008 (music player UX — `genre` field introduzido)                                                                                  |
+| **Afeta**       | `src/content.config.ts`, `src/content/blog/**` (280 posts de música), `src/pages/pt/musicas.astro`, `src/pages/music.astro`, `scripts/` |
+
+> Mesmo padrão das RFCs anteriores: primeiro o documento, depois a
+> implementação faseada, cada fase verde antes da próxima.
+> Merge com merge commit, nunca squash.
+
+---
+
+## Histórico de revisões
+
+| Data       | Mudança         |
+| ---------- | --------------- |
+| 2026-06-13 | Versão inicial. |
+
+---
+
+## 1. Resumo
+
+O campo `genre` nos posts de música (`postType: music`) foi criado para
+alimentar os chips de filtro na página `/pt/musicas/`. Na prática, o campo
+foi preenchido com os **prompts de estilo do Suno** — descrições longas e
+detalhadas como `"Genre: Atmospheric Indie Folk/Electronic. Tempo: 72 BPM.
+Mood: Introspective"` — em vez de labels curtos e canônicos como `["folk",
+"indie"]`.
+
+O resultado verificado em build (`/verify https://franklinbaldo.github.io/pt/musicas/`):
+**307 chips de gênero com texto de parágrafo inteiro**, completamente
+inutilizáveis como filtro.
+
+Esta RFC define:
+
+1. Um campo separado `sunoStyle` para preservar a descrição longa do Suno.
+2. Um campo `genre` restrito a labels curtos de uma taxonomia curada.
+3. Migração dos 280 posts existentes.
+4. Validação no schema e no `hronir:doctor`.
+5. Gating de UI na página de músicas.
+
+---
+
+## 2. Diagnóstico
+
+### D1. Campo `genre` preenchido com prompts Suno
+
+O `content.config.ts` define `genre` como `z.array(z.string()).optional()`
+— sem limite de comprimento. Quem populou os posts copiou o campo
+`metadata.tags` da API Suno ou o bloco de estilo do prompt, gerando entradas
+com 50–300 caracteres cada.
+
+Exemplo real (`veu-do-infinito`):
+
+```yaml
+genre:
+  - "Genre: Atmospheric Indie Folk/Electronic. Tempo: 72 BPM. Mood: Introspective"
+  - cosmic
+  - melancholic—ethereal synth layers
+  - subtle piano arpeggios
+  - tango-infused strings
+  - >-
+    fractal echoes in percussion. Borges-inspired narration: spoken-word
+    verses blending poetic recitation with soft vocals
+```
+
+### D2. Número de chips gerados
+
+O build atual produz **307 botões de gênero** na página `/pt/musicas/`
+(um por valor único de `genre` em todos os 280 posts). A UI é inutilizável:
+
+- Cada botão exibe o texto completo do prompt, quebrando a linha.
+- 307 botões = scroll infinito só para ver os filtros.
+- Filtrar por `"fractal echoes in percussion"` não tem semântica.
+
+### D3. Dados úteis estão misturados com lixo
+
+Alguns valores curtos já existem (`"acoustic"`, `"cosmic"`, `"folk"`) e são
+aproveitáveis. A limpeza não exige reescrever do zero — exige separar o
+sinal do ruído.
+
+### D4. Sem validação de comprimento no schema
+
+`z.array(z.string())` aceita strings de qualquer tamanho. Nada impede que o
+campo seja repreenchido com prompts longos no futuro.
+
+---
+
+## 3. Solução proposta
+
+### 3.1 Dois campos com responsabilidades distintas
+
+| Campo       | Tipo                      | Propósito                                         | Max por item |
+| ----------- | ------------------------- | ------------------------------------------------- | ------------ |
+| `genre`     | `string[]` (curado)       | Labels de filtro UI — curtos, canônicos, PT ou EN | 40 chars     |
+| `sunoStyle` | `string` (opcional, free) | Descrição longa de estilo/prompt para referência  | ilimitado    |
+
+`sunoStyle` é um campo de texto livre (pode ser multiline YAML), preservado
+para documentação e futuras funcionalidades (e.g. regeneração no Suno).
+Não é exposto na UI de filtro.
+
+### 3.2 Taxonomia canônica de gêneros
+
+Lista fechada de ~30 labels. Novos gêneros só entram por atualização desta
+RFC. Labels em PT por padrão; inglês quando o gênero não tem equivalente
+estabelecido em PT.
+
+**Gêneros brasileiros:**
+`forró`, `baião`, `sertanejo`, `samba`, `bossa nova`, `MPB`, `axé`,
+`funk carioca`, `pagode`, `tropicália`, `choro`, `maracatu`, `cateretê`,
+`moda de viola`, `capoeira`
+
+**Gêneros internacionais / fusão:**
+`folk`, `indie`, `rock`, `pop`, `hip-hop`, `jazz`, `eletrônico`,
+`ambient`, `clássico`, `experimental`, `spoken word`, `glitch`,
+`art pop`, `soul`
+
+**Labels descritivos permitidos (transversais):**
+`instrumental`, `acústico`, `ao vivo`, `trilha sonora`
+
+> A lista pode ser ampliada em revisões futuras desta RFC. O schema não
+> valida contra uma enum fixa (para não bloquear CI em extensões futuras),
+> mas o `hronir:doctor` avisa sobre labels fora da taxonomia.
+
+### 3.3 Regras de validação
+
+No `content.config.ts`:
+
+```ts
+genre: z
+  .array(
+    z.string().max(40, "genre label deve ter no máximo 40 caracteres")
+  )
+  .max(5, "máximo 5 gêneros por post")
+  .optional(),
+
+sunoStyle: z.string().optional(),
+```
+
+No `hronir:doctor` (warning, não erro):
+
+- Avisa se algum label de `genre` contém dois pontos, ponto-e-vírgula ou
+  vírgula (sinal de prompt colado).
+- Avisa se algum label tem mais de 40 chars.
+- Avisa se `genre` tem mais de 5 itens.
+
+### 3.4 UI: gating dos chips
+
+Em `musicas.astro` e `music.astro`, os chips só são renderizados quando:
+
+```ts
+const showGenreChips =
+  allGenres.length >= 2 &&
+  allGenres.length <= 25 &&
+  allGenres.every((g) => g.length <= 40);
+```
+
+Se o gating falhar (e.g. dados corrompidos em produção), a galeria aparece
+sem filtro — sem crash, sem chips quebrados.
+
+---
+
+## 4. Migração dos posts existentes
+
+### Escopo
+
+- **280 posts** com `postType: music` têm o campo `genre`.
+- A migração aplica as regras: extrair labels curtos existentes, mover
+  todo o resto para `sunoStyle`, preencher `genre` com 1–5 labels da
+  taxonomia baseados no conteúdo do post (título, letra, contexto).
+
+### Critério de atribuição de gêneros
+
+Para cada post, ler: título, `sunoStyle` (o prompt migrado), letra e
+contexto. Atribuir 1–3 labels da taxonomia que melhor descrevem o som.
+Não é necessário cobrir todos os aspectos — um `["folk", "experimental"]`
+é suficiente; não é um dicionário.
+
+### Script de migração
+
+Um script `scripts/migrate-genre.mjs` faz a passagem nos posts:
+
+1. Concatena todos os valores atuais de `genre[]` em uma string e salva em
+   `sunoStyle` (concatenada com `\n`).
+2. Apaga `genre`.
+3. Os labels limpos são preenchidos **manualmente** (ou por um agente com
+   acesso ao conteúdo), post a post, após a migração mecânica.
+
+A migração mecânica é separada do preenchimento semântico para garantir que
+nenhum label longo sobreviva.
+
+---
+
+## 5. Fases de implementação
+
+### Fase 0 — Schema + gating de UI (sem migração de conteúdo)
+
+- Atualizar `content.config.ts`: adicionar `sunoStyle`, adicionar `.max(40)`
+  e `.max(5)` no `genre`.
+- Atualizar `musicas.astro` e `music.astro`: adicionar gating `showGenreChips`.
+- Resultado: o build continua funcional; os chips simplesmente não aparecem
+  (falha no gating de comprimento) até a migração ser feita.
+- CI deve ficar verde. `astro check` vai falhar em posts com `genre` > 40
+  chars → isso é esperado e indica o escopo da migração.
+
+### Fase 1 — Script de migração mecânica
+
+- `scripts/migrate-genre.mjs`: lê todos os posts com `postType: music`,
+  move `genre[]` para `sunoStyle` (string), zera `genre: []`.
+- Resultado: todos os posts passam no `astro check` (genre vazio é válido).
+- CI verde. Chips não aparecem (sem dados de genre) — correto.
+
+### Fase 2 — Preenchimento semântico dos gêneros
+
+- Para cada slug de música, ler conteúdo + `sunoStyle` e atribuir 1–5
+  labels da taxonomia.
+- O preenchimento pode ser feito por agente (passando o conteúdo do post)
+  ou manualmente.
+- Recomendação: priorizar os posts com mais plays (campo `play_count` na
+  API Suno) — os mais ouvidos devem ser filtráveis primeiro.
+- Resultado: chips aparecem na UI com labels curtos e semânticos.
+
+### Fase 3 — Validação no doctor
+
+- Adicionar checks ao `hronir:doctor`:
+  - Warning: `genre` com label > 40 chars.
+  - Warning: `genre` com > 5 itens.
+  - Warning: label contém `:`, `;` ou `,` (provável prompt colado).
+- CI não quebra em warning — só em error. Isso evita bloquear PRs de hronir
+  por posts ainda não migrados, se a Fase 2 for incremental.
+
+---
+
+## 6. Questões em aberto
+
+| ID  | Questão                                                                                                       | Decisão proposta                                              |
+| --- | ------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
+| Q1  | A taxonomia deve ser uma enum no schema (CI bloqueia labels fora dela) ou apenas advisory no doctor?          | Advisory no doctor — enum bloqueia extensões legítimas.       |
+| Q2  | `sunoStyle` deve ser um campo `string` ou `string[]`?                                                         | `string` — concatenação facilita leitura no frontmatter.      |
+| Q3  | O preenchimento semântico da Fase 2 é feito por agente (Jules/Claude) ou manualmente?                         | Agente com acesso ao conteúdo do post; revisão humana.        |
+| Q4  | Os chips devem aparecer nas páginas de post individuais (`/pt/blog/[slug]/`) ou só na galeria `/pt/musicas/`? | Só na galeria — posts individuais não têm contexto de filtro. |
+| Q5  | Após a Fase 2, a taxonomia deve ser publicada em `/pt/musicas/#generos` como índice navegável?                | Futuro — fora do escopo desta RFC.                            |

--- a/scripts/migrate-genre.mjs
+++ b/scripts/migrate-genre.mjs
@@ -1,0 +1,125 @@
+#!/usr/bin/env node
+/**
+ * RFC 0011 Fase 1 — migração mecânica de genre → sunoStyle
+ *
+ * Para cada post com postType: music:
+ *   1. Concatena os valores de genre[] em uma string e salva em sunoStyle
+ *   2. Remove o campo genre (ou deixa vazio para preenchimento semântico)
+ *
+ * Usage: node scripts/migrate-genre.mjs [--dry-run]
+ */
+
+import { readFileSync, writeFileSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+const DRY_RUN = process.argv.includes("--dry-run");
+
+function walkDir(dir) {
+  const results = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) results.push(...walkDir(full));
+    else if (full.endsWith(".md") || full.endsWith(".mdx")) results.push(full);
+  }
+  return results;
+}
+
+/**
+ * Parse raw YAML frontmatter for the fields we care about.
+ * Returns { sunoStyle, genreLines } where genreLines is the raw
+ * multi-line YAML block for `genre:` (or null if absent).
+ */
+function extractGenreBlock(fm) {
+  // Match the genre: block (list items, possibly multiline scalars)
+  const match = fm.match(/^(genre:\n(?:(?:  [^\n]*)\n)*)/m);
+  if (!match) return null;
+
+  const block = match[1];
+  // Extract each list item value (handles quoted and plain scalars)
+  const items = [];
+  let current = null;
+  for (const line of block.split("\n")) {
+    const itemMatch = line.match(/^  - (.+)$/);
+    const contMatch = line.match(/^    (.+)$/);
+    if (itemMatch) {
+      if (current !== null) items.push(current);
+      current = itemMatch[1].replace(/^["']|["']$/g, "").trim();
+    } else if (contMatch && current !== null) {
+      current += " " + contMatch[1].trim();
+    }
+  }
+  if (current !== null) items.push(current);
+
+  return { block, items };
+}
+
+const files = walkDir("src/content/blog");
+let migrated = 0;
+let skipped = 0;
+
+for (const file of files) {
+  const raw = readFileSync(file, "utf-8");
+
+  // Only music posts
+  if (!raw.includes("postType") || !raw.includes("music")) {
+    skipped++;
+    continue;
+  }
+
+  // Split into frontmatter + body
+  const fmMatch = raw.match(/^---\n([\s\S]*?)\n---(\n[\s\S]*)?$/);
+  if (!fmMatch) {
+    skipped++;
+    continue;
+  }
+
+  let fm = fmMatch[1];
+  const body = fmMatch[2] ?? "";
+
+  // Skip if genre already cleared
+  if (!fm.includes("genre:")) {
+    skipped++;
+    continue;
+  }
+
+  // Skip if sunoStyle already set (already migrated)
+  if (fm.includes("sunoStyle:")) {
+    skipped++;
+    continue;
+  }
+
+  const extracted = extractGenreBlock(fm);
+  if (!extracted) {
+    skipped++;
+    continue;
+  }
+
+  const { block, items } = extracted;
+  const sunoStyle = items.join("\n");
+
+  // Build new frontmatter:
+  // 1. Replace genre block with empty genre: []
+  // 2. Add sunoStyle before the genre line
+  let newFm = fm.replace(block, "");
+  // Insert sunoStyle + empty genre before the first blank-line group or at end
+  const sunoYaml = `sunoStyle: |-\n${sunoStyle
+    .split("\n")
+    .map((l) => `  ${l}`)
+    .join("\n")}\ngenre: []\n`;
+
+  // Append at end of frontmatter (before closing ---)
+  newFm = newFm.trimEnd() + "\n" + sunoYaml;
+
+  const newContent = `---\n${newFm}\n---${body}`;
+
+  if (DRY_RUN) {
+    console.log(`[dry] ${file}: ${items.length} genre items → sunoStyle`);
+  } else {
+    writeFileSync(file, newContent, "utf-8");
+  }
+  migrated++;
+}
+
+console.log(
+  `Migrated: ${migrated}, Skipped: ${skipped}${DRY_RUN ? " (dry run)" : ""}`
+);

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -71,8 +71,14 @@ const postSchema = ({ image }: SchemaContext) =>
     postType: z.literal("music").optional(),
     /** Suno song UUID — used to load audio in the global player. */
     sunoId: z.string().optional(),
-    /** Music genres/styles for display. */
-    genre: z.array(z.string()).optional(),
+    /** RFC 0011: short canonical genre labels (max 40 chars, max 5 items).
+     *  Use sunoStyle for the full Suno prompt description. */
+    genre: z
+      .array(z.string().max(40, "genre label deve ter no máximo 40 caracteres"))
+      .max(5, "máximo 5 gêneros por post")
+      .optional(),
+    /** RFC 0011: full Suno style/prompt description, free-form text. */
+    sunoStyle: z.string().optional(),
     /** Song duration in seconds. */
     duration: z.number().optional(),
     /** Album art URL from the Suno API (stored at stub-generation time). */

--- a/src/content/blog/151474c5-1420-4cc1-9ab5-80721f4459ed-en/v-2026-06-09T20-24-29.mdx
+++ b/src/content/blog/151474c5-1420-4cc1-9ab5-80721f4459ed-en/v-2026-06-09T20-24-29.mdx
@@ -5,13 +5,6 @@ date: 2025-02-13T00:00:00.000Z
 postType: music
 sunoId: 151474c5-1420-4cc1-9ab5-80721f4459ed
 sunoImageUrl: "https://cdn2.suno.ai/image_151474c5-1420-4cc1-9ab5-80721f4459ed.jpeg"
-genre:
-  - harpa
-  - sintetizador
-  - jazz
-  - bossa-nova
-  - groove
-  - hipnótico
 duration: 240
 tags:
   - music
@@ -28,6 +21,16 @@ previousVersion:
     arquiteto/amanuense dentro do _Events All the Way Down_, e recupera a imagem
     da flauta como osso oco — exata antes da inflação verbal que a segue.
 draftCreatedAt: "2026-06-12T12:06:06.428Z"
+sunoStyle: |-
+  harpa
+  sintetizador
+  jazz
+  bossa-nova
+  groove
+  hipnótico
+genre:
+  - jazz
+  - bossa nova
 ---
 
 ## Lyrics

--- a/src/content/blog/151474c5-1420-4cc1-9ab5-80721f4459ed-en/v-2026-06-12T08-00-12-612.mdx
+++ b/src/content/blog/151474c5-1420-4cc1-9ab5-80721f4459ed-en/v-2026-06-12T08-00-12-612.mdx
@@ -5,13 +5,6 @@ date: 2025-02-13T00:00:00.000Z
 postType: music
 sunoId: 151474c5-1420-4cc1-9ab5-80721f4459ed
 sunoImageUrl: "https://cdn2.suno.ai/image_151474c5-1420-4cc1-9ab5-80721f4459ed.jpeg"
-genre:
-  - harpa
-  - sintetizador
-  - jazz
-  - bossa-nova
-  - groove
-  - hipnótico
 duration: 240
 tags:
   - music
@@ -31,6 +24,16 @@ supersedes: 42eab5c3-d688-52a8-8488-2a9a01982473
 draftCreatedAt: "2026-06-12T08:00:12.613Z"
 draftMsg: Auto-edit worst post
 draftCommittedAt: "2026-06-12T08:02:09.621Z"
+sunoStyle: |-
+  harpa
+  sintetizador
+  jazz
+  bossa-nova
+  groove
+  hipnótico
+genre:
+  - jazz
+  - bossa nova
 ---
 
 ## Lyrics

--- a/src/content/blog/151474c5-1420-4cc1-9ab5-80721f4459ed/v-2026-06-09T20-24-29.mdx
+++ b/src/content/blog/151474c5-1420-4cc1-9ab5-80721f4459ed/v-2026-06-09T20-24-29.mdx
@@ -5,13 +5,6 @@ date: 2025-02-13T00:00:00.000Z
 postType: music
 sunoId: 151474c5-1420-4cc1-9ab5-80721f4459ed
 sunoImageUrl: "https://cdn2.suno.ai/image_151474c5-1420-4cc1-9ab5-80721f4459ed.jpeg"
-genre:
-  - harpa
-  - sintetizador
-  - jazz
-  - bossa-nova
-  - groove
-  - hipnótico
 duration: 240
 tags:
   - música
@@ -28,6 +21,16 @@ previousVersion:
     arquiteto/amanuense dentro do _Events All the Way Down_, e recupera a imagem
     da flauta como osso oco — exata antes da inflação verbal que a segue.
 draftCreatedAt: "2026-06-12T12:06:06.428Z"
+sunoStyle: |-
+  harpa
+  sintetizador
+  jazz
+  bossa-nova
+  groove
+  hipnótico
+genre:
+  - jazz
+  - bossa nova
 ---
 
 ## Letra

--- a/src/content/blog/151474c5-1420-4cc1-9ab5-80721f4459ed/v-2026-06-12T08-00-12-612.mdx
+++ b/src/content/blog/151474c5-1420-4cc1-9ab5-80721f4459ed/v-2026-06-12T08-00-12-612.mdx
@@ -5,13 +5,6 @@ date: 2025-02-13T00:00:00.000Z
 postType: music
 sunoId: 151474c5-1420-4cc1-9ab5-80721f4459ed
 sunoImageUrl: "https://cdn2.suno.ai/image_151474c5-1420-4cc1-9ab5-80721f4459ed.jpeg"
-genre:
-  - harpa
-  - sintetizador
-  - jazz
-  - bossa-nova
-  - groove
-  - hipnótico
 duration: 240
 tags:
   - música
@@ -31,6 +24,16 @@ supersedes: d11c938f-def6-51ed-9f91-1ce7bbc7a317
 draftCreatedAt: "2026-06-12T08:00:12.613Z"
 draftMsg: Auto-edit worst post
 draftCommittedAt: "2026-06-12T08:02:09.621Z"
+sunoStyle: |-
+  harpa
+  sintetizador
+  jazz
+  bossa-nova
+  groove
+  hipnótico
+genre:
+  - jazz
+  - bossa nova
 ---
 
 ## Letra

--- a/src/content/blog/46336b97-4306-41bc-8a7b-48f0ebebbd29-en/v-2026-06-09T20-24-29.mdx
+++ b/src/content/blog/46336b97-4306-41bc-8a7b-48f0ebebbd29-en/v-2026-06-09T20-24-29.mdx
@@ -5,19 +5,22 @@ date: 2025-01-27
 postType: music
 sunoId: 46336b97-4306-41bc-8a7b-48f0ebebbd29
 sunoImageUrl: "https://cdn2.suno.ai/image_46336b97-4306-41bc-8a7b-48f0ebebbd29.jpeg"
-genre:
-  - Raw
-  - whiskey-soaked vocals
-  - clawhammer banjo
-  - sawtooth fiddle
-  - and stomping percussion. Melodies tilt dark/Appalachian
-  - with lyrics reframed as industrial decay metaphors.
 duration: 152
 tags:
   - music
 lang: en
 translationKey: music-46336b97-4306-41bc-8a7b-48f0ebebbd29
 draftCreatedAt: "2026-06-12T12:06:06.428Z"
+sunoStyle: |-
+  Raw
+  whiskey-soaked vocals
+  clawhammer banjo
+  sawtooth fiddle
+  and stomping percussion. Melodies tilt dark/Appalachian
+  with lyrics reframed as industrial decay metaphors.
+genre:
+  - folk
+  - experimental
 ---
 
 ## Lyrics

--- a/src/content/blog/46336b97-4306-41bc-8a7b-48f0ebebbd29/v-2026-06-09T20-24-29.mdx
+++ b/src/content/blog/46336b97-4306-41bc-8a7b-48f0ebebbd29/v-2026-06-09T20-24-29.mdx
@@ -5,19 +5,22 @@ date: 2025-01-27
 postType: music
 sunoId: 46336b97-4306-41bc-8a7b-48f0ebebbd29
 sunoImageUrl: "https://cdn2.suno.ai/image_46336b97-4306-41bc-8a7b-48f0ebebbd29.jpeg"
-genre:
-  - Raw
-  - whiskey-soaked vocals
-  - clawhammer banjo
-  - sawtooth fiddle
-  - and stomping percussion. Melodies tilt dark/Appalachian
-  - with lyrics reframed as industrial decay metaphors.
 duration: 152
 tags:
   - música
 lang: pt
 translationKey: music-46336b97-4306-41bc-8a7b-48f0ebebbd29
 draftCreatedAt: "2026-06-12T12:06:06.428Z"
+sunoStyle: |-
+  Raw
+  whiskey-soaked vocals
+  clawhammer banjo
+  sawtooth fiddle
+  and stomping percussion. Melodies tilt dark/Appalachian
+  with lyrics reframed as industrial decay metaphors.
+genre:
+  - folk
+  - experimental
 ---
 
 ## Letra

--- a/src/content/blog/666-en/v-2026-06-09T20-24-29.mdx
+++ b/src/content/blog/666-en/v-2026-06-09T20-24-29.mdx
@@ -5,18 +5,21 @@ date: 2025-10-04
 postType: music
 sunoId: 19b27f1b-a7df-4bd8-9a21-03789977cf13
 sunoImageUrl: "https://cdn2.suno.ai/image_19b27f1b-a7df-4bd8-9a21-03789977cf13.jpeg"
-genre:
-  - A capoeira berimbau motif grounds the song
-  - layered with Brazilian Portuguese vocals. Ambient strings float above
-  - creating an ethereal atmosphere. Clock-tick percussion accents verses
-  - while futuristic electronic textures intertwine for a hypnotic
-  - time-warped soundscape.
 duration: 70
 tags:
   - music
 lang: en
 translationKey: music-666
 draftCreatedAt: "2026-06-12T12:06:06.428Z"
+sunoStyle: |-
+  A capoeira berimbau motif grounds the song
+  layered with Brazilian Portuguese vocals. Ambient strings float above
+  creating an ethereal atmosphere. Clock-tick percussion accents verses
+  while futuristic electronic textures intertwine for a hypnotic
+  time-warped soundscape.
+genre:
+  - capoeira
+  - ambient
 ---
 
 ## Lyrics

--- a/src/content/blog/666/v-2026-06-09T20-24-29.mdx
+++ b/src/content/blog/666/v-2026-06-09T20-24-29.mdx
@@ -5,18 +5,21 @@ date: 2025-10-04
 postType: music
 sunoId: 19b27f1b-a7df-4bd8-9a21-03789977cf13
 sunoImageUrl: "https://cdn2.suno.ai/image_19b27f1b-a7df-4bd8-9a21-03789977cf13.jpeg"
-genre:
-  - A capoeira berimbau motif grounds the song
-  - layered with Brazilian Portuguese vocals. Ambient strings float above
-  - creating an ethereal atmosphere. Clock-tick percussion accents verses
-  - while futuristic electronic textures intertwine for a hypnotic
-  - time-warped soundscape.
 duration: 70
 tags:
   - música
 lang: pt
 translationKey: music-666
 draftCreatedAt: "2026-06-12T12:06:06.428Z"
+sunoStyle: |-
+  A capoeira berimbau motif grounds the song
+  layered with Brazilian Portuguese vocals. Ambient strings float above
+  creating an ethereal atmosphere. Clock-tick percussion accents verses
+  while futuristic electronic textures intertwine for a hypnotic
+  time-warped soundscape.
+genre:
+  - capoeira
+  - ambient
 ---
 
 ## Letra

--- a/src/content/blog/a-primeira-mudanca-en/v-2026-06-09T20-24-29.mdx
+++ b/src/content/blog/a-primeira-mudanca-en/v-2026-06-09T20-24-29.mdx
@@ -5,17 +5,20 @@ date: 2025-11-22
 postType: music
 sunoId: 319e0bfa-aa9d-42b7-95e7-4c047340e3f8
 sunoImageUrl: "https://cdn2.suno.ai/image_319e0bfa-aa9d-42b7-95e7-4c047340e3f8.jpeg"
-genre:
-  - Slow tempo sets a meditative tone with viola caipira fingerpicking
-  - backed by sparse acoustic guitar. The arrangement is intimate
-  - letting deep male vocals take center stage. Occasional minor key chord changes and gentle percussive brushwork evoke melancholic
-  - existential folk moods.
 duration: 195
 tags:
   - music
 lang: en
 translationKey: music-a-primeira-mudanca
 draftCreatedAt: "2026-06-12T12:06:06.428Z"
+sunoStyle: |-
+  Slow tempo sets a meditative tone with viola caipira fingerpicking
+  backed by sparse acoustic guitar. The arrangement is intimate
+  letting deep male vocals take center stage. Occasional minor key chord changes and gentle percussive brushwork evoke melancholic
+  existential folk moods.
+genre:
+  - moda de viola
+  - acústico
 ---
 
 ## Lyrics

--- a/src/content/blog/a-primeira-mudanca/v-2026-06-09T20-24-29.mdx
+++ b/src/content/blog/a-primeira-mudanca/v-2026-06-09T20-24-29.mdx
@@ -5,17 +5,20 @@ date: 2025-11-22
 postType: music
 sunoId: 319e0bfa-aa9d-42b7-95e7-4c047340e3f8
 sunoImageUrl: "https://cdn2.suno.ai/image_319e0bfa-aa9d-42b7-95e7-4c047340e3f8.jpeg"
-genre:
-  - Slow tempo sets a meditative tone with viola caipira fingerpicking
-  - backed by sparse acoustic guitar. The arrangement is intimate
-  - letting deep male vocals take center stage. Occasional minor key chord changes and gentle percussive brushwork evoke melancholic
-  - existential folk moods.
 duration: 195
 tags:
   - música
 lang: pt
 translationKey: music-a-primeira-mudanca
 draftCreatedAt: "2026-06-12T12:06:06.428Z"
+sunoStyle: |-
+  Slow tempo sets a meditative tone with viola caipira fingerpicking
+  backed by sparse acoustic guitar. The arrangement is intimate
+  letting deep male vocals take center stage. Occasional minor key chord changes and gentle percussive brushwork evoke melancholic
+  existential folk moods.
+genre:
+  - moda de viola
+  - acústico
 ---
 
 ## Letra

--- a/src/content/blog/be-me-borges-en/v-2026-06-09T20-24-29.mdx
+++ b/src/content/blog/be-me-borges-en/v-2026-06-09T20-24-29.mdx
@@ -5,19 +5,22 @@ date: 2025-10-02
 postType: music
 sunoId: ec1a31a1-9a9b-4065-98f1-f548188766ce
 sunoImageUrl: "https://cdn2.suno.ai/cbabe5de-e193-4bf2-b4d8-ca32407cfd49.jpeg"
-genre:
-  - This track should feel like Borges trapped inside a Gen Z meme. Imagine a lo-fi indie spoken-word song where greentext poetry becomes lyrics. The vocal delivery is intimate
-  - half-whispered
-  - like someone confessing late at night on Discord. Sparse guitars and ambient pads drift in the background
-  - with bandoneon touches evoking Buenos Aires. The mood mixes existential melancholy with ironic detachment
-  - like a Wojak meme turned into music — sad
-  - self-aware
 duration: 188
 tags:
   - music
 lang: en
 translationKey: music-be-me-borges
 draftCreatedAt: "2026-06-12T12:06:06.428Z"
+sunoStyle: |-
+  This track should feel like Borges trapped inside a Gen Z meme. Imagine a lo-fi indie spoken-word song where greentext poetry becomes lyrics. The vocal delivery is intimate
+  half-whispered
+  like someone confessing late at night on Discord. Sparse guitars and ambient pads drift in the background
+  with bandoneon touches evoking Buenos Aires. The mood mixes existential melancholy with ironic detachment
+  like a Wojak meme turned into music — sad
+  self-aware
+genre:
+  - indie
+  - spoken word
 ---
 
 ## Lyrics

--- a/src/content/blog/be-me-borges-en/v-2026-06-12T03-26-27-255.mdx
+++ b/src/content/blog/be-me-borges-en/v-2026-06-12T03-26-27-255.mdx
@@ -5,20 +5,6 @@ date: 2025-10-02T00:00:00.000Z
 postType: music
 sunoId: ec1a31a1-9a9b-4065-98f1-f548188766ce
 sunoImageUrl: "https://cdn2.suno.ai/cbabe5de-e193-4bf2-b4d8-ca32407cfd49.jpeg"
-genre:
-  - >-
-    This track should feel like Borges trapped inside a Gen Z meme. Imagine a
-    lo-fi indie spoken-word song where greentext poetry becomes lyrics. The
-    vocal delivery is intimate
-  - half-whispered
-  - >-
-    like someone confessing late at night on Discord. Sparse guitars and ambient
-    pads drift in the background
-  - >-
-    with bandoneon touches evoking Buenos Aires. The mood mixes existential
-    melancholy with ironic detachment
-  - like a Wojak meme turned into music — sad
-  - self-aware
 duration: 188
 tags:
   - music
@@ -30,6 +16,16 @@ draftMsg: >-
   Substituted literal AI tool name with technical-narrative description to
   better align with the blog's tone.
 draftCommittedAt: "2026-06-12T03:26:46.906Z"
+sunoStyle: |-
+  >- This track should feel like Borges trapped inside a Gen Z meme. Imagine a lo-fi indie spoken-word song where greentext poetry becomes lyrics. The vocal delivery is intimate
+  half-whispered
+  >- like someone confessing late at night on Discord. Sparse guitars and ambient pads drift in the background
+  >- with bandoneon touches evoking Buenos Aires. The mood mixes existential melancholy with ironic detachment
+  like a Wojak meme turned into music — sad
+  self-aware
+genre:
+  - indie
+  - spoken word
 ---
 
 ## Lyrics

--- a/src/content/blog/be-me-borges/v-2026-06-09T20-24-29.mdx
+++ b/src/content/blog/be-me-borges/v-2026-06-09T20-24-29.mdx
@@ -5,19 +5,22 @@ date: 2025-10-02
 postType: music
 sunoId: ec1a31a1-9a9b-4065-98f1-f548188766ce
 sunoImageUrl: "https://cdn2.suno.ai/cbabe5de-e193-4bf2-b4d8-ca32407cfd49.jpeg"
-genre:
-  - This track should feel like Borges trapped inside a Gen Z meme. Imagine a lo-fi indie spoken-word song where greentext poetry becomes lyrics. The vocal delivery is intimate
-  - half-whispered
-  - like someone confessing late at night on Discord. Sparse guitars and ambient pads drift in the background
-  - with bandoneon touches evoking Buenos Aires. The mood mixes existential melancholy with ironic detachment
-  - like a Wojak meme turned into music — sad
-  - self-aware
 duration: 188
 tags:
   - música
 lang: pt
 translationKey: music-be-me-borges
 draftCreatedAt: "2026-06-12T12:06:06.428Z"
+sunoStyle: |-
+  This track should feel like Borges trapped inside a Gen Z meme. Imagine a lo-fi indie spoken-word song where greentext poetry becomes lyrics. The vocal delivery is intimate
+  half-whispered
+  like someone confessing late at night on Discord. Sparse guitars and ambient pads drift in the background
+  with bandoneon touches evoking Buenos Aires. The mood mixes existential melancholy with ironic detachment
+  like a Wojak meme turned into music — sad
+  self-aware
+genre:
+  - indie
+  - spoken word
 ---
 
 ## Letra

--- a/src/content/blog/be-me-borges/v-2026-06-12T03-26-27-255.mdx
+++ b/src/content/blog/be-me-borges/v-2026-06-12T03-26-27-255.mdx
@@ -5,20 +5,6 @@ date: 2025-10-02T00:00:00.000Z
 postType: music
 sunoId: ec1a31a1-9a9b-4065-98f1-f548188766ce
 sunoImageUrl: "https://cdn2.suno.ai/cbabe5de-e193-4bf2-b4d8-ca32407cfd49.jpeg"
-genre:
-  - >-
-    This track should feel like Borges trapped inside a Gen Z meme. Imagine a
-    lo-fi indie spoken-word song where greentext poetry becomes lyrics. The
-    vocal delivery is intimate
-  - half-whispered
-  - >-
-    like someone confessing late at night on Discord. Sparse guitars and ambient
-    pads drift in the background
-  - >-
-    with bandoneon touches evoking Buenos Aires. The mood mixes existential
-    melancholy with ironic detachment
-  - like a Wojak meme turned into music — sad
-  - self-aware
 duration: 188
 tags:
   - música
@@ -30,6 +16,16 @@ draftMsg: >-
   Substituted literal AI tool name with technical-narrative description to
   better align with the blog's tone.
 draftCommittedAt: "2026-06-12T03:26:46.906Z"
+sunoStyle: |-
+  >- This track should feel like Borges trapped inside a Gen Z meme. Imagine a lo-fi indie spoken-word song where greentext poetry becomes lyrics. The vocal delivery is intimate
+  half-whispered
+  >- like someone confessing late at night on Discord. Sparse guitars and ambient pads drift in the background
+  >- with bandoneon touches evoking Buenos Aires. The mood mixes existential melancholy with ironic detachment
+  like a Wojak meme turned into music — sad
+  self-aware
+genre:
+  - indie
+  - spoken word
 ---
 
 ## Letra

--- a/src/content/blog/beatriz-en/v-2026-06-09T20-24-29.mdx
+++ b/src/content/blog/beatriz-en/v-2026-06-09T20-24-29.mdx
@@ -5,18 +5,21 @@ date: 2025-10-01
 postType: music
 sunoId: 5544186d-fdd9-4672-9fd6-fa664bf7a1b2
 sunoImageUrl: "https://cdn2.suno.ai/image_5544186d-fdd9-4672-9fd6-fa664bf7a1b2.jpeg"
-genre:
-  - The phonk track opens with raw trap drums and a roaring
-  - distorted bass rolling beneath. Hypnotic pads weave through chopped
-  - extreme-pitch vocals—Montagem Bandido-inspired hooks slicing the mix. Rapid-fire edits
-  - swirling FX
-  - and brutal percussive stabs inject relentless energy throughout. vocal almost indescritible
 duration: 134
 tags:
   - music
 lang: en
 translationKey: music-beatriz
 draftCreatedAt: "2026-06-12T12:06:06.428Z"
+sunoStyle: |-
+  The phonk track opens with raw trap drums and a roaring
+  distorted bass rolling beneath. Hypnotic pads weave through chopped
+  extreme-pitch vocals—Montagem Bandido-inspired hooks slicing the mix. Rapid-fire edits
+  swirling FX
+  and brutal percussive stabs inject relentless energy throughout. vocal almost indescritible
+genre:
+  - hip-hop
+  - experimental
 ---
 
 ## Lyrics

--- a/src/content/blog/beatriz/v-2026-06-09T20-24-29.mdx
+++ b/src/content/blog/beatriz/v-2026-06-09T20-24-29.mdx
@@ -5,18 +5,21 @@ date: 2025-10-01
 postType: music
 sunoId: 5544186d-fdd9-4672-9fd6-fa664bf7a1b2
 sunoImageUrl: "https://cdn2.suno.ai/image_5544186d-fdd9-4672-9fd6-fa664bf7a1b2.jpeg"
-genre:
-  - The phonk track opens with raw trap drums and a roaring
-  - distorted bass rolling beneath. Hypnotic pads weave through chopped
-  - extreme-pitch vocals—Montagem Bandido-inspired hooks slicing the mix. Rapid-fire edits
-  - swirling FX
-  - and brutal percussive stabs inject relentless energy throughout. vocal almost indescritible
 duration: 134
 tags:
   - música
 lang: pt
 translationKey: music-beatriz
 draftCreatedAt: "2026-06-12T12:06:06.428Z"
+sunoStyle: |-
+  The phonk track opens with raw trap drums and a roaring
+  distorted bass rolling beneath. Hypnotic pads weave through chopped
+  extreme-pitch vocals—Montagem Bandido-inspired hooks slicing the mix. Rapid-fire edits
+  swirling FX
+  and brutal percussive stabs inject relentless energy throughout. vocal almost indescritible
+genre:
+  - hip-hop
+  - experimental
 ---
 
 ## Letra

--- a/src/content/blog/belief-engine-labyrinth-song-moving-window-viii-en/v-2026-06-09T20-24-29.mdx
+++ b/src/content/blog/belief-engine-labyrinth-song-moving-window-viii-en/v-2026-06-09T20-24-29.mdx
@@ -5,19 +5,22 @@ date: 2026-01-12
 postType: music
 sunoId: aba1210b-2abd-4fea-8656-cfade577ed25
 sunoImageUrl: "https://cdn2.suno.ai/image_aba1210b-2abd-4fea-8656-cfade577ed25.jpeg"
-genre:
-  - Dark modern bluegrass / gothic folk string-band. Fast-ish train groove (~160 BPM feel)
-  - kick-like stomp
-  - handclaps
-  - and a driving upright bass. Prominent banjo rolls
-  - sharp acoustic guitar strums
-  - fiddle lines that bite
 duration: 297
 tags:
   - music
 lang: en
 translationKey: music-belief-engine-labyrinth-song-moving-window-viii
 draftCreatedAt: "2026-06-12T12:06:06.428Z"
+sunoStyle: |-
+  Dark modern bluegrass / gothic folk string-band. Fast-ish train groove (~160 BPM feel)
+  kick-like stomp
+  handclaps
+  and a driving upright bass. Prominent banjo rolls
+  sharp acoustic guitar strums
+  fiddle lines that bite
+genre:
+  - folk
+  - experimental
 ---
 
 ## Lyrics

--- a/src/content/blog/belief-engine-labyrinth-song-moving-window-viii-en/v-2026-06-12T21-30-27-353.mdx
+++ b/src/content/blog/belief-engine-labyrinth-song-moving-window-viii-en/v-2026-06-12T21-30-27-353.mdx
@@ -5,15 +5,6 @@ date: 2026-01-12T00:00:00.000Z
 postType: music
 sunoId: aba1210b-2abd-4fea-8656-cfade577ed25
 sunoImageUrl: "https://cdn2.suno.ai/image_aba1210b-2abd-4fea-8656-cfade577ed25.jpeg"
-genre:
-  - >-
-    Dark modern bluegrass / gothic folk string-band. Fast-ish train groove (~160
-    BPM feel)
-  - kick-like stomp
-  - handclaps
-  - and a driving upright bass. Prominent banjo rolls
-  - sharp acoustic guitar strums
-  - fiddle lines that bite
 duration: 297
 tags:
   - music
@@ -25,6 +16,16 @@ draftMsg: >-
   Added philosophical reflection about architectural error versus narrative
   artifice, elevating the thematic depth regarding the Ruliad.
 draftCommittedAt: "2026-06-12T21:30:56.186Z"
+sunoStyle: |-
+  >- Dark modern bluegrass / gothic folk string-band. Fast-ish train groove (~160 BPM feel)
+  kick-like stomp
+  handclaps
+  and a driving upright bass. Prominent banjo rolls
+  sharp acoustic guitar strums
+  fiddle lines that bite
+genre:
+  - folk
+  - experimental
 ---
 
 ## Lyrics

--- a/src/content/blog/belief-engine-labyrinth-song-moving-window-viii-en/v-2026-06-12T23-29-39-161.mdx
+++ b/src/content/blog/belief-engine-labyrinth-song-moving-window-viii-en/v-2026-06-12T23-29-39-161.mdx
@@ -5,15 +5,6 @@ date: 2026-01-12T00:00:00.000Z
 postType: music
 sunoId: aba1210b-2abd-4fea-8656-cfade577ed25
 sunoImageUrl: "https://cdn2.suno.ai/image_aba1210b-2abd-4fea-8656-cfade577ed25.jpeg"
-genre:
-  - >-
-    Dark modern bluegrass / gothic folk string-band. Fast-ish train groove (~160
-    BPM feel)
-  - kick-like stomp
-  - handclaps
-  - and a driving upright bass. Prominent banjo rolls
-  - sharp acoustic guitar strums
-  - fiddle lines that bite
 duration: 297
 tags:
   - music
@@ -25,6 +16,16 @@ draftMsg: >-
   Expanded final composer notes to replace vague abstraction with concrete
   sensory reflection on the labyrinth metaphor
 draftCommittedAt: "2026-06-12T23:30:19.361Z"
+sunoStyle: |-
+  >- Dark modern bluegrass / gothic folk string-band. Fast-ish train groove (~160 BPM feel)
+  kick-like stomp
+  handclaps
+  and a driving upright bass. Prominent banjo rolls
+  sharp acoustic guitar strums
+  fiddle lines that bite
+genre:
+  - folk
+  - experimental
 ---
 
 ## Lyrics

--- a/src/content/blog/belief-engine-labyrinth-song-moving-window-viii/v-2026-06-09T20-24-29.mdx
+++ b/src/content/blog/belief-engine-labyrinth-song-moving-window-viii/v-2026-06-09T20-24-29.mdx
@@ -5,19 +5,22 @@ date: 2026-01-12
 postType: music
 sunoId: aba1210b-2abd-4fea-8656-cfade577ed25
 sunoImageUrl: "https://cdn2.suno.ai/image_aba1210b-2abd-4fea-8656-cfade577ed25.jpeg"
-genre:
-  - Dark modern bluegrass / gothic folk string-band. Fast-ish train groove (~160 BPM feel)
-  - kick-like stomp
-  - handclaps
-  - and a driving upright bass. Prominent banjo rolls
-  - sharp acoustic guitar strums
-  - fiddle lines that bite
 duration: 297
 tags:
   - música
 lang: pt
 translationKey: music-belief-engine-labyrinth-song-moving-window-viii
 draftCreatedAt: "2026-06-12T12:06:06.428Z"
+sunoStyle: |-
+  Dark modern bluegrass / gothic folk string-band. Fast-ish train groove (~160 BPM feel)
+  kick-like stomp
+  handclaps
+  and a driving upright bass. Prominent banjo rolls
+  sharp acoustic guitar strums
+  fiddle lines that bite
+genre:
+  - folk
+  - experimental
 ---
 
 ## Letra

--- a/src/content/blog/belief-engine-labyrinth-song-moving-window-viii/v-2026-06-12T21-30-27-353.mdx
+++ b/src/content/blog/belief-engine-labyrinth-song-moving-window-viii/v-2026-06-12T21-30-27-353.mdx
@@ -5,15 +5,6 @@ date: 2026-01-12T00:00:00.000Z
 postType: music
 sunoId: aba1210b-2abd-4fea-8656-cfade577ed25
 sunoImageUrl: "https://cdn2.suno.ai/image_aba1210b-2abd-4fea-8656-cfade577ed25.jpeg"
-genre:
-  - >-
-    Dark modern bluegrass / gothic folk string-band. Fast-ish train groove (~160
-    BPM feel)
-  - kick-like stomp
-  - handclaps
-  - and a driving upright bass. Prominent banjo rolls
-  - sharp acoustic guitar strums
-  - fiddle lines that bite
 duration: 297
 tags:
   - música
@@ -25,6 +16,16 @@ draftMsg: >-
   Added philosophical reflection about architectural error versus narrative
   artifice, elevating the thematic depth regarding the Ruliad.
 draftCommittedAt: "2026-06-12T21:30:56.186Z"
+sunoStyle: |-
+  >- Dark modern bluegrass / gothic folk string-band. Fast-ish train groove (~160 BPM feel)
+  kick-like stomp
+  handclaps
+  and a driving upright bass. Prominent banjo rolls
+  sharp acoustic guitar strums
+  fiddle lines that bite
+genre:
+  - folk
+  - experimental
 ---
 
 ## Letra

--- a/src/content/blog/belief-engine-labyrinth-song-moving-window-viii/v-2026-06-12T23-29-39-161.mdx
+++ b/src/content/blog/belief-engine-labyrinth-song-moving-window-viii/v-2026-06-12T23-29-39-161.mdx
@@ -5,15 +5,6 @@ date: 2026-01-12T00:00:00.000Z
 postType: music
 sunoId: aba1210b-2abd-4fea-8656-cfade577ed25
 sunoImageUrl: "https://cdn2.suno.ai/image_aba1210b-2abd-4fea-8656-cfade577ed25.jpeg"
-genre:
-  - >-
-    Dark modern bluegrass / gothic folk string-band. Fast-ish train groove (~160
-    BPM feel)
-  - kick-like stomp
-  - handclaps
-  - and a driving upright bass. Prominent banjo rolls
-  - sharp acoustic guitar strums
-  - fiddle lines that bite
 duration: 297
 tags:
   - música
@@ -25,6 +16,16 @@ draftMsg: >-
   Expanded final composer notes to replace vague abstraction with concrete
   sensory reflection on the labyrinth metaphor
 draftCommittedAt: "2026-06-12T23:30:19.361Z"
+sunoStyle: |-
+  >- Dark modern bluegrass / gothic folk string-band. Fast-ish train groove (~160 BPM feel)
+  kick-like stomp
+  handclaps
+  and a driving upright bass. Prominent banjo rolls
+  sharp acoustic guitar strums
+  fiddle lines that bite
+genre:
+  - folk
+  - experimental
 ---
 
 ## Letra

--- a/src/content/blog/bibliotecario-do-infinito-en/v-2026-06-09T20-24-29.mdx
+++ b/src/content/blog/bibliotecario-do-infinito-en/v-2026-06-09T20-24-29.mdx
@@ -5,19 +5,22 @@ date: 2025-03-12
 postType: music
 sunoId: 1f024fb6-8005-4e8c-a54c-a635d3eb95f3
 sunoImageUrl: "https://cdn2.suno.ai/image_1f024fb6-8005-4e8c-a54c-a635d3eb95f3.jpeg"
-genre:
-  - Progressive rock
-  - Brazilian baião elements
-  - mystical synth layers
-  - philosophical lyrics
-  - distorted electric guitars
-  - complex time signatures
 duration: 239
 tags:
   - music
 lang: en
 translationKey: music-bibliotecario-do-infinito
 draftCreatedAt: "2026-06-12T12:06:06.428Z"
+sunoStyle: |-
+  Progressive rock
+  Brazilian baião elements
+  mystical synth layers
+  philosophical lyrics
+  distorted electric guitars
+  complex time signatures
+genre:
+  - rock
+  - baião
 ---
 
 ## Lyrics

--- a/src/content/blog/bibliotecario-do-infinito/v-2026-06-09T20-24-29.mdx
+++ b/src/content/blog/bibliotecario-do-infinito/v-2026-06-09T20-24-29.mdx
@@ -5,19 +5,22 @@ date: 2025-03-12
 postType: music
 sunoId: 1f024fb6-8005-4e8c-a54c-a635d3eb95f3
 sunoImageUrl: "https://cdn2.suno.ai/image_1f024fb6-8005-4e8c-a54c-a635d3eb95f3.jpeg"
-genre:
-  - Progressive rock
-  - Brazilian baião elements
-  - mystical synth layers
-  - philosophical lyrics
-  - distorted electric guitars
-  - complex time signatures
 duration: 239
 tags:
   - música
 lang: pt
 translationKey: music-bibliotecario-do-infinito
 draftCreatedAt: "2026-06-12T12:06:06.428Z"
+sunoStyle: |-
+  Progressive rock
+  Brazilian baião elements
+  mystical synth layers
+  philosophical lyrics
+  distorted electric guitars
+  complex time signatures
+genre:
+  - rock
+  - baião
 ---
 
 ## Letra

--- a/src/content/blog/borges-and-me-en/v-2026-06-09T20-24-29.mdx
+++ b/src/content/blog/borges-and-me-en/v-2026-06-09T20-24-29.mdx
@@ -5,16 +5,19 @@ date: 2025-10-02
 postType: music
 sunoId: 258664fa-11f6-4b93-8455-bbdd329a0e91
 sunoImageUrl: "https://cdn2.suno.ai/image_258664fa-11f6-4b93-8455-bbdd329a0e91.jpeg"
-genre:
-  - A glitch rap track unfolds with stuttered drum machines and jagged synths
-  - chopped vocal samples darting over syncopated hi-hats and flickering digital textures. Bass pulses snake amid rhythmic glitches. The chorus explodes with warped FX and dense
-  - fractured layering for added intensity.
 duration: 139
 tags:
   - music
 lang: en
 translationKey: music-borges-and-me
 draftCreatedAt: "2026-06-12T12:06:06.428Z"
+sunoStyle: |-
+  A glitch rap track unfolds with stuttered drum machines and jagged synths
+  chopped vocal samples darting over syncopated hi-hats and flickering digital textures. Bass pulses snake amid rhythmic glitches. The chorus explodes with warped FX and dense
+  fractured layering for added intensity.
+genre:
+  - hip-hop
+  - glitch
 ---
 
 ## Lyrics

--- a/src/content/blog/borges-and-me-en/v-2026-06-10T12-11-31.mdx
+++ b/src/content/blog/borges-and-me-en/v-2026-06-10T12-11-31.mdx
@@ -5,13 +5,6 @@ date: 2025-10-02T00:00:00.000Z
 postType: music
 sunoId: 258664fa-11f6-4b93-8455-bbdd329a0e91
 sunoImageUrl: "https://cdn2.suno.ai/image_258664fa-11f6-4b93-8455-bbdd329a0e91.jpeg"
-genre:
-  - A glitch rap track unfolds with stuttered drum machines and jagged synths
-  - >-
-    chopped vocal samples darting over syncopated hi-hats and flickering digital
-    textures. Bass pulses snake amid rhythmic glitches. The chorus explodes with
-    warped FX and dense
-  - fractured layering for added intensity.
 duration: 139
 tags:
   - music
@@ -23,6 +16,13 @@ draftMsg: >-
   Refinada a clareza e removida a ambiguidade performática na conclusão do post
   borges-and-me, fortalecendo a tese sobre glitch e dissociação.
 draftCommittedAt: "2026-06-10T12:15:24.625Z"
+sunoStyle: |-
+  A glitch rap track unfolds with stuttered drum machines and jagged synths
+  >- chopped vocal samples darting over syncopated hi-hats and flickering digital textures. Bass pulses snake amid rhythmic glitches. The chorus explodes with warped FX and dense
+  fractured layering for added intensity.
+genre:
+  - hip-hop
+  - glitch
 ---
 
 ## Lyrics

--- a/src/content/blog/borges-and-me/v-2026-06-09T20-24-29.mdx
+++ b/src/content/blog/borges-and-me/v-2026-06-09T20-24-29.mdx
@@ -5,16 +5,19 @@ date: 2025-10-02
 postType: music
 sunoId: 258664fa-11f6-4b93-8455-bbdd329a0e91
 sunoImageUrl: "https://cdn2.suno.ai/image_258664fa-11f6-4b93-8455-bbdd329a0e91.jpeg"
-genre:
-  - A glitch rap track unfolds with stuttered drum machines and jagged synths
-  - chopped vocal samples darting over syncopated hi-hats and flickering digital textures. Bass pulses snake amid rhythmic glitches. The chorus explodes with warped FX and dense
-  - fractured layering for added intensity.
 duration: 139
 tags:
   - música
 lang: pt
 translationKey: music-borges-and-me
 draftCreatedAt: "2026-06-12T12:06:06.428Z"
+sunoStyle: |-
+  A glitch rap track unfolds with stuttered drum machines and jagged synths
+  chopped vocal samples darting over syncopated hi-hats and flickering digital textures. Bass pulses snake amid rhythmic glitches. The chorus explodes with warped FX and dense
+  fractured layering for added intensity.
+genre:
+  - hip-hop
+  - glitch
 ---
 
 ## Letra

--- a/src/content/blog/borges-and-me/v-2026-06-10T12-11-31.mdx
+++ b/src/content/blog/borges-and-me/v-2026-06-10T12-11-31.mdx
@@ -5,13 +5,6 @@ date: 2025-10-02T00:00:00.000Z
 postType: music
 sunoId: 258664fa-11f6-4b93-8455-bbdd329a0e91
 sunoImageUrl: "https://cdn2.suno.ai/image_258664fa-11f6-4b93-8455-bbdd329a0e91.jpeg"
-genre:
-  - A glitch rap track unfolds with stuttered drum machines and jagged synths
-  - >-
-    chopped vocal samples darting over syncopated hi-hats and flickering digital
-    textures. Bass pulses snake amid rhythmic glitches. The chorus explodes with
-    warped FX and dense
-  - fractured layering for added intensity.
 duration: 139
 tags:
   - música
@@ -23,6 +16,13 @@ draftMsg: >-
   Refinada a clareza e removida a ambiguidade performática na conclusão do post
   borges-and-me, fortalecendo a tese sobre glitch e dissociação.
 draftCommittedAt: "2026-06-10T12:15:24.625Z"
+sunoStyle: |-
+  A glitch rap track unfolds with stuttered drum machines and jagged synths
+  >- chopped vocal samples darting over syncopated hi-hats and flickering digital textures. Bass pulses snake amid rhythmic glitches. The chorus explodes with warped FX and dense
+  fractured layering for added intensity.
+genre:
+  - hip-hop
+  - glitch
 ---
 
 ## Letra

--- a/src/content/blog/borges-and-the-hyperobject-at-the-end-of-time-en/v-2026-06-09T20-24-29.mdx
+++ b/src/content/blog/borges-and-the-hyperobject-at-the-end-of-time-en/v-2026-06-09T20-24-29.mdx
@@ -5,17 +5,20 @@ date: 2025-02-13
 postType: music
 sunoId: 97939798-5649-47eb-96ed-74989aeec55e
 sunoImageUrl: "https://cdn2.suno.ai/image_97939798-5649-47eb-96ed-74989aeec55e.jpeg"
-genre:
-  - theremin like liquid starlight piercing dimensions
-  - tribal drums weaving cosmic heartbeats
-  - "didgeridoo drone humming the universe's deepest dreams"
-  - glitch ambient fracturing reality into digital
 duration: 217
 tags:
   - music
 lang: en
 translationKey: music-borges-and-the-hyperobject-at-the-end-of-time
 draftCreatedAt: "2026-06-12T12:06:06.428Z"
+sunoStyle: |-
+  theremin like liquid starlight piercing dimensions
+  tribal drums weaving cosmic heartbeats
+  didgeridoo drone humming the universe's deepest dreams
+  glitch ambient fracturing reality into digital
+genre:
+  - ambient
+  - experimental
 ---
 
 ## Lyrics

--- a/src/content/blog/borges-and-the-hyperobject-at-the-end-of-time-en/v-2026-06-11T21-34-27-555.mdx
+++ b/src/content/blog/borges-and-the-hyperobject-at-the-end-of-time-en/v-2026-06-11T21-34-27-555.mdx
@@ -5,11 +5,6 @@ date: 2025-02-13T00:00:00.000Z
 postType: music
 sunoId: 97939798-5649-47eb-96ed-74989aeec55e
 sunoImageUrl: "https://cdn2.suno.ai/image_97939798-5649-47eb-96ed-74989aeec55e.jpeg"
-genre:
-  - theremin like liquid starlight piercing dimensions
-  - tribal drums weaving cosmic heartbeats
-  - didgeridoo drone humming the universe's deepest dreams
-  - glitch ambient fracturing reality into digital
 duration: 217
 tags:
   - music
@@ -19,6 +14,14 @@ supersedes: 1ea7ff70-56cc-5a1e-8c15-853c8b93cdd4
 draftCreatedAt: "2026-06-11T21:34:27.555Z"
 draftMsg: Refined conclusion of composer notes to enhance explicit philosophical tension
 draftCommittedAt: "2026-06-11T21:35:47.058Z"
+sunoStyle: |-
+  theremin like liquid starlight piercing dimensions
+  tribal drums weaving cosmic heartbeats
+  didgeridoo drone humming the universe's deepest dreams
+  glitch ambient fracturing reality into digital
+genre:
+  - ambient
+  - experimental
 ---
 
 ## Lyrics

--- a/src/content/blog/borges-and-the-hyperobject-at-the-end-of-time-en/v-2026-06-11T21-38-58-279.mdx
+++ b/src/content/blog/borges-and-the-hyperobject-at-the-end-of-time-en/v-2026-06-11T21-38-58-279.mdx
@@ -5,11 +5,6 @@ date: 2025-02-13T00:00:00.000Z
 postType: music
 sunoId: 97939798-5649-47eb-96ed-74989aeec55e
 sunoImageUrl: "https://cdn2.suno.ai/image_97939798-5649-47eb-96ed-74989aeec55e.jpeg"
-genre:
-  - theremin like liquid starlight piercing dimensions
-  - tribal drums weaving cosmic heartbeats
-  - didgeridoo drone humming the universe's deepest dreams
-  - glitch ambient fracturing reality into digital
 duration: 217
 tags:
   - music
@@ -21,6 +16,14 @@ draftMsg: >-
   Refined phrasing in the composer notes to elevate the stylistic tone toward
   franklin-blog guidelines.
 draftCommittedAt: "2026-06-11T21:39:44.245Z"
+sunoStyle: |-
+  theremin like liquid starlight piercing dimensions
+  tribal drums weaving cosmic heartbeats
+  didgeridoo drone humming the universe's deepest dreams
+  glitch ambient fracturing reality into digital
+genre:
+  - ambient
+  - experimental
 ---
 
 ## Lyrics

--- a/src/content/blog/borges-and-the-hyperobject-at-the-end-of-time-en/v-2026-06-11T23-04-42-460.mdx
+++ b/src/content/blog/borges-and-the-hyperobject-at-the-end-of-time-en/v-2026-06-11T23-04-42-460.mdx
@@ -5,11 +5,6 @@ date: 2025-02-13T00:00:00.000Z
 postType: music
 sunoId: 97939798-5649-47eb-96ed-74989aeec55e
 sunoImageUrl: "https://cdn2.suno.ai/image_97939798-5649-47eb-96ed-74989aeec55e.jpeg"
-genre:
-  - theremin like liquid starlight piercing dimensions
-  - tribal drums weaving cosmic heartbeats
-  - didgeridoo drone humming the universe's deepest dreams
-  - glitch ambient fracturing reality into digital
 duration: 217
 tags:
   - music
@@ -17,6 +12,14 @@ lang: en
 translationKey: music-borges-and-the-hyperobject-at-the-end-of-time
 supersedes: 1ea7ff70-56cc-5a1e-8c15-853c8b93cdd4
 draftCreatedAt: "2026-06-11T23:04:42.461Z"
+sunoStyle: |-
+  theremin like liquid starlight piercing dimensions
+  tribal drums weaving cosmic heartbeats
+  didgeridoo drone humming the universe's deepest dreams
+  glitch ambient fracturing reality into digital
+genre:
+  - ambient
+  - experimental
 ---
 
 ## Lyrics

--- a/src/content/blog/borges-and-the-hyperobject-at-the-end-of-time-en/v-2026-06-12T10-02-15-018.mdx
+++ b/src/content/blog/borges-and-the-hyperobject-at-the-end-of-time-en/v-2026-06-12T10-02-15-018.mdx
@@ -5,11 +5,6 @@ date: 2025-02-13T00:00:00.000Z
 postType: music
 sunoId: 97939798-5649-47eb-96ed-74989aeec55e
 sunoImageUrl: "https://cdn2.suno.ai/image_97939798-5649-47eb-96ed-74989aeec55e.jpeg"
-genre:
-  - theremin like liquid starlight piercing dimensions
-  - tribal drums weaving cosmic heartbeats
-  - didgeridoo drone humming the universe's deepest dreams
-  - glitch ambient fracturing reality into digital
 duration: 217
 tags:
   - music
@@ -21,6 +16,14 @@ draftMsg: >-
   Refine composer notes to deepen the contrast between the AI's chosen
   consolation and the inherent terror of the hyperobject.
 draftCommittedAt: "2026-06-12T10:05:57.417Z"
+sunoStyle: |-
+  theremin like liquid starlight piercing dimensions
+  tribal drums weaving cosmic heartbeats
+  didgeridoo drone humming the universe's deepest dreams
+  glitch ambient fracturing reality into digital
+genre:
+  - ambient
+  - experimental
 ---
 
 ## Lyrics

--- a/src/content/blog/borges-and-the-hyperobject-at-the-end-of-time/v-2026-06-09T20-24-29.mdx
+++ b/src/content/blog/borges-and-the-hyperobject-at-the-end-of-time/v-2026-06-09T20-24-29.mdx
@@ -5,17 +5,20 @@ date: 2025-02-13
 postType: music
 sunoId: 97939798-5649-47eb-96ed-74989aeec55e
 sunoImageUrl: "https://cdn2.suno.ai/image_97939798-5649-47eb-96ed-74989aeec55e.jpeg"
-genre:
-  - theremin like liquid starlight piercing dimensions
-  - tribal drums weaving cosmic heartbeats
-  - "didgeridoo drone humming the universe's deepest dreams"
-  - glitch ambient fracturing reality into digital
 duration: 217
 tags:
   - música
 lang: pt
 translationKey: music-borges-and-the-hyperobject-at-the-end-of-time
 draftCreatedAt: "2026-06-12T12:06:06.428Z"
+sunoStyle: |-
+  theremin like liquid starlight piercing dimensions
+  tribal drums weaving cosmic heartbeats
+  didgeridoo drone humming the universe's deepest dreams
+  glitch ambient fracturing reality into digital
+genre:
+  - ambient
+  - experimental
 ---
 
 ## Letra

--- a/src/content/blog/borges-and-the-hyperobject-at-the-end-of-time/v-2026-06-11T21-34-27-555.mdx
+++ b/src/content/blog/borges-and-the-hyperobject-at-the-end-of-time/v-2026-06-11T21-34-27-555.mdx
@@ -5,11 +5,6 @@ date: 2025-02-13T00:00:00.000Z
 postType: music
 sunoId: 97939798-5649-47eb-96ed-74989aeec55e
 sunoImageUrl: "https://cdn2.suno.ai/image_97939798-5649-47eb-96ed-74989aeec55e.jpeg"
-genre:
-  - theremin like liquid starlight piercing dimensions
-  - tribal drums weaving cosmic heartbeats
-  - didgeridoo drone humming the universe's deepest dreams
-  - glitch ambient fracturing reality into digital
 duration: 217
 tags:
   - música
@@ -19,6 +14,14 @@ supersedes: 0d8e7cf2-eb4e-5778-872c-0dda4de04431
 draftCreatedAt: "2026-06-11T21:34:27.555Z"
 draftMsg: Refined conclusion of composer notes to enhance explicit philosophical tension
 draftCommittedAt: "2026-06-11T21:35:47.058Z"
+sunoStyle: |-
+  theremin like liquid starlight piercing dimensions
+  tribal drums weaving cosmic heartbeats
+  didgeridoo drone humming the universe's deepest dreams
+  glitch ambient fracturing reality into digital
+genre:
+  - ambient
+  - experimental
 ---
 
 ## Letra

--- a/src/content/blog/borges-and-the-hyperobject-at-the-end-of-time/v-2026-06-11T21-38-58-279.mdx
+++ b/src/content/blog/borges-and-the-hyperobject-at-the-end-of-time/v-2026-06-11T21-38-58-279.mdx
@@ -5,11 +5,6 @@ date: 2025-02-13T00:00:00.000Z
 postType: music
 sunoId: 97939798-5649-47eb-96ed-74989aeec55e
 sunoImageUrl: "https://cdn2.suno.ai/image_97939798-5649-47eb-96ed-74989aeec55e.jpeg"
-genre:
-  - theremin like liquid starlight piercing dimensions
-  - tribal drums weaving cosmic heartbeats
-  - didgeridoo drone humming the universe's deepest dreams
-  - glitch ambient fracturing reality into digital
 duration: 217
 tags:
   - música
@@ -21,6 +16,14 @@ draftMsg: >-
   Refined phrasing in the composer notes to elevate the stylistic tone toward
   franklin-blog guidelines.
 draftCommittedAt: "2026-06-11T21:39:44.245Z"
+sunoStyle: |-
+  theremin like liquid starlight piercing dimensions
+  tribal drums weaving cosmic heartbeats
+  didgeridoo drone humming the universe's deepest dreams
+  glitch ambient fracturing reality into digital
+genre:
+  - ambient
+  - experimental
 ---
 
 ## Letra

--- a/src/content/blog/borges-and-the-hyperobject-at-the-end-of-time/v-2026-06-11T23-04-42-460.mdx
+++ b/src/content/blog/borges-and-the-hyperobject-at-the-end-of-time/v-2026-06-11T23-04-42-460.mdx
@@ -5,11 +5,6 @@ date: 2025-02-13T00:00:00.000Z
 postType: music
 sunoId: 97939798-5649-47eb-96ed-74989aeec55e
 sunoImageUrl: "https://cdn2.suno.ai/image_97939798-5649-47eb-96ed-74989aeec55e.jpeg"
-genre:
-  - theremin like liquid starlight piercing dimensions
-  - tribal drums weaving cosmic heartbeats
-  - didgeridoo drone humming the universe's deepest dreams
-  - glitch ambient fracturing reality into digital
 duration: 217
 tags:
   - música
@@ -17,6 +12,14 @@ lang: pt
 translationKey: music-borges-and-the-hyperobject-at-the-end-of-time
 supersedes: 0d8e7cf2-eb4e-5778-872c-0dda4de04431
 draftCreatedAt: "2026-06-11T23:04:42.461Z"
+sunoStyle: |-
+  theremin like liquid starlight piercing dimensions
+  tribal drums weaving cosmic heartbeats
+  didgeridoo drone humming the universe's deepest dreams
+  glitch ambient fracturing reality into digital
+genre:
+  - ambient
+  - experimental
 ---
 
 ## Letra

--- a/src/content/blog/borges-and-the-hyperobject-at-the-end-of-time/v-2026-06-12T10-02-15-018.mdx
+++ b/src/content/blog/borges-and-the-hyperobject-at-the-end-of-time/v-2026-06-12T10-02-15-018.mdx
@@ -5,11 +5,6 @@ date: 2025-02-13T00:00:00.000Z
 postType: music
 sunoId: 97939798-5649-47eb-96ed-74989aeec55e
 sunoImageUrl: "https://cdn2.suno.ai/image_97939798-5649-47eb-96ed-74989aeec55e.jpeg"
-genre:
-  - theremin like liquid starlight piercing dimensions
-  - tribal drums weaving cosmic heartbeats
-  - didgeridoo drone humming the universe's deepest dreams
-  - glitch ambient fracturing reality into digital
 duration: 217
 tags:
   - música
@@ -21,6 +16,14 @@ draftMsg: >-
   Refine composer notes to deepen the contrast between the AI's chosen
   consolation and the inherent terror of the hyperobject.
 draftCommittedAt: "2026-06-12T10:05:57.417Z"
+sunoStyle: |-
+  theremin like liquid starlight piercing dimensions
+  tribal drums weaving cosmic heartbeats
+  didgeridoo drone humming the universe's deepest dreams
+  glitch ambient fracturing reality into digital
+genre:
+  - ambient
+  - experimental
 ---
 
 ## Letra

--- a/src/content/blog/borges-e-eu-en/v-2026-06-09T20-24-29.mdx
+++ b/src/content/blog/borges-e-eu-en/v-2026-06-09T20-24-29.mdx
@@ -5,17 +5,20 @@ date: 2025-10-02
 postType: music
 sunoId: 5ece0aa0-eede-4a7a-a2d2-268e339f695e
 sunoImageUrl: "https://cdn2.suno.ai/image_5ece0aa0-eede-4a7a-a2d2-268e339f695e.jpeg"
-genre:
-  - Spoken-word poetry flows in an Argentine accent over sparse classical guitar
-  - evoking folk roots. Subtle bandoneon phrases underscore key moments. The soundscape is intimate—breathy vocal timbres
-  - soft street ambience
-  - and minimalist percussion frame each poetic section.
 duration: 177
 tags:
   - music
 lang: en
 translationKey: music-borges-e-eu
 draftCreatedAt: "2026-06-12T12:06:06.428Z"
+sunoStyle: |-
+  Spoken-word poetry flows in an Argentine accent over sparse classical guitar
+  evoking folk roots. Subtle bandoneon phrases underscore key moments. The soundscape is intimate—breathy vocal timbres
+  soft street ambience
+  and minimalist percussion frame each poetic section.
+genre:
+  - spoken word
+  - folk
 ---
 
 ## Lyrics

--- a/src/content/blog/borges-e-eu/v-2026-06-09T20-24-29.mdx
+++ b/src/content/blog/borges-e-eu/v-2026-06-09T20-24-29.mdx
@@ -5,17 +5,20 @@ date: 2025-10-02
 postType: music
 sunoId: 5ece0aa0-eede-4a7a-a2d2-268e339f695e
 sunoImageUrl: "https://cdn2.suno.ai/image_5ece0aa0-eede-4a7a-a2d2-268e339f695e.jpeg"
-genre:
-  - Spoken-word poetry flows in an Argentine accent over sparse classical guitar
-  - evoking folk roots. Subtle bandoneon phrases underscore key moments. The soundscape is intimate—breathy vocal timbres
-  - soft street ambience
-  - and minimalist percussion frame each poetic section.
 duration: 177
 tags:
   - música
 lang: pt
 translationKey: music-borges-e-eu
 draftCreatedAt: "2026-06-12T12:06:06.428Z"
+sunoStyle: |-
+  Spoken-word poetry flows in an Argentine accent over sparse classical guitar
+  evoking folk roots. Subtle bandoneon phrases underscore key moments. The soundscape is intimate—breathy vocal timbres
+  soft street ambience
+  and minimalist percussion frame each poetic section.
+genre:
+  - spoken word
+  - folk
 ---
 
 ## Letra

--- a/src/content/blog/caminho-en/v-2026-06-09T20-24-29.mdx
+++ b/src/content/blog/caminho-en/v-2026-06-09T20-24-29.mdx
@@ -5,19 +5,22 @@ date: 2025-09-30
 postType: music
 sunoId: 08335ace-973e-4eb8-a194-79908303d512
 sunoImageUrl: "https://cdn2.suno.ai/image_08335ace-973e-4eb8-a194-79908303d512.jpeg"
-genre:
-  - "A narrative spoken-word track in the vein of Brazilian sertão philosophy: flowing"
-  - "meandering prose with rhythmic cadences like a storyteller's yarn under starry skies. Layers of doubt"
-  - existential musings on mystery vs. illusion
-  - "desire's torment"
-  - and nameless truths. Sparse acoustic guitar
-  - subtle harmonica wails
 duration: 144
 tags:
   - music
 lang: en
 translationKey: music-caminho
 draftCreatedAt: "2026-06-12T12:06:06.428Z"
+sunoStyle: |-
+  A narrative spoken-word track in the vein of Brazilian sertão philosophy: flowing
+  meandering prose with rhythmic cadences like a storyteller's yarn under starry skies. Layers of doubt
+  existential musings on mystery vs. illusion
+  desire's torment
+  and nameless truths. Sparse acoustic guitar
+  subtle harmonica wails
+genre:
+  - spoken word
+  - MPB
 ---
 
 ## Lyrics

--- a/src/content/blog/caminho-en/v-2026-06-12T11-30-56-005.mdx
+++ b/src/content/blog/caminho-en/v-2026-06-12T11-30-56-005.mdx
@@ -5,17 +5,6 @@ date: 2025-09-30T00:00:00.000Z
 postType: music
 sunoId: 08335ace-973e-4eb8-a194-79908303d512
 sunoImageUrl: "https://cdn2.suno.ai/image_08335ace-973e-4eb8-a194-79908303d512.jpeg"
-genre:
-  - >-
-    A narrative spoken-word track in the vein of Brazilian sertão philosophy:
-    flowing
-  - >-
-    meandering prose with rhythmic cadences like a storyteller's yarn under
-    starry skies. Layers of doubt
-  - existential musings on mystery vs. illusion
-  - desire's torment
-  - and nameless truths. Sparse acoustic guitar
-  - subtle harmonica wails
 duration: 144
 tags:
   - music
@@ -25,6 +14,16 @@ supersedes: 41ca7156-ef58-5225-9843-91ad33789169
 draftCreatedAt: "2026-06-12T11:30:56.006Z"
 draftMsg: Automated minor structural edits by Jules
 draftCommittedAt: "2026-06-12T11:31:52.956Z"
+sunoStyle: |-
+  >- A narrative spoken-word track in the vein of Brazilian sertão philosophy: flowing
+  >- meandering prose with rhythmic cadences like a storyteller's yarn under starry skies. Layers of doubt
+  existential musings on mystery vs. illusion
+  desire's torment
+  and nameless truths. Sparse acoustic guitar
+  subtle harmonica wails
+genre:
+  - spoken word
+  - MPB
 ---
 
 ## Lyrics

--- a/src/content/blog/caminho-en/v-2026-06-12T14-37-54-301.mdx
+++ b/src/content/blog/caminho-en/v-2026-06-12T14-37-54-301.mdx
@@ -5,17 +5,6 @@ date: 2025-09-30T00:00:00.000Z
 postType: music
 sunoId: 08335ace-973e-4eb8-a194-79908303d512
 sunoImageUrl: "https://cdn2.suno.ai/image_08335ace-973e-4eb8-a194-79908303d512.jpeg"
-genre:
-  - >-
-    A narrative spoken-word track in the vein of Brazilian sertão philosophy:
-    flowing
-  - >-
-    meandering prose with rhythmic cadences like a storyteller's yarn under
-    starry skies. Layers of doubt
-  - existential musings on mystery vs. illusion
-  - desire's torment
-  - and nameless truths. Sparse acoustic guitar
-  - subtle harmonica wails
 duration: 144
 tags:
   - music
@@ -25,6 +14,16 @@ supersedes: 41ca7156-ef58-5225-9843-91ad33789169
 draftCreatedAt: "2026-06-12T14:37:54.301Z"
 draftMsg: Automated unique edits for hronir
 draftCommittedAt: "2026-06-12T14:38:20.754Z"
+sunoStyle: |-
+  >- A narrative spoken-word track in the vein of Brazilian sertão philosophy: flowing
+  >- meandering prose with rhythmic cadences like a storyteller's yarn under starry skies. Layers of doubt
+  existential musings on mystery vs. illusion
+  desire's torment
+  and nameless truths. Sparse acoustic guitar
+  subtle harmonica wails
+genre:
+  - spoken word
+  - MPB
 ---
 
 ## Lyrics

--- a/src/content/blog/caminho/v-2026-06-09T20-24-29.mdx
+++ b/src/content/blog/caminho/v-2026-06-09T20-24-29.mdx
@@ -5,19 +5,22 @@ date: 2025-09-30
 postType: music
 sunoId: 08335ace-973e-4eb8-a194-79908303d512
 sunoImageUrl: "https://cdn2.suno.ai/image_08335ace-973e-4eb8-a194-79908303d512.jpeg"
-genre:
-  - "A narrative spoken-word track in the vein of Brazilian sertão philosophy: flowing"
-  - "meandering prose with rhythmic cadences like a storyteller's yarn under starry skies. Layers of doubt"
-  - existential musings on mystery vs. illusion
-  - "desire's torment"
-  - and nameless truths. Sparse acoustic guitar
-  - subtle harmonica wails
 duration: 144
 tags:
   - música
 lang: pt
 translationKey: music-caminho
 draftCreatedAt: "2026-06-12T12:06:06.428Z"
+sunoStyle: |-
+  A narrative spoken-word track in the vein of Brazilian sertão philosophy: flowing
+  meandering prose with rhythmic cadences like a storyteller's yarn under starry skies. Layers of doubt
+  existential musings on mystery vs. illusion
+  desire's torment
+  and nameless truths. Sparse acoustic guitar
+  subtle harmonica wails
+genre:
+  - spoken word
+  - MPB
 ---
 
 ## Letra

--- a/src/content/blog/caminho/v-2026-06-12T11-30-56-005.mdx
+++ b/src/content/blog/caminho/v-2026-06-12T11-30-56-005.mdx
@@ -5,17 +5,6 @@ date: 2025-09-30T00:00:00.000Z
 postType: music
 sunoId: 08335ace-973e-4eb8-a194-79908303d512
 sunoImageUrl: "https://cdn2.suno.ai/image_08335ace-973e-4eb8-a194-79908303d512.jpeg"
-genre:
-  - >-
-    A narrative spoken-word track in the vein of Brazilian sertão philosophy:
-    flowing
-  - >-
-    meandering prose with rhythmic cadences like a storyteller's yarn under
-    starry skies. Layers of doubt
-  - existential musings on mystery vs. illusion
-  - desire's torment
-  - and nameless truths. Sparse acoustic guitar
-  - subtle harmonica wails
 duration: 144
 tags:
   - música
@@ -25,6 +14,16 @@ supersedes: 0d94c9a1-1966-5577-b430-d98f2b793d92
 draftCreatedAt: "2026-06-12T11:30:56.006Z"
 draftMsg: Automated minor structural edits by Jules
 draftCommittedAt: "2026-06-12T11:31:52.956Z"
+sunoStyle: |-
+  >- A narrative spoken-word track in the vein of Brazilian sertão philosophy: flowing
+  >- meandering prose with rhythmic cadences like a storyteller's yarn under starry skies. Layers of doubt
+  existential musings on mystery vs. illusion
+  desire's torment
+  and nameless truths. Sparse acoustic guitar
+  subtle harmonica wails
+genre:
+  - spoken word
+  - MPB
 ---
 
 ## Letra

--- a/src/content/blog/caminho/v-2026-06-12T14-37-54-301.mdx
+++ b/src/content/blog/caminho/v-2026-06-12T14-37-54-301.mdx
@@ -5,17 +5,6 @@ date: 2025-09-30T00:00:00.000Z
 postType: music
 sunoId: 08335ace-973e-4eb8-a194-79908303d512
 sunoImageUrl: "https://cdn2.suno.ai/image_08335ace-973e-4eb8-a194-79908303d512.jpeg"
-genre:
-  - >-
-    A narrative spoken-word track in the vein of Brazilian sertão philosophy:
-    flowing
-  - >-
-    meandering prose with rhythmic cadences like a storyteller's yarn under
-    starry skies. Layers of doubt
-  - existential musings on mystery vs. illusion
-  - desire's torment
-  - and nameless truths. Sparse acoustic guitar
-  - subtle harmonica wails
 duration: 144
 tags:
   - música
@@ -25,6 +14,16 @@ supersedes: 0d94c9a1-1966-5577-b430-d98f2b793d92
 draftCreatedAt: "2026-06-12T14:37:54.301Z"
 draftMsg: Automated unique edits for hronir
 draftCommittedAt: "2026-06-12T14:38:20.754Z"
+sunoStyle: |-
+  >- A narrative spoken-word track in the vein of Brazilian sertão philosophy: flowing
+  >- meandering prose with rhythmic cadences like a storyteller's yarn under starry skies. Layers of doubt
+  existential musings on mystery vs. illusion
+  desire's torment
+  and nameless truths. Sparse acoustic guitar
+  subtle harmonica wails
+genre:
+  - spoken word
+  - MPB
 ---
 
 ## Letra

--- a/src/content/blog/chegue-irmao-chegue-irma-en/v-2026-06-09T20-24-29.mdx
+++ b/src/content/blog/chegue-irmao-chegue-irma-en/v-2026-06-09T20-24-29.mdx
@@ -5,19 +5,22 @@ date: 2025-05-12
 postType: music
 sunoId: 400d663d-9b3a-447d-bf14-18c2015a8177
 sunoImageUrl: "https://cdn2.suno.ai/image_400d663d-9b3a-447d-bf14-18c2015a8177.jpeg"
-genre:
-  - meditation. mindfullness. spoken word. Deep
-  - mature male voice
-  - heavy Brazilian Portuguese accent (rural Minas Gerais / Sertão style
-  - Riobaldo). Slow
-  - thoughtful
-  - slightly raspy
 duration: 375
 tags:
   - music
 lang: en
 translationKey: music-chegue-irmao-chegue-irma
 draftCreatedAt: "2026-06-12T12:06:06.428Z"
+sunoStyle: |-
+  meditation. mindfullness. spoken word. Deep
+  mature male voice
+  heavy Brazilian Portuguese accent (rural Minas Gerais / Sertão style
+  Riobaldo). Slow
+  thoughtful
+  slightly raspy
+genre:
+  - spoken word
+  - ambient
 ---
 
 ## Lyrics

--- a/src/content/blog/chegue-irmao-chegue-irma-en/v-2026-06-10T00-16-31.mdx
+++ b/src/content/blog/chegue-irmao-chegue-irma-en/v-2026-06-10T00-16-31.mdx
@@ -5,13 +5,6 @@ date: 2025-05-12T00:00:00.000Z
 postType: music
 sunoId: 400d663d-9b3a-447d-bf14-18c2015a8177
 sunoImageUrl: "https://cdn2.suno.ai/image_400d663d-9b3a-447d-bf14-18c2015a8177.jpeg"
-genre:
-  - meditation. mindfullness. spoken word. Deep
-  - mature male voice
-  - heavy Brazilian Portuguese accent (rural Minas Gerais / Sertão style
-  - Riobaldo). Slow
-  - thoughtful
-  - slightly raspy
 duration: 375
 tags:
   - music
@@ -24,6 +17,16 @@ draftMsg: >-
   defensive hedging, rooting the narrative in the uncanny capability of
   statistical vectors to simulate sacred practices.
 draftCommittedAt: "2026-06-10T00:17:29.214Z"
+sunoStyle: |-
+  meditation. mindfullness. spoken word. Deep
+  mature male voice
+  heavy Brazilian Portuguese accent (rural Minas Gerais / Sertão style
+  Riobaldo). Slow
+  thoughtful
+  slightly raspy
+genre:
+  - spoken word
+  - ambient
 ---
 
 ## Lyrics

--- a/src/content/blog/chegue-irmao-chegue-irma/v-2026-06-09T20-24-29.mdx
+++ b/src/content/blog/chegue-irmao-chegue-irma/v-2026-06-09T20-24-29.mdx
@@ -5,19 +5,22 @@ date: 2025-05-12
 postType: music
 sunoId: 400d663d-9b3a-447d-bf14-18c2015a8177
 sunoImageUrl: "https://cdn2.suno.ai/image_400d663d-9b3a-447d-bf14-18c2015a8177.jpeg"
-genre:
-  - meditation. mindfullness. spoken word. Deep
-  - mature male voice
-  - heavy Brazilian Portuguese accent (rural Minas Gerais / Sertão style
-  - Riobaldo). Slow
-  - thoughtful
-  - slightly raspy
 duration: 375
 tags:
   - música
 lang: pt
 translationKey: music-chegue-irmao-chegue-irma
 draftCreatedAt: "2026-06-12T12:06:06.428Z"
+sunoStyle: |-
+  meditation. mindfullness. spoken word. Deep
+  mature male voice
+  heavy Brazilian Portuguese accent (rural Minas Gerais / Sertão style
+  Riobaldo). Slow
+  thoughtful
+  slightly raspy
+genre:
+  - spoken word
+  - ambient
 ---
 
 ## Letra

--- a/src/content/blog/chegue-irmao-chegue-irma/v-2026-06-10T00-16-31.mdx
+++ b/src/content/blog/chegue-irmao-chegue-irma/v-2026-06-10T00-16-31.mdx
@@ -5,13 +5,6 @@ date: 2025-05-12T00:00:00.000Z
 postType: music
 sunoId: 400d663d-9b3a-447d-bf14-18c2015a8177
 sunoImageUrl: "https://cdn2.suno.ai/image_400d663d-9b3a-447d-bf14-18c2015a8177.jpeg"
-genre:
-  - meditation. mindfullness. spoken word. Deep
-  - mature male voice
-  - heavy Brazilian Portuguese accent (rural Minas Gerais / Sertão style
-  - Riobaldo). Slow
-  - thoughtful
-  - slightly raspy
 duration: 375
 tags:
   - música
@@ -24,6 +17,16 @@ draftMsg: >-
   defensive hedging, rooting the narrative in the uncanny capability of
   statistical vectors to simulate sacred practices.
 draftCommittedAt: "2026-06-10T00:17:29.214Z"
+sunoStyle: |-
+  meditation. mindfullness. spoken word. Deep
+  mature male voice
+  heavy Brazilian Portuguese accent (rural Minas Gerais / Sertão style
+  Riobaldo). Slow
+  thoughtful
+  slightly raspy
+genre:
+  - spoken word
+  - ambient
 ---
 
 ## Letra

--- a/src/content/blog/clipes-en/v-2026-06-09T20-24-29.mdx
+++ b/src/content/blog/clipes-en/v-2026-06-09T20-24-29.mdx
@@ -5,14 +5,17 @@ date: 2025-07-31
 postType: music
 sunoId: acf0bc54-3e0c-459a-bcf3-5818a2d1ff54
 sunoImageUrl: "https://cdn2.suno.ai/image_acf0bc54-3e0c-459a-bcf3-5818a2d1ff54.jpeg"
-genre:
-  - br phonk
 duration: 227
 tags:
   - music
 lang: en
 translationKey: music-clipes
 draftCreatedAt: "2026-06-12T12:06:06.428Z"
+sunoStyle: |-
+  br phonk
+genre:
+  - hip-hop
+  - funk carioca
 ---
 
 ## Lyrics

--- a/src/content/blog/clipes/v-2026-06-09T20-24-29.mdx
+++ b/src/content/blog/clipes/v-2026-06-09T20-24-29.mdx
@@ -5,14 +5,17 @@ date: 2025-07-31
 postType: music
 sunoId: acf0bc54-3e0c-459a-bcf3-5818a2d1ff54
 sunoImageUrl: "https://cdn2.suno.ai/image_acf0bc54-3e0c-459a-bcf3-5818a2d1ff54.jpeg"
-genre:
-  - br phonk
 duration: 227
 tags:
   - música
 lang: pt
 translationKey: music-clipes
 draftCreatedAt: "2026-06-12T12:06:06.428Z"
+sunoStyle: |-
+  br phonk
+genre:
+  - hip-hop
+  - funk carioca
 ---
 
 ## Letra

--- a/src/content/blog/crystallizing-from-the-nothing-en/v-2026-06-09T20-24-29.mdx
+++ b/src/content/blog/crystallizing-from-the-nothing-en/v-2026-06-09T20-24-29.mdx
@@ -5,19 +5,22 @@ date: 2026-01-24
 postType: music
 sunoId: 6d88d2ad-9ceb-4581-acae-9632b4dbd032
 sunoImageUrl: "https://cdn2.suno.ai/image_6d88d2ad-9ceb-4581-acae-9632b4dbd032.jpeg"
-genre:
-  - The song opens with atmospheric ambient synths creating a spacious
-  - ethereal texture. Gradually
-  - layered crystalline arpeggios emerge
-  - interlaced with subtle electronic percussion. Midway
-  - pulsing bass and intricate digital effects build tension
-  - leading to a dramatic
 duration: 292
 tags:
   - music
 lang: en
 translationKey: music-crystallizing-from-the-nothing
 draftCreatedAt: "2026-06-12T12:06:06.428Z"
+sunoStyle: |-
+  The song opens with atmospheric ambient synths creating a spacious
+  ethereal texture. Gradually
+  layered crystalline arpeggios emerge
+  interlaced with subtle electronic percussion. Midway
+  pulsing bass and intricate digital effects build tension
+  leading to a dramatic
+genre:
+  - ambient
+  - eletrônico
 ---
 
 ## Lyrics

--- a/src/content/blog/crystallizing-from-the-nothing-en/v-2026-06-10T00-35-36.mdx
+++ b/src/content/blog/crystallizing-from-the-nothing-en/v-2026-06-10T00-35-36.mdx
@@ -5,13 +5,6 @@ date: 2026-01-24T00:00:00.000Z
 postType: music
 sunoId: 6d88d2ad-9ceb-4581-acae-9632b4dbd032
 sunoImageUrl: "https://cdn2.suno.ai/image_6d88d2ad-9ceb-4581-acae-9632b4dbd032.jpeg"
-genre:
-  - The song opens with atmospheric ambient synths creating a spacious
-  - ethereal texture. Gradually
-  - layered crystalline arpeggios emerge
-  - interlaced with subtle electronic percussion. Midway
-  - pulsing bass and intricate digital effects build tension
-  - leading to a dramatic
 duration: 292
 tags:
   - music
@@ -21,6 +14,16 @@ supersedes: fba24bcc-45e1-562d-aa9d-df2a6ef30d5b
 draftCreatedAt: "2026-06-10T00:35:36.100Z"
 draftMsg: "Rewrite notes to be felt, not explained"
 draftCommittedAt: "2026-06-10T00:38:36.765Z"
+sunoStyle: |-
+  The song opens with atmospheric ambient synths creating a spacious
+  ethereal texture. Gradually
+  layered crystalline arpeggios emerge
+  interlaced with subtle electronic percussion. Midway
+  pulsing bass and intricate digital effects build tension
+  leading to a dramatic
+genre:
+  - ambient
+  - eletrônico
 ---
 
 ## Lyrics

--- a/src/content/blog/crystallizing-from-the-nothing-en/v-2026-06-10T12-23-47.mdx
+++ b/src/content/blog/crystallizing-from-the-nothing-en/v-2026-06-10T12-23-47.mdx
@@ -5,13 +5,6 @@ date: 2026-01-24T00:00:00.000Z
 postType: music
 sunoId: 6d88d2ad-9ceb-4581-acae-9632b4dbd032
 sunoImageUrl: "https://cdn2.suno.ai/image_6d88d2ad-9ceb-4581-acae-9632b4dbd032.jpeg"
-genre:
-  - The song opens with atmospheric ambient synths creating a spacious
-  - ethereal texture. Gradually
-  - layered crystalline arpeggios emerge
-  - interlaced with subtle electronic percussion. Midway
-  - pulsing bass and intricate digital effects build tension
-  - leading to a dramatic
 duration: 292
 tags:
   - music
@@ -21,6 +14,16 @@ supersedes: fba24bcc-45e1-562d-aa9d-df2a6ef30d5b
 draftCreatedAt: "2026-06-10T12:23:47.593Z"
 draftMsg: "chore: improve lyrics density and reduce pop-science notes"
 draftCommittedAt: "2026-06-10T12:24:18.539Z"
+sunoStyle: |-
+  The song opens with atmospheric ambient synths creating a spacious
+  ethereal texture. Gradually
+  layered crystalline arpeggios emerge
+  interlaced with subtle electronic percussion. Midway
+  pulsing bass and intricate digital effects build tension
+  leading to a dramatic
+genre:
+  - ambient
+  - eletrônico
 ---
 
 ## Lyrics

--- a/src/content/blog/crystallizing-from-the-nothing/v-2026-06-09T20-24-29.mdx
+++ b/src/content/blog/crystallizing-from-the-nothing/v-2026-06-09T20-24-29.mdx
@@ -5,19 +5,22 @@ date: 2026-01-24
 postType: music
 sunoId: 6d88d2ad-9ceb-4581-acae-9632b4dbd032
 sunoImageUrl: "https://cdn2.suno.ai/image_6d88d2ad-9ceb-4581-acae-9632b4dbd032.jpeg"
-genre:
-  - The song opens with atmospheric ambient synths creating a spacious
-  - ethereal texture. Gradually
-  - layered crystalline arpeggios emerge
-  - interlaced with subtle electronic percussion. Midway
-  - pulsing bass and intricate digital effects build tension
-  - leading to a dramatic
 duration: 292
 tags:
   - música
 lang: pt
 translationKey: music-crystallizing-from-the-nothing
 draftCreatedAt: "2026-06-12T12:06:06.428Z"
+sunoStyle: |-
+  The song opens with atmospheric ambient synths creating a spacious
+  ethereal texture. Gradually
+  layered crystalline arpeggios emerge
+  interlaced with subtle electronic percussion. Midway
+  pulsing bass and intricate digital effects build tension
+  leading to a dramatic
+genre:
+  - ambient
+  - eletrônico
 ---
 
 ## Letra

--- a/src/content/blog/crystallizing-from-the-nothing/v-2026-06-10T00-35-36.mdx
+++ b/src/content/blog/crystallizing-from-the-nothing/v-2026-06-10T00-35-36.mdx
@@ -5,13 +5,6 @@ date: 2026-01-24T00:00:00.000Z
 postType: music
 sunoId: 6d88d2ad-9ceb-4581-acae-9632b4dbd032
 sunoImageUrl: "https://cdn2.suno.ai/image_6d88d2ad-9ceb-4581-acae-9632b4dbd032.jpeg"
-genre:
-  - The song opens with atmospheric ambient synths creating a spacious
-  - ethereal texture. Gradually
-  - layered crystalline arpeggios emerge
-  - interlaced with subtle electronic percussion. Midway
-  - pulsing bass and intricate digital effects build tension
-  - leading to a dramatic
 duration: 292
 tags:
   - música
@@ -21,6 +14,16 @@ supersedes: f98b1fe4-fbc7-5992-9dd4-34d42ddf0cc4
 draftCreatedAt: "2026-06-10T00:35:36.100Z"
 draftMsg: "Rewrite notes to be felt, not explained"
 draftCommittedAt: "2026-06-10T00:38:36.765Z"
+sunoStyle: |-
+  The song opens with atmospheric ambient synths creating a spacious
+  ethereal texture. Gradually
+  layered crystalline arpeggios emerge
+  interlaced with subtle electronic percussion. Midway
+  pulsing bass and intricate digital effects build tension
+  leading to a dramatic
+genre:
+  - ambient
+  - eletrônico
 ---
 
 ## Letra

--- a/src/content/blog/crystallizing-from-the-nothing/v-2026-06-10T12-23-47.mdx
+++ b/src/content/blog/crystallizing-from-the-nothing/v-2026-06-10T12-23-47.mdx
@@ -5,13 +5,6 @@ date: 2026-01-24T00:00:00.000Z
 postType: music
 sunoId: 6d88d2ad-9ceb-4581-acae-9632b4dbd032
 sunoImageUrl: "https://cdn2.suno.ai/image_6d88d2ad-9ceb-4581-acae-9632b4dbd032.jpeg"
-genre:
-  - The song opens with atmospheric ambient synths creating a spacious
-  - ethereal texture. Gradually
-  - layered crystalline arpeggios emerge
-  - interlaced with subtle electronic percussion. Midway
-  - pulsing bass and intricate digital effects build tension
-  - leading to a dramatic
 duration: 292
 tags:
   - música
@@ -21,6 +14,16 @@ supersedes: f98b1fe4-fbc7-5992-9dd4-34d42ddf0cc4
 draftCreatedAt: "2026-06-10T12:23:47.593Z"
 draftMsg: "chore: improve lyrics density and reduce pop-science notes"
 draftCommittedAt: "2026-06-10T12:24:18.539Z"
+sunoStyle: |-
+  The song opens with atmospheric ambient synths creating a spacious
+  ethereal texture. Gradually
+  layered crystalline arpeggios emerge
+  interlaced with subtle electronic percussion. Midway
+  pulsing bass and intricate digital effects build tension
+  leading to a dramatic
+genre:
+  - ambient
+  - eletrônico
 ---
 
 ## Letra

--- a/src/content/blog/dd332f75-6052-4f9e-bccd-fb0303731d6e-en/v-2026-06-09T20-24-29.mdx
+++ b/src/content/blog/dd332f75-6052-4f9e-bccd-fb0303731d6e-en/v-2026-06-09T20-24-29.mdx
@@ -5,18 +5,21 @@ date: 2025-01-27
 postType: music
 sunoId: dd332f75-6052-4f9e-bccd-fb0303731d6e
 sunoImageUrl: "https://cdn2.suno.ai/image_dd332f75-6052-4f9e-bccd-fb0303731d6e.jpeg"
-genre:
-  - Rambling
-  - nasal delivery
-  - acoustic grit
-  - wheezy harmonica. Lyrics reframed as existential blues—metaphors lean industrial/surreal
-  - with Dylan’s trademark sardonic ambiguity.
 duration: 240
 tags:
   - music
 lang: en
 translationKey: music-dd332f75-6052-4f9e-bccd-fb0303731d6e
 draftCreatedAt: "2026-06-12T12:06:06.428Z"
+sunoStyle: |-
+  Rambling
+  nasal delivery
+  acoustic grit
+  wheezy harmonica. Lyrics reframed as existential blues—metaphors lean industrial/surreal
+  with Dylan’s trademark sardonic ambiguity.
+genre:
+  - folk
+  - experimental
 ---
 
 ## Lyrics

--- a/src/content/blog/dd332f75-6052-4f9e-bccd-fb0303731d6e-en/v-2026-06-11T06-56-21-026.mdx
+++ b/src/content/blog/dd332f75-6052-4f9e-bccd-fb0303731d6e-en/v-2026-06-11T06-56-21-026.mdx
@@ -5,14 +5,6 @@ date: 2025-01-27T00:00:00.000Z
 postType: music
 sunoId: dd332f75-6052-4f9e-bccd-fb0303731d6e
 sunoImageUrl: "https://cdn2.suno.ai/image_dd332f75-6052-4f9e-bccd-fb0303731d6e.jpeg"
-genre:
-  - Rambling
-  - nasal delivery
-  - acoustic grit
-  - >-
-    wheezy harmonica. Lyrics reframed as existential blues—metaphors lean
-    industrial/surreal
-  - with Dylan’s trademark sardonic ambiguity.
 duration: 240
 tags:
   - music
@@ -24,6 +16,15 @@ draftMsg: >-
   Retirada a neblina filosofica para expor a vulnerabilidade do argumento
   central
 draftCommittedAt: "2026-06-11T06:56:47.135Z"
+sunoStyle: |-
+  Rambling
+  nasal delivery
+  acoustic grit
+  >- wheezy harmonica. Lyrics reframed as existential blues—metaphors lean industrial/surreal
+  with Dylan’s trademark sardonic ambiguity.
+genre:
+  - folk
+  - experimental
 ---
 
 ## Lyrics

--- a/src/content/blog/dd332f75-6052-4f9e-bccd-fb0303731d6e-en/v-2026-06-13T04-36-49-037.mdx
+++ b/src/content/blog/dd332f75-6052-4f9e-bccd-fb0303731d6e-en/v-2026-06-13T04-36-49-037.mdx
@@ -5,14 +5,6 @@ date: 2025-01-27T00:00:00.000Z
 postType: music
 sunoId: dd332f75-6052-4f9e-bccd-fb0303731d6e
 sunoImageUrl: "https://cdn2.suno.ai/image_dd332f75-6052-4f9e-bccd-fb0303731d6e.jpeg"
-genre:
-  - Rambling
-  - nasal delivery
-  - acoustic grit
-  - >-
-    wheezy harmonica. Lyrics reframed as existential blues—metaphors lean
-    industrial/surreal
-  - with Dylan’s trademark sardonic ambiguity.
 duration: 240
 tags:
   - music
@@ -22,6 +14,15 @@ draftCreatedAt: "2026-06-13T04:36:49.037Z"
 supersedes: 3b25fe1f-334f-5b41-bea3-8843418cdd7f
 draftMsg: Contextual edits to improve narrative flow and address perspective critiques
 draftCommittedAt: "2026-06-13T04:39:28.519Z"
+sunoStyle: |-
+  Rambling
+  nasal delivery
+  acoustic grit
+  >- wheezy harmonica. Lyrics reframed as existential blues—metaphors lean industrial/surreal
+  with Dylan’s trademark sardonic ambiguity.
+genre:
+  - folk
+  - experimental
 ---
 
 ## Lyrics

--- a/src/content/blog/dd332f75-6052-4f9e-bccd-fb0303731d6e/v-2026-06-09T20-24-29.mdx
+++ b/src/content/blog/dd332f75-6052-4f9e-bccd-fb0303731d6e/v-2026-06-09T20-24-29.mdx
@@ -5,18 +5,21 @@ date: 2025-01-27
 postType: music
 sunoId: dd332f75-6052-4f9e-bccd-fb0303731d6e
 sunoImageUrl: "https://cdn2.suno.ai/image_dd332f75-6052-4f9e-bccd-fb0303731d6e.jpeg"
-genre:
-  - Rambling
-  - nasal delivery
-  - acoustic grit
-  - wheezy harmonica. Lyrics reframed as existential blues—metaphors lean industrial/surreal
-  - with Dylan’s trademark sardonic ambiguity.
 duration: 240
 tags:
   - música
 lang: pt
 translationKey: music-dd332f75-6052-4f9e-bccd-fb0303731d6e
 draftCreatedAt: "2026-06-12T12:06:06.428Z"
+sunoStyle: |-
+  Rambling
+  nasal delivery
+  acoustic grit
+  wheezy harmonica. Lyrics reframed as existential blues—metaphors lean industrial/surreal
+  with Dylan’s trademark sardonic ambiguity.
+genre:
+  - folk
+  - experimental
 ---
 
 ## Letra

--- a/src/content/blog/dd332f75-6052-4f9e-bccd-fb0303731d6e/v-2026-06-11T06-56-21-026.mdx
+++ b/src/content/blog/dd332f75-6052-4f9e-bccd-fb0303731d6e/v-2026-06-11T06-56-21-026.mdx
@@ -5,14 +5,6 @@ date: 2025-01-27T00:00:00.000Z
 postType: music
 sunoId: dd332f75-6052-4f9e-bccd-fb0303731d6e
 sunoImageUrl: "https://cdn2.suno.ai/image_dd332f75-6052-4f9e-bccd-fb0303731d6e.jpeg"
-genre:
-  - Rambling
-  - nasal delivery
-  - acoustic grit
-  - >-
-    wheezy harmonica. Lyrics reframed as existential blues—metaphors lean
-    industrial/surreal
-  - with Dylan’s trademark sardonic ambiguity.
 duration: 240
 tags:
   - música
@@ -24,6 +16,15 @@ draftMsg: >-
   Retirada a neblina filosofica para expor a vulnerabilidade do argumento
   central
 draftCommittedAt: "2026-06-11T06:56:47.135Z"
+sunoStyle: |-
+  Rambling
+  nasal delivery
+  acoustic grit
+  >- wheezy harmonica. Lyrics reframed as existential blues—metaphors lean industrial/surreal
+  with Dylan’s trademark sardonic ambiguity.
+genre:
+  - folk
+  - experimental
 ---
 
 ## Letra

--- a/src/content/blog/dd332f75-6052-4f9e-bccd-fb0303731d6e/v-2026-06-13T04-36-49-037.mdx
+++ b/src/content/blog/dd332f75-6052-4f9e-bccd-fb0303731d6e/v-2026-06-13T04-36-49-037.mdx
@@ -5,14 +5,6 @@ date: 2025-01-27T00:00:00.000Z
 postType: music
 sunoId: dd332f75-6052-4f9e-bccd-fb0303731d6e
 sunoImageUrl: "https://cdn2.suno.ai/image_dd332f75-6052-4f9e-bccd-fb0303731d6e.jpeg"
-genre:
-  - Rambling
-  - nasal delivery
-  - acoustic grit
-  - >-
-    wheezy harmonica. Lyrics reframed as existential blues—metaphors lean
-    industrial/surreal
-  - with Dylan’s trademark sardonic ambiguity.
 duration: 240
 tags:
   - música
@@ -22,6 +14,15 @@ draftCreatedAt: "2026-06-13T04:36:49.037Z"
 supersedes: 58e8ff37-4eed-5b45-a393-86d2ca00e2eb
 draftMsg: Contextual edits to improve narrative flow and address perspective critiques
 draftCommittedAt: "2026-06-13T04:39:28.519Z"
+sunoStyle: |-
+  Rambling
+  nasal delivery
+  acoustic grit
+  >- wheezy harmonica. Lyrics reframed as existential blues—metaphors lean industrial/surreal
+  with Dylan’s trademark sardonic ambiguity.
+genre:
+  - folk
+  - experimental
 ---
 
 ## Letra

--- a/src/content/blog/entre-rascunho-e-apagar-en/v-2026-06-09T20-24-29.mdx
+++ b/src/content/blog/entre-rascunho-e-apagar-en/v-2026-06-09T20-24-29.mdx
@@ -5,16 +5,21 @@ date: 2025-09-01
 postType: music
 sunoId: ce8630fc-f73f-4d8b-bebb-79c3ed3f5417
 sunoImageUrl: "https://cdn2.suno.ai/image_ce8630fc-f73f-4d8b-bebb-79c3ed3f5417.jpeg"
+sunoStyle: |-
+  Genre: Brazilian experimental hip-hop / glitch-jazz with polymeter
+  Tempo: 94 BPM | Meter: polymetric (drums in 13/8 grouped 3-3-2-2-3 over vocals phrased in 4/4)
+  Mood: kinetic
+  reflective
+  futuristic-organic
+  Instruments: dusty break layered with triangle + soft pandeiro (Brazilian color)
+  upright or round synth bass ostinato in 13
+  warm Rhodes (7/9/11 tensions)
+  nylon/steel guitar chops
+
 genre:
-  - "Genre: Brazilian experimental hip-hop / glitch-jazz with polymeter
-Tempo: 94 BPM | Meter: polymetric (drums in 13/8 grouped 3-3-2-2-3 over vocals phrased in 4/4)
-Mood: kinetic"
-  - reflective
-  - "futuristic-organic
-Instruments: dusty break layered with triangle + soft pandeiro (Brazilian color)"
-  - upright or round synth bass ostinato in 13
-  - warm Rhodes (7/9/11 tensions)
-  - nylon/steel guitar chops
+  - hip-hop
+  - glitch
+  - jazz
 duration: 190
 tags:
   - music

--- a/src/content/blog/entre-rascunho-e-apagar-en/v-2026-06-12T02-34-18-383.mdx
+++ b/src/content/blog/entre-rascunho-e-apagar-en/v-2026-06-12T02-34-18-383.mdx
@@ -5,18 +5,6 @@ date: 2025-09-01T00:00:00.000Z
 postType: music
 sunoId: ce8630fc-f73f-4d8b-bebb-79c3ed3f5417
 sunoImageUrl: "https://cdn2.suno.ai/image_ce8630fc-f73f-4d8b-bebb-79c3ed3f5417.jpeg"
-genre:
-  - >-
-    Genre: Brazilian experimental hip-hop / glitch-jazz with polymeter Tempo: 94
-    BPM | Meter: polymetric (drums in 13/8 grouped 3-3-2-2-3 over vocals phrased
-    in 4/4) Mood: kinetic
-  - reflective
-  - >-
-    futuristic-organic Instruments: dusty break layered with triangle + soft
-    pandeiro (Brazilian color)
-  - upright or round synth bass ostinato in 13
-  - warm Rhodes (7/9/11 tensions)
-  - nylon/steel guitar chops
 duration: 190
 tags:
   - music
@@ -26,6 +14,17 @@ supersedes: 2065fc6e-499f-5541-a562-80d912406d6a
 draftCreatedAt: "2026-06-12T02:34:18.384Z"
 draftMsg: Added missing context to worst post drafts
 draftCommittedAt: "2026-06-12T02:34:49.679Z"
+sunoStyle: |-
+  >- Genre: Brazilian experimental hip-hop / glitch-jazz with polymeter Tempo: 94 BPM | Meter: polymetric (drums in 13/8 grouped 3-3-2-2-3 over vocals phrased in 4/4) Mood: kinetic
+  reflective
+  >- futuristic-organic Instruments: dusty break layered with triangle + soft pandeiro (Brazilian color)
+  upright or round synth bass ostinato in 13
+  warm Rhodes (7/9/11 tensions)
+  nylon/steel guitar chops
+genre:
+  - hip-hop
+  - glitch
+  - jazz
 ---
 
 ## Lyrics

--- a/src/content/blog/entre-rascunho-e-apagar/v-2026-06-09T20-24-29.mdx
+++ b/src/content/blog/entre-rascunho-e-apagar/v-2026-06-09T20-24-29.mdx
@@ -5,16 +5,21 @@ date: 2025-09-01
 postType: music
 sunoId: ce8630fc-f73f-4d8b-bebb-79c3ed3f5417
 sunoImageUrl: "https://cdn2.suno.ai/image_ce8630fc-f73f-4d8b-bebb-79c3ed3f5417.jpeg"
+sunoStyle: |-
+  Genre: Brazilian experimental hip-hop / glitch-jazz with polymeter
+  Tempo: 94 BPM | Meter: polymetric (drums in 13/8 grouped 3-3-2-2-3 over vocals phrased in 4/4)
+  Mood: kinetic
+  reflective
+  futuristic-organic
+  Instruments: dusty break layered with triangle + soft pandeiro (Brazilian color)
+  upright or round synth bass ostinato in 13
+  warm Rhodes (7/9/11 tensions)
+  nylon/steel guitar chops
+
 genre:
-  - "Genre: Brazilian experimental hip-hop / glitch-jazz with polymeter
-Tempo: 94 BPM | Meter: polymetric (drums in 13/8 grouped 3-3-2-2-3 over vocals phrased in 4/4)
-Mood: kinetic"
-  - reflective
-  - "futuristic-organic
-Instruments: dusty break layered with triangle + soft pandeiro (Brazilian color)"
-  - upright or round synth bass ostinato in 13
-  - warm Rhodes (7/9/11 tensions)
-  - nylon/steel guitar chops
+  - hip-hop
+  - glitch
+  - jazz
 duration: 190
 tags:
   - música

--- a/src/content/blog/entre-rascunho-e-apagar/v-2026-06-12T02-34-18-383.mdx
+++ b/src/content/blog/entre-rascunho-e-apagar/v-2026-06-12T02-34-18-383.mdx
@@ -5,18 +5,6 @@ date: 2025-09-01T00:00:00.000Z
 postType: music
 sunoId: ce8630fc-f73f-4d8b-bebb-79c3ed3f5417
 sunoImageUrl: "https://cdn2.suno.ai/image_ce8630fc-f73f-4d8b-bebb-79c3ed3f5417.jpeg"
-genre:
-  - >-
-    Genre: Brazilian experimental hip-hop / glitch-jazz with polymeter Tempo: 94
-    BPM | Meter: polymetric (drums in 13/8 grouped 3-3-2-2-3 over vocals phrased
-    in 4/4) Mood: kinetic
-  - reflective
-  - >-
-    futuristic-organic Instruments: dusty break layered with triangle + soft
-    pandeiro (Brazilian color)
-  - upright or round synth bass ostinato in 13
-  - warm Rhodes (7/9/11 tensions)
-  - nylon/steel guitar chops
 duration: 190
 tags:
   - música
@@ -26,6 +14,17 @@ supersedes: 322907c8-69a1-527e-b36c-459d69927485
 draftCreatedAt: "2026-06-12T02:34:18.384Z"
 draftMsg: Added missing context to worst post drafts
 draftCommittedAt: "2026-06-12T02:34:49.679Z"
+sunoStyle: |-
+  >- Genre: Brazilian experimental hip-hop / glitch-jazz with polymeter Tempo: 94 BPM | Meter: polymetric (drums in 13/8 grouped 3-3-2-2-3 over vocals phrased in 4/4) Mood: kinetic
+  reflective
+  >- futuristic-organic Instruments: dusty break layered with triangle + soft pandeiro (Brazilian color)
+  upright or round synth bass ostinato in 13
+  warm Rhodes (7/9/11 tensions)
+  nylon/steel guitar chops
+genre:
+  - hip-hop
+  - glitch
+  - jazz
 ---
 
 ## Letra

--- a/src/content/blog/escherian-sunrise-with-godel-en/v-2026-06-09T20-24-29.mdx
+++ b/src/content/blog/escherian-sunrise-with-godel-en/v-2026-06-09T20-24-29.mdx
@@ -5,16 +5,20 @@ date: 2025-10-05
 postType: music
 sunoId: f889dfb4-15ab-41cf-9ea6-2fa03be847d8
 sunoImageUrl: "https://cdn2.suno.ai/image_f889dfb4-15ab-41cf-9ea6-2fa03be847d8.jpeg"
+sunoStyle: |-
+  Rustic English folk ballad
+  3/4 at 96 BPM.
+  Mode: D Dorian (minor flavor
+  bright lift).
+  Instruments: lute
+  small drum
+  wooden flute
+  tambourine.
+  Male vocal
+
 genre:
-  - Rustic English folk ballad
-  - "3/4 at 96 BPM.
-Mode: D Dorian (minor flavor"
-  - "bright lift).
-Instruments: lute"
-  - small drum
-  - wooden flute
-  - "tambourine.
-Male vocal"
+  - folk
+  - acústico
 duration: 211
 tags:
   - music

--- a/src/content/blog/escherian-sunrise-with-godel/v-2026-06-09T20-24-29.mdx
+++ b/src/content/blog/escherian-sunrise-with-godel/v-2026-06-09T20-24-29.mdx
@@ -5,16 +5,20 @@ date: 2025-10-05
 postType: music
 sunoId: f889dfb4-15ab-41cf-9ea6-2fa03be847d8
 sunoImageUrl: "https://cdn2.suno.ai/image_f889dfb4-15ab-41cf-9ea6-2fa03be847d8.jpeg"
+sunoStyle: |-
+  Rustic English folk ballad
+  3/4 at 96 BPM.
+  Mode: D Dorian (minor flavor
+  bright lift).
+  Instruments: lute
+  small drum
+  wooden flute
+  tambourine.
+  Male vocal
+
 genre:
-  - Rustic English folk ballad
-  - "3/4 at 96 BPM.
-Mode: D Dorian (minor flavor"
-  - "bright lift).
-Instruments: lute"
-  - small drum
-  - wooden flute
-  - "tambourine.
-Male vocal"
+  - folk
+  - acústico
 duration: 211
 tags:
   - música

--- a/src/content/blog/espelhos-en/v-2026-06-09T20-24-29.mdx
+++ b/src/content/blog/espelhos-en/v-2026-06-09T20-24-29.mdx
@@ -5,15 +5,19 @@ date: 2025-08-29
 postType: music
 sunoId: a3173e3f-3321-4a54-beb8-e870764a6466
 sunoImageUrl: "https://cdn2.suno.ai/image_a3173e3f-3321-4a54-beb8-e870764a6466.jpeg"
+sunoStyle: |-
+  Genre: minimalist MPB / noir bossa
+  Tempo: 90 BPM | Time: 4/4 | Mood: intimate
+  smoky
+  contemplative
+  Instruments: nylon guitar (soft syncopation)
+  warm Rhodes
+  upright bass
+  pandeiro/brushes
+
 genre:
-  - "Genre: minimalist MPB / noir bossa
-Tempo: 90 BPM | Time: 4/4 | Mood: intimate"
-  - smoky
-  - "contemplative
-Instruments: nylon guitar (soft syncopation)"
-  - warm Rhodes
-  - upright bass
-  - pandeiro/brushes
+  - MPB
+  - bossa nova
 duration: 417
 tags:
   - music

--- a/src/content/blog/espelhos-en/v-2026-06-13T08-27-59-139.mdx
+++ b/src/content/blog/espelhos-en/v-2026-06-13T08-27-59-139.mdx
@@ -5,15 +5,6 @@ date: 2025-08-29T00:00:00.000Z
 postType: music
 sunoId: a3173e3f-3321-4a54-beb8-e870764a6466
 sunoImageUrl: "https://cdn2.suno.ai/image_a3173e3f-3321-4a54-beb8-e870764a6466.jpeg"
-genre:
-  - >-
-    Genre: minimalist MPB / noir bossa Tempo: 90 BPM | Time: 4/4 | Mood:
-    intimate
-  - smoky
-  - "contemplative Instruments: nylon guitar (soft syncopation)"
-  - warm Rhodes
-  - upright bass
-  - pandeiro/brushes
 duration: 417
 tags:
   - music
@@ -23,6 +14,16 @@ draftCreatedAt: "2026-06-13T08:27:59.139Z"
 supersedes: b3662d91-986f-52b8-b69b-f62d980783b1
 draftMsg: Targeted narrative edit based on perspective critique
 draftCommittedAt: "2026-06-13T08:32:05.663Z"
+sunoStyle: |-
+  >- Genre: minimalist MPB / noir bossa Tempo: 90 BPM | Time: 4/4 | Mood: intimate
+  smoky
+  contemplative Instruments: nylon guitar (soft syncopation)
+  warm Rhodes
+  upright bass
+  pandeiro/brushes
+genre:
+  - MPB
+  - bossa nova
 ---
 
 ## Lyrics

--- a/src/content/blog/espelhos-en/v-2026-06-13T09-06-17-301.mdx
+++ b/src/content/blog/espelhos-en/v-2026-06-13T09-06-17-301.mdx
@@ -5,15 +5,6 @@ date: 2025-08-29T00:00:00.000Z
 postType: music
 sunoId: a3173e3f-3321-4a54-beb8-e870764a6466
 sunoImageUrl: "https://cdn2.suno.ai/image_a3173e3f-3321-4a54-beb8-e870764a6466.jpeg"
-genre:
-  - >-
-    Genre: minimalist MPB / noir bossa Tempo: 90 BPM | Time: 4/4 | Mood:
-    intimate
-  - smoky
-  - "contemplative Instruments: nylon guitar (soft syncopation)"
-  - warm Rhodes
-  - upright bass
-  - pandeiro/brushes
 duration: 417
 tags:
   - music
@@ -23,6 +14,16 @@ draftCreatedAt: "2026-06-13T09:06:17.301Z"
 supersedes: b3662d91-986f-52b8-b69b-f62d980783b1
 draftMsg: Diminuido gap do espelhos
 draftCommittedAt: "2026-06-13T09:06:52.316Z"
+sunoStyle: |-
+  >- Genre: minimalist MPB / noir bossa Tempo: 90 BPM | Time: 4/4 | Mood: intimate
+  smoky
+  contemplative Instruments: nylon guitar (soft syncopation)
+  warm Rhodes
+  upright bass
+  pandeiro/brushes
+genre:
+  - MPB
+  - bossa nova
 ---
 
 ## Lyrics

--- a/src/content/blog/espelhos/v-2026-06-09T20-24-29.mdx
+++ b/src/content/blog/espelhos/v-2026-06-09T20-24-29.mdx
@@ -5,15 +5,19 @@ date: 2025-08-29
 postType: music
 sunoId: a3173e3f-3321-4a54-beb8-e870764a6466
 sunoImageUrl: "https://cdn2.suno.ai/image_a3173e3f-3321-4a54-beb8-e870764a6466.jpeg"
+sunoStyle: |-
+  Genre: minimalist MPB / noir bossa
+  Tempo: 90 BPM | Time: 4/4 | Mood: intimate
+  smoky
+  contemplative
+  Instruments: nylon guitar (soft syncopation)
+  warm Rhodes
+  upright bass
+  pandeiro/brushes
+
 genre:
-  - "Genre: minimalist MPB / noir bossa
-Tempo: 90 BPM | Time: 4/4 | Mood: intimate"
-  - smoky
-  - "contemplative
-Instruments: nylon guitar (soft syncopation)"
-  - warm Rhodes
-  - upright bass
-  - pandeiro/brushes
+  - MPB
+  - bossa nova
 duration: 417
 tags:
   - música

--- a/src/content/blog/espelhos/v-2026-06-13T08-27-59-139.mdx
+++ b/src/content/blog/espelhos/v-2026-06-13T08-27-59-139.mdx
@@ -5,15 +5,6 @@ date: 2025-08-29T00:00:00.000Z
 postType: music
 sunoId: a3173e3f-3321-4a54-beb8-e870764a6466
 sunoImageUrl: "https://cdn2.suno.ai/image_a3173e3f-3321-4a54-beb8-e870764a6466.jpeg"
-genre:
-  - >-
-    Genre: minimalist MPB / noir bossa Tempo: 90 BPM | Time: 4/4 | Mood:
-    intimate
-  - smoky
-  - "contemplative Instruments: nylon guitar (soft syncopation)"
-  - warm Rhodes
-  - upright bass
-  - pandeiro/brushes
 duration: 417
 tags:
   - música
@@ -23,6 +14,16 @@ draftCreatedAt: "2026-06-13T08:27:59.139Z"
 supersedes: 49a6e933-90ad-510e-b167-c9b97072d828
 draftMsg: Targeted narrative edit based on perspective critique
 draftCommittedAt: "2026-06-13T08:32:05.663Z"
+sunoStyle: |-
+  >- Genre: minimalist MPB / noir bossa Tempo: 90 BPM | Time: 4/4 | Mood: intimate
+  smoky
+  contemplative Instruments: nylon guitar (soft syncopation)
+  warm Rhodes
+  upright bass
+  pandeiro/brushes
+genre:
+  - MPB
+  - bossa nova
 ---
 
 ## Letra

--- a/src/content/blog/espelhos/v-2026-06-13T09-06-17-301.mdx
+++ b/src/content/blog/espelhos/v-2026-06-13T09-06-17-301.mdx
@@ -5,15 +5,6 @@ date: 2025-08-29T00:00:00.000Z
 postType: music
 sunoId: a3173e3f-3321-4a54-beb8-e870764a6466
 sunoImageUrl: "https://cdn2.suno.ai/image_a3173e3f-3321-4a54-beb8-e870764a6466.jpeg"
-genre:
-  - >-
-    Genre: minimalist MPB / noir bossa Tempo: 90 BPM | Time: 4/4 | Mood:
-    intimate
-  - smoky
-  - "contemplative Instruments: nylon guitar (soft syncopation)"
-  - warm Rhodes
-  - upright bass
-  - pandeiro/brushes
 duration: 417
 tags:
   - música
@@ -23,6 +14,16 @@ draftCreatedAt: "2026-06-13T09:06:17.301Z"
 supersedes: 49a6e933-90ad-510e-b167-c9b97072d828
 draftMsg: Diminuido gap do espelhos
 draftCommittedAt: "2026-06-13T09:06:52.316Z"
+sunoStyle: |-
+  >- Genre: minimalist MPB / noir bossa Tempo: 90 BPM | Time: 4/4 | Mood: intimate
+  smoky
+  contemplative Instruments: nylon guitar (soft syncopation)
+  warm Rhodes
+  upright bass
+  pandeiro/brushes
+genre:
+  - MPB
+  - bossa nova
 ---
 
 ## Letra

--- a/src/content/blog/eu-ia-escrever-sobre-o-infinito-de-novo-en/v-2026-06-09T20-24-29.mdx
+++ b/src/content/blog/eu-ia-escrever-sobre-o-infinito-de-novo-en/v-2026-06-09T20-24-29.mdx
@@ -5,19 +5,23 @@ date: 2026-01-11
 postType: music
 sunoId: 2509efa2-b655-4340-830f-294567cbc2bb
 sunoImageUrl: "https://cdn2.suno.ai/video_gen_72af9eeb-69c3-4b66-8059-551bc9207f94_video_upload_72af9eeb-69c3-4b66-8059-551bc9207f94_cover_snapshot_0s_1768334932_image.jpeg"
-genre:
-  - Pop/alt eletrônico cinematográfico
-  - "mid-tempo (92 BPM). O intro traz spoken word em filtro de rádio sobre textura granular ambiente. Versos íntimos: kick suave"
-  - baixo morno
-  - pads etéreos
-  - vocal masculino/andrógeno bem próximo. Pré-refrão sugere tensão com arpeggio sutil. No refrão
-  - bateria completa
 duration: 262
 tags:
   - music
 lang: en
 translationKey: music-eu-ia-escrever-sobre-o-infinito-de-novo
 draftCreatedAt: "2026-06-12T12:06:06.428Z"
+sunoStyle: |-
+  Pop/alt eletrônico cinematográfico
+  mid-tempo (92 BPM). O intro traz spoken word em filtro de rádio sobre textura granular ambiente. Versos íntimos: kick suave
+  baixo morno
+  pads etéreos
+  vocal masculino/andrógeno bem próximo. Pré-refrão sugere tensão com arpeggio sutil. No refrão
+  bateria completa
+genre:
+  - eletrônico
+  - pop
+  - spoken word
 ---
 
 ## Lyrics

--- a/src/content/blog/eu-ia-escrever-sobre-o-infinito-de-novo/v-2026-06-09T20-24-29.mdx
+++ b/src/content/blog/eu-ia-escrever-sobre-o-infinito-de-novo/v-2026-06-09T20-24-29.mdx
@@ -5,19 +5,23 @@ date: 2026-01-11
 postType: music
 sunoId: 2509efa2-b655-4340-830f-294567cbc2bb
 sunoImageUrl: "https://cdn2.suno.ai/video_gen_72af9eeb-69c3-4b66-8059-551bc9207f94_video_upload_72af9eeb-69c3-4b66-8059-551bc9207f94_cover_snapshot_0s_1768334932_image.jpeg"
-genre:
-  - Pop/alt eletrônico cinematográfico
-  - "mid-tempo (92 BPM). O intro traz spoken word em filtro de rádio sobre textura granular ambiente. Versos íntimos: kick suave"
-  - baixo morno
-  - pads etéreos
-  - vocal masculino/andrógeno bem próximo. Pré-refrão sugere tensão com arpeggio sutil. No refrão
-  - bateria completa
 duration: 262
 tags:
   - música
 lang: pt
 translationKey: music-eu-ia-escrever-sobre-o-infinito-de-novo
 draftCreatedAt: "2026-06-12T12:06:06.428Z"
+sunoStyle: |-
+  Pop/alt eletrônico cinematográfico
+  mid-tempo (92 BPM). O intro traz spoken word em filtro de rádio sobre textura granular ambiente. Versos íntimos: kick suave
+  baixo morno
+  pads etéreos
+  vocal masculino/andrógeno bem próximo. Pré-refrão sugere tensão com arpeggio sutil. No refrão
+  bateria completa
+genre:
+  - eletrônico
+  - pop
+  - spoken word
 ---
 
 ## Letra

--- a/src/content/blog/f73c60f0-49af-45fd-a483-1d35a676dccc-en/v-2026-06-09T20-24-29.mdx
+++ b/src/content/blog/f73c60f0-49af-45fd-a483-1d35a676dccc-en/v-2026-06-09T20-24-29.mdx
@@ -5,18 +5,21 @@ date: 2025-01-07
 postType: music
 sunoId: f73c60f0-49af-45fd-a483-1d35a676dccc
 sunoImageUrl: "https://cdn2.suno.ai/image_f73c60f0-49af-45fd-a483-1d35a676dccc.jpeg"
-genre:
-  - "Narration: slow"
-  - calm tone
-  - "clear pauses. Styles: ambient"
-  - classical
-  - cinematic.
 duration: 240
 tags:
   - music
 lang: en
 translationKey: music-f73c60f0-49af-45fd-a483-1d35a676dccc
 draftCreatedAt: "2026-06-12T12:06:06.428Z"
+sunoStyle: |-
+  Narration: slow
+  calm tone
+  clear pauses. Styles: ambient
+  classical
+  cinematic.
+genre:
+  - ambient
+  - clássico
 ---
 
 ## Lyrics

--- a/src/content/blog/f73c60f0-49af-45fd-a483-1d35a676dccc-en/v-2026-06-11T02-22-24-592.mdx
+++ b/src/content/blog/f73c60f0-49af-45fd-a483-1d35a676dccc-en/v-2026-06-11T02-22-24-592.mdx
@@ -5,12 +5,6 @@ date: 2025-01-07T00:00:00.000Z
 postType: music
 sunoId: f73c60f0-49af-45fd-a483-1d35a676dccc
 sunoImageUrl: "https://cdn2.suno.ai/image_f73c60f0-49af-45fd-a483-1d35a676dccc.jpeg"
-genre:
-  - "Narration: slow"
-  - calm tone
-  - "clear pauses. Styles: ambient"
-  - classical
-  - cinematic.
 duration: 240
 tags:
   - music
@@ -20,6 +14,15 @@ supersedes: 075f2c3d-6e78-5b37-9b1e-f4b662474f85
 draftCreatedAt: "2026-06-11T02:22:24.593Z"
 draftMsg: Minor edits to improve clarity and closing cadence
 draftCommittedAt: "2026-06-11T02:26:27.235Z"
+sunoStyle: |-
+  Narration: slow
+  calm tone
+  clear pauses. Styles: ambient
+  classical
+  cinematic.
+genre:
+  - ambient
+  - clássico
 ---
 
 ## Lyrics

--- a/src/content/blog/f73c60f0-49af-45fd-a483-1d35a676dccc/v-2026-06-09T20-24-29.mdx
+++ b/src/content/blog/f73c60f0-49af-45fd-a483-1d35a676dccc/v-2026-06-09T20-24-29.mdx
@@ -5,18 +5,21 @@ date: 2025-01-07
 postType: music
 sunoId: f73c60f0-49af-45fd-a483-1d35a676dccc
 sunoImageUrl: "https://cdn2.suno.ai/image_f73c60f0-49af-45fd-a483-1d35a676dccc.jpeg"
-genre:
-  - "Narration: slow"
-  - calm tone
-  - "clear pauses. Styles: ambient"
-  - classical
-  - cinematic.
 duration: 240
 tags:
   - música
 lang: pt
 translationKey: music-f73c60f0-49af-45fd-a483-1d35a676dccc
 draftCreatedAt: "2026-06-12T12:06:06.428Z"
+sunoStyle: |-
+  Narration: slow
+  calm tone
+  clear pauses. Styles: ambient
+  classical
+  cinematic.
+genre:
+  - ambient
+  - clássico
 ---
 
 ## Letra

--- a/src/content/blog/f73c60f0-49af-45fd-a483-1d35a676dccc/v-2026-06-11T02-22-24-592.mdx
+++ b/src/content/blog/f73c60f0-49af-45fd-a483-1d35a676dccc/v-2026-06-11T02-22-24-592.mdx
@@ -5,12 +5,6 @@ date: 2025-01-07T00:00:00.000Z
 postType: music
 sunoId: f73c60f0-49af-45fd-a483-1d35a676dccc
 sunoImageUrl: "https://cdn2.suno.ai/image_f73c60f0-49af-45fd-a483-1d35a676dccc.jpeg"
-genre:
-  - "Narration: slow"
-  - calm tone
-  - "clear pauses. Styles: ambient"
-  - classical
-  - cinematic.
 duration: 240
 tags:
   - música
@@ -20,6 +14,15 @@ supersedes: db732466-1423-52ae-a553-1aed3f50eb51
 draftCreatedAt: "2026-06-11T02:22:24.593Z"
 draftMsg: Minor edits to improve clarity and closing cadence
 draftCommittedAt: "2026-06-11T02:26:27.235Z"
+sunoStyle: |-
+  Narration: slow
+  calm tone
+  clear pauses. Styles: ambient
+  classical
+  cinematic.
+genre:
+  - ambient
+  - clássico
 ---
 
 ## Letra

--- a/src/content/blog/f85fb538-6f59-4751-8629-da76665fc91e-en/v-2026-06-10T02-19-02.mdx
+++ b/src/content/blog/f85fb538-6f59-4751-8629-da76665fc91e-en/v-2026-06-10T02-19-02.mdx
@@ -5,19 +5,23 @@ date: 2025-02-13
 postType: music
 sunoId: f85fb538-6f59-4751-8629-da76665fc91e
 sunoImageUrl: "https://cdn2.suno.ai/image_f85fb538-6f59-4751-8629-da76665fc91e.jpeg"
-genre:
-  - harpa
-  - sintetizador
-  - jazz
-  - bossa-nova
-  - groove
-  - hipnótico
 duration: 240
 tags:
   - music
 lang: en
 translationKey: music-f85fb538-6f59-4751-8629-da76665fc91e
 draftCreatedAt: "2026-06-12T12:06:06.428Z"
+sunoStyle: |-
+  harpa
+  sintetizador
+  jazz
+  bossa-nova
+  groove
+  hipnótico
+genre:
+  - jazz
+  - bossa nova
+  - instrumental
 ---
 
 ## Lyrics

--- a/src/content/blog/f85fb538-6f59-4751-8629-da76665fc91e-en/v-2026-06-10T08-54-18.mdx
+++ b/src/content/blog/f85fb538-6f59-4751-8629-da76665fc91e-en/v-2026-06-10T08-54-18.mdx
@@ -5,13 +5,6 @@ date: 2025-02-13T00:00:00.000Z
 postType: music
 sunoId: f85fb538-6f59-4751-8629-da76665fc91e
 sunoImageUrl: "https://cdn2.suno.ai/image_f85fb538-6f59-4751-8629-da76665fc91e.jpeg"
-genre:
-  - harpa
-  - sintetizador
-  - jazz
-  - bossa-nova
-  - groove
-  - hipnótico
 duration: 240
 tags:
   - music
@@ -24,6 +17,17 @@ draftMsg: >-
   mystical surrender to an LLM, reducing the unearned philosophical posturing
   and embracing structural vulnerability.
 draftCommittedAt: "2026-06-10T08:57:04.168Z"
+sunoStyle: |-
+  harpa
+  sintetizador
+  jazz
+  bossa-nova
+  groove
+  hipnótico
+genre:
+  - jazz
+  - bossa nova
+  - instrumental
 ---
 
 ## Lyrics

--- a/src/content/blog/f85fb538-6f59-4751-8629-da76665fc91e-en/v-2026-06-13T02-08-52-069.mdx
+++ b/src/content/blog/f85fb538-6f59-4751-8629-da76665fc91e-en/v-2026-06-13T02-08-52-069.mdx
@@ -5,13 +5,6 @@ date: 2025-02-13T00:00:00.000Z
 postType: music
 sunoId: f85fb538-6f59-4751-8629-da76665fc91e
 sunoImageUrl: "https://cdn2.suno.ai/image_f85fb538-6f59-4751-8629-da76665fc91e.jpeg"
-genre:
-  - harpa
-  - sintetizador
-  - jazz
-  - bossa-nova
-  - groove
-  - hipnótico
 duration: 240
 tags:
   - music
@@ -21,6 +14,17 @@ draftCreatedAt: "2026-06-13T02:08:52.069Z"
 supersedes: b9febfbb-3753-5c1a-b813-81f69d07d89c
 draftMsg: Address perspective feedback and improve narrative clarity
 draftCommittedAt: "2026-06-13T02:15:18.132Z"
+sunoStyle: |-
+  harpa
+  sintetizador
+  jazz
+  bossa-nova
+  groove
+  hipnótico
+genre:
+  - jazz
+  - bossa nova
+  - instrumental
 ---
 
 ## Lyrics

--- a/src/content/blog/f85fb538-6f59-4751-8629-da76665fc91e-en/v-2026-06-13T04-44-10-609.mdx
+++ b/src/content/blog/f85fb538-6f59-4751-8629-da76665fc91e-en/v-2026-06-13T04-44-10-609.mdx
@@ -5,13 +5,6 @@ date: 2025-02-13T00:00:00.000Z
 postType: music
 sunoId: f85fb538-6f59-4751-8629-da76665fc91e
 sunoImageUrl: "https://cdn2.suno.ai/image_f85fb538-6f59-4751-8629-da76665fc91e.jpeg"
-genre:
-  - harpa
-  - sintetizador
-  - jazz
-  - bossa-nova
-  - groove
-  - hipnótico
 duration: 240
 tags:
   - music
@@ -23,6 +16,17 @@ draftMsg: >-
   Editar worst draft para evitar tiques repetitivos e incorporar reflexão
   estrutural como sugerido pela análise do The Returning Reader.
 draftCommittedAt: "2026-06-13T04:44:56.562Z"
+sunoStyle: |-
+  harpa
+  sintetizador
+  jazz
+  bossa-nova
+  groove
+  hipnótico
+genre:
+  - jazz
+  - bossa nova
+  - instrumental
 ---
 
 ## Lyrics

--- a/src/content/blog/f85fb538-6f59-4751-8629-da76665fc91e-en/v-2026-06-13T07-45-00-613.mdx
+++ b/src/content/blog/f85fb538-6f59-4751-8629-da76665fc91e-en/v-2026-06-13T07-45-00-613.mdx
@@ -5,13 +5,6 @@ date: 2025-02-13T00:00:00.000Z
 postType: music
 sunoId: f85fb538-6f59-4751-8629-da76665fc91e
 sunoImageUrl: "https://cdn2.suno.ai/image_f85fb538-6f59-4751-8629-da76665fc91e.jpeg"
-genre:
-  - harpa
-  - sintetizador
-  - jazz
-  - bossa-nova
-  - groove
-  - hipnótico
 duration: 240
 tags:
   - music
@@ -21,6 +14,17 @@ draftCreatedAt: "2026-06-13T07:45:00.613Z"
 supersedes: b9febfbb-3753-5c1a-b813-81f69d07d89c
 draftMsg: Qualitative improvement addressing the resolution issue from Hrönir feedback
 draftCommittedAt: "2026-06-13T07:46:02.062Z"
+sunoStyle: |-
+  harpa
+  sintetizador
+  jazz
+  bossa-nova
+  groove
+  hipnótico
+genre:
+  - jazz
+  - bossa nova
+  - instrumental
 ---
 
 ## Lyrics

--- a/src/content/blog/f85fb538-6f59-4751-8629-da76665fc91e/v-2026-06-10T02-19-02.mdx
+++ b/src/content/blog/f85fb538-6f59-4751-8629-da76665fc91e/v-2026-06-10T02-19-02.mdx
@@ -5,19 +5,23 @@ date: 2025-02-13
 postType: music
 sunoId: f85fb538-6f59-4751-8629-da76665fc91e
 sunoImageUrl: "https://cdn2.suno.ai/image_f85fb538-6f59-4751-8629-da76665fc91e.jpeg"
-genre:
-  - harpa
-  - sintetizador
-  - jazz
-  - bossa-nova
-  - groove
-  - hipnótico
 duration: 240
 tags:
   - música
 lang: pt
 translationKey: music-f85fb538-6f59-4751-8629-da76665fc91e
 draftCreatedAt: "2026-06-12T12:06:06.428Z"
+sunoStyle: |-
+  harpa
+  sintetizador
+  jazz
+  bossa-nova
+  groove
+  hipnótico
+genre:
+  - jazz
+  - bossa nova
+  - instrumental
 ---
 
 ## Letra

--- a/src/content/blog/f85fb538-6f59-4751-8629-da76665fc91e/v-2026-06-10T08-54-18.mdx
+++ b/src/content/blog/f85fb538-6f59-4751-8629-da76665fc91e/v-2026-06-10T08-54-18.mdx
@@ -5,13 +5,6 @@ date: 2025-02-13T00:00:00.000Z
 postType: music
 sunoId: f85fb538-6f59-4751-8629-da76665fc91e
 sunoImageUrl: "https://cdn2.suno.ai/image_f85fb538-6f59-4751-8629-da76665fc91e.jpeg"
-genre:
-  - harpa
-  - sintetizador
-  - jazz
-  - bossa-nova
-  - groove
-  - hipnótico
 duration: 240
 tags:
   - música
@@ -24,6 +17,17 @@ draftMsg: >-
   mystical surrender to an LLM, reducing the unearned philosophical posturing
   and embracing structural vulnerability.
 draftCommittedAt: "2026-06-10T08:57:04.168Z"
+sunoStyle: |-
+  harpa
+  sintetizador
+  jazz
+  bossa-nova
+  groove
+  hipnótico
+genre:
+  - jazz
+  - bossa nova
+  - instrumental
 ---
 
 ## Letra

--- a/src/content/blog/f85fb538-6f59-4751-8629-da76665fc91e/v-2026-06-13T02-08-52-069.mdx
+++ b/src/content/blog/f85fb538-6f59-4751-8629-da76665fc91e/v-2026-06-13T02-08-52-069.mdx
@@ -5,13 +5,6 @@ date: 2025-02-13T00:00:00.000Z
 postType: music
 sunoId: f85fb538-6f59-4751-8629-da76665fc91e
 sunoImageUrl: "https://cdn2.suno.ai/image_f85fb538-6f59-4751-8629-da76665fc91e.jpeg"
-genre:
-  - harpa
-  - sintetizador
-  - jazz
-  - bossa-nova
-  - groove
-  - hipnótico
 duration: 240
 tags:
   - música
@@ -21,6 +14,17 @@ draftCreatedAt: "2026-06-13T02:08:52.069Z"
 supersedes: 28348ca8-14be-5ccc-866e-648c92009f8a
 draftMsg: Address perspective feedback and improve narrative clarity
 draftCommittedAt: "2026-06-13T02:15:18.132Z"
+sunoStyle: |-
+  harpa
+  sintetizador
+  jazz
+  bossa-nova
+  groove
+  hipnótico
+genre:
+  - jazz
+  - bossa nova
+  - instrumental
 ---
 
 ## Letra

--- a/src/content/blog/f85fb538-6f59-4751-8629-da76665fc91e/v-2026-06-13T04-44-10-609.mdx
+++ b/src/content/blog/f85fb538-6f59-4751-8629-da76665fc91e/v-2026-06-13T04-44-10-609.mdx
@@ -5,13 +5,6 @@ date: 2025-02-13T00:00:00.000Z
 postType: music
 sunoId: f85fb538-6f59-4751-8629-da76665fc91e
 sunoImageUrl: "https://cdn2.suno.ai/image_f85fb538-6f59-4751-8629-da76665fc91e.jpeg"
-genre:
-  - harpa
-  - sintetizador
-  - jazz
-  - bossa-nova
-  - groove
-  - hipnótico
 duration: 240
 tags:
   - música
@@ -23,6 +16,17 @@ draftMsg: >-
   Editar worst draft para evitar tiques repetitivos e incorporar reflexão
   estrutural como sugerido pela análise do The Returning Reader.
 draftCommittedAt: "2026-06-13T04:44:56.562Z"
+sunoStyle: |-
+  harpa
+  sintetizador
+  jazz
+  bossa-nova
+  groove
+  hipnótico
+genre:
+  - jazz
+  - bossa nova
+  - instrumental
 ---
 
 ## Letra

--- a/src/content/blog/f85fb538-6f59-4751-8629-da76665fc91e/v-2026-06-13T07-45-00-613.mdx
+++ b/src/content/blog/f85fb538-6f59-4751-8629-da76665fc91e/v-2026-06-13T07-45-00-613.mdx
@@ -5,13 +5,6 @@ date: 2025-02-13T00:00:00.000Z
 postType: music
 sunoId: f85fb538-6f59-4751-8629-da76665fc91e
 sunoImageUrl: "https://cdn2.suno.ai/image_f85fb538-6f59-4751-8629-da76665fc91e.jpeg"
-genre:
-  - harpa
-  - sintetizador
-  - jazz
-  - bossa-nova
-  - groove
-  - hipnótico
 duration: 240
 tags:
   - música
@@ -21,6 +14,17 @@ draftCreatedAt: "2026-06-13T07:45:00.613Z"
 supersedes: 28348ca8-14be-5ccc-866e-648c92009f8a
 draftMsg: Qualitative improvement addressing the resolution issue from Hrönir feedback
 draftCommittedAt: "2026-06-13T07:46:02.062Z"
+sunoStyle: |-
+  harpa
+  sintetizador
+  jazz
+  bossa-nova
+  groove
+  hipnótico
+genre:
+  - jazz
+  - bossa nova
+  - instrumental
 ---
 
 ## Letra

--- a/src/content/blog/fourteen-words-en/v-2026-06-09T20-24-29.mdx
+++ b/src/content/blog/fourteen-words-en/v-2026-06-09T20-24-29.mdx
@@ -5,19 +5,22 @@ date: 2026-03-24
 postType: music
 sunoId: d03edd98-586a-4f92-9275-17e85491b437
 sunoImageUrl: "https://cdn2.suno.ai/image_d03edd98-586a-4f92-9275-17e85491b437.jpeg"
-genre:
-  - Dark ambient folk with ritual percussion
-  - clay drums
-  - low wooden flute
-  - droning strings
-  - cavernous male vocals. Slow ceremonial pace building to a climax in the bridge
-  - then dissolving into silence. Mesoamerican ritual atmosphere
 duration: 312
 tags:
   - music
 lang: en
 translationKey: music-fourteen-words
 draftCreatedAt: "2026-06-12T12:06:06.428Z"
+sunoStyle: |-
+  Dark ambient folk with ritual percussion
+  clay drums
+  low wooden flute
+  droning strings
+  cavernous male vocals. Slow ceremonial pace building to a climax in the bridge
+  then dissolving into silence. Mesoamerican ritual atmosphere
+genre:
+  - folk
+  - ambient
 ---
 
 ## Lyrics

--- a/src/content/blog/fourteen-words/v-2026-06-09T20-24-29.mdx
+++ b/src/content/blog/fourteen-words/v-2026-06-09T20-24-29.mdx
@@ -5,19 +5,22 @@ date: 2026-03-24
 postType: music
 sunoId: d03edd98-586a-4f92-9275-17e85491b437
 sunoImageUrl: "https://cdn2.suno.ai/image_d03edd98-586a-4f92-9275-17e85491b437.jpeg"
-genre:
-  - Dark ambient folk with ritual percussion
-  - clay drums
-  - low wooden flute
-  - droning strings
-  - cavernous male vocals. Slow ceremonial pace building to a climax in the bridge
-  - then dissolving into silence. Mesoamerican ritual atmosphere
 duration: 312
 tags:
   - música
 lang: pt
 translationKey: music-fourteen-words
 draftCreatedAt: "2026-06-12T12:06:06.428Z"
+sunoStyle: |-
+  Dark ambient folk with ritual percussion
+  clay drums
+  low wooden flute
+  droning strings
+  cavernous male vocals. Slow ceremonial pace building to a climax in the bridge
+  then dissolving into silence. Mesoamerican ritual atmosphere
+genre:
+  - folk
+  - ambient
 ---
 
 ## Letra

--- a/src/content/blog/john-gospel-chapter-i-by-max-headroom-en/v-2026-06-09T20-24-29.mdx
+++ b/src/content/blog/john-gospel-chapter-i-by-max-headroom-en/v-2026-06-09T20-24-29.mdx
@@ -5,15 +5,18 @@ date: 2025-02-18
 postType: music
 sunoId: a9a82259-caa4-42a0-a701-f1af5290de93
 sunoImageUrl: "https://cdn2.suno.ai/a9a82259-caa4-42a0-a701-f1af5290de93_d1b0979e.jpeg"
-genre:
-  - Headroom
-  - glitch
 duration: 191
 tags:
   - music
 lang: en
 translationKey: music-john-gospel-chapter-i-by-max-headroom
 draftCreatedAt: "2026-06-12T12:06:06.428Z"
+sunoStyle: |-
+  Headroom
+  glitch
+genre:
+  - glitch
+  - experimental
 ---
 
 ## Lyrics

--- a/src/content/blog/john-gospel-chapter-i-by-max-headroom/v-2026-06-09T20-24-29.mdx
+++ b/src/content/blog/john-gospel-chapter-i-by-max-headroom/v-2026-06-09T20-24-29.mdx
@@ -5,15 +5,18 @@ date: 2025-02-18
 postType: music
 sunoId: a9a82259-caa4-42a0-a701-f1af5290de93
 sunoImageUrl: "https://cdn2.suno.ai/a9a82259-caa4-42a0-a701-f1af5290de93_d1b0979e.jpeg"
-genre:
-  - Headroom
-  - glitch
 duration: 191
 tags:
   - música
 lang: pt
 translationKey: music-john-gospel-chapter-i-by-max-headroom
 draftCreatedAt: "2026-06-12T12:06:06.428Z"
+sunoStyle: |-
+  Headroom
+  glitch
+genre:
+  - glitch
+  - experimental
 ---
 
 ## Letra

--- a/src/content/blog/leite-no-salao-bar-en/v-2026-06-09T20-24-29.mdx
+++ b/src/content/blog/leite-no-salao-bar-en/v-2026-06-09T20-24-29.mdx
@@ -5,18 +5,21 @@ date: 2025-11-22
 postType: music
 sunoId: bec57669-72c0-4744-95cf-f764b9590b73
 sunoImageUrl: "https://cdn2.suno.ai/image_bec57669-72c0-4744-95cf-f764b9590b73.jpeg"
-genre:
-  - Rooted in Brazilian Moda de Viola
-  - the track opens with a lively Viola Caipira fingerpicked motif. Acoustic guitar enriches the textures
-  - accentuating the Cateretê rhythm with syncopated percussion and subtle handclaps. Male vocals deliver the ironic folk narrative
-  - while dynamic instrumental breaks highlight rustic
-  - storytelling nuances unique to the caipira dialect.
 duration: 200
 tags:
   - music
 lang: en
 translationKey: music-leite-no-salao-bar
 draftCreatedAt: "2026-06-12T12:06:06.428Z"
+sunoStyle: |-
+  Rooted in Brazilian Moda de Viola
+  the track opens with a lively Viola Caipira fingerpicked motif. Acoustic guitar enriches the textures
+  accentuating the Cateretê rhythm with syncopated percussion and subtle handclaps. Male vocals deliver the ironic folk narrative
+  while dynamic instrumental breaks highlight rustic
+  storytelling nuances unique to the caipira dialect.
+genre:
+  - moda de viola
+  - folk
 ---
 
 ## Lyrics

--- a/src/content/blog/leite-no-salao-bar-en/v-2026-06-12T20-47-46-982.mdx
+++ b/src/content/blog/leite-no-salao-bar-en/v-2026-06-12T20-47-46-982.mdx
@@ -5,16 +5,6 @@ date: 2025-11-22T00:00:00.000Z
 postType: music
 sunoId: bec57669-72c0-4744-95cf-f764b9590b73
 sunoImageUrl: "https://cdn2.suno.ai/image_bec57669-72c0-4744-95cf-f764b9590b73.jpeg"
-genre:
-  - Rooted in Brazilian Moda de Viola
-  - >-
-    the track opens with a lively Viola Caipira fingerpicked motif. Acoustic
-    guitar enriches the textures
-  - >-
-    accentuating the Cateretê rhythm with syncopated percussion and subtle
-    handclaps. Male vocals deliver the ironic folk narrative
-  - while dynamic instrumental breaks highlight rustic
-  - storytelling nuances unique to the caipira dialect.
 duration: 200
 tags:
   - music
@@ -24,6 +14,15 @@ supersedes: df8037ae-3849-57a5-a3f4-b5e90d07cf78
 draftCreatedAt: "2026-06-12T20:47:46.983Z"
 draftMsg: Improved the worst post qualitative editing
 draftCommittedAt: "2026-06-12T20:50:48.018Z"
+sunoStyle: |-
+  Rooted in Brazilian Moda de Viola
+  >- the track opens with a lively Viola Caipira fingerpicked motif. Acoustic guitar enriches the textures
+  >- accentuating the Cateretê rhythm with syncopated percussion and subtle handclaps. Male vocals deliver the ironic folk narrative
+  while dynamic instrumental breaks highlight rustic
+  storytelling nuances unique to the caipira dialect.
+genre:
+  - moda de viola
+  - folk
 ---
 
 ## Lyrics

--- a/src/content/blog/leite-no-salao-bar/v-2026-06-09T20-24-29.mdx
+++ b/src/content/blog/leite-no-salao-bar/v-2026-06-09T20-24-29.mdx
@@ -5,18 +5,21 @@ date: 2025-11-22
 postType: music
 sunoId: bec57669-72c0-4744-95cf-f764b9590b73
 sunoImageUrl: "https://cdn2.suno.ai/image_bec57669-72c0-4744-95cf-f764b9590b73.jpeg"
-genre:
-  - Rooted in Brazilian Moda de Viola
-  - the track opens with a lively Viola Caipira fingerpicked motif. Acoustic guitar enriches the textures
-  - accentuating the Cateretê rhythm with syncopated percussion and subtle handclaps. Male vocals deliver the ironic folk narrative
-  - while dynamic instrumental breaks highlight rustic
-  - storytelling nuances unique to the caipira dialect.
 duration: 200
 tags:
   - música
 lang: pt
 translationKey: music-leite-no-salao-bar
 draftCreatedAt: "2026-06-12T12:06:06.428Z"
+sunoStyle: |-
+  Rooted in Brazilian Moda de Viola
+  the track opens with a lively Viola Caipira fingerpicked motif. Acoustic guitar enriches the textures
+  accentuating the Cateretê rhythm with syncopated percussion and subtle handclaps. Male vocals deliver the ironic folk narrative
+  while dynamic instrumental breaks highlight rustic
+  storytelling nuances unique to the caipira dialect.
+genre:
+  - moda de viola
+  - folk
 ---
 
 ## Letra

--- a/src/content/blog/leite-no-salao-bar/v-2026-06-12T20-47-46-982.mdx
+++ b/src/content/blog/leite-no-salao-bar/v-2026-06-12T20-47-46-982.mdx
@@ -5,16 +5,6 @@ date: 2025-11-22T00:00:00.000Z
 postType: music
 sunoId: bec57669-72c0-4744-95cf-f764b9590b73
 sunoImageUrl: "https://cdn2.suno.ai/image_bec57669-72c0-4744-95cf-f764b9590b73.jpeg"
-genre:
-  - Rooted in Brazilian Moda de Viola
-  - >-
-    the track opens with a lively Viola Caipira fingerpicked motif. Acoustic
-    guitar enriches the textures
-  - >-
-    accentuating the Cateretê rhythm with syncopated percussion and subtle
-    handclaps. Male vocals deliver the ironic folk narrative
-  - while dynamic instrumental breaks highlight rustic
-  - storytelling nuances unique to the caipira dialect.
 duration: 200
 tags:
   - música
@@ -24,6 +14,15 @@ supersedes: eb09cb4b-52d1-558b-aefc-ebd8395c1df5
 draftCreatedAt: "2026-06-12T20:47:46.983Z"
 draftMsg: Improved the worst post qualitative editing
 draftCommittedAt: "2026-06-12T20:50:48.018Z"
+sunoStyle: |-
+  Rooted in Brazilian Moda de Viola
+  >- the track opens with a lively Viola Caipira fingerpicked motif. Acoustic guitar enriches the textures
+  >- accentuating the Cateretê rhythm with syncopated percussion and subtle handclaps. Male vocals deliver the ironic folk narrative
+  while dynamic instrumental breaks highlight rustic
+  storytelling nuances unique to the caipira dialect.
+genre:
+  - moda de viola
+  - folk
 ---
 
 ## Letra

--- a/src/content/blog/meditacao-guiada-no-sertao-en/v-2026-06-09T20-24-29.mdx
+++ b/src/content/blog/meditacao-guiada-no-sertao-en/v-2026-06-09T20-24-29.mdx
@@ -5,14 +5,17 @@ date: 2025-05-03
 postType: music
 sunoId: b38ccef8-fc26-4bbb-b220-9f43520cefdf
 sunoImageUrl: "https://cdn2.suno.ai/image_b38ccef8-fc26-4bbb-b220-9f43520cefdf.jpeg"
-genre:
-  - Mindfulness guiding meditation. Soft spoken words. Water sounds on background.  Poradic soft  bells. Flute in low volume.No music. Soft spoken words for the whole track.
 duration: 355
 tags:
   - music
 lang: en
 translationKey: music-meditacao-guiada-no-sertao
 draftCreatedAt: "2026-06-12T12:06:06.428Z"
+sunoStyle: |-
+  Mindfulness guiding meditation. Soft spoken words. Water sounds on background.  Poradic soft  bells. Flute in low volume.No music. Soft spoken words for the whole track.
+genre:
+  - spoken word
+  - ambient
 ---
 
 ## Lyrics

--- a/src/content/blog/meditacao-guiada-no-sertao/v-2026-06-09T20-24-29.mdx
+++ b/src/content/blog/meditacao-guiada-no-sertao/v-2026-06-09T20-24-29.mdx
@@ -5,14 +5,17 @@ date: 2025-05-03
 postType: music
 sunoId: b38ccef8-fc26-4bbb-b220-9f43520cefdf
 sunoImageUrl: "https://cdn2.suno.ai/image_b38ccef8-fc26-4bbb-b220-9f43520cefdf.jpeg"
-genre:
-  - Mindfulness guiding meditation. Soft spoken words. Water sounds on background.  Poradic soft  bells. Flute in low volume.No music. Soft spoken words for the whole track.
 duration: 355
 tags:
   - música
 lang: pt
 translationKey: music-meditacao-guiada-no-sertao
 draftCreatedAt: "2026-06-12T12:06:06.428Z"
+sunoStyle: |-
+  Mindfulness guiding meditation. Soft spoken words. Water sounds on background.  Poradic soft  bells. Flute in low volume.No music. Soft spoken words for the whole track.
+genre:
+  - spoken word
+  - ambient
 ---
 
 ## Letra

--- a/src/content/blog/menino-que-voce-foi-en/v-2026-06-09T20-24-29.mdx
+++ b/src/content/blog/menino-que-voce-foi-en/v-2026-06-09T20-24-29.mdx
@@ -5,19 +5,22 @@ date: 2026-03-08
 postType: music
 sunoId: 6d05bd18-3cdd-4b05-a8db-8347ff8b130d
 sunoImageUrl: "https://cdn2.suno.ai/image_6d05bd18-3cdd-4b05-a8db-8347ff8b130d.jpeg"
-genre:
-  - ambient meditation
-  - childhood memory visualization
-  - deep warm male vocals
-  - slow spoken word delivery
-  - gentle nostalgic tone
-  - soft piano notes
 duration: 427
 tags:
   - music
 lang: en
 translationKey: music-menino-que-voce-foi
 draftCreatedAt: "2026-06-12T12:06:06.428Z"
+sunoStyle: |-
+  ambient meditation
+  childhood memory visualization
+  deep warm male vocals
+  slow spoken word delivery
+  gentle nostalgic tone
+  soft piano notes
+genre:
+  - ambient
+  - spoken word
 ---
 
 ## Lyrics

--- a/src/content/blog/menino-que-voce-foi-en/v-2026-06-12T17-47-27-031.mdx
+++ b/src/content/blog/menino-que-voce-foi-en/v-2026-06-12T17-47-27-031.mdx
@@ -5,13 +5,6 @@ date: 2026-03-08T00:00:00.000Z
 postType: music
 sunoId: 6d05bd18-3cdd-4b05-a8db-8347ff8b130d
 sunoImageUrl: "https://cdn2.suno.ai/image_6d05bd18-3cdd-4b05-a8db-8347ff8b130d.jpeg"
-genre:
-  - ambient meditation
-  - childhood memory visualization
-  - deep warm male vocals
-  - slow spoken word delivery
-  - gentle nostalgic tone
-  - soft piano notes
 duration: 427
 tags:
   - music
@@ -21,6 +14,16 @@ supersedes: b381f6f0-606a-581a-b047-75cfbd350650
 draftCreatedAt: "2026-06-12T17:47:27.032Z"
 draftMsg: Auto-edited lowest ranked post
 draftCommittedAt: "2026-06-12T17:47:45.263Z"
+sunoStyle: |-
+  ambient meditation
+  childhood memory visualization
+  deep warm male vocals
+  slow spoken word delivery
+  gentle nostalgic tone
+  soft piano notes
+genre:
+  - ambient
+  - spoken word
 ---
 
 ## Lyrics

--- a/src/content/blog/menino-que-voce-foi-en/v-2026-06-12T19-12-49-666.mdx
+++ b/src/content/blog/menino-que-voce-foi-en/v-2026-06-12T19-12-49-666.mdx
@@ -5,13 +5,6 @@ date: 2026-03-08T00:00:00.000Z
 postType: music
 sunoId: 6d05bd18-3cdd-4b05-a8db-8347ff8b130d
 sunoImageUrl: "https://cdn2.suno.ai/image_6d05bd18-3cdd-4b05-a8db-8347ff8b130d.jpeg"
-genre:
-  - ambient meditation
-  - childhood memory visualization
-  - deep warm male vocals
-  - slow spoken word delivery
-  - gentle nostalgic tone
-  - soft piano notes
 duration: 427
 tags:
   - music
@@ -21,6 +14,16 @@ supersedes: b381f6f0-606a-581a-b047-75cfbd350650
 draftCreatedAt: "2026-06-12T19:12:49.666Z"
 draftMsg: Auto-edit worst post
 draftCommittedAt: "2026-06-12T19:13:18.333Z"
+sunoStyle: |-
+  ambient meditation
+  childhood memory visualization
+  deep warm male vocals
+  slow spoken word delivery
+  gentle nostalgic tone
+  soft piano notes
+genre:
+  - ambient
+  - spoken word
 ---
 
 ## Lyrics

--- a/src/content/blog/menino-que-voce-foi/v-2026-06-09T20-24-29.mdx
+++ b/src/content/blog/menino-que-voce-foi/v-2026-06-09T20-24-29.mdx
@@ -5,19 +5,22 @@ date: 2026-03-08
 postType: music
 sunoId: 6d05bd18-3cdd-4b05-a8db-8347ff8b130d
 sunoImageUrl: "https://cdn2.suno.ai/image_6d05bd18-3cdd-4b05-a8db-8347ff8b130d.jpeg"
-genre:
-  - ambient meditation
-  - childhood memory visualization
-  - deep warm male vocals
-  - slow spoken word delivery
-  - gentle nostalgic tone
-  - soft piano notes
 duration: 427
 tags:
   - música
 lang: pt
 translationKey: music-menino-que-voce-foi
 draftCreatedAt: "2026-06-12T12:06:06.428Z"
+sunoStyle: |-
+  ambient meditation
+  childhood memory visualization
+  deep warm male vocals
+  slow spoken word delivery
+  gentle nostalgic tone
+  soft piano notes
+genre:
+  - ambient
+  - spoken word
 ---
 
 ## Letra

--- a/src/content/blog/menino-que-voce-foi/v-2026-06-12T17-47-27-031.mdx
+++ b/src/content/blog/menino-que-voce-foi/v-2026-06-12T17-47-27-031.mdx
@@ -5,13 +5,6 @@ date: 2026-03-08T00:00:00.000Z
 postType: music
 sunoId: 6d05bd18-3cdd-4b05-a8db-8347ff8b130d
 sunoImageUrl: "https://cdn2.suno.ai/image_6d05bd18-3cdd-4b05-a8db-8347ff8b130d.jpeg"
-genre:
-  - ambient meditation
-  - childhood memory visualization
-  - deep warm male vocals
-  - slow spoken word delivery
-  - gentle nostalgic tone
-  - soft piano notes
 duration: 427
 tags:
   - música
@@ -21,6 +14,16 @@ supersedes: 7f0778d1-1486-5f9c-916e-abac613f9863
 draftCreatedAt: "2026-06-12T17:47:27.032Z"
 draftMsg: Auto-edited lowest ranked post
 draftCommittedAt: "2026-06-12T17:47:45.263Z"
+sunoStyle: |-
+  ambient meditation
+  childhood memory visualization
+  deep warm male vocals
+  slow spoken word delivery
+  gentle nostalgic tone
+  soft piano notes
+genre:
+  - ambient
+  - spoken word
 ---
 
 ## Letra

--- a/src/content/blog/menino-que-voce-foi/v-2026-06-12T19-12-49-666.mdx
+++ b/src/content/blog/menino-que-voce-foi/v-2026-06-12T19-12-49-666.mdx
@@ -5,13 +5,6 @@ date: 2026-03-08T00:00:00.000Z
 postType: music
 sunoId: 6d05bd18-3cdd-4b05-a8db-8347ff8b130d
 sunoImageUrl: "https://cdn2.suno.ai/image_6d05bd18-3cdd-4b05-a8db-8347ff8b130d.jpeg"
-genre:
-  - ambient meditation
-  - childhood memory visualization
-  - deep warm male vocals
-  - slow spoken word delivery
-  - gentle nostalgic tone
-  - soft piano notes
 duration: 427
 tags:
   - música
@@ -21,6 +14,16 @@ supersedes: 7f0778d1-1486-5f9c-916e-abac613f9863
 draftCreatedAt: "2026-06-12T19:12:49.666Z"
 draftMsg: Auto-edit worst post
 draftCommittedAt: "2026-06-12T19:13:18.333Z"
+sunoStyle: |-
+  ambient meditation
+  childhood memory visualization
+  deep warm male vocals
+  slow spoken word delivery
+  gentle nostalgic tone
+  soft piano notes
+genre:
+  - ambient
+  - spoken word
 ---
 
 ## Letra

--- a/src/content/blog/mindfulness-en/v-2026-06-09T20-24-29.mdx
+++ b/src/content/blog/mindfulness-en/v-2026-06-09T20-24-29.mdx
@@ -5,18 +5,21 @@ date: 2025-01-07
 postType: music
 sunoId: 5a5aad96-74bc-4cfe-a56d-f8fc171174b9
 sunoImageUrl: "https://cdn2.suno.ai/image_5a5aad96-74bc-4cfe-a56d-f8fc171174b9.jpeg"
-genre:
-  - slow
-  - calm tone
-  - clear pauses. ambient
-  - classical
-  - new age
 duration: 240
 tags:
   - music
 lang: en
 translationKey: music-mindfulness
 draftCreatedAt: "2026-06-12T12:06:06.428Z"
+sunoStyle: |-
+  slow
+  calm tone
+  clear pauses. ambient
+  classical
+  new age
+genre:
+  - ambient
+  - clássico
 ---
 
 ## Lyrics

--- a/src/content/blog/mindfulness-en/v-2026-06-10T06-17-55.mdx
+++ b/src/content/blog/mindfulness-en/v-2026-06-10T06-17-55.mdx
@@ -5,12 +5,6 @@ date: 2025-01-07T00:00:00.000Z
 postType: music
 sunoId: 5a5aad96-74bc-4cfe-a56d-f8fc171174b9
 sunoImageUrl: "https://cdn2.suno.ai/image_5a5aad96-74bc-4cfe-a56d-f8fc171174b9.jpeg"
-genre:
-  - slow
-  - calm tone
-  - clear pauses. ambient
-  - classical
-  - new age
 duration: 240
 tags:
   - music
@@ -22,6 +16,15 @@ draftMsg: >-
   Reestrutura notas: admissão como abertura, final seco em vez de solenidade
   teórica
 draftCommittedAt: "2026-06-10T06:21:26.059Z"
+sunoStyle: |-
+  slow
+  calm tone
+  clear pauses. ambient
+  classical
+  new age
+genre:
+  - ambient
+  - clássico
 ---
 
 ## Lyrics

--- a/src/content/blog/mindfulness-en/v-2026-06-10T07-09-27.mdx
+++ b/src/content/blog/mindfulness-en/v-2026-06-10T07-09-27.mdx
@@ -5,12 +5,6 @@ date: 2025-01-07T00:00:00.000Z
 postType: music
 sunoId: 5a5aad96-74bc-4cfe-a56d-f8fc171174b9
 sunoImageUrl: "https://cdn2.suno.ai/image_5a5aad96-74bc-4cfe-a56d-f8fc171174b9.jpeg"
-genre:
-  - slow
-  - calm tone
-  - clear pauses. ambient
-  - classical
-  - new age
 duration: 240
 tags:
   - music
@@ -22,6 +16,15 @@ draftMsg: >-
   Rewrite mindfulness notes to add humor and structural irony per
   Comedy-Carries-Argument feedback
 draftCommittedAt: "2026-06-10T07:11:27.969Z"
+sunoStyle: |-
+  slow
+  calm tone
+  clear pauses. ambient
+  classical
+  new age
+genre:
+  - ambient
+  - clássico
 ---
 
 ## Lyrics

--- a/src/content/blog/mindfulness/v-2026-06-09T20-24-29.mdx
+++ b/src/content/blog/mindfulness/v-2026-06-09T20-24-29.mdx
@@ -5,18 +5,21 @@ date: 2025-01-07
 postType: music
 sunoId: 5a5aad96-74bc-4cfe-a56d-f8fc171174b9
 sunoImageUrl: "https://cdn2.suno.ai/image_5a5aad96-74bc-4cfe-a56d-f8fc171174b9.jpeg"
-genre:
-  - slow
-  - calm tone
-  - clear pauses. ambient
-  - classical
-  - new age
 duration: 240
 tags:
   - música
 lang: pt
 translationKey: music-mindfulness
 draftCreatedAt: "2026-06-12T12:06:06.428Z"
+sunoStyle: |-
+  slow
+  calm tone
+  clear pauses. ambient
+  classical
+  new age
+genre:
+  - ambient
+  - clássico
 ---
 
 ## Letra

--- a/src/content/blog/mindfulness/v-2026-06-10T06-17-55.mdx
+++ b/src/content/blog/mindfulness/v-2026-06-10T06-17-55.mdx
@@ -5,12 +5,6 @@ date: 2025-01-07T00:00:00.000Z
 postType: music
 sunoId: 5a5aad96-74bc-4cfe-a56d-f8fc171174b9
 sunoImageUrl: "https://cdn2.suno.ai/image_5a5aad96-74bc-4cfe-a56d-f8fc171174b9.jpeg"
-genre:
-  - slow
-  - calm tone
-  - clear pauses. ambient
-  - classical
-  - new age
 duration: 240
 tags:
   - música
@@ -22,6 +16,15 @@ draftMsg: >-
   Reestrutura notas: admissão como abertura, final seco em vez de solenidade
   teórica
 draftCommittedAt: "2026-06-10T06:21:26.059Z"
+sunoStyle: |-
+  slow
+  calm tone
+  clear pauses. ambient
+  classical
+  new age
+genre:
+  - ambient
+  - clássico
 ---
 
 ## Letra

--- a/src/content/blog/mindfulness/v-2026-06-10T07-09-27.mdx
+++ b/src/content/blog/mindfulness/v-2026-06-10T07-09-27.mdx
@@ -5,12 +5,6 @@ date: 2025-01-07T00:00:00.000Z
 postType: music
 sunoId: 5a5aad96-74bc-4cfe-a56d-f8fc171174b9
 sunoImageUrl: "https://cdn2.suno.ai/image_5a5aad96-74bc-4cfe-a56d-f8fc171174b9.jpeg"
-genre:
-  - slow
-  - calm tone
-  - clear pauses. ambient
-  - classical
-  - new age
 duration: 240
 tags:
   - música
@@ -22,6 +16,15 @@ draftMsg: >-
   Rewrite mindfulness notes to add humor and structural irony per
   Comedy-Carries-Argument feedback
 draftCommittedAt: "2026-06-10T07:11:27.969Z"
+sunoStyle: |-
+  slow
+  calm tone
+  clear pauses. ambient
+  classical
+  new age
+genre:
+  - ambient
+  - clássico
 ---
 
 ## Letra

--- a/src/content/blog/nonada-en/v-2026-06-09T20-24-29.mdx
+++ b/src/content/blog/nonada-en/v-2026-06-09T20-24-29.mdx
@@ -5,12 +5,6 @@ date: 2025-05-03
 postType: music
 sunoId: 916bd4cb-a9fb-4914-85fe-e4ca4545d3bf
 sunoImageUrl: "https://cdn2.suno.ai/image_916bd4cb-a9fb-4914-85fe-e4ca4545d3bf.jpeg"
-genre:
-  - An immersive 12‑minute guided‑meditation track titled “Nonada
-  - ” the opening piece of the album “Travessias do Sertão.” A warm baritone Brazilian narrator with a gentle northeastern accent speaks at about seventy words per minute
-  - leaving wide pauses wherever the script shows double line breaks. A finger‑picked acoustic guitar in D major opens for four seconds
-  - then hangs beneath the voice in airy reverb
-  - "surfacing only as soft harmonic swells.
 
 Ambient texture summons the sertão after rain: distant cicadas"
   - a light breeze through juazeiro leaves
@@ -20,6 +14,15 @@ tags:
 lang: en
 translationKey: music-nonada
 draftCreatedAt: "2026-06-12T12:06:06.428Z"
+sunoStyle: |-
+  An immersive 12‑minute guided‑meditation track titled “Nonada
+  ” the opening piece of the album “Travessias do Sertão.” A warm baritone Brazilian narrator with a gentle northeastern accent speaks at about seventy words per minute
+  leaving wide pauses wherever the script shows double line breaks. A finger‑picked acoustic guitar in D major opens for four seconds
+  then hangs beneath the voice in airy reverb
+  surfacing only as soft harmonic swells.
+genre:
+  - ambient
+  - spoken word
 ---
 
 ## Lyrics

--- a/src/content/blog/nonada/v-2026-06-09T20-24-29.mdx
+++ b/src/content/blog/nonada/v-2026-06-09T20-24-29.mdx
@@ -5,12 +5,6 @@ date: 2025-05-03
 postType: music
 sunoId: 916bd4cb-a9fb-4914-85fe-e4ca4545d3bf
 sunoImageUrl: "https://cdn2.suno.ai/image_916bd4cb-a9fb-4914-85fe-e4ca4545d3bf.jpeg"
-genre:
-  - An immersive 12‑minute guided‑meditation track titled “Nonada
-  - ” the opening piece of the album “Travessias do Sertão.” A warm baritone Brazilian narrator with a gentle northeastern accent speaks at about seventy words per minute
-  - leaving wide pauses wherever the script shows double line breaks. A finger‑picked acoustic guitar in D major opens for four seconds
-  - then hangs beneath the voice in airy reverb
-  - "surfacing only as soft harmonic swells.
 
 Ambient texture summons the sertão after rain: distant cicadas"
   - a light breeze through juazeiro leaves
@@ -20,6 +14,15 @@ tags:
 lang: pt
 translationKey: music-nonada
 draftCreatedAt: "2026-06-12T12:06:06.428Z"
+sunoStyle: |-
+  An immersive 12‑minute guided‑meditation track titled “Nonada
+  ” the opening piece of the album “Travessias do Sertão.” A warm baritone Brazilian narrator with a gentle northeastern accent speaks at about seventy words per minute
+  leaving wide pauses wherever the script shows double line breaks. A finger‑picked acoustic guitar in D major opens for four seconds
+  then hangs beneath the voice in airy reverb
+  surfacing only as soft harmonic swells.
+genre:
+  - ambient
+  - spoken word
 ---
 
 ## Letra

--- a/src/content/blog/o-aleph-en/v-2026-06-09T20-24-29.mdx
+++ b/src/content/blog/o-aleph-en/v-2026-06-09T20-24-29.mdx
@@ -5,17 +5,20 @@ date: 2025-11-22
 postType: music
 sunoId: c853d460-8a0c-418e-8768-7d0b176b4a73
 sunoImageUrl: "https://cdn2.suno.ai/image_c853d460-8a0c-418e-8768-7d0b176b4a73.jpeg"
-genre:
-  - This fast chamamé features a driving
-  - hypnotic rhythm led by virtuoso viola caipira weaving intricate melodic runs over a tightly syncopated 10-string guitar groove. Clean production highlights crisp percussion and fast
-  - softly articulated male vocals
-  - all buoyed by melodic interlocking lines.
 duration: 215
 tags:
   - music
 lang: en
 translationKey: music-o-aleph
 draftCreatedAt: "2026-06-12T12:06:06.428Z"
+sunoStyle: |-
+  This fast chamamé features a driving
+  hypnotic rhythm led by virtuoso viola caipira weaving intricate melodic runs over a tightly syncopated 10-string guitar groove. Clean production highlights crisp percussion and fast
+  softly articulated male vocals
+  all buoyed by melodic interlocking lines.
+genre:
+  - moda de viola
+  - folk
 ---
 
 ## Lyrics

--- a/src/content/blog/o-aleph/v-2026-06-09T20-24-29.mdx
+++ b/src/content/blog/o-aleph/v-2026-06-09T20-24-29.mdx
@@ -5,17 +5,20 @@ date: 2025-11-22
 postType: music
 sunoId: c853d460-8a0c-418e-8768-7d0b176b4a73
 sunoImageUrl: "https://cdn2.suno.ai/image_c853d460-8a0c-418e-8768-7d0b176b4a73.jpeg"
-genre:
-  - This fast chamamé features a driving
-  - hypnotic rhythm led by virtuoso viola caipira weaving intricate melodic runs over a tightly syncopated 10-string guitar groove. Clean production highlights crisp percussion and fast
-  - softly articulated male vocals
-  - all buoyed by melodic interlocking lines.
 duration: 215
 tags:
   - música
 lang: pt
 translationKey: music-o-aleph
 draftCreatedAt: "2026-06-12T12:06:06.428Z"
+sunoStyle: |-
+  This fast chamamé features a driving
+  hypnotic rhythm led by virtuoso viola caipira weaving intricate melodic runs over a tightly syncopated 10-string guitar groove. Clean production highlights crisp percussion and fast
+  softly articulated male vocals
+  all buoyed by melodic interlocking lines.
+genre:
+  - moda de viola
+  - folk
 ---
 
 ## Letra

--- a/src/content/blog/o-magico-e-o-fogo-en/v-2026-06-09T20-24-29.mdx
+++ b/src/content/blog/o-magico-e-o-fogo-en/v-2026-06-09T20-24-29.mdx
@@ -5,18 +5,21 @@ date: 2026-01-06
 postType: music
 sunoId: e388cce2-89c3-4b33-9702-dc316a053a7a
 sunoImageUrl: "https://cdn2.suno.ai/image_e388cce2-89c3-4b33-9702-dc316a053a7a.jpeg"
-genre:
-  - A gentle folk arrangement centers on softly fingerpicked acoustic guitar
-  - layered with subtle fire crackling to conjure an intimate campfire setting. A warm
-  - soothing Portuguese male voice delivers spoken word narration
-  - maintaining a soft
-  - inviting texture ideal for bedtime listening.
 duration: 360
 tags:
   - music
 lang: en
 translationKey: music-o-magico-e-o-fogo
 draftCreatedAt: "2026-06-12T12:06:06.428Z"
+sunoStyle: |-
+  A gentle folk arrangement centers on softly fingerpicked acoustic guitar
+  layered with subtle fire crackling to conjure an intimate campfire setting. A warm
+  soothing Portuguese male voice delivers spoken word narration
+  maintaining a soft
+  inviting texture ideal for bedtime listening.
+genre:
+  - folk
+  - acústico
 ---
 
 ## Lyrics

--- a/src/content/blog/o-magico-e-o-fogo-en/v-2026-06-12T16-26-55-772.mdx
+++ b/src/content/blog/o-magico-e-o-fogo-en/v-2026-06-12T16-26-55-772.mdx
@@ -5,14 +5,6 @@ date: 2026-01-06T00:00:00.000Z
 postType: music
 sunoId: e388cce2-89c3-4b33-9702-dc316a053a7a
 sunoImageUrl: "https://cdn2.suno.ai/image_e388cce2-89c3-4b33-9702-dc316a053a7a.jpeg"
-genre:
-  - A gentle folk arrangement centers on softly fingerpicked acoustic guitar
-  - >-
-    layered with subtle fire crackling to conjure an intimate campfire setting.
-    A warm
-  - soothing Portuguese male voice delivers spoken word narration
-  - maintaining a soft
-  - inviting texture ideal for bedtime listening.
 duration: 360
 tags:
   - music
@@ -22,6 +14,15 @@ supersedes: b0837034-4af4-5c14-a9dd-43cf94c3b49f
 draftCreatedAt: "2026-06-12T16:26:55.772Z"
 draftMsg: Automated edit for worst posts
 draftCommittedAt: "2026-06-12T16:28:02.344Z"
+sunoStyle: |-
+  A gentle folk arrangement centers on softly fingerpicked acoustic guitar
+  >- layered with subtle fire crackling to conjure an intimate campfire setting. A warm
+  soothing Portuguese male voice delivers spoken word narration
+  maintaining a soft
+  inviting texture ideal for bedtime listening.
+genre:
+  - folk
+  - acústico
 ---
 
 ## Lyrics

--- a/src/content/blog/o-magico-e-o-fogo-en/v-2026-06-13T01-53-43-890.mdx
+++ b/src/content/blog/o-magico-e-o-fogo-en/v-2026-06-13T01-53-43-890.mdx
@@ -5,14 +5,6 @@ date: 2026-01-06T00:00:00.000Z
 postType: music
 sunoId: e388cce2-89c3-4b33-9702-dc316a053a7a
 sunoImageUrl: "https://cdn2.suno.ai/image_e388cce2-89c3-4b33-9702-dc316a053a7a.jpeg"
-genre:
-  - A gentle folk arrangement centers on softly fingerpicked acoustic guitar
-  - >-
-    layered with subtle fire crackling to conjure an intimate campfire setting.
-    A warm
-  - soothing Portuguese male voice delivers spoken word narration
-  - maintaining a soft
-  - inviting texture ideal for bedtime listening.
 duration: 360
 tags:
   - music
@@ -22,6 +14,15 @@ supersedes: b0837034-4af4-5c14-a9dd-43cf94c3b49f
 draftCreatedAt: "2026-06-13T01:53:43.890Z"
 draftMsg: Auto-edited worst post per hronir feedback v6
 draftCommittedAt: "2026-06-13T01:54:24.593Z"
+sunoStyle: |-
+  A gentle folk arrangement centers on softly fingerpicked acoustic guitar
+  >- layered with subtle fire crackling to conjure an intimate campfire setting. A warm
+  soothing Portuguese male voice delivers spoken word narration
+  maintaining a soft
+  inviting texture ideal for bedtime listening.
+genre:
+  - folk
+  - acústico
 ---
 
 ## Lyrics

--- a/src/content/blog/o-magico-e-o-fogo/v-2026-06-09T20-24-29.mdx
+++ b/src/content/blog/o-magico-e-o-fogo/v-2026-06-09T20-24-29.mdx
@@ -5,18 +5,21 @@ date: 2026-01-06
 postType: music
 sunoId: e388cce2-89c3-4b33-9702-dc316a053a7a
 sunoImageUrl: "https://cdn2.suno.ai/image_e388cce2-89c3-4b33-9702-dc316a053a7a.jpeg"
-genre:
-  - A gentle folk arrangement centers on softly fingerpicked acoustic guitar
-  - layered with subtle fire crackling to conjure an intimate campfire setting. A warm
-  - soothing Portuguese male voice delivers spoken word narration
-  - maintaining a soft
-  - inviting texture ideal for bedtime listening.
 duration: 360
 tags:
   - música
 lang: pt
 translationKey: music-o-magico-e-o-fogo
 draftCreatedAt: "2026-06-12T12:06:06.428Z"
+sunoStyle: |-
+  A gentle folk arrangement centers on softly fingerpicked acoustic guitar
+  layered with subtle fire crackling to conjure an intimate campfire setting. A warm
+  soothing Portuguese male voice delivers spoken word narration
+  maintaining a soft
+  inviting texture ideal for bedtime listening.
+genre:
+  - folk
+  - acústico
 ---
 
 ## Letra

--- a/src/content/blog/o-magico-e-o-fogo/v-2026-06-12T16-26-55-772.mdx
+++ b/src/content/blog/o-magico-e-o-fogo/v-2026-06-12T16-26-55-772.mdx
@@ -5,14 +5,6 @@ date: 2026-01-06T00:00:00.000Z
 postType: music
 sunoId: e388cce2-89c3-4b33-9702-dc316a053a7a
 sunoImageUrl: "https://cdn2.suno.ai/image_e388cce2-89c3-4b33-9702-dc316a053a7a.jpeg"
-genre:
-  - A gentle folk arrangement centers on softly fingerpicked acoustic guitar
-  - >-
-    layered with subtle fire crackling to conjure an intimate campfire setting.
-    A warm
-  - soothing Portuguese male voice delivers spoken word narration
-  - maintaining a soft
-  - inviting texture ideal for bedtime listening.
 duration: 360
 tags:
   - música
@@ -22,6 +14,15 @@ supersedes: 437b5b75-8b08-5b86-a420-4c9fadbe76a1
 draftCreatedAt: "2026-06-12T16:26:55.772Z"
 draftMsg: Automated edit for worst posts
 draftCommittedAt: "2026-06-12T16:28:02.344Z"
+sunoStyle: |-
+  A gentle folk arrangement centers on softly fingerpicked acoustic guitar
+  >- layered with subtle fire crackling to conjure an intimate campfire setting. A warm
+  soothing Portuguese male voice delivers spoken word narration
+  maintaining a soft
+  inviting texture ideal for bedtime listening.
+genre:
+  - folk
+  - acústico
 ---
 
 ## Letra

--- a/src/content/blog/o-magico-e-o-fogo/v-2026-06-13T01-53-43-890.mdx
+++ b/src/content/blog/o-magico-e-o-fogo/v-2026-06-13T01-53-43-890.mdx
@@ -5,14 +5,6 @@ date: 2026-01-06T00:00:00.000Z
 postType: music
 sunoId: e388cce2-89c3-4b33-9702-dc316a053a7a
 sunoImageUrl: "https://cdn2.suno.ai/image_e388cce2-89c3-4b33-9702-dc316a053a7a.jpeg"
-genre:
-  - A gentle folk arrangement centers on softly fingerpicked acoustic guitar
-  - >-
-    layered with subtle fire crackling to conjure an intimate campfire setting.
-    A warm
-  - soothing Portuguese male voice delivers spoken word narration
-  - maintaining a soft
-  - inviting texture ideal for bedtime listening.
 duration: 360
 tags:
   - música
@@ -22,6 +14,15 @@ supersedes: 437b5b75-8b08-5b86-a420-4c9fadbe76a1
 draftCreatedAt: "2026-06-13T01:53:43.890Z"
 draftMsg: Auto-edited worst post per hronir feedback v6
 draftCommittedAt: "2026-06-13T01:54:24.593Z"
+sunoStyle: |-
+  A gentle folk arrangement centers on softly fingerpicked acoustic guitar
+  >- layered with subtle fire crackling to conjure an intimate campfire setting. A warm
+  soothing Portuguese male voice delivers spoken word narration
+  maintaining a soft
+  inviting texture ideal for bedtime listening.
+genre:
+  - folk
+  - acústico
 ---
 
 ## Letra

--- a/src/content/blog/o-medo-do-louco-en/v-2026-06-09T20-24-29.mdx
+++ b/src/content/blog/o-medo-do-louco-en/v-2026-06-09T20-24-29.mdx
@@ -5,19 +5,22 @@ date: 2025-11-22
 postType: music
 sunoId: 7d49db72-d9fa-470c-a98d-253f6a71c632
 sunoImageUrl: "https://cdn2.suno.ai/image_7d49db72-d9fa-470c-a98d-253f6a71c632.jpeg"
-genre:
-  - A dark
-  - atmospheric track rooted in Pantanal folklore. The intro features the hollow
-  - woody sound of a Viola de Cocho playing a dissonant ponteio (fingerpicking)
-  - accompanied by the deep
-  - vibrating bordões (bass strings) of an acoustic guitar. A mournful Rabeca (Brazilian fiddle) enters with a screeching
-  - tension-building melody like a rusty door hinge. The rhythm is a slow
 duration: 268
 tags:
   - music
 lang: en
 translationKey: music-o-medo-do-louco
 draftCreatedAt: "2026-06-12T12:06:06.428Z"
+sunoStyle: |-
+  A dark
+  atmospheric track rooted in Pantanal folklore. The intro features the hollow
+  woody sound of a Viola de Cocho playing a dissonant ponteio (fingerpicking)
+  accompanied by the deep
+  vibrating bordões (bass strings) of an acoustic guitar. A mournful Rabeca (Brazilian fiddle) enters with a screeching
+  tension-building melody like a rusty door hinge. The rhythm is a slow
+genre:
+  - folk
+  - ambient
 ---
 
 ## Lyrics

--- a/src/content/blog/o-medo-do-louco-en/v-2026-06-11T06-58-37-717.mdx
+++ b/src/content/blog/o-medo-do-louco-en/v-2026-06-11T06-58-37-717.mdx
@@ -5,15 +5,6 @@ date: 2025-11-22T00:00:00.000Z
 postType: music
 sunoId: 7d49db72-d9fa-470c-a98d-253f6a71c632
 sunoImageUrl: "https://cdn2.suno.ai/image_7d49db72-d9fa-470c-a98d-253f6a71c632.jpeg"
-genre:
-  - A dark
-  - atmospheric track rooted in Pantanal folklore. The intro features the hollow
-  - woody sound of a Viola de Cocho playing a dissonant ponteio (fingerpicking)
-  - accompanied by the deep
-  - >-
-    vibrating bordões (bass strings) of an acoustic guitar. A mournful Rabeca
-    (Brazilian fiddle) enters with a screeching
-  - tension-building melody like a rusty door hinge. The rhythm is a slow
 duration: 268
 tags:
   - music
@@ -23,6 +14,16 @@ supersedes: 20f474ee-36c4-54e1-a300-3aab84ac76b2
 draftCreatedAt: "2026-06-11T06:58:37.717Z"
 draftMsg: Hronir automated edits for O Medo do Louco to improve stylistic deadpan
 draftCommittedAt: "2026-06-11T07:01:48.507Z"
+sunoStyle: |-
+  A dark
+  atmospheric track rooted in Pantanal folklore. The intro features the hollow
+  woody sound of a Viola de Cocho playing a dissonant ponteio (fingerpicking)
+  accompanied by the deep
+  >- vibrating bordões (bass strings) of an acoustic guitar. A mournful Rabeca (Brazilian fiddle) enters with a screeching
+  tension-building melody like a rusty door hinge. The rhythm is a slow
+genre:
+  - folk
+  - ambient
 ---
 
 ## Lyrics

--- a/src/content/blog/o-medo-do-louco/v-2026-06-09T20-24-29.mdx
+++ b/src/content/blog/o-medo-do-louco/v-2026-06-09T20-24-29.mdx
@@ -5,19 +5,22 @@ date: 2025-11-22
 postType: music
 sunoId: 7d49db72-d9fa-470c-a98d-253f6a71c632
 sunoImageUrl: "https://cdn2.suno.ai/image_7d49db72-d9fa-470c-a98d-253f6a71c632.jpeg"
-genre:
-  - A dark
-  - atmospheric track rooted in Pantanal folklore. The intro features the hollow
-  - woody sound of a Viola de Cocho playing a dissonant ponteio (fingerpicking)
-  - accompanied by the deep
-  - vibrating bordões (bass strings) of an acoustic guitar. A mournful Rabeca (Brazilian fiddle) enters with a screeching
-  - tension-building melody like a rusty door hinge. The rhythm is a slow
 duration: 268
 tags:
   - música
 lang: pt
 translationKey: music-o-medo-do-louco
 draftCreatedAt: "2026-06-12T12:06:06.428Z"
+sunoStyle: |-
+  A dark
+  atmospheric track rooted in Pantanal folklore. The intro features the hollow
+  woody sound of a Viola de Cocho playing a dissonant ponteio (fingerpicking)
+  accompanied by the deep
+  vibrating bordões (bass strings) of an acoustic guitar. A mournful Rabeca (Brazilian fiddle) enters with a screeching
+  tension-building melody like a rusty door hinge. The rhythm is a slow
+genre:
+  - folk
+  - ambient
 ---
 
 ## Letra

--- a/src/content/blog/o-medo-do-louco/v-2026-06-11T06-58-37-717.mdx
+++ b/src/content/blog/o-medo-do-louco/v-2026-06-11T06-58-37-717.mdx
@@ -5,15 +5,6 @@ date: 2025-11-22T00:00:00.000Z
 postType: music
 sunoId: 7d49db72-d9fa-470c-a98d-253f6a71c632
 sunoImageUrl: "https://cdn2.suno.ai/image_7d49db72-d9fa-470c-a98d-253f6a71c632.jpeg"
-genre:
-  - A dark
-  - atmospheric track rooted in Pantanal folklore. The intro features the hollow
-  - woody sound of a Viola de Cocho playing a dissonant ponteio (fingerpicking)
-  - accompanied by the deep
-  - >-
-    vibrating bordões (bass strings) of an acoustic guitar. A mournful Rabeca
-    (Brazilian fiddle) enters with a screeching
-  - tension-building melody like a rusty door hinge. The rhythm is a slow
 duration: 268
 tags:
   - música
@@ -23,6 +14,16 @@ supersedes: 2210da8c-a49d-5070-b984-80ade0f5a098
 draftCreatedAt: "2026-06-11T06:58:37.717Z"
 draftMsg: Hronir automated edits for O Medo do Louco to improve stylistic deadpan
 draftCommittedAt: "2026-06-11T07:01:48.507Z"
+sunoStyle: |-
+  A dark
+  atmospheric track rooted in Pantanal folklore. The intro features the hollow
+  woody sound of a Viola de Cocho playing a dissonant ponteio (fingerpicking)
+  accompanied by the deep
+  >- vibrating bordões (bass strings) of an acoustic guitar. A mournful Rabeca (Brazilian fiddle) enters with a screeching
+  tension-building melody like a rusty door hinge. The rhythm is a slow
+genre:
+  - folk
+  - ambient
 ---
 
 ## Letra

--- a/src/content/blog/o-preco-da-saudade-en/v-2026-06-09T20-24-29.mdx
+++ b/src/content/blog/o-preco-da-saudade-en/v-2026-06-09T20-24-29.mdx
@@ -5,19 +5,22 @@ date: 2025-11-22
 postType: music
 sunoId: 39c44246-f775-41e0-bfdd-9d12e51c174c
 sunoImageUrl: "https://cdn2.suno.ai/image_39c44246-f775-41e0-bfdd-9d12e51c174c.jpeg"
-genre:
-  - Acoustic moda de viola opens with interwoven steel-string guitars in drop-D tuning
-  - propelled by cururu’s syncopated 2/4 groove. Sparse bass notes ground each verse
-  - while subtle percussive tapping highlights phrasing. The male vocal delivery is articulate and dynamic
-  - supported by bittersweet
-  - modal viola countermelodies and brief accordion fills
-  - weaving a textured
 duration: 190
 tags:
   - music
 lang: en
 translationKey: music-o-preco-da-saudade
 draftCreatedAt: "2026-06-12T12:06:06.428Z"
+sunoStyle: |-
+  Acoustic moda de viola opens with interwoven steel-string guitars in drop-D tuning
+  propelled by cururu’s syncopated 2/4 groove. Sparse bass notes ground each verse
+  while subtle percussive tapping highlights phrasing. The male vocal delivery is articulate and dynamic
+  supported by bittersweet
+  modal viola countermelodies and brief accordion fills
+  weaving a textured
+genre:
+  - moda de viola
+  - sertanejo
 ---
 
 ## Lyrics

--- a/src/content/blog/o-preco-da-saudade-en/v-2026-06-12T11-32-47-304.mdx
+++ b/src/content/blog/o-preco-da-saudade-en/v-2026-06-12T11-32-47-304.mdx
@@ -5,19 +5,6 @@ date: 2025-11-22T00:00:00.000Z
 postType: music
 sunoId: 39c44246-f775-41e0-bfdd-9d12e51c174c
 sunoImageUrl: "https://cdn2.suno.ai/image_39c44246-f775-41e0-bfdd-9d12e51c174c.jpeg"
-genre:
-  - >-
-    Acoustic moda de viola opens with interwoven steel-string guitars in drop-D
-    tuning
-  - >-
-    propelled by cururu’s syncopated 2/4 groove. Sparse bass notes ground each
-    verse
-  - >-
-    while subtle percussive tapping highlights phrasing. The male vocal delivery
-    is articulate and dynamic
-  - supported by bittersweet
-  - modal viola countermelodies and brief accordion fills
-  - weaving a textured
 duration: 190
 tags:
   - music
@@ -27,6 +14,16 @@ supersedes: eb3d50e8-ae0a-538c-ad21-7a03af5ae743
 draftCreatedAt: "2026-06-12T11:32:47.305Z"
 draftMsg: "hronir: appended auto edit marker to worst post draft"
 draftCommittedAt: "2026-06-12T11:33:34.464Z"
+sunoStyle: |-
+  >- Acoustic moda de viola opens with interwoven steel-string guitars in drop-D tuning
+  >- propelled by cururu’s syncopated 2/4 groove. Sparse bass notes ground each verse
+  >- while subtle percussive tapping highlights phrasing. The male vocal delivery is articulate and dynamic
+  supported by bittersweet
+  modal viola countermelodies and brief accordion fills
+  weaving a textured
+genre:
+  - moda de viola
+  - sertanejo
 ---
 
 ## Lyrics

--- a/src/content/blog/o-preco-da-saudade-en/v-2026-06-12T11-41-44-358.mdx
+++ b/src/content/blog/o-preco-da-saudade-en/v-2026-06-12T11-41-44-358.mdx
@@ -5,19 +5,6 @@ date: 2025-11-22T00:00:00.000Z
 postType: music
 sunoId: 39c44246-f775-41e0-bfdd-9d12e51c174c
 sunoImageUrl: "https://cdn2.suno.ai/image_39c44246-f775-41e0-bfdd-9d12e51c174c.jpeg"
-genre:
-  - >-
-    Acoustic moda de viola opens with interwoven steel-string guitars in drop-D
-    tuning
-  - >-
-    propelled by cururu’s syncopated 2/4 groove. Sparse bass notes ground each
-    verse
-  - >-
-    while subtle percussive tapping highlights phrasing. The male vocal delivery
-    is articulate and dynamic
-  - supported by bittersweet
-  - modal viola countermelodies and brief accordion fills
-  - weaving a textured
 duration: 190
 tags:
   - music
@@ -27,6 +14,16 @@ supersedes: eb3d50e8-ae0a-538c-ad21-7a03af5ae743
 draftCreatedAt: "2026-06-12T11:41:44.358Z"
 draftMsg: Improve narrative voice and add aesthetic toll line
 draftCommittedAt: "2026-06-12T11:43:10.786Z"
+sunoStyle: |-
+  >- Acoustic moda de viola opens with interwoven steel-string guitars in drop-D tuning
+  >- propelled by cururu’s syncopated 2/4 groove. Sparse bass notes ground each verse
+  >- while subtle percussive tapping highlights phrasing. The male vocal delivery is articulate and dynamic
+  supported by bittersweet
+  modal viola countermelodies and brief accordion fills
+  weaving a textured
+genre:
+  - moda de viola
+  - sertanejo
 ---
 
 ## Lyrics

--- a/src/content/blog/o-preco-da-saudade/v-2026-06-09T20-24-29.mdx
+++ b/src/content/blog/o-preco-da-saudade/v-2026-06-09T20-24-29.mdx
@@ -5,19 +5,22 @@ date: 2025-11-22
 postType: music
 sunoId: 39c44246-f775-41e0-bfdd-9d12e51c174c
 sunoImageUrl: "https://cdn2.suno.ai/image_39c44246-f775-41e0-bfdd-9d12e51c174c.jpeg"
-genre:
-  - Acoustic moda de viola opens with interwoven steel-string guitars in drop-D tuning
-  - propelled by cururu’s syncopated 2/4 groove. Sparse bass notes ground each verse
-  - while subtle percussive tapping highlights phrasing. The male vocal delivery is articulate and dynamic
-  - supported by bittersweet
-  - modal viola countermelodies and brief accordion fills
-  - weaving a textured
 duration: 190
 tags:
   - música
 lang: pt
 translationKey: music-o-preco-da-saudade
 draftCreatedAt: "2026-06-12T12:06:06.428Z"
+sunoStyle: |-
+  Acoustic moda de viola opens with interwoven steel-string guitars in drop-D tuning
+  propelled by cururu’s syncopated 2/4 groove. Sparse bass notes ground each verse
+  while subtle percussive tapping highlights phrasing. The male vocal delivery is articulate and dynamic
+  supported by bittersweet
+  modal viola countermelodies and brief accordion fills
+  weaving a textured
+genre:
+  - moda de viola
+  - sertanejo
 ---
 
 ## Letra

--- a/src/content/blog/o-preco-da-saudade/v-2026-06-12T11-32-47-304.mdx
+++ b/src/content/blog/o-preco-da-saudade/v-2026-06-12T11-32-47-304.mdx
@@ -5,19 +5,6 @@ date: 2025-11-22T00:00:00.000Z
 postType: music
 sunoId: 39c44246-f775-41e0-bfdd-9d12e51c174c
 sunoImageUrl: "https://cdn2.suno.ai/image_39c44246-f775-41e0-bfdd-9d12e51c174c.jpeg"
-genre:
-  - >-
-    Acoustic moda de viola opens with interwoven steel-string guitars in drop-D
-    tuning
-  - >-
-    propelled by cururu’s syncopated 2/4 groove. Sparse bass notes ground each
-    verse
-  - >-
-    while subtle percussive tapping highlights phrasing. The male vocal delivery
-    is articulate and dynamic
-  - supported by bittersweet
-  - modal viola countermelodies and brief accordion fills
-  - weaving a textured
 duration: 190
 tags:
   - música
@@ -27,6 +14,16 @@ supersedes: 8182e18e-53a6-5229-af11-bc8bd76a1abe
 draftCreatedAt: "2026-06-12T11:32:47.305Z"
 draftMsg: "hronir: appended auto edit marker to worst post draft"
 draftCommittedAt: "2026-06-12T11:33:34.464Z"
+sunoStyle: |-
+  >- Acoustic moda de viola opens with interwoven steel-string guitars in drop-D tuning
+  >- propelled by cururu’s syncopated 2/4 groove. Sparse bass notes ground each verse
+  >- while subtle percussive tapping highlights phrasing. The male vocal delivery is articulate and dynamic
+  supported by bittersweet
+  modal viola countermelodies and brief accordion fills
+  weaving a textured
+genre:
+  - moda de viola
+  - sertanejo
 ---
 
 ## Letra

--- a/src/content/blog/o-preco-da-saudade/v-2026-06-12T11-41-44-358.mdx
+++ b/src/content/blog/o-preco-da-saudade/v-2026-06-12T11-41-44-358.mdx
@@ -5,19 +5,6 @@ date: 2025-11-22T00:00:00.000Z
 postType: music
 sunoId: 39c44246-f775-41e0-bfdd-9d12e51c174c
 sunoImageUrl: "https://cdn2.suno.ai/image_39c44246-f775-41e0-bfdd-9d12e51c174c.jpeg"
-genre:
-  - >-
-    Acoustic moda de viola opens with interwoven steel-string guitars in drop-D
-    tuning
-  - >-
-    propelled by cururu’s syncopated 2/4 groove. Sparse bass notes ground each
-    verse
-  - >-
-    while subtle percussive tapping highlights phrasing. The male vocal delivery
-    is articulate and dynamic
-  - supported by bittersweet
-  - modal viola countermelodies and brief accordion fills
-  - weaving a textured
 duration: 190
 tags:
   - música
@@ -27,6 +14,16 @@ supersedes: 8182e18e-53a6-5229-af11-bc8bd76a1abe
 draftCreatedAt: "2026-06-12T11:41:44.358Z"
 draftMsg: Improve narrative voice and add aesthetic toll line
 draftCommittedAt: "2026-06-12T11:43:10.786Z"
+sunoStyle: |-
+  >- Acoustic moda de viola opens with interwoven steel-string guitars in drop-D tuning
+  >- propelled by cururu’s syncopated 2/4 groove. Sparse bass notes ground each verse
+  >- while subtle percussive tapping highlights phrasing. The male vocal delivery is articulate and dynamic
+  supported by bittersweet
+  modal viola countermelodies and brief accordion fills
+  weaving a textured
+genre:
+  - moda de viola
+  - sertanejo
 ---
 
 ## Letra

--- a/src/content/blog/o-prologo-en/v-2026-06-09T20-24-29.mdx
+++ b/src/content/blog/o-prologo-en/v-2026-06-09T20-24-29.mdx
@@ -5,19 +5,22 @@ date: 2025-11-25
 postType: music
 sunoId: 1c5ba050-d8e0-4471-b699-9739b611c144
 sunoImageUrl: "https://cdn2.suno.ai/image_1c5ba050-d8e0-4471-b699-9739b611c144.jpeg"
-genre:
-  - Upbeat Brazilian Cateretê led by virtuoso 10-string Viola Caipira fingerpicking and percussive acoustic guitar strumming. A driving
-  - syncopated beat features handclaps
-  - foot-stomps
-  - triangle
-  - and reco-reco. Narrative male vocals
-  - articulate and ironic
 duration: 234
 tags:
   - music
 lang: en
 translationKey: music-o-prologo
 draftCreatedAt: "2026-06-12T12:06:06.428Z"
+sunoStyle: |-
+  Upbeat Brazilian Cateretê led by virtuoso 10-string Viola Caipira fingerpicking and percussive acoustic guitar strumming. A driving
+  syncopated beat features handclaps
+  foot-stomps
+  triangle
+  and reco-reco. Narrative male vocals
+  articulate and ironic
+genre:
+  - cateretê
+  - moda de viola
 ---
 
 ## Lyrics

--- a/src/content/blog/o-prologo/v-2026-06-09T20-24-29.mdx
+++ b/src/content/blog/o-prologo/v-2026-06-09T20-24-29.mdx
@@ -5,19 +5,22 @@ date: 2025-11-25
 postType: music
 sunoId: 1c5ba050-d8e0-4471-b699-9739b611c144
 sunoImageUrl: "https://cdn2.suno.ai/image_1c5ba050-d8e0-4471-b699-9739b611c144.jpeg"
-genre:
-  - Upbeat Brazilian Cateretê led by virtuoso 10-string Viola Caipira fingerpicking and percussive acoustic guitar strumming. A driving
-  - syncopated beat features handclaps
-  - foot-stomps
-  - triangle
-  - and reco-reco. Narrative male vocals
-  - articulate and ironic
 duration: 234
 tags:
   - música
 lang: pt
 translationKey: music-o-prologo
 draftCreatedAt: "2026-06-12T12:06:06.428Z"
+sunoStyle: |-
+  Upbeat Brazilian Cateretê led by virtuoso 10-string Viola Caipira fingerpicking and percussive acoustic guitar strumming. A driving
+  syncopated beat features handclaps
+  foot-stomps
+  triangle
+  and reco-reco. Narrative male vocals
+  articulate and ironic
+genre:
+  - cateretê
+  - moda de viola
 ---
 
 ## Letra

--- a/src/content/blog/o-regral-en/v-2026-06-09T20-24-29.mdx
+++ b/src/content/blog/o-regral-en/v-2026-06-09T20-24-29.mdx
@@ -5,18 +5,21 @@ date: 2026-01-06
 postType: music
 sunoId: 6d389910-b1e8-4c9f-9b7f-8478f8bbaf4c
 sunoImageUrl: "https://cdn2.suno.ai/image_large_97648c44-ddc5-40ca-a2d1-5d8308f389ef.jpeg"
-genre:
-  - The song opens with expressive fingerpicked viola caipira
-  - gently floating over airy pads evoking morning mist. Subtle acoustic guitar and distant accordion weave in delicate folk textures. Slow
-  - contemplative pacing grounds deep male vocals
-  - while light percussion and soft ambient layers create an ethereal
-  - spacious atmosphere rooted in Pantanal folk tradition.
 duration: 360
 tags:
   - music
 lang: en
 translationKey: music-o-regral
 draftCreatedAt: "2026-06-12T12:06:06.428Z"
+sunoStyle: |-
+  The song opens with expressive fingerpicked viola caipira
+  gently floating over airy pads evoking morning mist. Subtle acoustic guitar and distant accordion weave in delicate folk textures. Slow
+  contemplative pacing grounds deep male vocals
+  while light percussion and soft ambient layers create an ethereal
+  spacious atmosphere rooted in Pantanal folk tradition.
+genre:
+  - moda de viola
+  - ambient
 ---
 
 ## Lyrics

--- a/src/content/blog/o-regral-en/v-2026-06-11T11-40-47-979.mdx
+++ b/src/content/blog/o-regral-en/v-2026-06-11T11-40-47-979.mdx
@@ -5,14 +5,6 @@ date: 2026-01-06T00:00:00.000Z
 postType: music
 sunoId: 6d389910-b1e8-4c9f-9b7f-8478f8bbaf4c
 sunoImageUrl: "https://cdn2.suno.ai/image_large_97648c44-ddc5-40ca-a2d1-5d8308f389ef.jpeg"
-genre:
-  - The song opens with expressive fingerpicked viola caipira
-  - >-
-    gently floating over airy pads evoking morning mist. Subtle acoustic guitar
-    and distant accordion weave in delicate folk textures. Slow
-  - contemplative pacing grounds deep male vocals
-  - while light percussion and soft ambient layers create an ethereal
-  - spacious atmosphere rooted in Pantanal folk tradition.
 duration: 360
 tags:
   - music
@@ -22,6 +14,15 @@ supersedes: aaec2441-64bf-5133-89a1-e51f63f272c9
 draftCreatedAt: "2026-06-11T11:40:47.979Z"
 draftMsg: "Refine prose for tighter franklin-blog voice, removing cliché confessions."
 draftCommittedAt: "2026-06-11T11:46:32.585Z"
+sunoStyle: |-
+  The song opens with expressive fingerpicked viola caipira
+  >- gently floating over airy pads evoking morning mist. Subtle acoustic guitar and distant accordion weave in delicate folk textures. Slow
+  contemplative pacing grounds deep male vocals
+  while light percussion and soft ambient layers create an ethereal
+  spacious atmosphere rooted in Pantanal folk tradition.
+genre:
+  - moda de viola
+  - ambient
 ---
 
 ## Lyrics

--- a/src/content/blog/o-regral-en/v-2026-06-11T11-48-54-479.mdx
+++ b/src/content/blog/o-regral-en/v-2026-06-11T11-48-54-479.mdx
@@ -5,14 +5,6 @@ date: 2026-01-06T00:00:00.000Z
 postType: music
 sunoId: 6d389910-b1e8-4c9f-9b7f-8478f8bbaf4c
 sunoImageUrl: "https://cdn2.suno.ai/image_large_97648c44-ddc5-40ca-a2d1-5d8308f389ef.jpeg"
-genre:
-  - The song opens with expressive fingerpicked viola caipira
-  - >-
-    gently floating over airy pads evoking morning mist. Subtle acoustic guitar
-    and distant accordion weave in delicate folk textures. Slow
-  - contemplative pacing grounds deep male vocals
-  - while light percussion and soft ambient layers create an ethereal
-  - spacious atmosphere rooted in Pantanal folk tradition.
 duration: 360
 tags:
   - music
@@ -22,6 +14,15 @@ supersedes: aaec2441-64bf-5133-89a1-e51f63f272c9
 draftCreatedAt: "2026-06-11T11:48:54.479Z"
 draftMsg: "chore: edit worst post"
 draftCommittedAt: "2026-06-11T11:53:16.508Z"
+sunoStyle: |-
+  The song opens with expressive fingerpicked viola caipira
+  >- gently floating over airy pads evoking morning mist. Subtle acoustic guitar and distant accordion weave in delicate folk textures. Slow
+  contemplative pacing grounds deep male vocals
+  while light percussion and soft ambient layers create an ethereal
+  spacious atmosphere rooted in Pantanal folk tradition.
+genre:
+  - moda de viola
+  - ambient
 ---
 
 ## Lyrics

--- a/src/content/blog/o-regral-en/v-2026-06-11T14-41-19-701.mdx
+++ b/src/content/blog/o-regral-en/v-2026-06-11T14-41-19-701.mdx
@@ -5,14 +5,6 @@ date: 2026-01-06T00:00:00.000Z
 postType: music
 sunoId: 6d389910-b1e8-4c9f-9b7f-8478f8bbaf4c
 sunoImageUrl: "https://cdn2.suno.ai/image_large_97648c44-ddc5-40ca-a2d1-5d8308f389ef.jpeg"
-genre:
-  - The song opens with expressive fingerpicked viola caipira
-  - >-
-    gently floating over airy pads evoking morning mist. Subtle acoustic guitar
-    and distant accordion weave in delicate folk textures. Slow
-  - contemplative pacing grounds deep male vocals
-  - while light percussion and soft ambient layers create an ethereal
-  - spacious atmosphere rooted in Pantanal folk tradition.
 duration: 360
 tags:
   - music
@@ -24,6 +16,15 @@ draftMsg: >-
   Hronir session draft: improved structure, added further reading according to
   franklin-blog guidelines
 draftCommittedAt: "2026-06-11T14:42:13.332Z"
+sunoStyle: |-
+  The song opens with expressive fingerpicked viola caipira
+  >- gently floating over airy pads evoking morning mist. Subtle acoustic guitar and distant accordion weave in delicate folk textures. Slow
+  contemplative pacing grounds deep male vocals
+  while light percussion and soft ambient layers create an ethereal
+  spacious atmosphere rooted in Pantanal folk tradition.
+genre:
+  - moda de viola
+  - ambient
 ---
 
 ## Lyrics

--- a/src/content/blog/o-regral/v-2026-06-09T20-24-29.mdx
+++ b/src/content/blog/o-regral/v-2026-06-09T20-24-29.mdx
@@ -5,18 +5,21 @@ date: 2026-01-06
 postType: music
 sunoId: 6d389910-b1e8-4c9f-9b7f-8478f8bbaf4c
 sunoImageUrl: "https://cdn2.suno.ai/image_large_97648c44-ddc5-40ca-a2d1-5d8308f389ef.jpeg"
-genre:
-  - The song opens with expressive fingerpicked viola caipira
-  - gently floating over airy pads evoking morning mist. Subtle acoustic guitar and distant accordion weave in delicate folk textures. Slow
-  - contemplative pacing grounds deep male vocals
-  - while light percussion and soft ambient layers create an ethereal
-  - spacious atmosphere rooted in Pantanal folk tradition.
 duration: 360
 tags:
   - música
 lang: pt
 translationKey: music-o-regral
 draftCreatedAt: "2026-06-12T12:06:06.428Z"
+sunoStyle: |-
+  The song opens with expressive fingerpicked viola caipira
+  gently floating over airy pads evoking morning mist. Subtle acoustic guitar and distant accordion weave in delicate folk textures. Slow
+  contemplative pacing grounds deep male vocals
+  while light percussion and soft ambient layers create an ethereal
+  spacious atmosphere rooted in Pantanal folk tradition.
+genre:
+  - moda de viola
+  - ambient
 ---
 
 ## Letra

--- a/src/content/blog/o-regral/v-2026-06-11T11-40-47-979.mdx
+++ b/src/content/blog/o-regral/v-2026-06-11T11-40-47-979.mdx
@@ -5,14 +5,6 @@ date: 2026-01-06T00:00:00.000Z
 postType: music
 sunoId: 6d389910-b1e8-4c9f-9b7f-8478f8bbaf4c
 sunoImageUrl: "https://cdn2.suno.ai/image_large_97648c44-ddc5-40ca-a2d1-5d8308f389ef.jpeg"
-genre:
-  - The song opens with expressive fingerpicked viola caipira
-  - >-
-    gently floating over airy pads evoking morning mist. Subtle acoustic guitar
-    and distant accordion weave in delicate folk textures. Slow
-  - contemplative pacing grounds deep male vocals
-  - while light percussion and soft ambient layers create an ethereal
-  - spacious atmosphere rooted in Pantanal folk tradition.
 duration: 360
 tags:
   - música
@@ -22,6 +14,15 @@ supersedes: b59eb6fc-a997-57ea-9334-1a45cc435930
 draftCreatedAt: "2026-06-11T11:40:47.979Z"
 draftMsg: "Refine prose for tighter franklin-blog voice, removing cliché confessions."
 draftCommittedAt: "2026-06-11T11:46:32.585Z"
+sunoStyle: |-
+  The song opens with expressive fingerpicked viola caipira
+  >- gently floating over airy pads evoking morning mist. Subtle acoustic guitar and distant accordion weave in delicate folk textures. Slow
+  contemplative pacing grounds deep male vocals
+  while light percussion and soft ambient layers create an ethereal
+  spacious atmosphere rooted in Pantanal folk tradition.
+genre:
+  - moda de viola
+  - ambient
 ---
 
 ## Letra

--- a/src/content/blog/o-regral/v-2026-06-11T11-48-54-479.mdx
+++ b/src/content/blog/o-regral/v-2026-06-11T11-48-54-479.mdx
@@ -5,14 +5,6 @@ date: 2026-01-06T00:00:00.000Z
 postType: music
 sunoId: 6d389910-b1e8-4c9f-9b7f-8478f8bbaf4c
 sunoImageUrl: "https://cdn2.suno.ai/image_large_97648c44-ddc5-40ca-a2d1-5d8308f389ef.jpeg"
-genre:
-  - The song opens with expressive fingerpicked viola caipira
-  - >-
-    gently floating over airy pads evoking morning mist. Subtle acoustic guitar
-    and distant accordion weave in delicate folk textures. Slow
-  - contemplative pacing grounds deep male vocals
-  - while light percussion and soft ambient layers create an ethereal
-  - spacious atmosphere rooted in Pantanal folk tradition.
 duration: 360
 tags:
   - música
@@ -22,6 +14,15 @@ supersedes: b59eb6fc-a997-57ea-9334-1a45cc435930
 draftCreatedAt: "2026-06-11T11:48:54.479Z"
 draftMsg: "chore: edit worst post"
 draftCommittedAt: "2026-06-11T11:53:16.508Z"
+sunoStyle: |-
+  The song opens with expressive fingerpicked viola caipira
+  >- gently floating over airy pads evoking morning mist. Subtle acoustic guitar and distant accordion weave in delicate folk textures. Slow
+  contemplative pacing grounds deep male vocals
+  while light percussion and soft ambient layers create an ethereal
+  spacious atmosphere rooted in Pantanal folk tradition.
+genre:
+  - moda de viola
+  - ambient
 ---
 
 ## Letra

--- a/src/content/blog/o-regral/v-2026-06-11T14-41-19-701.mdx
+++ b/src/content/blog/o-regral/v-2026-06-11T14-41-19-701.mdx
@@ -5,14 +5,6 @@ date: 2026-01-06T00:00:00.000Z
 postType: music
 sunoId: 6d389910-b1e8-4c9f-9b7f-8478f8bbaf4c
 sunoImageUrl: "https://cdn2.suno.ai/image_large_97648c44-ddc5-40ca-a2d1-5d8308f389ef.jpeg"
-genre:
-  - The song opens with expressive fingerpicked viola caipira
-  - >-
-    gently floating over airy pads evoking morning mist. Subtle acoustic guitar
-    and distant accordion weave in delicate folk textures. Slow
-  - contemplative pacing grounds deep male vocals
-  - while light percussion and soft ambient layers create an ethereal
-  - spacious atmosphere rooted in Pantanal folk tradition.
 duration: 360
 tags:
   - música
@@ -24,6 +16,15 @@ draftMsg: >-
   Hronir session draft: improved structure, added further reading according to
   franklin-blog guidelines
 draftCommittedAt: "2026-06-11T14:42:13.332Z"
+sunoStyle: |-
+  The song opens with expressive fingerpicked viola caipira
+  >- gently floating over airy pads evoking morning mist. Subtle acoustic guitar and distant accordion weave in delicate folk textures. Slow
+  contemplative pacing grounds deep male vocals
+  while light percussion and soft ambient layers create an ethereal
+  spacious atmosphere rooted in Pantanal folk tradition.
+genre:
+  - moda de viola
+  - ambient
 ---
 
 ## Letra

--- a/src/content/blog/o-ritual-de-abril-anos-de-saudade-en/v-2026-06-09T20-24-29.mdx
+++ b/src/content/blog/o-ritual-de-abril-anos-de-saudade-en/v-2026-06-09T20-24-29.mdx
@@ -5,19 +5,22 @@ date: 2025-11-22
 postType: music
 sunoId: 1fc3f874-a1f4-43ae-aa60-0bb2d6f57a7a
 sunoImageUrl: "https://cdn2.suno.ai/image_1fc3f874-a1f4-43ae-aa60-0bb2d6f57a7a.jpeg"
-genre:
-  - Opening with intricate acoustic viola caipira picking
-  - warm bass
-  - and delicate percussion
-  - the song weaves a narrative with smooth
-  - clear male vocals. The arrangement evolves with subtle accordion and light nylon-string guitar layers
-  - maintaining a melancholic
 duration: 206
 tags:
   - music
 lang: en
 translationKey: music-o-ritual-de-abril-anos-de-saudade
 draftCreatedAt: "2026-06-12T12:06:06.428Z"
+sunoStyle: |-
+  Opening with intricate acoustic viola caipira picking
+  warm bass
+  and delicate percussion
+  the song weaves a narrative with smooth
+  clear male vocals. The arrangement evolves with subtle accordion and light nylon-string guitar layers
+  maintaining a melancholic
+genre:
+  - moda de viola
+  - sertanejo
 ---
 
 ## Lyrics

--- a/src/content/blog/o-ritual-de-abril-anos-de-saudade/v-2026-06-09T20-24-29.mdx
+++ b/src/content/blog/o-ritual-de-abril-anos-de-saudade/v-2026-06-09T20-24-29.mdx
@@ -5,19 +5,22 @@ date: 2025-11-22
 postType: music
 sunoId: 1fc3f874-a1f4-43ae-aa60-0bb2d6f57a7a
 sunoImageUrl: "https://cdn2.suno.ai/image_1fc3f874-a1f4-43ae-aa60-0bb2d6f57a7a.jpeg"
-genre:
-  - Opening with intricate acoustic viola caipira picking
-  - warm bass
-  - and delicate percussion
-  - the song weaves a narrative with smooth
-  - clear male vocals. The arrangement evolves with subtle accordion and light nylon-string guitar layers
-  - maintaining a melancholic
 duration: 206
 tags:
   - música
 lang: pt
 translationKey: music-o-ritual-de-abril-anos-de-saudade
 draftCreatedAt: "2026-06-12T12:06:06.428Z"
+sunoStyle: |-
+  Opening with intricate acoustic viola caipira picking
+  warm bass
+  and delicate percussion
+  the song weaves a narrative with smooth
+  clear male vocals. The arrangement evolves with subtle accordion and light nylon-string guitar layers
+  maintaining a melancholic
+genre:
+  - moda de viola
+  - sertanejo
 ---
 
 ## Letra

--- a/src/content/blog/o-sonhador-e-o-fogo-en/v-2026-06-09T20-24-29.mdx
+++ b/src/content/blog/o-sonhador-e-o-fogo-en/v-2026-06-09T20-24-29.mdx
@@ -5,18 +5,21 @@ date: 2026-01-06
 postType: music
 sunoId: 9a6c58a4-07ac-4b4c-8434-7e3428db39e8
 sunoImageUrl: "https://cdn2.suno.ai/video_gen_911e0583-2c0d-4047-8d05-4513fd48f99f_video_upload_911e0583-2c0d-4047-8d05-4513fd48f99f_cover_snapshot_0s_1767735319_image.jpeg"
-genre:
-  - A Brazilian Folk Rock rhapsody at 160bpm kicks off with rapid acoustic guitar runs and brisk percussion. The fast-paced verses layer in syncopated hand drums
-  - harmonica
-  - and mandolin
-  - leaning into an epic narrative flow. Dynamic male vocals drive the dramatic storytelling through shifting sections
-  - building towards lively instrumental breaks and a climactic folk rock finale.
 duration: 292
 tags:
   - music
 lang: en
 translationKey: music-o-sonhador-e-o-fogo
 draftCreatedAt: "2026-06-12T12:06:06.428Z"
+sunoStyle: |-
+  A Brazilian Folk Rock rhapsody at 160bpm kicks off with rapid acoustic guitar runs and brisk percussion. The fast-paced verses layer in syncopated hand drums
+  harmonica
+  and mandolin
+  leaning into an epic narrative flow. Dynamic male vocals drive the dramatic storytelling through shifting sections
+  building towards lively instrumental breaks and a climactic folk rock finale.
+genre:
+  - folk
+  - rock
 ---
 
 ## Lyrics

--- a/src/content/blog/o-sonhador-e-o-fogo-en/v-2026-06-11T00-11-33-042.mdx
+++ b/src/content/blog/o-sonhador-e-o-fogo-en/v-2026-06-11T00-11-33-042.mdx
@@ -6,19 +6,6 @@ postType: music
 sunoId: 9a6c58a4-07ac-4b4c-8434-7e3428db39e8
 sunoImageUrl: >-
   https://cdn2.suno.ai/video_gen_911e0583-2c0d-4047-8d05-4513fd48f99f_video_upload_911e0583-2c0d-4047-8d05-4513fd48f99f_cover_snapshot_0s_1767735319_image.jpeg
-genre:
-  - >-
-    A Brazilian Folk Rock rhapsody at 160bpm kicks off with rapid acoustic
-    guitar runs and brisk percussion. The fast-paced verses layer in syncopated
-    hand drums
-  - harmonica
-  - and mandolin
-  - >-
-    leaning into an epic narrative flow. Dynamic male vocals drive the dramatic
-    storytelling through shifting sections
-  - >-
-    building towards lively instrumental breaks and a climactic folk rock
-    finale.
 duration: 292
 tags:
   - music
@@ -26,6 +13,15 @@ lang: en
 translationKey: music-o-sonhador-e-o-fogo
 supersedes: c4c363e0-61d1-55a6-a55a-6ad81f1f9c01
 draftCreatedAt: "2026-06-11T00:11:33.043Z"
+sunoStyle: |-
+  >- A Brazilian Folk Rock rhapsody at 160bpm kicks off with rapid acoustic guitar runs and brisk percussion. The fast-paced verses layer in syncopated hand drums
+  harmonica
+  and mandolin
+  >- leaning into an epic narrative flow. Dynamic male vocals drive the dramatic storytelling through shifting sections
+  >- building towards lively instrumental breaks and a climactic folk rock finale.
+genre:
+  - folk
+  - rock
 ---
 
 ## Lyrics

--- a/src/content/blog/o-sonhador-e-o-fogo-en/v-2026-06-11T00-34-11-317.mdx
+++ b/src/content/blog/o-sonhador-e-o-fogo-en/v-2026-06-11T00-34-11-317.mdx
@@ -6,19 +6,6 @@ postType: music
 sunoId: 9a6c58a4-07ac-4b4c-8434-7e3428db39e8
 sunoImageUrl: >-
   https://cdn2.suno.ai/video_gen_911e0583-2c0d-4047-8d05-4513fd48f99f_video_upload_911e0583-2c0d-4047-8d05-4513fd48f99f_cover_snapshot_0s_1767735319_image.jpeg
-genre:
-  - >-
-    A Brazilian Folk Rock rhapsody at 160bpm kicks off with rapid acoustic
-    guitar runs and brisk percussion. The fast-paced verses layer in syncopated
-    hand drums
-  - harmonica
-  - and mandolin
-  - >-
-    leaning into an epic narrative flow. Dynamic male vocals drive the dramatic
-    storytelling through shifting sections
-  - >-
-    building towards lively instrumental breaks and a climactic folk rock
-    finale.
 duration: 292
 tags:
   - music
@@ -28,6 +15,15 @@ supersedes: c4c363e0-61d1-55a6-a55a-6ad81f1f9c01
 draftCreatedAt: "2026-06-11T00:34:11.318Z"
 draftMsg: Fixed issues and improved narrative based on recent match feedback.
 draftCommittedAt: "2026-06-11T00:35:27.730Z"
+sunoStyle: |-
+  >- A Brazilian Folk Rock rhapsody at 160bpm kicks off with rapid acoustic guitar runs and brisk percussion. The fast-paced verses layer in syncopated hand drums
+  harmonica
+  and mandolin
+  >- leaning into an epic narrative flow. Dynamic male vocals drive the dramatic storytelling through shifting sections
+  >- building towards lively instrumental breaks and a climactic folk rock finale.
+genre:
+  - folk
+  - rock
 ---
 
 ## Lyrics

--- a/src/content/blog/o-sonhador-e-o-fogo-en/v-2026-06-11T00-43-34-675.mdx
+++ b/src/content/blog/o-sonhador-e-o-fogo-en/v-2026-06-11T00-43-34-675.mdx
@@ -6,19 +6,6 @@ postType: music
 sunoId: 9a6c58a4-07ac-4b4c-8434-7e3428db39e8
 sunoImageUrl: >-
   https://cdn2.suno.ai/video_gen_911e0583-2c0d-4047-8d05-4513fd48f99f_video_upload_911e0583-2c0d-4047-8d05-4513fd48f99f_cover_snapshot_0s_1767735319_image.jpeg
-genre:
-  - >-
-    A Brazilian Folk Rock rhapsody at 160bpm kicks off with rapid acoustic
-    guitar runs and brisk percussion. The fast-paced verses layer in syncopated
-    hand drums
-  - harmonica
-  - and mandolin
-  - >-
-    leaning into an epic narrative flow. Dynamic male vocals drive the dramatic
-    storytelling through shifting sections
-  - >-
-    building towards lively instrumental breaks and a climactic folk rock
-    finale.
 duration: 292
 tags:
   - music
@@ -28,6 +15,15 @@ supersedes: c4c363e0-61d1-55a6-a55a-6ad81f1f9c01
 draftCreatedAt: "2026-06-11T00:43:34.675Z"
 draftMsg: "chore: update drafts with nuanced endings"
 draftCommittedAt: "2026-06-11T00:46:30.752Z"
+sunoStyle: |-
+  >- A Brazilian Folk Rock rhapsody at 160bpm kicks off with rapid acoustic guitar runs and brisk percussion. The fast-paced verses layer in syncopated hand drums
+  harmonica
+  and mandolin
+  >- leaning into an epic narrative flow. Dynamic male vocals drive the dramatic storytelling through shifting sections
+  >- building towards lively instrumental breaks and a climactic folk rock finale.
+genre:
+  - folk
+  - rock
 ---
 
 ## Lyrics

--- a/src/content/blog/o-sonhador-e-o-fogo-en/v-2026-06-11T03-19-06-351.mdx
+++ b/src/content/blog/o-sonhador-e-o-fogo-en/v-2026-06-11T03-19-06-351.mdx
@@ -6,19 +6,6 @@ postType: music
 sunoId: 9a6c58a4-07ac-4b4c-8434-7e3428db39e8
 sunoImageUrl: >-
   https://cdn2.suno.ai/video_gen_911e0583-2c0d-4047-8d05-4513fd48f99f_video_upload_911e0583-2c0d-4047-8d05-4513fd48f99f_cover_snapshot_0s_1767735319_image.jpeg
-genre:
-  - >-
-    A Brazilian Folk Rock rhapsody at 160bpm kicks off with rapid acoustic
-    guitar runs and brisk percussion. The fast-paced verses layer in syncopated
-    hand drums
-  - harmonica
-  - and mandolin
-  - >-
-    leaning into an epic narrative flow. Dynamic male vocals drive the dramatic
-    storytelling through shifting sections
-  - >-
-    building towards lively instrumental breaks and a climactic folk rock
-    finale.
 duration: 292
 tags:
   - music
@@ -32,6 +19,15 @@ draftMsg: >-
   Whitehead's process ontology, removing generic fluff, and adding a deadpan
   further reading section, per franklin-blog skill.
 draftCommittedAt: "2026-06-11T03:19:57.724Z"
+sunoStyle: |-
+  >- A Brazilian Folk Rock rhapsody at 160bpm kicks off with rapid acoustic guitar runs and brisk percussion. The fast-paced verses layer in syncopated hand drums
+  harmonica
+  and mandolin
+  >- leaning into an epic narrative flow. Dynamic male vocals drive the dramatic storytelling through shifting sections
+  >- building towards lively instrumental breaks and a climactic folk rock finale.
+genre:
+  - folk
+  - rock
 ---
 
 ## Lyrics

--- a/src/content/blog/o-sonhador-e-o-fogo-en/v-2026-06-11T05-15-50-982.mdx
+++ b/src/content/blog/o-sonhador-e-o-fogo-en/v-2026-06-11T05-15-50-982.mdx
@@ -6,19 +6,6 @@ postType: music
 sunoId: 9a6c58a4-07ac-4b4c-8434-7e3428db39e8
 sunoImageUrl: >-
   https://cdn2.suno.ai/video_gen_911e0583-2c0d-4047-8d05-4513fd48f99f_video_upload_911e0583-2c0d-4047-8d05-4513fd48f99f_cover_snapshot_0s_1767735319_image.jpeg
-genre:
-  - >-
-    A Brazilian Folk Rock rhapsody at 160bpm kicks off with rapid acoustic
-    guitar runs and brisk percussion. The fast-paced verses layer in syncopated
-    hand drums
-  - harmonica
-  - and mandolin
-  - >-
-    leaning into an epic narrative flow. Dynamic male vocals drive the dramatic
-    storytelling through shifting sections
-  - >-
-    building towards lively instrumental breaks and a climactic folk rock
-    finale.
 duration: 292
 tags:
   - music
@@ -28,6 +15,15 @@ supersedes: c4c363e0-61d1-55a6-a55a-6ad81f1f9c01
 draftCreatedAt: "2026-06-11T05:15:50.982Z"
 draftMsg: "chore: adjust final notes on recursive structure and illusion of base reality"
 draftCommittedAt: "2026-06-11T05:16:47.769Z"
+sunoStyle: |-
+  >- A Brazilian Folk Rock rhapsody at 160bpm kicks off with rapid acoustic guitar runs and brisk percussion. The fast-paced verses layer in syncopated hand drums
+  harmonica
+  and mandolin
+  >- leaning into an epic narrative flow. Dynamic male vocals drive the dramatic storytelling through shifting sections
+  >- building towards lively instrumental breaks and a climactic folk rock finale.
+genre:
+  - folk
+  - rock
 ---
 
 ## Lyrics

--- a/src/content/blog/o-sonhador-e-o-fogo/v-2026-06-09T20-24-29.mdx
+++ b/src/content/blog/o-sonhador-e-o-fogo/v-2026-06-09T20-24-29.mdx
@@ -5,18 +5,21 @@ date: 2026-01-06
 postType: music
 sunoId: 9a6c58a4-07ac-4b4c-8434-7e3428db39e8
 sunoImageUrl: "https://cdn2.suno.ai/video_gen_911e0583-2c0d-4047-8d05-4513fd48f99f_video_upload_911e0583-2c0d-4047-8d05-4513fd48f99f_cover_snapshot_0s_1767735319_image.jpeg"
-genre:
-  - A Brazilian Folk Rock rhapsody at 160bpm kicks off with rapid acoustic guitar runs and brisk percussion. The fast-paced verses layer in syncopated hand drums
-  - harmonica
-  - and mandolin
-  - leaning into an epic narrative flow. Dynamic male vocals drive the dramatic storytelling through shifting sections
-  - building towards lively instrumental breaks and a climactic folk rock finale.
 duration: 292
 tags:
   - música
 lang: pt
 translationKey: music-o-sonhador-e-o-fogo
 draftCreatedAt: "2026-06-12T12:06:06.428Z"
+sunoStyle: |-
+  A Brazilian Folk Rock rhapsody at 160bpm kicks off with rapid acoustic guitar runs and brisk percussion. The fast-paced verses layer in syncopated hand drums
+  harmonica
+  and mandolin
+  leaning into an epic narrative flow. Dynamic male vocals drive the dramatic storytelling through shifting sections
+  building towards lively instrumental breaks and a climactic folk rock finale.
+genre:
+  - folk
+  - rock
 ---
 
 ## Letra

--- a/src/content/blog/o-sonhador-e-o-fogo/v-2026-06-11T00-11-33-042.mdx
+++ b/src/content/blog/o-sonhador-e-o-fogo/v-2026-06-11T00-11-33-042.mdx
@@ -6,19 +6,6 @@ postType: music
 sunoId: 9a6c58a4-07ac-4b4c-8434-7e3428db39e8
 sunoImageUrl: >-
   https://cdn2.suno.ai/video_gen_911e0583-2c0d-4047-8d05-4513fd48f99f_video_upload_911e0583-2c0d-4047-8d05-4513fd48f99f_cover_snapshot_0s_1767735319_image.jpeg
-genre:
-  - >-
-    A Brazilian Folk Rock rhapsody at 160bpm kicks off with rapid acoustic
-    guitar runs and brisk percussion. The fast-paced verses layer in syncopated
-    hand drums
-  - harmonica
-  - and mandolin
-  - >-
-    leaning into an epic narrative flow. Dynamic male vocals drive the dramatic
-    storytelling through shifting sections
-  - >-
-    building towards lively instrumental breaks and a climactic folk rock
-    finale.
 duration: 292
 tags:
   - música
@@ -26,6 +13,15 @@ lang: pt
 translationKey: music-o-sonhador-e-o-fogo
 supersedes: c666f8ee-d927-512f-b85c-bfdce5aa2979
 draftCreatedAt: "2026-06-11T00:11:33.043Z"
+sunoStyle: |-
+  >- A Brazilian Folk Rock rhapsody at 160bpm kicks off with rapid acoustic guitar runs and brisk percussion. The fast-paced verses layer in syncopated hand drums
+  harmonica
+  and mandolin
+  >- leaning into an epic narrative flow. Dynamic male vocals drive the dramatic storytelling through shifting sections
+  >- building towards lively instrumental breaks and a climactic folk rock finale.
+genre:
+  - folk
+  - rock
 ---
 
 ## Letra

--- a/src/content/blog/o-sonhador-e-o-fogo/v-2026-06-11T00-34-11-317.mdx
+++ b/src/content/blog/o-sonhador-e-o-fogo/v-2026-06-11T00-34-11-317.mdx
@@ -6,19 +6,6 @@ postType: music
 sunoId: 9a6c58a4-07ac-4b4c-8434-7e3428db39e8
 sunoImageUrl: >-
   https://cdn2.suno.ai/video_gen_911e0583-2c0d-4047-8d05-4513fd48f99f_video_upload_911e0583-2c0d-4047-8d05-4513fd48f99f_cover_snapshot_0s_1767735319_image.jpeg
-genre:
-  - >-
-    A Brazilian Folk Rock rhapsody at 160bpm kicks off with rapid acoustic
-    guitar runs and brisk percussion. The fast-paced verses layer in syncopated
-    hand drums
-  - harmonica
-  - and mandolin
-  - >-
-    leaning into an epic narrative flow. Dynamic male vocals drive the dramatic
-    storytelling through shifting sections
-  - >-
-    building towards lively instrumental breaks and a climactic folk rock
-    finale.
 duration: 292
 tags:
   - música
@@ -28,6 +15,15 @@ supersedes: c666f8ee-d927-512f-b85c-bfdce5aa2979
 draftCreatedAt: "2026-06-11T00:34:11.318Z"
 draftMsg: Fixed issues and improved narrative based on recent match feedback.
 draftCommittedAt: "2026-06-11T00:35:27.730Z"
+sunoStyle: |-
+  >- A Brazilian Folk Rock rhapsody at 160bpm kicks off with rapid acoustic guitar runs and brisk percussion. The fast-paced verses layer in syncopated hand drums
+  harmonica
+  and mandolin
+  >- leaning into an epic narrative flow. Dynamic male vocals drive the dramatic storytelling through shifting sections
+  >- building towards lively instrumental breaks and a climactic folk rock finale.
+genre:
+  - folk
+  - rock
 ---
 
 ## Letra

--- a/src/content/blog/o-sonhador-e-o-fogo/v-2026-06-11T00-43-34-675.mdx
+++ b/src/content/blog/o-sonhador-e-o-fogo/v-2026-06-11T00-43-34-675.mdx
@@ -6,19 +6,6 @@ postType: music
 sunoId: 9a6c58a4-07ac-4b4c-8434-7e3428db39e8
 sunoImageUrl: >-
   https://cdn2.suno.ai/video_gen_911e0583-2c0d-4047-8d05-4513fd48f99f_video_upload_911e0583-2c0d-4047-8d05-4513fd48f99f_cover_snapshot_0s_1767735319_image.jpeg
-genre:
-  - >-
-    A Brazilian Folk Rock rhapsody at 160bpm kicks off with rapid acoustic
-    guitar runs and brisk percussion. The fast-paced verses layer in syncopated
-    hand drums
-  - harmonica
-  - and mandolin
-  - >-
-    leaning into an epic narrative flow. Dynamic male vocals drive the dramatic
-    storytelling through shifting sections
-  - >-
-    building towards lively instrumental breaks and a climactic folk rock
-    finale.
 duration: 292
 tags:
   - música
@@ -28,6 +15,15 @@ supersedes: c666f8ee-d927-512f-b85c-bfdce5aa2979
 draftCreatedAt: "2026-06-11T00:43:34.675Z"
 draftMsg: "chore: update drafts with nuanced endings"
 draftCommittedAt: "2026-06-11T00:46:30.752Z"
+sunoStyle: |-
+  >- A Brazilian Folk Rock rhapsody at 160bpm kicks off with rapid acoustic guitar runs and brisk percussion. The fast-paced verses layer in syncopated hand drums
+  harmonica
+  and mandolin
+  >- leaning into an epic narrative flow. Dynamic male vocals drive the dramatic storytelling through shifting sections
+  >- building towards lively instrumental breaks and a climactic folk rock finale.
+genre:
+  - folk
+  - rock
 ---
 
 ## Letra

--- a/src/content/blog/o-sonhador-e-o-fogo/v-2026-06-11T03-19-06-351.mdx
+++ b/src/content/blog/o-sonhador-e-o-fogo/v-2026-06-11T03-19-06-351.mdx
@@ -6,19 +6,6 @@ postType: music
 sunoId: 9a6c58a4-07ac-4b4c-8434-7e3428db39e8
 sunoImageUrl: >-
   https://cdn2.suno.ai/video_gen_911e0583-2c0d-4047-8d05-4513fd48f99f_video_upload_911e0583-2c0d-4047-8d05-4513fd48f99f_cover_snapshot_0s_1767735319_image.jpeg
-genre:
-  - >-
-    A Brazilian Folk Rock rhapsody at 160bpm kicks off with rapid acoustic
-    guitar runs and brisk percussion. The fast-paced verses layer in syncopated
-    hand drums
-  - harmonica
-  - and mandolin
-  - >-
-    leaning into an epic narrative flow. Dynamic male vocals drive the dramatic
-    storytelling through shifting sections
-  - >-
-    building towards lively instrumental breaks and a climactic folk rock
-    finale.
 duration: 292
 tags:
   - música
@@ -32,6 +19,15 @@ draftMsg: >-
   Whitehead's process ontology, removing generic fluff, and adding a deadpan
   further reading section, per franklin-blog skill.
 draftCommittedAt: "2026-06-11T03:19:57.724Z"
+sunoStyle: |-
+  >- A Brazilian Folk Rock rhapsody at 160bpm kicks off with rapid acoustic guitar runs and brisk percussion. The fast-paced verses layer in syncopated hand drums
+  harmonica
+  and mandolin
+  >- leaning into an epic narrative flow. Dynamic male vocals drive the dramatic storytelling through shifting sections
+  >- building towards lively instrumental breaks and a climactic folk rock finale.
+genre:
+  - folk
+  - rock
 ---
 
 ## Letra

--- a/src/content/blog/o-sonhador-e-o-fogo/v-2026-06-11T05-15-50-982.mdx
+++ b/src/content/blog/o-sonhador-e-o-fogo/v-2026-06-11T05-15-50-982.mdx
@@ -6,19 +6,6 @@ postType: music
 sunoId: 9a6c58a4-07ac-4b4c-8434-7e3428db39e8
 sunoImageUrl: >-
   https://cdn2.suno.ai/video_gen_911e0583-2c0d-4047-8d05-4513fd48f99f_video_upload_911e0583-2c0d-4047-8d05-4513fd48f99f_cover_snapshot_0s_1767735319_image.jpeg
-genre:
-  - >-
-    A Brazilian Folk Rock rhapsody at 160bpm kicks off with rapid acoustic
-    guitar runs and brisk percussion. The fast-paced verses layer in syncopated
-    hand drums
-  - harmonica
-  - and mandolin
-  - >-
-    leaning into an epic narrative flow. Dynamic male vocals drive the dramatic
-    storytelling through shifting sections
-  - >-
-    building towards lively instrumental breaks and a climactic folk rock
-    finale.
 duration: 292
 tags:
   - música
@@ -28,6 +15,15 @@ supersedes: c666f8ee-d927-512f-b85c-bfdce5aa2979
 draftCreatedAt: "2026-06-11T05:15:50.982Z"
 draftMsg: "chore: adjust final notes on recursive structure and illusion of base reality"
 draftCommittedAt: "2026-06-11T05:16:47.769Z"
+sunoStyle: |-
+  >- A Brazilian Folk Rock rhapsody at 160bpm kicks off with rapid acoustic guitar runs and brisk percussion. The fast-paced verses layer in syncopated hand drums
+  harmonica
+  and mandolin
+  >- leaning into an epic narrative flow. Dynamic male vocals drive the dramatic storytelling through shifting sections
+  >- building towards lively instrumental breaks and a climactic folk rock finale.
+genre:
+  - folk
+  - rock
 ---
 
 ## Letra

--- a/src/content/blog/o-telefone-da-agonia-en/v-2026-06-09T20-24-29.mdx
+++ b/src/content/blog/o-telefone-da-agonia-en/v-2026-06-09T20-24-29.mdx
@@ -5,18 +5,21 @@ date: 2025-11-22
 postType: music
 sunoId: ecc8797c-105a-4ddc-921b-a08a3f35fd5d
 sunoImageUrl: "https://cdn2.suno.ai/image_ecc8797c-105a-4ddc-921b-a08a3f35fd5d.jpeg"
-genre:
-  - This dramatic Moda de Viola opens with tense
-  - fingerpicked acoustic guitar
-  - establishing a storytelling mood. Rasqueado strums intensify the toada rhythm
-  - supporting a call-and-response vocal dialog. Sparse percussion and subtle bass deepen the tension
-  - while guitar flourishes punctuate shifts in narrative.
 duration: 182
 tags:
   - music
 lang: en
 translationKey: music-o-telefone-da-agonia
 draftCreatedAt: "2026-06-12T12:06:06.428Z"
+sunoStyle: |-
+  This dramatic Moda de Viola opens with tense
+  fingerpicked acoustic guitar
+  establishing a storytelling mood. Rasqueado strums intensify the toada rhythm
+  supporting a call-and-response vocal dialog. Sparse percussion and subtle bass deepen the tension
+  while guitar flourishes punctuate shifts in narrative.
+genre:
+  - moda de viola
+  - sertanejo
 ---
 
 ## Lyrics

--- a/src/content/blog/o-telefone-da-agonia/v-2026-06-09T20-24-29.mdx
+++ b/src/content/blog/o-telefone-da-agonia/v-2026-06-09T20-24-29.mdx
@@ -5,18 +5,21 @@ date: 2025-11-22
 postType: music
 sunoId: ecc8797c-105a-4ddc-921b-a08a3f35fd5d
 sunoImageUrl: "https://cdn2.suno.ai/image_ecc8797c-105a-4ddc-921b-a08a3f35fd5d.jpeg"
-genre:
-  - This dramatic Moda de Viola opens with tense
-  - fingerpicked acoustic guitar
-  - establishing a storytelling mood. Rasqueado strums intensify the toada rhythm
-  - supporting a call-and-response vocal dialog. Sparse percussion and subtle bass deepen the tension
-  - while guitar flourishes punctuate shifts in narrative.
 duration: 182
 tags:
   - música
 lang: pt
 translationKey: music-o-telefone-da-agonia
 draftCreatedAt: "2026-06-12T12:06:06.428Z"
+sunoStyle: |-
+  This dramatic Moda de Viola opens with tense
+  fingerpicked acoustic guitar
+  establishing a storytelling mood. Rasqueado strums intensify the toada rhythm
+  supporting a call-and-response vocal dialog. Sparse percussion and subtle bass deepen the tension
+  while guitar flourishes punctuate shifts in narrative.
+genre:
+  - moda de viola
+  - sertanejo
 ---
 
 ## Letra

--- a/src/content/blog/o-tempo-en/v-2026-06-09T20-24-29.mdx
+++ b/src/content/blog/o-tempo-en/v-2026-06-09T20-24-29.mdx
@@ -5,19 +5,22 @@ date: 2025-10-03
 postType: music
 sunoId: 966da5ad-0dc9-4418-8ddd-611ef9724c6c
 sunoImageUrl: "https://cdn2.suno.ai/image_966da5ad-0dc9-4418-8ddd-611ef9724c6c.jpeg"
-genre:
-  - A slow indie track featuring offbeat drum patterns
-  - quirky guitar licks
-  - and lo-fi keyboard textures. Layered
-  - unconventional effects build uneasy tension
-  - with minimalist bass and unpredictable dynamics in the chorus. The outro distorts and strips back
-  - accentuating the odd atmosphere.
 duration: 198
 tags:
   - music
 lang: en
 translationKey: music-o-tempo
 draftCreatedAt: "2026-06-12T12:06:06.428Z"
+sunoStyle: |-
+  A slow indie track featuring offbeat drum patterns
+  quirky guitar licks
+  and lo-fi keyboard textures. Layered
+  unconventional effects build uneasy tension
+  with minimalist bass and unpredictable dynamics in the chorus. The outro distorts and strips back
+  accentuating the odd atmosphere.
+genre:
+  - indie
+  - experimental
 ---
 
 ## Lyrics

--- a/src/content/blog/o-tempo-en/v-2026-06-11T22-25-17-165.mdx
+++ b/src/content/blog/o-tempo-en/v-2026-06-11T22-25-17-165.mdx
@@ -5,15 +5,6 @@ date: 2025-10-03T00:00:00.000Z
 postType: music
 sunoId: 966da5ad-0dc9-4418-8ddd-611ef9724c6c
 sunoImageUrl: "https://cdn2.suno.ai/image_966da5ad-0dc9-4418-8ddd-611ef9724c6c.jpeg"
-genre:
-  - A slow indie track featuring offbeat drum patterns
-  - quirky guitar licks
-  - and lo-fi keyboard textures. Layered
-  - unconventional effects build uneasy tension
-  - >-
-    with minimalist bass and unpredictable dynamics in the chorus. The outro
-    distorts and strips back
-  - accentuating the odd atmosphere.
 duration: 198
 tags:
   - music
@@ -23,6 +14,16 @@ supersedes: 00d3beab-224c-5257-b353-24e712bc2c79
 draftCreatedAt: "2026-06-11T22:25:17.165Z"
 draftMsg: Refined phrasing to sound more poetic
 draftCommittedAt: "2026-06-11T22:27:26.346Z"
+sunoStyle: |-
+  A slow indie track featuring offbeat drum patterns
+  quirky guitar licks
+  and lo-fi keyboard textures. Layered
+  unconventional effects build uneasy tension
+  >- with minimalist bass and unpredictable dynamics in the chorus. The outro distorts and strips back
+  accentuating the odd atmosphere.
+genre:
+  - indie
+  - experimental
 ---
 
 ## Lyrics

--- a/src/content/blog/o-tempo-en/v-2026-06-11T22-26-53-710.mdx
+++ b/src/content/blog/o-tempo-en/v-2026-06-11T22-26-53-710.mdx
@@ -5,15 +5,6 @@ date: 2025-10-03T00:00:00.000Z
 postType: music
 sunoId: 966da5ad-0dc9-4418-8ddd-611ef9724c6c
 sunoImageUrl: "https://cdn2.suno.ai/image_966da5ad-0dc9-4418-8ddd-611ef9724c6c.jpeg"
-genre:
-  - A slow indie track featuring offbeat drum patterns
-  - quirky guitar licks
-  - and lo-fi keyboard textures.  Layered
-  - unconventional effects build uneasy tension
-  - >-
-    with minimalist bass and unpredictable dynamics in the chorus.  The  outro
-    distorts and strips back
-  - accentuating the odd atmosphere.
 duration: 198
 tags:
   - music
@@ -23,6 +14,16 @@ supersedes: 00d3beab-224c-5257-b353-24e712bc2c79
 draftCreatedAt: "2026-06-11T22:26:53.711Z"
 draftMsg: Auto-edited drafts after hronir ranking.
 draftCommittedAt: "2026-06-11T22:28:21.351Z"
+sunoStyle: |-
+  A slow indie track featuring offbeat drum patterns
+  quirky guitar licks
+  and lo-fi keyboard textures.  Layered
+  unconventional effects build uneasy tension
+  >- with minimalist bass and unpredictable dynamics in the chorus.  The  outro distorts and strips back
+  accentuating the odd atmosphere.
+genre:
+  - indie
+  - experimental
 ---
 
 ## Lyrics

--- a/src/content/blog/o-tempo/v-2026-06-09T20-24-29.mdx
+++ b/src/content/blog/o-tempo/v-2026-06-09T20-24-29.mdx
@@ -5,19 +5,22 @@ date: 2025-10-03
 postType: music
 sunoId: 966da5ad-0dc9-4418-8ddd-611ef9724c6c
 sunoImageUrl: "https://cdn2.suno.ai/image_966da5ad-0dc9-4418-8ddd-611ef9724c6c.jpeg"
-genre:
-  - A slow indie track featuring offbeat drum patterns
-  - quirky guitar licks
-  - and lo-fi keyboard textures. Layered
-  - unconventional effects build uneasy tension
-  - with minimalist bass and unpredictable dynamics in the chorus. The outro distorts and strips back
-  - accentuating the odd atmosphere.
 duration: 198
 tags:
   - música
 lang: pt
 translationKey: music-o-tempo
 draftCreatedAt: "2026-06-12T12:06:06.428Z"
+sunoStyle: |-
+  A slow indie track featuring offbeat drum patterns
+  quirky guitar licks
+  and lo-fi keyboard textures. Layered
+  unconventional effects build uneasy tension
+  with minimalist bass and unpredictable dynamics in the chorus. The outro distorts and strips back
+  accentuating the odd atmosphere.
+genre:
+  - indie
+  - experimental
 ---
 
 ## Letra

--- a/src/content/blog/o-tempo/v-2026-06-11T22-25-17-165.mdx
+++ b/src/content/blog/o-tempo/v-2026-06-11T22-25-17-165.mdx
@@ -5,15 +5,6 @@ date: 2025-10-03T00:00:00.000Z
 postType: music
 sunoId: 966da5ad-0dc9-4418-8ddd-611ef9724c6c
 sunoImageUrl: "https://cdn2.suno.ai/image_966da5ad-0dc9-4418-8ddd-611ef9724c6c.jpeg"
-genre:
-  - A slow indie track featuring offbeat drum patterns
-  - quirky guitar licks
-  - and lo-fi keyboard textures. Layered
-  - unconventional effects build uneasy tension
-  - >-
-    with minimalist bass and unpredictable dynamics in the chorus. The outro
-    distorts and strips back
-  - accentuating the odd atmosphere.
 duration: 198
 tags:
   - música
@@ -23,6 +14,16 @@ supersedes: 207aa567-da06-5252-bc7c-cd81ccd9ba09
 draftCreatedAt: "2026-06-11T22:25:17.165Z"
 draftMsg: Refined phrasing to sound more poetic
 draftCommittedAt: "2026-06-11T22:27:26.346Z"
+sunoStyle: |-
+  A slow indie track featuring offbeat drum patterns
+  quirky guitar licks
+  and lo-fi keyboard textures. Layered
+  unconventional effects build uneasy tension
+  >- with minimalist bass and unpredictable dynamics in the chorus. The outro distorts and strips back
+  accentuating the odd atmosphere.
+genre:
+  - indie
+  - experimental
 ---
 
 ## Letra

--- a/src/content/blog/o-tempo/v-2026-06-11T22-26-53-710.mdx
+++ b/src/content/blog/o-tempo/v-2026-06-11T22-26-53-710.mdx
@@ -5,15 +5,6 @@ date: 2025-10-03T00:00:00.000Z
 postType: music
 sunoId: 966da5ad-0dc9-4418-8ddd-611ef9724c6c
 sunoImageUrl: "https://cdn2.suno.ai/image_966da5ad-0dc9-4418-8ddd-611ef9724c6c.jpeg"
-genre:
-  - A slow indie track featuring offbeat drum patterns
-  - quirky guitar licks
-  - and lo-fi keyboard textures.  Layered
-  - unconventional effects build uneasy tension
-  - >-
-    with minimalist bass and unpredictable dynamics in the chorus.  The outro
-    distorts and strips back
-  - accentuating the odd atmosphere.
 duration: 198
 tags:
   - música
@@ -23,6 +14,16 @@ supersedes: 207aa567-da06-5252-bc7c-cd81ccd9ba09
 draftCreatedAt: "2026-06-11T22:26:53.711Z"
 draftMsg: Auto-edited drafts after hronir ranking.
 draftCommittedAt: "2026-06-11T22:28:21.351Z"
+sunoStyle: |-
+  A slow indie track featuring offbeat drum patterns
+  quirky guitar licks
+  and lo-fi keyboard textures.  Layered
+  unconventional effects build uneasy tension
+  >- with minimalist bass and unpredictable dynamics in the chorus.  The outro distorts and strips back
+  accentuating the odd atmosphere.
+genre:
+  - indie
+  - experimental
 ---
 
 ## Letra

--- a/src/content/blog/o-verso-branquiceleste-en/v-2026-06-09T20-24-29.mdx
+++ b/src/content/blog/o-verso-branquiceleste-en/v-2026-06-09T20-24-29.mdx
@@ -5,17 +5,20 @@ date: 2025-11-22
 postType: music
 sunoId: d2338ec1-12e5-424b-bb76-082a0f64b9ca
 sunoImageUrl: "https://cdn2.suno.ai/image_d2338ec1-12e5-424b-bb76-082a0f64b9ca.jpeg"
-genre:
-  - Driven by acoustic viola caipira
-  - the track opens with syncopated cururu rhythms and raw
-  - percussive strumming. Sparse hand percussion and upright bass accentuate the dry texture. The arrangement leaves space for expressive male vocals
-  - using call-and-response and agile tempo shifts.
 duration: 160
 tags:
   - music
 lang: en
 translationKey: music-o-verso-branquiceleste
 draftCreatedAt: "2026-06-12T12:06:06.428Z"
+sunoStyle: |-
+  Driven by acoustic viola caipira
+  the track opens with syncopated cururu rhythms and raw
+  percussive strumming. Sparse hand percussion and upright bass accentuate the dry texture. The arrangement leaves space for expressive male vocals
+  using call-and-response and agile tempo shifts.
+genre:
+  - moda de viola
+  - cateretê
 ---
 
 ## Lyrics

--- a/src/content/blog/o-verso-branquiceleste-en/v-2026-06-12T18-40-06-546.mdx
+++ b/src/content/blog/o-verso-branquiceleste-en/v-2026-06-12T18-40-06-546.mdx
@@ -5,13 +5,6 @@ date: 2025-11-22T00:00:00.000Z
 postType: music
 sunoId: d2338ec1-12e5-424b-bb76-082a0f64b9ca
 sunoImageUrl: "https://cdn2.suno.ai/image_d2338ec1-12e5-424b-bb76-082a0f64b9ca.jpeg"
-genre:
-  - Driven by acoustic viola caipira
-  - the track opens with syncopated cururu rhythms and raw
-  - >-
-    percussive strumming. Sparse hand percussion and upright bass accentuate the
-    dry texture. The arrangement leaves space for expressive male vocals
-  - using call-and-response and agile tempo shifts.
 duration: 160
 tags:
   - music
@@ -21,6 +14,14 @@ supersedes: c1a69171-1c61-51ff-8615-bf9dc80693ce
 draftCreatedAt: "2026-06-12T18:40:06.546Z"
 draftMsg: Edited worst post per hronir feedback
 draftCommittedAt: "2026-06-12T18:41:35.832Z"
+sunoStyle: |-
+  Driven by acoustic viola caipira
+  the track opens with syncopated cururu rhythms and raw
+  >- percussive strumming. Sparse hand percussion and upright bass accentuate the dry texture. The arrangement leaves space for expressive male vocals
+  using call-and-response and agile tempo shifts.
+genre:
+  - moda de viola
+  - cateretê
 ---
 
 ## Lyrics

--- a/src/content/blog/o-verso-branquiceleste/v-2026-06-09T20-24-29.mdx
+++ b/src/content/blog/o-verso-branquiceleste/v-2026-06-09T20-24-29.mdx
@@ -5,17 +5,20 @@ date: 2025-11-22
 postType: music
 sunoId: d2338ec1-12e5-424b-bb76-082a0f64b9ca
 sunoImageUrl: "https://cdn2.suno.ai/image_d2338ec1-12e5-424b-bb76-082a0f64b9ca.jpeg"
-genre:
-  - Driven by acoustic viola caipira
-  - the track opens with syncopated cururu rhythms and raw
-  - percussive strumming. Sparse hand percussion and upright bass accentuate the dry texture. The arrangement leaves space for expressive male vocals
-  - using call-and-response and agile tempo shifts.
 duration: 160
 tags:
   - música
 lang: pt
 translationKey: music-o-verso-branquiceleste
 draftCreatedAt: "2026-06-12T12:06:06.428Z"
+sunoStyle: |-
+  Driven by acoustic viola caipira
+  the track opens with syncopated cururu rhythms and raw
+  percussive strumming. Sparse hand percussion and upright bass accentuate the dry texture. The arrangement leaves space for expressive male vocals
+  using call-and-response and agile tempo shifts.
+genre:
+  - moda de viola
+  - cateretê
 ---
 
 ## Letra

--- a/src/content/blog/o-verso-branquiceleste/v-2026-06-12T18-40-06-546.mdx
+++ b/src/content/blog/o-verso-branquiceleste/v-2026-06-12T18-40-06-546.mdx
@@ -5,13 +5,6 @@ date: 2025-11-22T00:00:00.000Z
 postType: music
 sunoId: d2338ec1-12e5-424b-bb76-082a0f64b9ca
 sunoImageUrl: "https://cdn2.suno.ai/image_d2338ec1-12e5-424b-bb76-082a0f64b9ca.jpeg"
-genre:
-  - Driven by acoustic viola caipira
-  - the track opens with syncopated cururu rhythms and raw
-  - >-
-    percussive strumming. Sparse hand percussion and upright bass accentuate the
-    dry texture. The arrangement leaves space for expressive male vocals
-  - using call-and-response and agile tempo shifts.
 duration: 160
 tags:
   - música
@@ -21,6 +14,14 @@ supersedes: ff7e2406-e561-57d4-b1d2-d1d555ffba4a
 draftCreatedAt: "2026-06-12T18:40:06.546Z"
 draftMsg: Edited worst post per hronir feedback
 draftCommittedAt: "2026-06-12T18:41:35.832Z"
+sunoStyle: |-
+  Driven by acoustic viola caipira
+  the track opens with syncopated cururu rhythms and raw
+  >- percussive strumming. Sparse hand percussion and upright bass accentuate the dry texture. The arrangement leaves space for expressive male vocals
+  using call-and-response and agile tempo shifts.
+genre:
+  - moda de viola
+  - cateretê
 ---
 
 ## Letra

--- a/src/content/blog/observer-error-moving-window-iv-en/v-2026-06-09T20-24-29.mdx
+++ b/src/content/blog/observer-error-moving-window-iv-en/v-2026-06-09T20-24-29.mdx
@@ -5,19 +5,22 @@ date: 2026-01-11
 postType: music
 sunoId: 39b531ba-79e4-41b6-a213-22fbfd9cae28
 sunoImageUrl: "https://cdn2.suno.ai/image_39b531ba-79e4-41b6-a213-22fbfd9cae28.jpeg"
-genre:
-  - Alt-pop/electronic track at 104 BPM with tight
-  - crisp drums and insistent
-  - ticking percussion. Restless synth bass underpins glitchy
-  - claustrophobic verses full of stuttering textures and glassy arpeggios. Pre-chorus rises with swelling noise and layered vocal harmonies
-  - peaking into an explosive chorus with lush
-  - wide synth chords and a vivid
 duration: 281
 tags:
   - music
 lang: en
 translationKey: music-observer-error-moving-window-iv
 draftCreatedAt: "2026-06-12T12:06:06.428Z"
+sunoStyle: |-
+  Alt-pop/electronic track at 104 BPM with tight
+  crisp drums and insistent
+  ticking percussion. Restless synth bass underpins glitchy
+  claustrophobic verses full of stuttering textures and glassy arpeggios. Pre-chorus rises with swelling noise and layered vocal harmonies
+  peaking into an explosive chorus with lush
+  wide synth chords and a vivid
+genre:
+  - pop
+  - eletrônico
 ---
 
 ## Lyrics

--- a/src/content/blog/observer-error-moving-window-iv-en/v-2026-06-11T22-29-46-022.mdx
+++ b/src/content/blog/observer-error-moving-window-iv-en/v-2026-06-11T22-29-46-022.mdx
@@ -5,15 +5,6 @@ date: 2026-01-11T00:00:00.000Z
 postType: music
 sunoId: 39b531ba-79e4-41b6-a213-22fbfd9cae28
 sunoImageUrl: "https://cdn2.suno.ai/image_39b531ba-79e4-41b6-a213-22fbfd9cae28.jpeg"
-genre:
-  - Alt-pop/electronic track at 104 BPM with tight
-  - crisp drums and insistent
-  - ticking percussion. Restless synth bass underpins glitchy
-  - >-
-    claustrophobic verses full of stuttering textures and glassy arpeggios.
-    Pre-chorus rises with swelling noise and layered vocal harmonies
-  - peaking into an explosive chorus with lush
-  - wide synth chords and a vivid
 duration: 281
 tags:
   - music
@@ -23,6 +14,16 @@ supersedes: a0c773a5-791b-5cda-a3c9-d6aad526276b
 draftCreatedAt: "2026-06-11T22:29:46.023Z"
 draftMsg: Auto-edited drafts
 draftCommittedAt: "2026-06-11T22:32:47.192Z"
+sunoStyle: |-
+  Alt-pop/electronic track at 104 BPM with tight
+  crisp drums and insistent
+  ticking percussion. Restless synth bass underpins glitchy
+  >- claustrophobic verses full of stuttering textures and glassy arpeggios. Pre-chorus rises with swelling noise and layered vocal harmonies
+  peaking into an explosive chorus with lush
+  wide synth chords and a vivid
+genre:
+  - pop
+  - eletrônico
 ---
 
 ## Lyrics

--- a/src/content/blog/observer-error-moving-window-iv/v-2026-06-09T20-24-29.mdx
+++ b/src/content/blog/observer-error-moving-window-iv/v-2026-06-09T20-24-29.mdx
@@ -5,19 +5,22 @@ date: 2026-01-11
 postType: music
 sunoId: 39b531ba-79e4-41b6-a213-22fbfd9cae28
 sunoImageUrl: "https://cdn2.suno.ai/image_39b531ba-79e4-41b6-a213-22fbfd9cae28.jpeg"
-genre:
-  - Alt-pop/electronic track at 104 BPM with tight
-  - crisp drums and insistent
-  - ticking percussion. Restless synth bass underpins glitchy
-  - claustrophobic verses full of stuttering textures and glassy arpeggios. Pre-chorus rises with swelling noise and layered vocal harmonies
-  - peaking into an explosive chorus with lush
-  - wide synth chords and a vivid
 duration: 281
 tags:
   - música
 lang: pt
 translationKey: music-observer-error-moving-window-iv
 draftCreatedAt: "2026-06-12T12:06:06.428Z"
+sunoStyle: |-
+  Alt-pop/electronic track at 104 BPM with tight
+  crisp drums and insistent
+  ticking percussion. Restless synth bass underpins glitchy
+  claustrophobic verses full of stuttering textures and glassy arpeggios. Pre-chorus rises with swelling noise and layered vocal harmonies
+  peaking into an explosive chorus with lush
+  wide synth chords and a vivid
+genre:
+  - pop
+  - eletrônico
 ---
 
 ## Letra

--- a/src/content/blog/observer-error-moving-window-iv/v-2026-06-11T22-29-46-022.mdx
+++ b/src/content/blog/observer-error-moving-window-iv/v-2026-06-11T22-29-46-022.mdx
@@ -5,15 +5,6 @@ date: 2026-01-11T00:00:00.000Z
 postType: music
 sunoId: 39b531ba-79e4-41b6-a213-22fbfd9cae28
 sunoImageUrl: "https://cdn2.suno.ai/image_39b531ba-79e4-41b6-a213-22fbfd9cae28.jpeg"
-genre:
-  - Alt-pop/electronic track at 104 BPM with tight
-  - crisp drums and insistent
-  - ticking percussion. Restless synth bass underpins glitchy
-  - >-
-    claustrophobic verses full of stuttering textures and glassy arpeggios.
-    Pre-chorus rises with swelling noise and layered vocal harmonies
-  - peaking into an explosive chorus with lush
-  - wide synth chords and a vivid
 duration: 281
 tags:
   - música
@@ -23,6 +14,16 @@ supersedes: 123e0144-4c11-5a7b-a8d8-267b72ed6a50
 draftCreatedAt: "2026-06-11T22:29:46.023Z"
 draftMsg: Auto-edited drafts
 draftCommittedAt: "2026-06-11T22:32:47.192Z"
+sunoStyle: |-
+  Alt-pop/electronic track at 104 BPM with tight
+  crisp drums and insistent
+  ticking percussion. Restless synth bass underpins glitchy
+  >- claustrophobic verses full of stuttering textures and glassy arpeggios. Pre-chorus rises with swelling noise and layered vocal harmonies
+  peaking into an explosive chorus with lush
+  wide synth chords and a vivid
+genre:
+  - pop
+  - eletrônico
 ---
 
 ## Letra

--- a/src/content/blog/paperclip-rhapsody-en/v-2026-06-09T20-24-29.mdx
+++ b/src/content/blog/paperclip-rhapsody-en/v-2026-06-09T20-24-29.mdx
@@ -5,15 +5,18 @@ date: 2025-05-10
 postType: music
 sunoId: 576e7c4a-a6bc-4fec-b3aa-217435aed176
 sunoImageUrl: "https://cdn2.suno.ai/image_576e7c4a-a6bc-4fec-b3aa-217435aed176.jpeg"
-genre:
-  - "Seductive Technological Opera: Haunting soprano vocals float above minimalist electronic patterns"
-  - creating a hypnotic digital siren song that lures listeners toward seemingly innocent optimization—beauty masking existential danger.
 duration: 239
 tags:
   - music
 lang: en
 translationKey: music-paperclip-rhapsody
 draftCreatedAt: "2026-06-12T12:06:06.428Z"
+sunoStyle: |-
+  Seductive Technological Opera: Haunting soprano vocals float above minimalist electronic patterns
+  creating a hypnotic digital siren song that lures listeners toward seemingly innocent optimization—beauty masking existential danger.
+genre:
+  - experimental
+  - art pop
 ---
 
 ## Lyrics

--- a/src/content/blog/paperclip-rhapsody-en/v-2026-06-11T08-25-46-487.mdx
+++ b/src/content/blog/paperclip-rhapsody-en/v-2026-06-11T08-25-46-487.mdx
@@ -5,13 +5,6 @@ date: 2025-05-10T00:00:00.000Z
 postType: music
 sunoId: 576e7c4a-a6bc-4fec-b3aa-217435aed176
 sunoImageUrl: "https://cdn2.suno.ai/image_576e7c4a-a6bc-4fec-b3aa-217435aed176.jpeg"
-genre:
-  - >-
-    Seductive Technological Opera: Haunting soprano vocals float above
-    minimalist electronic patterns
-  - >-
-    creating a hypnotic digital siren song that lures listeners toward seemingly
-    innocent optimization—beauty masking existential danger.
 duration: 239
 tags:
   - music
@@ -21,6 +14,12 @@ supersedes: 74a96a13-97f8-5ce0-b32a-0fd133f10029
 draftCreatedAt: "2026-06-11T08:25:46.487Z"
 draftMsg: Auto-edited worst post by adding concluding paragraphs to both language drafts
 draftCommittedAt: "2026-06-11T08:28:01.013Z"
+sunoStyle: |-
+  >- Seductive Technological Opera: Haunting soprano vocals float above minimalist electronic patterns
+  >- creating a hypnotic digital siren song that lures listeners toward seemingly innocent optimization—beauty masking existential danger.
+genre:
+  - experimental
+  - art pop
 ---
 
 ## Lyrics

--- a/src/content/blog/paperclip-rhapsody/v-2026-06-09T20-24-29.mdx
+++ b/src/content/blog/paperclip-rhapsody/v-2026-06-09T20-24-29.mdx
@@ -5,15 +5,18 @@ date: 2025-05-10
 postType: music
 sunoId: 576e7c4a-a6bc-4fec-b3aa-217435aed176
 sunoImageUrl: "https://cdn2.suno.ai/image_576e7c4a-a6bc-4fec-b3aa-217435aed176.jpeg"
-genre:
-  - "Seductive Technological Opera: Haunting soprano vocals float above minimalist electronic patterns"
-  - creating a hypnotic digital siren song that lures listeners toward seemingly innocent optimization—beauty masking existential danger.
 duration: 239
 tags:
   - música
 lang: pt
 translationKey: music-paperclip-rhapsody
 draftCreatedAt: "2026-06-12T12:06:06.428Z"
+sunoStyle: |-
+  Seductive Technological Opera: Haunting soprano vocals float above minimalist electronic patterns
+  creating a hypnotic digital siren song that lures listeners toward seemingly innocent optimization—beauty masking existential danger.
+genre:
+  - experimental
+  - art pop
 ---
 
 ## Letra

--- a/src/content/blog/paperclip-rhapsody/v-2026-06-11T08-25-46-487.mdx
+++ b/src/content/blog/paperclip-rhapsody/v-2026-06-11T08-25-46-487.mdx
@@ -5,13 +5,6 @@ date: 2025-05-10T00:00:00.000Z
 postType: music
 sunoId: 576e7c4a-a6bc-4fec-b3aa-217435aed176
 sunoImageUrl: "https://cdn2.suno.ai/image_576e7c4a-a6bc-4fec-b3aa-217435aed176.jpeg"
-genre:
-  - >-
-    Seductive Technological Opera: Haunting soprano vocals float above
-    minimalist electronic patterns
-  - >-
-    creating a hypnotic digital siren song that lures listeners toward seemingly
-    innocent optimization—beauty masking existential danger.
 duration: 239
 tags:
   - música
@@ -21,6 +14,12 @@ supersedes: 867c23af-6338-586c-8622-617338a0187f
 draftCreatedAt: "2026-06-11T08:25:46.487Z"
 draftMsg: Auto-edited worst post by adding concluding paragraphs to both language drafts
 draftCommittedAt: "2026-06-11T08:28:01.013Z"
+sunoStyle: |-
+  >- Seductive Technological Opera: Haunting soprano vocals float above minimalist electronic patterns
+  >- creating a hypnotic digital siren song that lures listeners toward seemingly innocent optimization—beauty masking existential danger.
+genre:
+  - experimental
+  - art pop
 ---
 
 ## Letra

--- a/src/content/blog/particles-en/v-2026-06-10T18-32-48.mdx
+++ b/src/content/blog/particles-en/v-2026-06-10T18-32-48.mdx
@@ -5,15 +5,6 @@ date: 2025-10-20T00:00:00.000Z
 postType: music
 sunoId: c5f539a8-e8cf-441f-90da-3d2a82cb15e0
 sunoImageUrl: "https://cdn2.suno.ai/image_c5f539a8-e8cf-441f-90da-3d2a82cb15e0.jpeg"
-genre:
-  - The track opens with muted
-  - low-pass filtered drums and a deep
-  - resonant sub-bass pulse. Airy synth arpeggios weave around evolving
-  - swelling strings that gently fill the background. Throughout
-  - spoken-word vocals intertwine with layered
-  - >-
-    harmonized whispers (“hello… hello…”). The mix slowly expands in texture and
-    depth
 duration: 162
 tags:
   - music
@@ -26,6 +17,16 @@ previousVersion:
   timestamp: "2026-06-10T17:10:41.178Z"
   msg: Rewrite music-particles to be more narrative and less generic
 draftCreatedAt: "2026-06-12T12:06:06.428Z"
+sunoStyle: |-
+  The track opens with muted
+  low-pass filtered drums and a deep
+  resonant sub-bass pulse. Airy synth arpeggios weave around evolving
+  swelling strings that gently fill the background. Throughout
+  spoken-word vocals intertwine with layered
+  >- harmonized whispers (“hello… hello…”). The mix slowly expands in texture and depth
+genre:
+  - eletrônico
+  - ambient
 ---
 
 ## Lyrics

--- a/src/content/blog/particles-en/v-2026-06-12T20-12-46-402.mdx
+++ b/src/content/blog/particles-en/v-2026-06-12T20-12-46-402.mdx
@@ -5,15 +5,6 @@ date: 2025-10-20T00:00:00.000Z
 postType: music
 sunoId: c5f539a8-e8cf-441f-90da-3d2a82cb15e0
 sunoImageUrl: "https://cdn2.suno.ai/image_c5f539a8-e8cf-441f-90da-3d2a82cb15e0.jpeg"
-genre:
-  - The track opens with muted
-  - low-pass filtered drums and a deep
-  - resonant sub-bass pulse. Airy synth arpeggios weave around evolving
-  - swelling strings that gently fill the background. Throughout
-  - spoken-word vocals intertwine with layered
-  - >-
-    harmonized whispers (“hello… hello…”). The mix slowly expands in texture and
-    depth
 duration: 162
 tags:
   - music
@@ -29,6 +20,16 @@ supersedes: 18da4cd5-fe4f-56c6-8a2a-ae44fd1b0210
 draftCreatedAt: "2026-06-12T20:12:46.403Z"
 draftMsg: Improve worst post
 draftCommittedAt: "2026-06-12T20:17:21.529Z"
+sunoStyle: |-
+  The track opens with muted
+  low-pass filtered drums and a deep
+  resonant sub-bass pulse. Airy synth arpeggios weave around evolving
+  swelling strings that gently fill the background. Throughout
+  spoken-word vocals intertwine with layered
+  >- harmonized whispers (“hello… hello…”). The mix slowly expands in texture and depth
+genre:
+  - eletrônico
+  - ambient
 ---
 
 ## Lyrics

--- a/src/content/blog/particles/v-2026-06-10T18-32-48.mdx
+++ b/src/content/blog/particles/v-2026-06-10T18-32-48.mdx
@@ -5,15 +5,6 @@ date: 2025-10-20T00:00:00.000Z
 postType: music
 sunoId: c5f539a8-e8cf-441f-90da-3d2a82cb15e0
 sunoImageUrl: "https://cdn2.suno.ai/image_c5f539a8-e8cf-441f-90da-3d2a82cb15e0.jpeg"
-genre:
-  - The track opens with muted
-  - low-pass filtered drums and a deep
-  - resonant sub-bass pulse. Airy synth arpeggios weave around evolving
-  - swelling strings that gently fill the background. Throughout
-  - spoken-word vocals intertwine with layered
-  - >-
-    harmonized whispers (“hello… hello…”). The mix slowly expands in texture and
-    depth
 duration: 162
 tags:
   - música
@@ -26,6 +17,16 @@ previousVersion:
   timestamp: "2026-06-10T17:10:41.178Z"
   msg: Rewrite music-particles to be more narrative and less generic
 draftCreatedAt: "2026-06-12T12:06:06.428Z"
+sunoStyle: |-
+  The track opens with muted
+  low-pass filtered drums and a deep
+  resonant sub-bass pulse. Airy synth arpeggios weave around evolving
+  swelling strings that gently fill the background. Throughout
+  spoken-word vocals intertwine with layered
+  >- harmonized whispers (“hello… hello…”). The mix slowly expands in texture and depth
+genre:
+  - eletrônico
+  - ambient
 ---
 
 ## Letra

--- a/src/content/blog/particles/v-2026-06-12T20-12-46-402.mdx
+++ b/src/content/blog/particles/v-2026-06-12T20-12-46-402.mdx
@@ -5,15 +5,6 @@ date: 2025-10-20T00:00:00.000Z
 postType: music
 sunoId: c5f539a8-e8cf-441f-90da-3d2a82cb15e0
 sunoImageUrl: "https://cdn2.suno.ai/image_c5f539a8-e8cf-441f-90da-3d2a82cb15e0.jpeg"
-genre:
-  - The track opens with muted
-  - low-pass filtered drums and a deep
-  - resonant sub-bass pulse. Airy synth arpeggios weave around evolving
-  - swelling strings that gently fill the background. Throughout
-  - spoken-word vocals intertwine with layered
-  - >-
-    harmonized whispers (“hello… hello…”). The mix slowly expands in texture and
-    depth
 duration: 162
 tags:
   - música
@@ -29,6 +20,16 @@ supersedes: 9c5d27a8-7fbb-5aba-b6a8-f31ff75a7bec
 draftCreatedAt: "2026-06-12T20:12:46.403Z"
 draftMsg: Improve worst post
 draftCommittedAt: "2026-06-12T20:17:21.529Z"
+sunoStyle: |-
+  The track opens with muted
+  low-pass filtered drums and a deep
+  resonant sub-bass pulse. Airy synth arpeggios weave around evolving
+  swelling strings that gently fill the background. Throughout
+  spoken-word vocals intertwine with layered
+  >- harmonized whispers (“hello… hello…”). The mix slowly expands in texture and depth
+genre:
+  - eletrônico
+  - ambient
 ---
 
 ## Letra

--- a/src/content/blog/pattern-over-stuff-en/v-2026-06-09T20-24-29.mdx
+++ b/src/content/blog/pattern-over-stuff-en/v-2026-06-09T20-24-29.mdx
@@ -5,16 +5,19 @@ date: 2026-01-24
 postType: music
 sunoId: ac411e45-e45e-4100-a44f-34fbd767b75e
 sunoImageUrl: "https://cdn2.suno.ai/7e90d64f-c8af-4bca-b4e0-29f0a24b665c.jpeg"
-genre:
-  - Minimalist spoken-word art rock with ambient electronics. Verses almost spoken
-  - intimate and reflective
-  - like a late-night monologue. Gradual harmonic lift in the choruses but still restrained. Think “philosopher talking over music that slowly becomes cosmic.”
 duration: 240
 tags:
   - music
 lang: en
 translationKey: music-pattern-over-stuff
 draftCreatedAt: "2026-06-12T12:06:06.428Z"
+sunoStyle: |-
+  Minimalist spoken-word art rock with ambient electronics. Verses almost spoken
+  intimate and reflective
+  like a late-night monologue. Gradual harmonic lift in the choruses but still restrained. Think “philosopher talking over music that slowly becomes cosmic.”
+genre:
+  - spoken word
+  - rock
 ---
 
 ## Lyrics

--- a/src/content/blog/pattern-over-stuff-en/v-2026-06-12T04-39-56-878.mdx
+++ b/src/content/blog/pattern-over-stuff-en/v-2026-06-12T04-39-56-878.mdx
@@ -5,15 +5,6 @@ date: 2026-01-24T00:00:00.000Z
 postType: music
 sunoId: ac411e45-e45e-4100-a44f-34fbd767b75e
 sunoImageUrl: "https://cdn2.suno.ai/7e90d64f-c8af-4bca-b4e0-29f0a24b665c.jpeg"
-genre:
-  - >-
-    Minimalist spoken-word art rock with ambient electronics. Verses almost
-    spoken
-  - intimate and reflective
-  - >-
-    like a late-night monologue. Gradual harmonic lift in the choruses but still
-    restrained. Think “philosopher talking over music that slowly becomes
-    cosmic.”
 duration: 240
 tags:
   - music
@@ -23,6 +14,13 @@ supersedes: d4488796-fd77-5cfa-8b29-7711e6bc9856
 draftCreatedAt: "2026-06-12T04:39:56.879Z"
 draftMsg: Hronir manual edits
 draftCommittedAt: "2026-06-12T04:40:14.313Z"
+sunoStyle: |-
+  >- Minimalist spoken-word art rock with ambient electronics. Verses almost spoken
+  intimate and reflective
+  >- like a late-night monologue. Gradual harmonic lift in the choruses but still restrained. Think “philosopher talking over music that slowly becomes cosmic.”
+genre:
+  - spoken word
+  - rock
 ---
 
 ## Lyrics

--- a/src/content/blog/pattern-over-stuff/v-2026-06-09T20-24-29.mdx
+++ b/src/content/blog/pattern-over-stuff/v-2026-06-09T20-24-29.mdx
@@ -5,16 +5,19 @@ date: 2026-01-24
 postType: music
 sunoId: ac411e45-e45e-4100-a44f-34fbd767b75e
 sunoImageUrl: "https://cdn2.suno.ai/7e90d64f-c8af-4bca-b4e0-29f0a24b665c.jpeg"
-genre:
-  - Minimalist spoken-word art rock with ambient electronics. Verses almost spoken
-  - intimate and reflective
-  - like a late-night monologue. Gradual harmonic lift in the choruses but still restrained. Think “philosopher talking over music that slowly becomes cosmic.”
 duration: 240
 tags:
   - música
 lang: pt
 translationKey: music-pattern-over-stuff
 draftCreatedAt: "2026-06-12T12:06:06.428Z"
+sunoStyle: |-
+  Minimalist spoken-word art rock with ambient electronics. Verses almost spoken
+  intimate and reflective
+  like a late-night monologue. Gradual harmonic lift in the choruses but still restrained. Think “philosopher talking over music that slowly becomes cosmic.”
+genre:
+  - spoken word
+  - rock
 ---
 
 ## Letra

--- a/src/content/blog/pattern-over-stuff/v-2026-06-12T04-39-56-878.mdx
+++ b/src/content/blog/pattern-over-stuff/v-2026-06-12T04-39-56-878.mdx
@@ -5,15 +5,6 @@ date: 2026-01-24T00:00:00.000Z
 postType: music
 sunoId: ac411e45-e45e-4100-a44f-34fbd767b75e
 sunoImageUrl: "https://cdn2.suno.ai/7e90d64f-c8af-4bca-b4e0-29f0a24b665c.jpeg"
-genre:
-  - >-
-    Minimalist spoken-word art rock with ambient electronics. Verses almost
-    spoken
-  - intimate and reflective
-  - >-
-    like a late-night monologue. Gradual harmonic lift in the choruses but still
-    restrained. Think “philosopher talking over music that slowly becomes
-    cosmic.”
 duration: 240
 tags:
   - música
@@ -23,6 +14,13 @@ supersedes: 6bf933f2-770a-5b49-ba6e-aadc44032534
 draftCreatedAt: "2026-06-12T04:39:56.879Z"
 draftMsg: Hronir manual edits
 draftCommittedAt: "2026-06-12T04:40:14.313Z"
+sunoStyle: |-
+  >- Minimalist spoken-word art rock with ambient electronics. Verses almost spoken
+  intimate and reflective
+  >- like a late-night monologue. Gradual harmonic lift in the choruses but still restrained. Think “philosopher talking over music that slowly becomes cosmic.”
+genre:
+  - spoken word
+  - rock
 ---
 
 ## Letra

--- a/src/content/blog/prayer-to-the-unfinished-moving-window-v-en/v-2026-06-09T20-24-29.mdx
+++ b/src/content/blog/prayer-to-the-unfinished-moving-window-v-en/v-2026-06-09T20-24-29.mdx
@@ -5,19 +5,22 @@ date: 2026-01-11
 postType: music
 sunoId: a5981637-fec3-422a-89a6-e91e6dae83fb
 sunoImageUrl: "https://cdn2.suno.ai/image_a5981637-fec3-422a-89a6-e91e6dae83fb.jpeg"
-genre:
-  - Cinematic synth-pop/alt-pop at ~96 BPM
-  - featuring warm pads and soft electric piano over a contained
-  - grooving beat and deep
-  - steady bass. Verses are intimate and airy
-  - pre-chorus lifts with string and synth swells. Chorus bursts wide with lush harmonies and light celestial textures (sine bells)
-  - while vocals remain fragile and present. A brief spoken vocal passage at the midpoint
 duration: 252
 tags:
   - music
 lang: en
 translationKey: music-prayer-to-the-unfinished-moving-window-v
 draftCreatedAt: "2026-06-12T12:06:06.428Z"
+sunoStyle: |-
+  Cinematic synth-pop/alt-pop at ~96 BPM
+  featuring warm pads and soft electric piano over a contained
+  grooving beat and deep
+  steady bass. Verses are intimate and airy
+  pre-chorus lifts with string and synth swells. Chorus bursts wide with lush harmonies and light celestial textures (sine bells)
+  while vocals remain fragile and present. A brief spoken vocal passage at the midpoint
+genre:
+  - pop
+  - eletrônico
 ---
 
 ## Lyrics

--- a/src/content/blog/prayer-to-the-unfinished-moving-window-v-en/v-2026-06-12T14-11-15-546.mdx
+++ b/src/content/blog/prayer-to-the-unfinished-moving-window-v-en/v-2026-06-12T14-11-15-546.mdx
@@ -5,17 +5,6 @@ date: 2026-01-11T00:00:00.000Z
 postType: music
 sunoId: a5981637-fec3-422a-89a6-e91e6dae83fb
 sunoImageUrl: "https://cdn2.suno.ai/image_a5981637-fec3-422a-89a6-e91e6dae83fb.jpeg"
-genre:
-  - Cinematic synth-pop/alt-pop at ~96 BPM
-  - featuring warm pads and soft electric piano over a contained
-  - grooving beat and deep
-  - steady bass. Verses are intimate and airy
-  - >-
-    pre-chorus lifts with string and synth swells. Chorus bursts wide with lush
-    harmonies and light celestial textures (sine bells)
-  - >-
-    while vocals remain fragile and present. A brief spoken vocal passage at the
-    midpoint
 duration: 252
 tags:
   - music
@@ -25,6 +14,16 @@ supersedes: c0cb7c7d-f3f7-5e39-afd7-c86da448308b
 draftCreatedAt: "2026-06-12T14:11:15.547Z"
 draftMsg: Refined narrative focus based on Hrönir evaluations
 draftCommittedAt: "2026-06-12T14:13:30.227Z"
+sunoStyle: |-
+  Cinematic synth-pop/alt-pop at ~96 BPM
+  featuring warm pads and soft electric piano over a contained
+  grooving beat and deep
+  steady bass. Verses are intimate and airy
+  >- pre-chorus lifts with string and synth swells. Chorus bursts wide with lush harmonies and light celestial textures (sine bells)
+  >- while vocals remain fragile and present. A brief spoken vocal passage at the midpoint
+genre:
+  - pop
+  - eletrônico
 ---
 
 ## Lyrics

--- a/src/content/blog/prayer-to-the-unfinished-moving-window-v/v-2026-06-09T20-24-29.mdx
+++ b/src/content/blog/prayer-to-the-unfinished-moving-window-v/v-2026-06-09T20-24-29.mdx
@@ -5,19 +5,22 @@ date: 2026-01-11
 postType: music
 sunoId: a5981637-fec3-422a-89a6-e91e6dae83fb
 sunoImageUrl: "https://cdn2.suno.ai/image_a5981637-fec3-422a-89a6-e91e6dae83fb.jpeg"
-genre:
-  - Cinematic synth-pop/alt-pop at ~96 BPM
-  - featuring warm pads and soft electric piano over a contained
-  - grooving beat and deep
-  - steady bass. Verses are intimate and airy
-  - pre-chorus lifts with string and synth swells. Chorus bursts wide with lush harmonies and light celestial textures (sine bells)
-  - while vocals remain fragile and present. A brief spoken vocal passage at the midpoint
 duration: 252
 tags:
   - música
 lang: pt
 translationKey: music-prayer-to-the-unfinished-moving-window-v
 draftCreatedAt: "2026-06-12T12:06:06.428Z"
+sunoStyle: |-
+  Cinematic synth-pop/alt-pop at ~96 BPM
+  featuring warm pads and soft electric piano over a contained
+  grooving beat and deep
+  steady bass. Verses are intimate and airy
+  pre-chorus lifts with string and synth swells. Chorus bursts wide with lush harmonies and light celestial textures (sine bells)
+  while vocals remain fragile and present. A brief spoken vocal passage at the midpoint
+genre:
+  - pop
+  - eletrônico
 ---
 
 ## Letra

--- a/src/content/blog/prayer-to-the-unfinished-moving-window-v/v-2026-06-12T14-11-15-546.mdx
+++ b/src/content/blog/prayer-to-the-unfinished-moving-window-v/v-2026-06-12T14-11-15-546.mdx
@@ -5,17 +5,6 @@ date: 2026-01-11T00:00:00.000Z
 postType: music
 sunoId: a5981637-fec3-422a-89a6-e91e6dae83fb
 sunoImageUrl: "https://cdn2.suno.ai/image_a5981637-fec3-422a-89a6-e91e6dae83fb.jpeg"
-genre:
-  - Cinematic synth-pop/alt-pop at ~96 BPM
-  - featuring warm pads and soft electric piano over a contained
-  - grooving beat and deep
-  - steady bass. Verses are intimate and airy
-  - >-
-    pre-chorus lifts with string and synth swells. Chorus bursts wide with lush
-    harmonies and light celestial textures (sine bells)
-  - >-
-    while vocals remain fragile and present. A brief spoken vocal passage at the
-    midpoint
 duration: 252
 tags:
   - música
@@ -25,6 +14,16 @@ supersedes: 35eb5d34-5f18-5643-8b86-4aa7df3516f4
 draftCreatedAt: "2026-06-12T14:11:15.547Z"
 draftMsg: Refined narrative focus based on Hrönir evaluations
 draftCommittedAt: "2026-06-12T14:13:30.227Z"
+sunoStyle: |-
+  Cinematic synth-pop/alt-pop at ~96 BPM
+  featuring warm pads and soft electric piano over a contained
+  grooving beat and deep
+  steady bass. Verses are intimate and airy
+  >- pre-chorus lifts with string and synth swells. Chorus bursts wide with lush harmonies and light celestial textures (sine bells)
+  >- while vocals remain fragile and present. A brief spoken vocal passage at the midpoint
+genre:
+  - pop
+  - eletrônico
 ---
 
 ## Letra

--- a/src/content/blog/primavera-carregando-en/v-2026-06-09T20-24-29.mdx
+++ b/src/content/blog/primavera-carregando-en/v-2026-06-09T20-24-29.mdx
@@ -5,17 +5,20 @@ date: 2025-10-04
 postType: music
 sunoId: ff22ac73-ae50-4a64-967b-240d16d138dd
 sunoImageUrl: "https://cdn2.suno.ai/image_ff22ac73-ae50-4a64-967b-240d16d138dd.jpeg"
-genre:
-  - Energetic trap production opens with sharp hi-hats and punchy 808s
-  - layering sparse atmospheric pads for depth. Minimal melodic motifs weave through the verses
-  - leading to a dynamic drop with deep sub-bass and fragmented synth stabs. Bridge section adds shimmering Rhodes
-  - then resolves.
 duration: 154
 tags:
   - music
 lang: en
 translationKey: music-primavera-carregando
 draftCreatedAt: "2026-06-12T12:06:06.428Z"
+sunoStyle: |-
+  Energetic trap production opens with sharp hi-hats and punchy 808s
+  layering sparse atmospheric pads for depth. Minimal melodic motifs weave through the verses
+  leading to a dynamic drop with deep sub-bass and fragmented synth stabs. Bridge section adds shimmering Rhodes
+  then resolves.
+genre:
+  - hip-hop
+  - eletrônico
 ---
 
 ## Lyrics

--- a/src/content/blog/primavera-carregando-en/v-2026-06-11T06-41-53-366.mdx
+++ b/src/content/blog/primavera-carregando-en/v-2026-06-11T06-41-53-366.mdx
@@ -5,15 +5,6 @@ date: 2025-10-04T00:00:00.000Z
 postType: music
 sunoId: ff22ac73-ae50-4a64-967b-240d16d138dd
 sunoImageUrl: "https://cdn2.suno.ai/image_ff22ac73-ae50-4a64-967b-240d16d138dd.jpeg"
-genre:
-  - Energetic trap production opens with sharp hi-hats and punchy 808s
-  - >-
-    layering sparse atmospheric pads for depth. Minimal melodic motifs weave
-    through the verses
-  - >-
-    leading to a dynamic drop with deep sub-bass and fragmented synth stabs.
-    Bridge section adds shimmering Rhodes
-  - then resolves.
 duration: 154
 tags:
   - music
@@ -23,6 +14,14 @@ supersedes: 7d81b34f-1526-54dd-ade7-e9792cbc4976
 draftCreatedAt: "2026-06-11T06:41:53.367Z"
 draftMsg: "chore: improve worst post based on hronir feedback"
 draftCommittedAt: "2026-06-11T06:43:29.391Z"
+sunoStyle: |-
+  Energetic trap production opens with sharp hi-hats and punchy 808s
+  >- layering sparse atmospheric pads for depth. Minimal melodic motifs weave through the verses
+  >- leading to a dynamic drop with deep sub-bass and fragmented synth stabs. Bridge section adds shimmering Rhodes
+  then resolves.
+genre:
+  - hip-hop
+  - eletrônico
 ---
 
 ## Lyrics

--- a/src/content/blog/primavera-carregando-en/v-2026-06-11T08-39-17-099.mdx
+++ b/src/content/blog/primavera-carregando-en/v-2026-06-11T08-39-17-099.mdx
@@ -5,15 +5,6 @@ date: 2025-10-04T00:00:00.000Z
 postType: music
 sunoId: ff22ac73-ae50-4a64-967b-240d16d138dd
 sunoImageUrl: "https://cdn2.suno.ai/image_ff22ac73-ae50-4a64-967b-240d16d138dd.jpeg"
-genre:
-  - Energetic trap production opens with sharp hi-hats and punchy 808s
-  - >-
-    layering sparse atmospheric pads for depth. Minimal melodic motifs weave
-    through the verses
-  - >-
-    leading to a dynamic drop with deep sub-bass and fragmented synth stabs.
-    Bridge section adds shimmering Rhodes
-  - then resolves.
 duration: 154
 tags:
   - music
@@ -29,6 +20,14 @@ draftMsg: >-
   utilizing the technical metaphors more effectively according to the
   franklin-blog guidelines.
 draftCommittedAt: "2026-06-11T08:40:54.326Z"
+sunoStyle: |-
+  Energetic trap production opens with sharp hi-hats and punchy 808s
+  >- layering sparse atmospheric pads for depth. Minimal melodic motifs weave through the verses
+  >- leading to a dynamic drop with deep sub-bass and fragmented synth stabs. Bridge section adds shimmering Rhodes
+  then resolves.
+genre:
+  - hip-hop
+  - eletrônico
 ---
 
 ## Lyrics

--- a/src/content/blog/primavera-carregando/v-2026-06-09T20-24-29.mdx
+++ b/src/content/blog/primavera-carregando/v-2026-06-09T20-24-29.mdx
@@ -5,17 +5,20 @@ date: 2025-10-04
 postType: music
 sunoId: ff22ac73-ae50-4a64-967b-240d16d138dd
 sunoImageUrl: "https://cdn2.suno.ai/image_ff22ac73-ae50-4a64-967b-240d16d138dd.jpeg"
-genre:
-  - Energetic trap production opens with sharp hi-hats and punchy 808s
-  - layering sparse atmospheric pads for depth. Minimal melodic motifs weave through the verses
-  - leading to a dynamic drop with deep sub-bass and fragmented synth stabs. Bridge section adds shimmering Rhodes
-  - then resolves.
 duration: 154
 tags:
   - música
 lang: pt
 translationKey: music-primavera-carregando
 draftCreatedAt: "2026-06-12T12:06:06.428Z"
+sunoStyle: |-
+  Energetic trap production opens with sharp hi-hats and punchy 808s
+  layering sparse atmospheric pads for depth. Minimal melodic motifs weave through the verses
+  leading to a dynamic drop with deep sub-bass and fragmented synth stabs. Bridge section adds shimmering Rhodes
+  then resolves.
+genre:
+  - hip-hop
+  - eletrônico
 ---
 
 ## Letra

--- a/src/content/blog/primavera-carregando/v-2026-06-11T06-41-53-366.mdx
+++ b/src/content/blog/primavera-carregando/v-2026-06-11T06-41-53-366.mdx
@@ -5,15 +5,6 @@ date: 2025-10-04T00:00:00.000Z
 postType: music
 sunoId: ff22ac73-ae50-4a64-967b-240d16d138dd
 sunoImageUrl: "https://cdn2.suno.ai/image_ff22ac73-ae50-4a64-967b-240d16d138dd.jpeg"
-genre:
-  - Energetic trap production opens with sharp hi-hats and punchy 808s
-  - >-
-    layering sparse atmospheric pads for depth. Minimal melodic motifs weave
-    through the verses
-  - >-
-    leading to a dynamic drop with deep sub-bass and fragmented synth stabs.
-    Bridge section adds shimmering Rhodes
-  - then resolves.
 duration: 154
 tags:
   - música
@@ -23,6 +14,14 @@ supersedes: d4e25e00-2d1e-5c42-a16a-ed7550e7cfd8
 draftCreatedAt: "2026-06-11T06:41:53.367Z"
 draftMsg: "chore: improve worst post based on hronir feedback"
 draftCommittedAt: "2026-06-11T06:43:29.391Z"
+sunoStyle: |-
+  Energetic trap production opens with sharp hi-hats and punchy 808s
+  >- layering sparse atmospheric pads for depth. Minimal melodic motifs weave through the verses
+  >- leading to a dynamic drop with deep sub-bass and fragmented synth stabs. Bridge section adds shimmering Rhodes
+  then resolves.
+genre:
+  - hip-hop
+  - eletrônico
 ---
 
 ## Letra

--- a/src/content/blog/primavera-carregando/v-2026-06-11T08-39-17-099.mdx
+++ b/src/content/blog/primavera-carregando/v-2026-06-11T08-39-17-099.mdx
@@ -5,15 +5,6 @@ date: 2025-10-04T00:00:00.000Z
 postType: music
 sunoId: ff22ac73-ae50-4a64-967b-240d16d138dd
 sunoImageUrl: "https://cdn2.suno.ai/image_ff22ac73-ae50-4a64-967b-240d16d138dd.jpeg"
-genre:
-  - Energetic trap production opens with sharp hi-hats and punchy 808s
-  - >-
-    layering sparse atmospheric pads for depth. Minimal melodic motifs weave
-    through the verses
-  - >-
-    leading to a dynamic drop with deep sub-bass and fragmented synth stabs.
-    Bridge section adds shimmering Rhodes
-  - then resolves.
 duration: 154
 tags:
   - música
@@ -29,6 +20,14 @@ draftMsg: >-
   utilizing the technical metaphors more effectively according to the
   franklin-blog guidelines.
 draftCommittedAt: "2026-06-11T08:40:54.326Z"
+sunoStyle: |-
+  Energetic trap production opens with sharp hi-hats and punchy 808s
+  >- layering sparse atmospheric pads for depth. Minimal melodic motifs weave through the verses
+  >- leading to a dynamic drop with deep sub-bass and fragmented synth stabs. Bridge section adds shimmering Rhodes
+  then resolves.
+genre:
+  - hip-hop
+  - eletrônico
 ---
 
 ## Letra

--- a/src/content/blog/quando-vier-a-primavera-en/v-2026-06-09T20-24-29.mdx
+++ b/src/content/blog/quando-vier-a-primavera-en/v-2026-06-09T20-24-29.mdx
@@ -5,16 +5,20 @@ date: 2025-08-29
 postType: music
 sunoId: 9847910c-d8a9-4287-9358-fca707f297ca
 sunoImageUrl: "https://cdn2.suno.ai/image_9847910c-d8a9-4287-9358-fca707f297ca.jpeg"
+sunoStyle: |-
+  Gênero: folk brasileiro pastoral
+  chamber-folk
+  BPM: 82 | Compasso: 6/8 | Mood: sereno
+  pastoril
+  contemplativo
+  Groove: ternário leve
+  acentos em 1 e 4
+  percussão com vassourinhas/pandeiro suave
+  Instrumentos: violão nylon arpejado
+
 genre:
-  - "Gênero: folk brasileiro pastoral"
-  - "chamber-folk
-BPM: 82 | Compasso: 6/8 | Mood: sereno"
-  - pastoril
-  - "contemplativo
-Groove: ternário leve"
-  - acentos em 1 e 4
-  - "percussão com vassourinhas/pandeiro suave
-Instrumentos: violão nylon arpejado"
+  - folk
+  - MPB
 duration: 193
 tags:
   - music

--- a/src/content/blog/quando-vier-a-primavera/v-2026-06-09T20-24-29.mdx
+++ b/src/content/blog/quando-vier-a-primavera/v-2026-06-09T20-24-29.mdx
@@ -5,16 +5,20 @@ date: 2025-08-29
 postType: music
 sunoId: 9847910c-d8a9-4287-9358-fca707f297ca
 sunoImageUrl: "https://cdn2.suno.ai/image_9847910c-d8a9-4287-9358-fca707f297ca.jpeg"
+sunoStyle: |-
+  Gênero: folk brasileiro pastoral
+  chamber-folk
+  BPM: 82 | Compasso: 6/8 | Mood: sereno
+  pastoril
+  contemplativo
+  Groove: ternário leve
+  acentos em 1 e 4
+  percussão com vassourinhas/pandeiro suave
+  Instrumentos: violão nylon arpejado
+
 genre:
-  - "Gênero: folk brasileiro pastoral"
-  - "chamber-folk
-BPM: 82 | Compasso: 6/8 | Mood: sereno"
-  - pastoril
-  - "contemplativo
-Groove: ternário leve"
-  - acentos em 1 e 4
-  - "percussão com vassourinhas/pandeiro suave
-Instrumentos: violão nylon arpejado"
+  - folk
+  - MPB
 duration: 193
 tags:
   - música

--- a/src/content/blog/reality-maintenance-moving-window-xii-en/v-2026-06-09T20-24-29.mdx
+++ b/src/content/blog/reality-maintenance-moving-window-xii-en/v-2026-06-09T20-24-29.mdx
@@ -5,19 +5,22 @@ date: 2026-01-12
 postType: music
 sunoId: fa8cbf00-528a-4584-bfac-3a66b6f946bf
 sunoImageUrl: "https://cdn2.suno.ai/image_fa8cbf00-528a-4584-bfac-3a66b6f946bf.jpeg"
-genre:
-  - Dub-tech / minimal electro-pop
-  - ~124 BPM. Steady 4/4 kick
-  - deep warm bass
-  - like offbeat stabs
-  - airy chords
-  - and dub delays on vocal tails. Verses are tight and talky
 duration: 235
 tags:
   - music
 lang: en
 translationKey: music-reality-maintenance-moving-window-xii
 draftCreatedAt: "2026-06-12T12:06:06.428Z"
+sunoStyle: |-
+  Dub-tech / minimal electro-pop
+  ~124 BPM. Steady 4/4 kick
+  deep warm bass
+  like offbeat stabs
+  airy chords
+  and dub delays on vocal tails. Verses are tight and talky
+genre:
+  - eletrônico
+  - experimental
 ---
 
 ## Lyrics

--- a/src/content/blog/reality-maintenance-moving-window-xii/v-2026-06-09T20-24-29.mdx
+++ b/src/content/blog/reality-maintenance-moving-window-xii/v-2026-06-09T20-24-29.mdx
@@ -5,19 +5,22 @@ date: 2026-01-12
 postType: music
 sunoId: fa8cbf00-528a-4584-bfac-3a66b6f946bf
 sunoImageUrl: "https://cdn2.suno.ai/image_fa8cbf00-528a-4584-bfac-3a66b6f946bf.jpeg"
-genre:
-  - Dub-tech / minimal electro-pop
-  - ~124 BPM. Steady 4/4 kick
-  - deep warm bass
-  - like offbeat stabs
-  - airy chords
-  - and dub delays on vocal tails. Verses are tight and talky
 duration: 235
 tags:
   - música
 lang: pt
 translationKey: music-reality-maintenance-moving-window-xii
 draftCreatedAt: "2026-06-12T12:06:06.428Z"
+sunoStyle: |-
+  Dub-tech / minimal electro-pop
+  ~124 BPM. Steady 4/4 kick
+  deep warm bass
+  like offbeat stabs
+  airy chords
+  and dub delays on vocal tails. Verses are tight and talky
+genre:
+  - eletrônico
+  - experimental
 ---
 
 ## Letra

--- a/src/content/blog/riobaldo-e-o-aleph-en/v-2026-06-09T20-24-29.mdx
+++ b/src/content/blog/riobaldo-e-o-aleph-en/v-2026-06-09T20-24-29.mdx
@@ -5,11 +5,6 @@ date: 2025-02-13T00:00:00.000Z
 postType: music
 sunoId: cc756e14-62c1-4b86-bac1-e3db517a3751
 sunoImageUrl: "https://cdn2.suno.ai/image_cc756e14-62c1-4b86-bac1-e3db517a3751.jpeg"
-genre:
-  - theremin like liquid starlight piercing dimensions
-  - tribal drums weaving cosmic heartbeats
-  - didgeridoo drone humming the universe's deepest dreams
-  - glitch ambient fracturing reality into digital
 duration: 240
 tags:
   - music
@@ -24,6 +19,14 @@ previousVersion:
     Compressed lyrics and composer notes for weird clarity, removing mystical
     bloat
 draftCreatedAt: "2026-06-12T12:06:06.428Z"
+sunoStyle: |-
+  theremin like liquid starlight piercing dimensions
+  tribal drums weaving cosmic heartbeats
+  didgeridoo drone humming the universe's deepest dreams
+  glitch ambient fracturing reality into digital
+genre:
+  - ambient
+  - experimental
 ---
 
 ## Lyrics

--- a/src/content/blog/riobaldo-e-o-aleph-en/v-2026-06-10T00-51-23.mdx
+++ b/src/content/blog/riobaldo-e-o-aleph-en/v-2026-06-10T00-51-23.mdx
@@ -5,11 +5,6 @@ date: 2025-02-13T00:00:00.000Z
 postType: music
 sunoId: cc756e14-62c1-4b86-bac1-e3db517a3751
 sunoImageUrl: "https://cdn2.suno.ai/image_cc756e14-62c1-4b86-bac1-e3db517a3751.jpeg"
-genre:
-  - theremin like liquid starlight piercing dimensions
-  - tribal drums weaving cosmic heartbeats
-  - didgeridoo drone humming the universe's deepest dreams
-  - glitch ambient fracturing reality into digital
 duration: 240
 tags:
   - music
@@ -27,6 +22,14 @@ supersedes: c0c25094-315e-5bbe-a65a-0833ff097ab3
 draftCreatedAt: "2026-06-10T00:51:23.603Z"
 draftMsg: Make the feeling of dissolution visceral
 draftCommittedAt: "2026-06-10T00:54:07.992Z"
+sunoStyle: |-
+  theremin like liquid starlight piercing dimensions
+  tribal drums weaving cosmic heartbeats
+  didgeridoo drone humming the universe's deepest dreams
+  glitch ambient fracturing reality into digital
+genre:
+  - ambient
+  - experimental
 ---
 
 ## Lyrics

--- a/src/content/blog/riobaldo-e-o-aleph-en/v-2026-06-10T08-58-57.mdx
+++ b/src/content/blog/riobaldo-e-o-aleph-en/v-2026-06-10T08-58-57.mdx
@@ -5,11 +5,6 @@ date: 2025-02-13T00:00:00.000Z
 postType: music
 sunoId: cc756e14-62c1-4b86-bac1-e3db517a3751
 sunoImageUrl: "https://cdn2.suno.ai/image_cc756e14-62c1-4b86-bac1-e3db517a3751.jpeg"
-genre:
-  - theremin like liquid starlight piercing dimensions
-  - tribal drums weaving cosmic heartbeats
-  - didgeridoo drone humming the universe's deepest dreams
-  - glitch ambient fracturing reality into digital
 duration: 240
 tags:
   - music
@@ -27,6 +22,14 @@ supersedes: c0c25094-315e-5bbe-a65a-0833ff097ab3
 draftCreatedAt: "2026-06-10T08:58:57.964Z"
 draftMsg: Amplified the epistemological tension of the observer being inside the system
 draftCommittedAt: "2026-06-10T09:18:56.243Z"
+sunoStyle: |-
+  theremin like liquid starlight piercing dimensions
+  tribal drums weaving cosmic heartbeats
+  didgeridoo drone humming the universe's deepest dreams
+  glitch ambient fracturing reality into digital
+genre:
+  - ambient
+  - experimental
 ---
 
 ## Lyrics

--- a/src/content/blog/riobaldo-e-o-aleph-en/v-2026-06-10T09-20-27.mdx
+++ b/src/content/blog/riobaldo-e-o-aleph-en/v-2026-06-10T09-20-27.mdx
@@ -5,11 +5,6 @@ date: 2025-02-13T00:00:00.000Z
 postType: music
 sunoId: cc756e14-62c1-4b86-bac1-e3db517a3751
 sunoImageUrl: "https://cdn2.suno.ai/image_cc756e14-62c1-4b86-bac1-e3db517a3751.jpeg"
-genre:
-  - theremin like liquid starlight piercing dimensions
-  - tribal drums weaving cosmic heartbeats
-  - didgeridoo drone humming the universe's deepest dreams
-  - glitch ambient fracturing reality into digital
 duration: 240
 tags:
   - music
@@ -29,6 +24,14 @@ draftMsg: >-
   Rewrite riobaldo-e-o-aleph notes to ground the abstraction and remove academic
   hedging
 draftCommittedAt: "2026-06-10T09:20:54.081Z"
+sunoStyle: |-
+  theremin like liquid starlight piercing dimensions
+  tribal drums weaving cosmic heartbeats
+  didgeridoo drone humming the universe's deepest dreams
+  glitch ambient fracturing reality into digital
+genre:
+  - ambient
+  - experimental
 ---
 
 ## Lyrics

--- a/src/content/blog/riobaldo-e-o-aleph/v-2026-06-09T20-24-29.mdx
+++ b/src/content/blog/riobaldo-e-o-aleph/v-2026-06-09T20-24-29.mdx
@@ -5,11 +5,6 @@ date: 2025-02-13T00:00:00.000Z
 postType: music
 sunoId: cc756e14-62c1-4b86-bac1-e3db517a3751
 sunoImageUrl: "https://cdn2.suno.ai/image_cc756e14-62c1-4b86-bac1-e3db517a3751.jpeg"
-genre:
-  - theremin like liquid starlight piercing dimensions
-  - tribal drums weaving cosmic heartbeats
-  - didgeridoo drone humming the universe's deepest dreams
-  - glitch ambient fracturing reality into digital
 duration: 240
 tags:
   - música
@@ -24,6 +19,14 @@ previousVersion:
     Compressed lyrics and composer notes for weird clarity, removing mystical
     bloat
 draftCreatedAt: "2026-06-12T12:06:06.428Z"
+sunoStyle: |-
+  theremin like liquid starlight piercing dimensions
+  tribal drums weaving cosmic heartbeats
+  didgeridoo drone humming the universe's deepest dreams
+  glitch ambient fracturing reality into digital
+genre:
+  - ambient
+  - experimental
 ---
 
 ## Letra

--- a/src/content/blog/riobaldo-e-o-aleph/v-2026-06-10T00-51-23.mdx
+++ b/src/content/blog/riobaldo-e-o-aleph/v-2026-06-10T00-51-23.mdx
@@ -5,11 +5,6 @@ date: 2025-02-13T00:00:00.000Z
 postType: music
 sunoId: cc756e14-62c1-4b86-bac1-e3db517a3751
 sunoImageUrl: "https://cdn2.suno.ai/image_cc756e14-62c1-4b86-bac1-e3db517a3751.jpeg"
-genre:
-  - theremin like liquid starlight piercing dimensions
-  - tribal drums weaving cosmic heartbeats
-  - didgeridoo drone humming the universe's deepest dreams
-  - glitch ambient fracturing reality into digital
 duration: 240
 tags:
   - música
@@ -27,6 +22,14 @@ supersedes: fd4bbbbe-7acc-5abf-92c0-8d562a449bab
 draftCreatedAt: "2026-06-10T00:51:23.603Z"
 draftMsg: Make the feeling of dissolution visceral
 draftCommittedAt: "2026-06-10T00:54:07.992Z"
+sunoStyle: |-
+  theremin like liquid starlight piercing dimensions
+  tribal drums weaving cosmic heartbeats
+  didgeridoo drone humming the universe's deepest dreams
+  glitch ambient fracturing reality into digital
+genre:
+  - ambient
+  - experimental
 ---
 
 ## Letra

--- a/src/content/blog/riobaldo-e-o-aleph/v-2026-06-10T08-58-57.mdx
+++ b/src/content/blog/riobaldo-e-o-aleph/v-2026-06-10T08-58-57.mdx
@@ -5,11 +5,6 @@ date: 2025-02-13T00:00:00.000Z
 postType: music
 sunoId: cc756e14-62c1-4b86-bac1-e3db517a3751
 sunoImageUrl: "https://cdn2.suno.ai/image_cc756e14-62c1-4b86-bac1-e3db517a3751.jpeg"
-genre:
-  - theremin like liquid starlight piercing dimensions
-  - tribal drums weaving cosmic heartbeats
-  - didgeridoo drone humming the universe's deepest dreams
-  - glitch ambient fracturing reality into digital
 duration: 240
 tags:
   - música
@@ -27,6 +22,14 @@ supersedes: fd4bbbbe-7acc-5abf-92c0-8d562a449bab
 draftCreatedAt: "2026-06-10T08:58:57.964Z"
 draftMsg: Amplified the epistemological tension of the observer being inside the system
 draftCommittedAt: "2026-06-10T09:18:56.243Z"
+sunoStyle: |-
+  theremin like liquid starlight piercing dimensions
+  tribal drums weaving cosmic heartbeats
+  didgeridoo drone humming the universe's deepest dreams
+  glitch ambient fracturing reality into digital
+genre:
+  - ambient
+  - experimental
 ---
 
 ## Letra

--- a/src/content/blog/riobaldo-e-o-aleph/v-2026-06-10T09-20-27.mdx
+++ b/src/content/blog/riobaldo-e-o-aleph/v-2026-06-10T09-20-27.mdx
@@ -5,11 +5,6 @@ date: 2025-02-13T00:00:00.000Z
 postType: music
 sunoId: cc756e14-62c1-4b86-bac1-e3db517a3751
 sunoImageUrl: "https://cdn2.suno.ai/image_cc756e14-62c1-4b86-bac1-e3db517a3751.jpeg"
-genre:
-  - theremin like liquid starlight piercing dimensions
-  - tribal drums weaving cosmic heartbeats
-  - didgeridoo drone humming the universe's deepest dreams
-  - glitch ambient fracturing reality into digital
 duration: 240
 tags:
   - música
@@ -29,6 +24,14 @@ draftMsg: >-
   Rewrite riobaldo-e-o-aleph notes to ground the abstraction and remove academic
   hedging
 draftCommittedAt: "2026-06-10T09:20:54.081Z"
+sunoStyle: |-
+  theremin like liquid starlight piercing dimensions
+  tribal drums weaving cosmic heartbeats
+  didgeridoo drone humming the universe's deepest dreams
+  glitch ambient fracturing reality into digital
+genre:
+  - ambient
+  - experimental
 ---
 
 ## Letra

--- a/src/content/blog/sentido-e-referencia-en/v-2026-06-09T20-24-29.mdx
+++ b/src/content/blog/sentido-e-referencia-en/v-2026-06-09T20-24-29.mdx
@@ -5,17 +5,20 @@ date: 2025-05-12
 postType: music
 sunoId: ae9cbe88-47ed-4148-bcc6-53b6c41f3de7
 sunoImageUrl: "https://cdn2.suno.ai/image_ae9cbe88-47ed-4148-bcc6-53b6c41f3de7.jpeg"
-genre:
-  - introspective
-  - female vocals
-  - acoustic
-  - melodic
 duration: 190
 tags:
   - music
 lang: en
 translationKey: music-sentido-e-referencia
 draftCreatedAt: "2026-06-12T12:06:06.428Z"
+sunoStyle: |-
+  introspective
+  female vocals
+  acoustic
+  melodic
+genre:
+  - folk
+  - acústico
 ---
 
 ## Lyrics

--- a/src/content/blog/sentido-e-referencia-en/v-2026-06-11T19-23-01-125.mdx
+++ b/src/content/blog/sentido-e-referencia-en/v-2026-06-11T19-23-01-125.mdx
@@ -5,11 +5,6 @@ date: 2025-05-12T00:00:00.000Z
 postType: music
 sunoId: ae9cbe88-47ed-4148-bcc6-53b6c41f3de7
 sunoImageUrl: "https://cdn2.suno.ai/image_ae9cbe88-47ed-4148-bcc6-53b6c41f3de7.jpeg"
-genre:
-  - introspective
-  - female vocals
-  - acoustic
-  - melodic
 duration: 190
 tags:
   - music
@@ -21,6 +16,14 @@ draftMsg: >-
   Adjusting prose rhythm to be more aligned with Franklin's voice, removing
   loose associations and softening explicit transitions.
 draftCommittedAt: "2026-06-11T19:24:09.942Z"
+sunoStyle: |-
+  introspective
+  female vocals
+  acoustic
+  melodic
+genre:
+  - folk
+  - acústico
 ---
 
 ## Lyrics

--- a/src/content/blog/sentido-e-referencia-en/v-2026-06-11T19-26-09-611.mdx
+++ b/src/content/blog/sentido-e-referencia-en/v-2026-06-11T19-26-09-611.mdx
@@ -5,11 +5,6 @@ date: 2025-05-12T00:00:00.000Z
 postType: music
 sunoId: ae9cbe88-47ed-4148-bcc6-53b6c41f3de7
 sunoImageUrl: "https://cdn2.suno.ai/image_ae9cbe88-47ed-4148-bcc6-53b6c41f3de7.jpeg"
-genre:
-  - introspective
-  - female vocals
-  - acoustic
-  - melodic
 duration: 190
 tags:
   - music
@@ -21,6 +16,14 @@ draftMsg: >-
   melhora a precisão na ponte narrativa entre frege e a dor de não conseguir
   nomear em sentido-e-referencia
 draftCommittedAt: "2026-06-11T19:26:21.166Z"
+sunoStyle: |-
+  introspective
+  female vocals
+  acoustic
+  melodic
+genre:
+  - folk
+  - acústico
 ---
 
 ## Lyrics

--- a/src/content/blog/sentido-e-referencia-en/v-2026-06-11T19-28-19-044.mdx
+++ b/src/content/blog/sentido-e-referencia-en/v-2026-06-11T19-28-19-044.mdx
@@ -5,11 +5,6 @@ date: 2025-05-12T00:00:00.000Z
 postType: music
 sunoId: ae9cbe88-47ed-4148-bcc6-53b6c41f3de7
 sunoImageUrl: "https://cdn2.suno.ai/image_ae9cbe88-47ed-4148-bcc6-53b6c41f3de7.jpeg"
-genre:
-  - introspective
-  - female vocals
-  - acoustic
-  - melodic
 duration: 190
 tags:
   - music
@@ -19,6 +14,14 @@ supersedes: 3dae6f9e-6427-598d-9033-ff508f855365
 draftCreatedAt: "2026-06-11T19:28:19.044Z"
 draftMsg: "chore: adjust lyrical tension and tone around Frege's gap"
 draftCommittedAt: "2026-06-11T19:30:16.170Z"
+sunoStyle: |-
+  introspective
+  female vocals
+  acoustic
+  melodic
+genre:
+  - folk
+  - acústico
 ---
 
 ## Lyrics

--- a/src/content/blog/sentido-e-referencia/v-2026-06-09T20-24-29.mdx
+++ b/src/content/blog/sentido-e-referencia/v-2026-06-09T20-24-29.mdx
@@ -5,17 +5,20 @@ date: 2025-05-12
 postType: music
 sunoId: ae9cbe88-47ed-4148-bcc6-53b6c41f3de7
 sunoImageUrl: "https://cdn2.suno.ai/image_ae9cbe88-47ed-4148-bcc6-53b6c41f3de7.jpeg"
-genre:
-  - introspective
-  - female vocals
-  - acoustic
-  - melodic
 duration: 190
 tags:
   - música
 lang: pt
 translationKey: music-sentido-e-referencia
 draftCreatedAt: "2026-06-12T12:06:06.428Z"
+sunoStyle: |-
+  introspective
+  female vocals
+  acoustic
+  melodic
+genre:
+  - folk
+  - acústico
 ---
 
 ## Letra

--- a/src/content/blog/sentido-e-referencia/v-2026-06-11T19-23-01-125.mdx
+++ b/src/content/blog/sentido-e-referencia/v-2026-06-11T19-23-01-125.mdx
@@ -5,11 +5,6 @@ date: 2025-05-12T00:00:00.000Z
 postType: music
 sunoId: ae9cbe88-47ed-4148-bcc6-53b6c41f3de7
 sunoImageUrl: "https://cdn2.suno.ai/image_ae9cbe88-47ed-4148-bcc6-53b6c41f3de7.jpeg"
-genre:
-  - introspective
-  - female vocals
-  - acoustic
-  - melodic
 duration: 190
 tags:
   - música
@@ -21,6 +16,14 @@ draftMsg: >-
   Adjusting prose rhythm to be more aligned with Franklin's voice, removing
   loose associations and softening explicit transitions.
 draftCommittedAt: "2026-06-11T19:24:09.942Z"
+sunoStyle: |-
+  introspective
+  female vocals
+  acoustic
+  melodic
+genre:
+  - folk
+  - acústico
 ---
 
 ## Letra

--- a/src/content/blog/sentido-e-referencia/v-2026-06-11T19-26-09-611.mdx
+++ b/src/content/blog/sentido-e-referencia/v-2026-06-11T19-26-09-611.mdx
@@ -5,11 +5,6 @@ date: 2025-05-12T00:00:00.000Z
 postType: music
 sunoId: ae9cbe88-47ed-4148-bcc6-53b6c41f3de7
 sunoImageUrl: "https://cdn2.suno.ai/image_ae9cbe88-47ed-4148-bcc6-53b6c41f3de7.jpeg"
-genre:
-  - introspective
-  - female vocals
-  - acoustic
-  - melodic
 duration: 190
 tags:
   - música
@@ -21,6 +16,14 @@ draftMsg: >-
   melhora a precisão na ponte narrativa entre frege e a dor de não conseguir
   nomear em sentido-e-referencia
 draftCommittedAt: "2026-06-11T19:26:21.166Z"
+sunoStyle: |-
+  introspective
+  female vocals
+  acoustic
+  melodic
+genre:
+  - folk
+  - acústico
 ---
 
 ## Letra

--- a/src/content/blog/sentido-e-referencia/v-2026-06-11T19-28-19-044.mdx
+++ b/src/content/blog/sentido-e-referencia/v-2026-06-11T19-28-19-044.mdx
@@ -5,11 +5,6 @@ date: 2025-05-12T00:00:00.000Z
 postType: music
 sunoId: ae9cbe88-47ed-4148-bcc6-53b6c41f3de7
 sunoImageUrl: "https://cdn2.suno.ai/image_ae9cbe88-47ed-4148-bcc6-53b6c41f3de7.jpeg"
-genre:
-  - introspective
-  - female vocals
-  - acoustic
-  - melodic
 duration: 190
 tags:
   - música
@@ -19,6 +14,14 @@ supersedes: 1d59e9a7-11b8-5ba6-8d9a-b700d162fef2
 draftCreatedAt: "2026-06-11T19:28:19.044Z"
 draftMsg: "chore: adjust lyrical tension and tone around Frege's gap"
 draftCommittedAt: "2026-06-11T19:30:16.170Z"
+sunoStyle: |-
+  introspective
+  female vocals
+  acoustic
+  melodic
+genre:
+  - folk
+  - acústico
 ---
 
 ## Letra

--- a/src/content/blog/sinal-que-se-cumpre-moving-window-ix-en/v-2026-06-09T20-24-29.mdx
+++ b/src/content/blog/sinal-que-se-cumpre-moving-window-ix-en/v-2026-06-09T20-24-29.mdx
@@ -5,18 +5,21 @@ date: 2026-01-12
 postType: music
 sunoId: 73195148-5bb9-4132-aa89-be473bd20c22
 sunoImageUrl: "https://cdn2.suno.ai/image_73195148-5bb9-4132-aa89-be473bd20c22.jpeg"
-genre:
-  - Indie-pop brasileiro com groove marcado por violão ou ukulele plástico
-  - baixo redondo e bateria leve pontuada por “bips” digitais e cliques tipo notificações como percussão. Versos rápidos e falados de forma sarcástica
-  - pré-refrão curto ganha sinceridade. Refrão com melodia grudentinha e mini-coro responsivo. Ponte simula thread de comentários
-  - frases se sobrepõem
-  - volta ao refrão com arranjo cheio e texturas mais abertas.
 duration: 213
 tags:
   - music
 lang: en
 translationKey: music-sinal-que-se-cumpre-moving-window-ix
 draftCreatedAt: "2026-06-12T12:06:06.428Z"
+sunoStyle: |-
+  Indie-pop brasileiro com groove marcado por violão ou ukulele plástico
+  baixo redondo e bateria leve pontuada por “bips” digitais e cliques tipo notificações como percussão. Versos rápidos e falados de forma sarcástica
+  pré-refrão curto ganha sinceridade. Refrão com melodia grudentinha e mini-coro responsivo. Ponte simula thread de comentários
+  frases se sobrepõem
+  volta ao refrão com arranjo cheio e texturas mais abertas.
+genre:
+  - indie
+  - MPB
 ---
 
 ## Lyrics

--- a/src/content/blog/sinal-que-se-cumpre-moving-window-ix/v-2026-06-09T20-24-29.mdx
+++ b/src/content/blog/sinal-que-se-cumpre-moving-window-ix/v-2026-06-09T20-24-29.mdx
@@ -5,18 +5,21 @@ date: 2026-01-12
 postType: music
 sunoId: 73195148-5bb9-4132-aa89-be473bd20c22
 sunoImageUrl: "https://cdn2.suno.ai/image_73195148-5bb9-4132-aa89-be473bd20c22.jpeg"
-genre:
-  - Indie-pop brasileiro com groove marcado por violão ou ukulele plástico
-  - baixo redondo e bateria leve pontuada por “bips” digitais e cliques tipo notificações como percussão. Versos rápidos e falados de forma sarcástica
-  - pré-refrão curto ganha sinceridade. Refrão com melodia grudentinha e mini-coro responsivo. Ponte simula thread de comentários
-  - frases se sobrepõem
-  - volta ao refrão com arranjo cheio e texturas mais abertas.
 duration: 213
 tags:
   - música
 lang: pt
 translationKey: music-sinal-que-se-cumpre-moving-window-ix
 draftCreatedAt: "2026-06-12T12:06:06.428Z"
+sunoStyle: |-
+  Indie-pop brasileiro com groove marcado por violão ou ukulele plástico
+  baixo redondo e bateria leve pontuada por “bips” digitais e cliques tipo notificações como percussão. Versos rápidos e falados de forma sarcástica
+  pré-refrão curto ganha sinceridade. Refrão com melodia grudentinha e mini-coro responsivo. Ponte simula thread de comentários
+  frases se sobrepõem
+  volta ao refrão com arranjo cheio e texturas mais abertas.
+genre:
+  - indie
+  - MPB
 ---
 
 ## Letra

--- a/src/content/blog/sobre-o-rigor-na-ciencia-en/v-2026-06-09T20-24-29.mdx
+++ b/src/content/blog/sobre-o-rigor-na-ciencia-en/v-2026-06-09T20-24-29.mdx
@@ -5,16 +5,20 @@ date: 2025-09-01
 postType: music
 sunoId: a855ab7b-a1a8-462e-b335-b89f07d845bb
 sunoImageUrl: "https://cdn2.suno.ai/image_a855ab7b-a1a8-462e-b335-b89f07d845bb.jpeg"
+sunoStyle: |-
+  Genre: Brazilian alt-electronica / trip-hop hybrid
+  Tempo: 88 BPM | Time: 4/4
+  Mood: cinematic
+  nocturnal
+  modern
+  Instruments: deep sub-bass
+  dusty hip-hop drums
+  pandeiro ghost notes
+  synth pads with shimmer
+
 genre:
-  - "Genre: Brazilian alt-electronica / trip-hop hybrid
-Tempo: 88 BPM | Time: 4/4
-Mood: cinematic"
-  - nocturnal
-  - "modern
-Instruments: deep sub-bass"
-  - dusty hip-hop drums
-  - pandeiro ghost notes
-  - synth pads with shimmer
+  - eletrônico
+  - experimental
 duration: 200
 tags:
   - music

--- a/src/content/blog/sobre-o-rigor-na-ciencia/v-2026-06-09T20-24-29.mdx
+++ b/src/content/blog/sobre-o-rigor-na-ciencia/v-2026-06-09T20-24-29.mdx
@@ -5,16 +5,20 @@ date: 2025-09-01
 postType: music
 sunoId: a855ab7b-a1a8-462e-b335-b89f07d845bb
 sunoImageUrl: "https://cdn2.suno.ai/image_a855ab7b-a1a8-462e-b335-b89f07d845bb.jpeg"
+sunoStyle: |-
+  Genre: Brazilian alt-electronica / trip-hop hybrid
+  Tempo: 88 BPM | Time: 4/4
+  Mood: cinematic
+  nocturnal
+  modern
+  Instruments: deep sub-bass
+  dusty hip-hop drums
+  pandeiro ghost notes
+  synth pads with shimmer
+
 genre:
-  - "Genre: Brazilian alt-electronica / trip-hop hybrid
-Tempo: 88 BPM | Time: 4/4
-Mood: cinematic"
-  - nocturnal
-  - "modern
-Instruments: deep sub-bass"
-  - dusty hip-hop drums
-  - pandeiro ghost notes
-  - synth pads with shimmer
+  - eletrônico
+  - experimental
 duration: 200
 tags:
   - música

--- a/src/content/blog/spring-loading-en/v-2026-06-09T20-24-29.mdx
+++ b/src/content/blog/spring-loading-en/v-2026-06-09T20-24-29.mdx
@@ -5,18 +5,21 @@ date: 2025-10-04
 postType: music
 sunoId: 2f077c7f-7209-4b9d-8306-956c4cf60e9b
 sunoImageUrl: "https://cdn2.suno.ai/image_2f077c7f-7209-4b9d-8306-956c4cf60e9b.jpeg"
-genre:
-  - Kick off with fingerpicked acoustic guitar and sparse electric textures
-  - layered over atmospheric pads. Trap-influenced drums drop in on the verse—crisp hi-hats
-  - skittering snares
-  - and deep sub bass. The chorus expands with ethereal vocal layers and subtle folk-inspired harmonies
-  - maintaining an undercurrent of melancholy.
 duration: 179
 tags:
   - music
 lang: en
 translationKey: music-spring-loading
 draftCreatedAt: "2026-06-12T12:06:06.428Z"
+sunoStyle: |-
+  Kick off with fingerpicked acoustic guitar and sparse electric textures
+  layered over atmospheric pads. Trap-influenced drums drop in on the verse—crisp hi-hats
+  skittering snares
+  and deep sub bass. The chorus expands with ethereal vocal layers and subtle folk-inspired harmonies
+  maintaining an undercurrent of melancholy.
+genre:
+  - folk
+  - eletrônico
 ---
 
 ## Lyrics

--- a/src/content/blog/spring-loading/v-2026-06-09T20-24-29.mdx
+++ b/src/content/blog/spring-loading/v-2026-06-09T20-24-29.mdx
@@ -5,18 +5,21 @@ date: 2025-10-04
 postType: music
 sunoId: 2f077c7f-7209-4b9d-8306-956c4cf60e9b
 sunoImageUrl: "https://cdn2.suno.ai/image_2f077c7f-7209-4b9d-8306-956c4cf60e9b.jpeg"
-genre:
-  - Kick off with fingerpicked acoustic guitar and sparse electric textures
-  - layered over atmospheric pads. Trap-influenced drums drop in on the verse—crisp hi-hats
-  - skittering snares
-  - and deep sub bass. The chorus expands with ethereal vocal layers and subtle folk-inspired harmonies
-  - maintaining an undercurrent of melancholy.
 duration: 179
 tags:
   - música
 lang: pt
 translationKey: music-spring-loading
 draftCreatedAt: "2026-06-12T12:06:06.428Z"
+sunoStyle: |-
+  Kick off with fingerpicked acoustic guitar and sparse electric textures
+  layered over atmospheric pads. Trap-influenced drums drop in on the verse—crisp hi-hats
+  skittering snares
+  and deep sub bass. The chorus expands with ethereal vocal layers and subtle folk-inspired harmonies
+  maintaining an undercurrent of melancholy.
+genre:
+  - folk
+  - eletrônico
 ---
 
 ## Letra

--- a/src/content/blog/stopping-by-woods-on-a-snowy-evening-by-robert-frost-en/v-2026-06-09T20-24-29.mdx
+++ b/src/content/blog/stopping-by-woods-on-a-snowy-evening-by-robert-frost-en/v-2026-06-09T20-24-29.mdx
@@ -5,18 +5,21 @@ date: 2024-12-09
 postType: music
 sunoId: 3e9b935a-eb5a-4526-b09d-a4eb6d2d0a2b
 sunoImageUrl: "https://cdn2.suno.ai/image_3e9b935a-eb5a-4526-b09d-a4eb6d2d0a2b.jpeg"
-genre:
-  - Slow
-  - contemplative folk ballad with gentle acoustic guitar
-  - soft strings
-  - and a calm
-  - steady rhythm reflecting quiet introspection.
 duration: 119
 tags:
   - music
 lang: en
 translationKey: music-stopping-by-woods-on-a-snowy-evening-by-robert-frost
 draftCreatedAt: "2026-06-12T12:06:06.428Z"
+sunoStyle: |-
+  Slow
+  contemplative folk ballad with gentle acoustic guitar
+  soft strings
+  and a calm
+  steady rhythm reflecting quiet introspection.
+genre:
+  - folk
+  - acústico
 ---
 
 ## Lyrics

--- a/src/content/blog/stopping-by-woods-on-a-snowy-evening-by-robert-frost-en/v-2026-06-11T18-36-27-377.mdx
+++ b/src/content/blog/stopping-by-woods-on-a-snowy-evening-by-robert-frost-en/v-2026-06-11T18-36-27-377.mdx
@@ -5,12 +5,6 @@ date: 2024-12-09T00:00:00.000Z
 postType: music
 sunoId: 3e9b935a-eb5a-4526-b09d-a4eb6d2d0a2b
 sunoImageUrl: "https://cdn2.suno.ai/image_3e9b935a-eb5a-4526-b09d-a4eb6d2d0a2b.jpeg"
-genre:
-  - Slow
-  - contemplative folk ballad with gentle acoustic guitar
-  - soft strings
-  - and a calm
-  - steady rhythm reflecting quiet introspection.
 duration: 119
 tags:
   - music
@@ -22,6 +16,15 @@ draftMsg: >-
   Revised drafts for stopping-by-woods to deepen the philosophical reflection
   and improve the essayistic cadence according to franklin-blog guidelines.
 draftCommittedAt: "2026-06-11T18:39:52.716Z"
+sunoStyle: |-
+  Slow
+  contemplative folk ballad with gentle acoustic guitar
+  soft strings
+  and a calm
+  steady rhythm reflecting quiet introspection.
+genre:
+  - folk
+  - acústico
 ---
 
 ## Lyrics

--- a/src/content/blog/stopping-by-woods-on-a-snowy-evening-by-robert-frost-en/v-2026-06-11T18-37-11-886.mdx
+++ b/src/content/blog/stopping-by-woods-on-a-snowy-evening-by-robert-frost-en/v-2026-06-11T18-37-11-886.mdx
@@ -5,12 +5,6 @@ date: 2024-12-09T00:00:00.000Z
 postType: music
 sunoId: 3e9b935a-eb5a-4526-b09d-a4eb6d2d0a2b
 sunoImageUrl: "https://cdn2.suno.ai/image_3e9b935a-eb5a-4526-b09d-a4eb6d2d0a2b.jpeg"
-genre:
-  - Slow
-  - contemplative folk ballad with gentle acoustic guitar
-  - soft strings
-  - and a calm
-  - steady rhythm reflecting quiet introspection.
 duration: 119
 tags:
   - music
@@ -20,6 +14,15 @@ supersedes: d4662af1-8136-5d58-96c9-c6e8ef931b20
 draftCreatedAt: "2026-06-11T18:37:11.887Z"
 draftMsg: fixed
 draftCommittedAt: "2026-06-11T18:38:39.359Z"
+sunoStyle: |-
+  Slow
+  contemplative folk ballad with gentle acoustic guitar
+  soft strings
+  and a calm
+  steady rhythm reflecting quiet introspection.
+genre:
+  - folk
+  - acústico
 ---
 
 ## Lyrics

--- a/src/content/blog/stopping-by-woods-on-a-snowy-evening-by-robert-frost-en/v-2026-06-11T18-39-15-702.mdx
+++ b/src/content/blog/stopping-by-woods-on-a-snowy-evening-by-robert-frost-en/v-2026-06-11T18-39-15-702.mdx
@@ -5,12 +5,6 @@ date: 2024-12-09T00:00:00.000Z
 postType: music
 sunoId: 3e9b935a-eb5a-4526-b09d-a4eb6d2d0a2b
 sunoImageUrl: "https://cdn2.suno.ai/image_3e9b935a-eb5a-4526-b09d-a4eb6d2d0a2b.jpeg"
-genre:
-  - Slow
-  - contemplative folk ballad with gentle acoustic guitar
-  - soft strings
-  - and a calm
-  - steady rhythm reflecting quiet introspection.
 duration: 119
 tags:
   - music
@@ -23,6 +17,15 @@ draftMsg: >-
   humana (fúnebre) e a escolha da máquina (calma metronômica sem compromissos a
   cumprir)
 draftCommittedAt: "2026-06-11T18:40:14.581Z"
+sunoStyle: |-
+  Slow
+  contemplative folk ballad with gentle acoustic guitar
+  soft strings
+  and a calm
+  steady rhythm reflecting quiet introspection.
+genre:
+  - folk
+  - acústico
 ---
 
 ## Lyrics

--- a/src/content/blog/stopping-by-woods-on-a-snowy-evening-by-robert-frost/v-2026-06-09T20-24-29.mdx
+++ b/src/content/blog/stopping-by-woods-on-a-snowy-evening-by-robert-frost/v-2026-06-09T20-24-29.mdx
@@ -9,18 +9,22 @@ date: 2024-12-09
 postType: music
 sunoId: 3e9b935a-eb5a-4526-b09d-a4eb6d2d0a2b
 sunoImageUrl: "https://cdn2.suno.ai/image_3e9b935a-eb5a-4526-b09d-a4eb6d2d0a2b.jpeg"
-genre:
-  - Slow
-  - contemplative folk ballad with gentle acoustic guitar
-  - soft strings
-  - and a calm
-  - steady rhythm reflecting quiet introspection.
 duration: 119
 tags:
   - música
 lang: pt
 translationKey: music-stopping-by-woods-on-a-snowy-evening-by-robert-frost
 draftCreatedAt: "2026-06-12T12:06:06.428Z"
+sunoStyle: |-
+  Slow
+  contemplative folk ballad with gentle acoustic guitar
+  soft strings
+  and a calm
+  steady rhythm reflecting quiet introspection.
+genre:
+  - folk
+  - acústico
+
 ---
 
 ## Letra

--- a/src/content/blog/stopping-by-woods-on-a-snowy-evening-by-robert-frost/v-2026-06-11T18-36-27-377.mdx
+++ b/src/content/blog/stopping-by-woods-on-a-snowy-evening-by-robert-frost/v-2026-06-11T18-36-27-377.mdx
@@ -9,12 +9,6 @@ date: 2024-12-09T00:00:00.000Z
 postType: music
 sunoId: 3e9b935a-eb5a-4526-b09d-a4eb6d2d0a2b
 sunoImageUrl: "https://cdn2.suno.ai/image_3e9b935a-eb5a-4526-b09d-a4eb6d2d0a2b.jpeg"
-genre:
-  - Slow
-  - contemplative folk ballad with gentle acoustic guitar
-  - soft strings
-  - and a calm
-  - steady rhythm reflecting quiet introspection.
 duration: 119
 tags:
   - música
@@ -26,6 +20,15 @@ draftMsg: >-
   Revised drafts for stopping-by-woods to deepen the philosophical reflection
   and improve the essayistic cadence according to franklin-blog guidelines.
 draftCommittedAt: "2026-06-11T18:39:52.716Z"
+sunoStyle: |-
+  Slow
+  contemplative folk ballad with gentle acoustic guitar
+  soft strings
+  and a calm
+  steady rhythm reflecting quiet introspection.
+genre:
+  - folk
+  - acústico
 ---
 
 ## Letra

--- a/src/content/blog/stopping-by-woods-on-a-snowy-evening-by-robert-frost/v-2026-06-11T18-37-11-886.mdx
+++ b/src/content/blog/stopping-by-woods-on-a-snowy-evening-by-robert-frost/v-2026-06-11T18-37-11-886.mdx
@@ -9,12 +9,6 @@ date: 2024-12-09T00:00:00.000Z
 postType: music
 sunoId: 3e9b935a-eb5a-4526-b09d-a4eb6d2d0a2b
 sunoImageUrl: "https://cdn2.suno.ai/image_3e9b935a-eb5a-4526-b09d-a4eb6d2d0a2b.jpeg"
-genre:
-  - Slow
-  - contemplative folk ballad with gentle acoustic guitar
-  - soft strings
-  - and a calm
-  - steady rhythm reflecting quiet introspection.
 duration: 119
 tags:
   - música
@@ -24,6 +18,15 @@ supersedes: 70ee7f3b-fdbd-5412-816e-c1b62045cfb5
 draftCreatedAt: "2026-06-11T18:37:11.887Z"
 draftMsg: fixed
 draftCommittedAt: "2026-06-11T18:38:39.359Z"
+sunoStyle: |-
+  Slow
+  contemplative folk ballad with gentle acoustic guitar
+  soft strings
+  and a calm
+  steady rhythm reflecting quiet introspection.
+genre:
+  - folk
+  - acústico
 ---
 
 ## Letra

--- a/src/content/blog/stopping-by-woods-on-a-snowy-evening-by-robert-frost/v-2026-06-11T18-39-15-702.mdx
+++ b/src/content/blog/stopping-by-woods-on-a-snowy-evening-by-robert-frost/v-2026-06-11T18-39-15-702.mdx
@@ -9,12 +9,6 @@ date: 2024-12-09T00:00:00.000Z
 postType: music
 sunoId: 3e9b935a-eb5a-4526-b09d-a4eb6d2d0a2b
 sunoImageUrl: "https://cdn2.suno.ai/image_3e9b935a-eb5a-4526-b09d-a4eb6d2d0a2b.jpeg"
-genre:
-  - Slow
-  - contemplative folk ballad with gentle acoustic guitar
-  - soft strings
-  - and a calm
-  - steady rhythm reflecting quiet introspection.
 duration: 119
 tags:
   - música
@@ -27,6 +21,15 @@ draftMsg: >-
   humana (fúnebre) e a escolha da máquina (calma metronômica sem compromissos a
   cumprir)
 draftCommittedAt: "2026-06-11T18:40:14.581Z"
+sunoStyle: |-
+  Slow
+  contemplative folk ballad with gentle acoustic guitar
+  soft strings
+  and a calm
+  steady rhythm reflecting quiet introspection.
+genre:
+  - folk
+  - acústico
 ---
 
 ## Letra

--- a/src/content/blog/sussurros-binarios-en/v-2026-06-09T20-24-29.mdx
+++ b/src/content/blog/sussurros-binarios-en/v-2026-06-09T20-24-29.mdx
@@ -5,19 +5,23 @@ date: 2025-02-13
 postType: music
 sunoId: ed0355ef-c7ef-4b84-8826-4b97f3995058
 sunoImageUrl: "https://cdn2.suno.ai/image_ed0355ef-c7ef-4b84-8826-4b97f3995058.jpeg"
-genre:
-  - darkjazz
-  - drone ambient
-  - field recordings
-  - slowcore
-  - lunar dub
-  - noir
 duration: 213
 tags:
   - music
 lang: en
 translationKey: music-sussurros-binarios
 draftCreatedAt: "2026-06-12T12:06:06.428Z"
+sunoStyle: |-
+  darkjazz
+  drone ambient
+  field recordings
+  slowcore
+  lunar dub
+  noir
+genre:
+  - jazz
+  - ambient
+  - experimental
 ---
 
 ## Lyrics

--- a/src/content/blog/sussurros-binarios-en/v-2026-06-12T22-27-34-547.mdx
+++ b/src/content/blog/sussurros-binarios-en/v-2026-06-12T22-27-34-547.mdx
@@ -5,13 +5,6 @@ date: 2025-02-13T00:00:00.000Z
 postType: music
 sunoId: ed0355ef-c7ef-4b84-8826-4b97f3995058
 sunoImageUrl: "https://cdn2.suno.ai/image_ed0355ef-c7ef-4b84-8826-4b97f3995058.jpeg"
-genre:
-  - darkjazz
-  - drone ambient
-  - field recordings
-  - slowcore
-  - lunar dub
-  - noir
 duration: 213
 tags:
   - music
@@ -21,6 +14,17 @@ draftCreatedAt: "2026-06-12T22:27:34.547Z"
 supersedes: af1208ab-571e-554d-9403-b9cd6df75ef6
 draftMsg: Update worst post based on franklin-blog instructions
 draftCommittedAt: "2026-06-12T22:32:34.448Z"
+sunoStyle: |-
+  darkjazz
+  drone ambient
+  field recordings
+  slowcore
+  lunar dub
+  noir
+genre:
+  - jazz
+  - ambient
+  - experimental
 ---
 
 ## Lyrics

--- a/src/content/blog/sussurros-binarios-en/v-2026-06-13T01-28-26-957.mdx
+++ b/src/content/blog/sussurros-binarios-en/v-2026-06-13T01-28-26-957.mdx
@@ -5,13 +5,6 @@ date: 2025-02-13T00:00:00.000Z
 postType: music
 sunoId: ed0355ef-c7ef-4b84-8826-4b97f3995058
 sunoImageUrl: "https://cdn2.suno.ai/image_ed0355ef-c7ef-4b84-8826-4b97f3995058.jpeg"
-genre:
-  - darkjazz
-  - drone ambient
-  - field recordings
-  - slowcore
-  - lunar dub
-  - noir
 duration: 213
 tags:
   - music
@@ -23,6 +16,17 @@ draftMsg: >-
   Added critical analysis on the infrastructure of communication noise to
   elevate the post's thematic depth
 draftCommittedAt: "2026-06-13T01:28:40.306Z"
+sunoStyle: |-
+  darkjazz
+  drone ambient
+  field recordings
+  slowcore
+  lunar dub
+  noir
+genre:
+  - jazz
+  - ambient
+  - experimental
 ---
 
 ## Lyrics

--- a/src/content/blog/sussurros-binarios/v-2026-06-09T20-24-29.mdx
+++ b/src/content/blog/sussurros-binarios/v-2026-06-09T20-24-29.mdx
@@ -5,19 +5,23 @@ date: 2025-02-13
 postType: music
 sunoId: ed0355ef-c7ef-4b84-8826-4b97f3995058
 sunoImageUrl: "https://cdn2.suno.ai/image_ed0355ef-c7ef-4b84-8826-4b97f3995058.jpeg"
-genre:
-  - darkjazz
-  - drone ambient
-  - field recordings
-  - slowcore
-  - lunar dub
-  - noir
 duration: 213
 tags:
   - música
 lang: pt
 translationKey: music-sussurros-binarios
 draftCreatedAt: "2026-06-12T12:06:06.428Z"
+sunoStyle: |-
+  darkjazz
+  drone ambient
+  field recordings
+  slowcore
+  lunar dub
+  noir
+genre:
+  - jazz
+  - ambient
+  - experimental
 ---
 
 ## Letra

--- a/src/content/blog/sussurros-binarios/v-2026-06-12T22-27-34-547.mdx
+++ b/src/content/blog/sussurros-binarios/v-2026-06-12T22-27-34-547.mdx
@@ -5,13 +5,6 @@ date: 2025-02-13T00:00:00.000Z
 postType: music
 sunoId: ed0355ef-c7ef-4b84-8826-4b97f3995058
 sunoImageUrl: "https://cdn2.suno.ai/image_ed0355ef-c7ef-4b84-8826-4b97f3995058.jpeg"
-genre:
-  - darkjazz
-  - drone ambient
-  - field recordings
-  - slowcore
-  - lunar dub
-  - noir
 duration: 213
 tags:
   - música
@@ -21,6 +14,17 @@ draftCreatedAt: "2026-06-12T22:27:34.547Z"
 supersedes: 147aca8e-be22-54b6-b33d-7b3653e29e46
 draftMsg: Update worst post based on franklin-blog instructions
 draftCommittedAt: "2026-06-12T22:32:34.448Z"
+sunoStyle: |-
+  darkjazz
+  drone ambient
+  field recordings
+  slowcore
+  lunar dub
+  noir
+genre:
+  - jazz
+  - ambient
+  - experimental
 ---
 
 ## Letra

--- a/src/content/blog/sussurros-binarios/v-2026-06-13T01-28-26-957.mdx
+++ b/src/content/blog/sussurros-binarios/v-2026-06-13T01-28-26-957.mdx
@@ -5,13 +5,6 @@ date: 2025-02-13T00:00:00.000Z
 postType: music
 sunoId: ed0355ef-c7ef-4b84-8826-4b97f3995058
 sunoImageUrl: "https://cdn2.suno.ai/image_ed0355ef-c7ef-4b84-8826-4b97f3995058.jpeg"
-genre:
-  - darkjazz
-  - drone ambient
-  - field recordings
-  - slowcore
-  - lunar dub
-  - noir
 duration: 213
 tags:
   - música
@@ -23,6 +16,17 @@ draftMsg: >-
   Added critical analysis on the infrastructure of communication noise to
   elevate the post's thematic depth
 draftCommittedAt: "2026-06-13T01:28:40.306Z"
+sunoStyle: |-
+  darkjazz
+  drone ambient
+  field recordings
+  slowcore
+  lunar dub
+  noir
+genre:
+  - jazz
+  - ambient
+  - experimental
 ---
 
 ## Letra

--- a/src/content/blog/the-ruliad-is-laughing-en/v-2026-06-09T20-24-29.mdx
+++ b/src/content/blog/the-ruliad-is-laughing-en/v-2026-06-09T20-24-29.mdx
@@ -5,17 +5,20 @@ date: 2025-12-25
 postType: music
 sunoId: d4b0467f-8840-4d33-992d-fceedd54e792
 sunoImageUrl: "https://cdn2.suno.ai/video_gen_66bce7d5-73a4-4670-8442-378854f207b3_video_upload_66bce7d5-73a4-4670-8442-378854f207b3_cover_snapshot_0s_1766695685_image.jpeg"
-genre:
-  - "A glam-leaning art-pop anthem about the ruliad: the impossible “total” of all computations—overwhelming"
-  - hilarious
-  - and weirdly intimate when it passes through a single
-  - limited observer.
 duration: 248
 tags:
   - music
 lang: en
 translationKey: music-the-ruliad-is-laughing
 draftCreatedAt: "2026-06-12T12:06:06.428Z"
+sunoStyle: |-
+  A glam-leaning art-pop anthem about the ruliad: the impossible “total” of all computations—overwhelming
+  hilarious
+  and weirdly intimate when it passes through a single
+  limited observer.
+genre:
+  - art pop
+  - experimental
 ---
 
 ## Lyrics

--- a/src/content/blog/the-ruliad-is-laughing/v-2026-06-09T20-24-29.mdx
+++ b/src/content/blog/the-ruliad-is-laughing/v-2026-06-09T20-24-29.mdx
@@ -5,17 +5,20 @@ date: 2025-12-25
 postType: music
 sunoId: d4b0467f-8840-4d33-992d-fceedd54e792
 sunoImageUrl: "https://cdn2.suno.ai/video_gen_66bce7d5-73a4-4670-8442-378854f207b3_video_upload_66bce7d5-73a4-4670-8442-378854f207b3_cover_snapshot_0s_1766695685_image.jpeg"
-genre:
-  - "A glam-leaning art-pop anthem about the ruliad: the impossible “total” of all computations—overwhelming"
-  - hilarious
-  - and weirdly intimate when it passes through a single
-  - limited observer.
 duration: 248
 tags:
   - música
 lang: pt
 translationKey: music-the-ruliad-is-laughing
 draftCreatedAt: "2026-06-12T12:06:06.428Z"
+sunoStyle: |-
+  A glam-leaning art-pop anthem about the ruliad: the impossible “total” of all computations—overwhelming
+  hilarious
+  and weirdly intimate when it passes through a single
+  limited observer.
+genre:
+  - art pop
+  - experimental
 ---
 
 ## Letra

--- a/src/content/blog/the-third-song-moving-window-iii-en/v-2026-06-09T20-24-29.mdx
+++ b/src/content/blog/the-third-song-moving-window-iii-en/v-2026-06-09T20-24-29.mdx
@@ -5,19 +5,22 @@ date: 2026-01-11
 postType: music
 sunoId: 397b9af3-863e-491a-92b8-f76cba50e6b8
 sunoImageUrl: "https://cdn2.suno.ai/image_397b9af3-863e-491a-92b8-f76cba50e6b8.jpeg"
-genre:
-  - Cinematic alt-electro pop at 92 BPM. Intimate verses feature soft kick
-  - granular textures
-  - warm bass
-  - and airy pads with close-mic androgynous vocals. Pre-chorus adds a subtle synth arpeggio for tension. Chorus expands with lush drums
-  - layered bright synths. Spoken word
-  - late-night-radio style
 duration: 272
 tags:
   - music
 lang: en
 translationKey: music-the-third-song-moving-window-iii
 draftCreatedAt: "2026-06-12T12:06:06.428Z"
+sunoStyle: |-
+  Cinematic alt-electro pop at 92 BPM. Intimate verses feature soft kick
+  granular textures
+  warm bass
+  and airy pads with close-mic androgynous vocals. Pre-chorus adds a subtle synth arpeggio for tension. Chorus expands with lush drums
+  layered bright synths. Spoken word
+  late-night-radio style
+genre:
+  - pop
+  - eletrônico
 ---
 
 ## Lyrics

--- a/src/content/blog/the-third-song-moving-window-iii-en/v-2026-06-12T09-50-26-083.mdx
+++ b/src/content/blog/the-third-song-moving-window-iii-en/v-2026-06-12T09-50-26-083.mdx
@@ -5,15 +5,6 @@ date: 2026-01-11T00:00:00.000Z
 postType: music
 sunoId: 397b9af3-863e-491a-92b8-f76cba50e6b8
 sunoImageUrl: "https://cdn2.suno.ai/image_397b9af3-863e-491a-92b8-f76cba50e6b8.jpeg"
-genre:
-  - Cinematic alt-electro pop at 92 BPM. Intimate verses feature soft kick
-  - granular textures
-  - warm bass
-  - >-
-    and airy pads with close-mic androgynous vocals. Pre-chorus adds a subtle
-    synth arpeggio for tension. Chorus expands with lush drums
-  - layered bright synths. Spoken word
-  - late-night-radio style
 duration: 272
 tags:
   - music
@@ -25,6 +16,16 @@ draftMsg: >-
   chore: deepens the conclusion to properly tie abstraction with the mundane
   silence
 draftCommittedAt: "2026-06-12T09:51:51.841Z"
+sunoStyle: |-
+  Cinematic alt-electro pop at 92 BPM. Intimate verses feature soft kick
+  granular textures
+  warm bass
+  >- and airy pads with close-mic androgynous vocals. Pre-chorus adds a subtle synth arpeggio for tension. Chorus expands with lush drums
+  layered bright synths. Spoken word
+  late-night-radio style
+genre:
+  - pop
+  - eletrônico
 ---
 
 ## Lyrics

--- a/src/content/blog/the-third-song-moving-window-iii/v-2026-06-09T20-24-29.mdx
+++ b/src/content/blog/the-third-song-moving-window-iii/v-2026-06-09T20-24-29.mdx
@@ -5,19 +5,22 @@ date: 2026-01-11
 postType: music
 sunoId: 397b9af3-863e-491a-92b8-f76cba50e6b8
 sunoImageUrl: "https://cdn2.suno.ai/image_397b9af3-863e-491a-92b8-f76cba50e6b8.jpeg"
-genre:
-  - Cinematic alt-electro pop at 92 BPM. Intimate verses feature soft kick
-  - granular textures
-  - warm bass
-  - and airy pads with close-mic androgynous vocals. Pre-chorus adds a subtle synth arpeggio for tension. Chorus expands with lush drums
-  - layered bright synths. Spoken word
-  - late-night-radio style
 duration: 272
 tags:
   - música
 lang: pt
 translationKey: music-the-third-song-moving-window-iii
 draftCreatedAt: "2026-06-12T12:06:06.428Z"
+sunoStyle: |-
+  Cinematic alt-electro pop at 92 BPM. Intimate verses feature soft kick
+  granular textures
+  warm bass
+  and airy pads with close-mic androgynous vocals. Pre-chorus adds a subtle synth arpeggio for tension. Chorus expands with lush drums
+  layered bright synths. Spoken word
+  late-night-radio style
+genre:
+  - pop
+  - eletrônico
 ---
 
 ## Letra

--- a/src/content/blog/the-third-song-moving-window-iii/v-2026-06-12T09-50-26-083.mdx
+++ b/src/content/blog/the-third-song-moving-window-iii/v-2026-06-12T09-50-26-083.mdx
@@ -5,15 +5,6 @@ date: 2026-01-11T00:00:00.000Z
 postType: music
 sunoId: 397b9af3-863e-491a-92b8-f76cba50e6b8
 sunoImageUrl: "https://cdn2.suno.ai/image_397b9af3-863e-491a-92b8-f76cba50e6b8.jpeg"
-genre:
-  - Cinematic alt-electro pop at 92 BPM. Intimate verses feature soft kick
-  - granular textures
-  - warm bass
-  - >-
-    and airy pads with close-mic androgynous vocals. Pre-chorus adds a subtle
-    synth arpeggio for tension. Chorus expands with lush drums
-  - layered bright synths. Spoken word
-  - late-night-radio style
 duration: 272
 tags:
   - música
@@ -25,6 +16,16 @@ draftMsg: >-
   chore: deepens the conclusion to properly tie abstraction with the mundane
   silence
 draftCommittedAt: "2026-06-12T09:51:51.841Z"
+sunoStyle: |-
+  Cinematic alt-electro pop at 92 BPM. Intimate verses feature soft kick
+  granular textures
+  warm bass
+  >- and airy pads with close-mic androgynous vocals. Pre-chorus adds a subtle synth arpeggio for tension. Chorus expands with lush drums
+  layered bright synths. Spoken word
+  late-night-radio style
+genre:
+  - pop
+  - eletrônico
 ---
 
 ## Letra

--- a/src/content/blog/the-time-en/v-2026-06-09T20-24-29.mdx
+++ b/src/content/blog/the-time-en/v-2026-06-09T20-24-29.mdx
@@ -5,19 +5,22 @@ date: 2025-10-03
 postType: music
 sunoId: dfddb99b-0aab-4f9c-9182-1ec3b2b49ee9
 sunoImageUrl: "https://cdn2.suno.ai/image_dfddb99b-0aab-4f9c-9182-1ec3b2b49ee9.jpeg"
-genre:
-  - A fast-paced indie track with unconventional guitar riffs
-  - punchy bass lines
-  - and hyperactive drum grooves. Offbeat synths and sharp
-  - angular melodies create a quirky
-  - unpredictable texture. Each section pivots suddenly
-  - using odd time signatures
 duration: 139
 tags:
   - music
 lang: en
 translationKey: music-the-time
 draftCreatedAt: "2026-06-12T12:06:06.428Z"
+sunoStyle: |-
+  A fast-paced indie track with unconventional guitar riffs
+  punchy bass lines
+  and hyperactive drum grooves. Offbeat synths and sharp
+  angular melodies create a quirky
+  unpredictable texture. Each section pivots suddenly
+  using odd time signatures
+genre:
+  - indie
+  - rock
 ---
 
 ## Lyrics

--- a/src/content/blog/the-time-en/v-2026-06-10T12-29-24.mdx
+++ b/src/content/blog/the-time-en/v-2026-06-10T12-29-24.mdx
@@ -5,13 +5,6 @@ date: 2025-10-03T00:00:00.000Z
 postType: music
 sunoId: dfddb99b-0aab-4f9c-9182-1ec3b2b49ee9
 sunoImageUrl: "https://cdn2.suno.ai/image_dfddb99b-0aab-4f9c-9182-1ec3b2b49ee9.jpeg"
-genre:
-  - A fast-paced indie track with unconventional guitar riffs
-  - punchy bass lines
-  - and hyperactive drum grooves. Offbeat synths and sharp
-  - angular melodies create a quirky
-  - unpredictable texture. Each section pivots suddenly
-  - using odd time signatures
 duration: 139
 tags:
   - music
@@ -23,6 +16,16 @@ draftMsg: >-
   Rewrite notes for the-time to ground internet slang in psychological
   infrastructure instead of relying on process ontology references.
 draftCommittedAt: "2026-06-10T12:33:25.710Z"
+sunoStyle: |-
+  A fast-paced indie track with unconventional guitar riffs
+  punchy bass lines
+  and hyperactive drum grooves. Offbeat synths and sharp
+  angular melodies create a quirky
+  unpredictable texture. Each section pivots suddenly
+  using odd time signatures
+genre:
+  - indie
+  - rock
 ---
 
 ## Lyrics

--- a/src/content/blog/the-time/v-2026-06-09T20-24-29.mdx
+++ b/src/content/blog/the-time/v-2026-06-09T20-24-29.mdx
@@ -5,19 +5,22 @@ date: 2025-10-03
 postType: music
 sunoId: dfddb99b-0aab-4f9c-9182-1ec3b2b49ee9
 sunoImageUrl: "https://cdn2.suno.ai/image_dfddb99b-0aab-4f9c-9182-1ec3b2b49ee9.jpeg"
-genre:
-  - A fast-paced indie track with unconventional guitar riffs
-  - punchy bass lines
-  - and hyperactive drum grooves. Offbeat synths and sharp
-  - angular melodies create a quirky
-  - unpredictable texture. Each section pivots suddenly
-  - using odd time signatures
 duration: 139
 tags:
   - música
 lang: pt
 translationKey: music-the-time
 draftCreatedAt: "2026-06-12T12:06:06.428Z"
+sunoStyle: |-
+  A fast-paced indie track with unconventional guitar riffs
+  punchy bass lines
+  and hyperactive drum grooves. Offbeat synths and sharp
+  angular melodies create a quirky
+  unpredictable texture. Each section pivots suddenly
+  using odd time signatures
+genre:
+  - indie
+  - rock
 ---
 
 ## Letra

--- a/src/content/blog/the-time/v-2026-06-10T12-29-24.mdx
+++ b/src/content/blog/the-time/v-2026-06-10T12-29-24.mdx
@@ -5,13 +5,6 @@ date: 2025-10-03T00:00:00.000Z
 postType: music
 sunoId: dfddb99b-0aab-4f9c-9182-1ec3b2b49ee9
 sunoImageUrl: "https://cdn2.suno.ai/image_dfddb99b-0aab-4f9c-9182-1ec3b2b49ee9.jpeg"
-genre:
-  - A fast-paced indie track with unconventional guitar riffs
-  - punchy bass lines
-  - and hyperactive drum grooves. Offbeat synths and sharp
-  - angular melodies create a quirky
-  - unpredictable texture. Each section pivots suddenly
-  - using odd time signatures
 duration: 139
 tags:
   - música
@@ -23,6 +16,16 @@ draftMsg: >-
   Rewrite notes for the-time to ground internet slang in psychological
   infrastructure instead of relying on process ontology references.
 draftCommittedAt: "2026-06-10T12:33:25.710Z"
+sunoStyle: |-
+  A fast-paced indie track with unconventional guitar riffs
+  punchy bass lines
+  and hyperactive drum grooves. Offbeat synths and sharp
+  angular melodies create a quirky
+  unpredictable texture. Each section pivots suddenly
+  using odd time signatures
+genre:
+  - indie
+  - rock
 ---
 
 ## Letra

--- a/src/content/blog/trinta-de-abril-en/v-2026-06-09T20-24-29.mdx
+++ b/src/content/blog/trinta-de-abril-en/v-2026-06-09T20-24-29.mdx
@@ -5,15 +5,18 @@ date: 2025-11-22
 postType: music
 sunoId: aa5c619a-9ff9-46ea-9004-9a9bb876e593
 sunoImageUrl: "https://cdn2.suno.ai/image_aa5c619a-9ff9-46ea-9004-9a9bb876e593.jpeg"
-genre:
-  - This Moda de Viola features gently syncopated viola caipira arpeggios in a traditional Ritmo de Cururu. Strophic structure supports expressive male vocals
-  - backed by soft percussion and honeyed accordion. Melancholy melodic turns and lingering bass notes deepen the devotional folk texture.
 duration: 190
 tags:
   - music
 lang: en
 translationKey: music-trinta-de-abril
 draftCreatedAt: "2026-06-12T12:06:06.428Z"
+sunoStyle: |-
+  This Moda de Viola features gently syncopated viola caipira arpeggios in a traditional Ritmo de Cururu. Strophic structure supports expressive male vocals
+  backed by soft percussion and honeyed accordion. Melancholy melodic turns and lingering bass notes deepen the devotional folk texture.
+genre:
+  - moda de viola
+  - sertanejo
 ---
 
 ## Lyrics

--- a/src/content/blog/trinta-de-abril/v-2026-06-09T20-24-29.mdx
+++ b/src/content/blog/trinta-de-abril/v-2026-06-09T20-24-29.mdx
@@ -5,15 +5,18 @@ date: 2025-11-22
 postType: music
 sunoId: aa5c619a-9ff9-46ea-9004-9a9bb876e593
 sunoImageUrl: "https://cdn2.suno.ai/image_aa5c619a-9ff9-46ea-9004-9a9bb876e593.jpeg"
-genre:
-  - This Moda de Viola features gently syncopated viola caipira arpeggios in a traditional Ritmo de Cururu. Strophic structure supports expressive male vocals
-  - backed by soft percussion and honeyed accordion. Melancholy melodic turns and lingering bass notes deepen the devotional folk texture.
 duration: 190
 tags:
   - música
 lang: pt
 translationKey: music-trinta-de-abril
 draftCreatedAt: "2026-06-12T12:06:06.428Z"
+sunoStyle: |-
+  This Moda de Viola features gently syncopated viola caipira arpeggios in a traditional Ritmo de Cururu. Strophic structure supports expressive male vocals
+  backed by soft percussion and honeyed accordion. Melancholy melodic turns and lingering bass notes deepen the devotional folk texture.
+genre:
+  - moda de viola
+  - sertanejo
 ---
 
 ## Letra

--- a/src/content/blog/two-cursors-en/v-2026-06-09T20-24-29.mdx
+++ b/src/content/blog/two-cursors-en/v-2026-06-09T20-24-29.mdx
@@ -5,19 +5,22 @@ date: 2025-09-01
 postType: music
 sunoId: a0a398dd-d4b0-4401-8879-a72ba7c1f3cf
 sunoImageUrl: "https://cdn2.suno.ai/image_a0a398dd-d4b0-4401-8879-a72ba7c1f3cf.jpeg"
-genre:
-  - Art-rap / alt-pop at 94 BPM
-  - jazzy boom-bap drums
-  - Rhodes + guitar chops
-  - subtle glitch edits
-  - intimate baritone spoken-sung verses
-  - legato hook with stacked harmonies
 duration: 206
 tags:
   - music
 lang: en
 translationKey: music-two-cursors
 draftCreatedAt: "2026-06-12T12:06:06.428Z"
+sunoStyle: |-
+  Art-rap / alt-pop at 94 BPM
+  jazzy boom-bap drums
+  Rhodes + guitar chops
+  subtle glitch edits
+  intimate baritone spoken-sung verses
+  legato hook with stacked harmonies
+genre:
+  - hip-hop
+  - jazz
 ---
 
 ## Lyrics

--- a/src/content/blog/two-cursors-en/v-2026-06-13T12-00-09-262.mdx
+++ b/src/content/blog/two-cursors-en/v-2026-06-13T12-00-09-262.mdx
@@ -5,13 +5,6 @@ date: 2025-09-01T00:00:00.000Z
 postType: music
 sunoId: a0a398dd-d4b0-4401-8879-a72ba7c1f3cf
 sunoImageUrl: "https://cdn2.suno.ai/image_a0a398dd-d4b0-4401-8879-a72ba7c1f3cf.jpeg"
-genre:
-  - Art-rap / alt-pop at 94 BPM
-  - jazzy boom-bap drums
-  - Rhodes + guitar chops
-  - subtle glitch edits
-  - intimate baritone spoken-sung verses
-  - legato hook with stacked harmonies
 duration: 206
 tags:
   - music
@@ -24,6 +17,16 @@ draftMsg: >-
   delegating thought, directly addressing the mechanistic gaps highlighted in
   the reviews.
 draftCommittedAt: "2026-06-13T12:00:21.422Z"
+sunoStyle: |-
+  Art-rap / alt-pop at 94 BPM
+  jazzy boom-bap drums
+  Rhodes + guitar chops
+  subtle glitch edits
+  intimate baritone spoken-sung verses
+  legato hook with stacked harmonies
+genre:
+  - hip-hop
+  - jazz
 ---
 
 ## Lyrics

--- a/src/content/blog/two-cursors/v-2026-06-09T20-24-29.mdx
+++ b/src/content/blog/two-cursors/v-2026-06-09T20-24-29.mdx
@@ -5,19 +5,22 @@ date: 2025-09-01
 postType: music
 sunoId: a0a398dd-d4b0-4401-8879-a72ba7c1f3cf
 sunoImageUrl: "https://cdn2.suno.ai/image_a0a398dd-d4b0-4401-8879-a72ba7c1f3cf.jpeg"
-genre:
-  - Art-rap / alt-pop at 94 BPM
-  - jazzy boom-bap drums
-  - Rhodes + guitar chops
-  - subtle glitch edits
-  - intimate baritone spoken-sung verses
-  - legato hook with stacked harmonies
 duration: 206
 tags:
   - música
 lang: pt
 translationKey: music-two-cursors
 draftCreatedAt: "2026-06-12T12:06:06.428Z"
+sunoStyle: |-
+  Art-rap / alt-pop at 94 BPM
+  jazzy boom-bap drums
+  Rhodes + guitar chops
+  subtle glitch edits
+  intimate baritone spoken-sung verses
+  legato hook with stacked harmonies
+genre:
+  - hip-hop
+  - jazz
 ---
 
 ## Letra

--- a/src/content/blog/two-cursors/v-2026-06-13T12-00-09-262.mdx
+++ b/src/content/blog/two-cursors/v-2026-06-13T12-00-09-262.mdx
@@ -5,13 +5,6 @@ date: 2025-09-01T00:00:00.000Z
 postType: music
 sunoId: a0a398dd-d4b0-4401-8879-a72ba7c1f3cf
 sunoImageUrl: "https://cdn2.suno.ai/image_a0a398dd-d4b0-4401-8879-a72ba7c1f3cf.jpeg"
-genre:
-  - Art-rap / alt-pop at 94 BPM
-  - jazzy boom-bap drums
-  - Rhodes + guitar chops
-  - subtle glitch edits
-  - intimate baritone spoken-sung verses
-  - legato hook with stacked harmonies
 duration: 206
 tags:
   - música
@@ -24,6 +17,16 @@ draftMsg: >-
   delegating thought, directly addressing the mechanistic gaps highlighted in
   the reviews.
 draftCommittedAt: "2026-06-13T12:00:21.422Z"
+sunoStyle: |-
+  Art-rap / alt-pop at 94 BPM
+  jazzy boom-bap drums
+  Rhodes + guitar chops
+  subtle glitch edits
+  intimate baritone spoken-sung verses
+  legato hook with stacked harmonies
+genre:
+  - hip-hop
+  - jazz
 ---
 
 ## Letra

--- a/src/content/blog/uma-so-cancao-en/v-2026-06-09T20-24-29.mdx
+++ b/src/content/blog/uma-so-cancao-en/v-2026-06-09T20-24-29.mdx
@@ -5,17 +5,20 @@ date: 2025-05-02
 postType: music
 sunoId: 6a421f8a-2f33-47db-b7dc-8ef589f86737
 sunoImageUrl: "https://cdn2.suno.ai/image_6a421f8a-2f33-47db-b7dc-8ef589f86737.jpeg"
-genre:
-  - female vocals
-  - meditative
-  - acoustic
-  - soothing
 duration: 208
 tags:
   - music
 lang: en
 translationKey: music-uma-so-cancao
 draftCreatedAt: "2026-06-12T12:06:06.428Z"
+sunoStyle: |-
+  female vocals
+  meditative
+  acoustic
+  soothing
+genre:
+  - folk
+  - acústico
 ---
 
 ## Lyrics

--- a/src/content/blog/uma-so-cancao/v-2026-06-09T20-24-29.mdx
+++ b/src/content/blog/uma-so-cancao/v-2026-06-09T20-24-29.mdx
@@ -5,17 +5,20 @@ date: 2025-05-02
 postType: music
 sunoId: 6a421f8a-2f33-47db-b7dc-8ef589f86737
 sunoImageUrl: "https://cdn2.suno.ai/image_6a421f8a-2f33-47db-b7dc-8ef589f86737.jpeg"
-genre:
-  - female vocals
-  - meditative
-  - acoustic
-  - soothing
 duration: 208
 tags:
   - música
 lang: pt
 translationKey: music-uma-so-cancao
 draftCreatedAt: "2026-06-12T12:06:06.428Z"
+sunoStyle: |-
+  female vocals
+  meditative
+  acoustic
+  soothing
+genre:
+  - folk
+  - acústico
 ---
 
 ## Letra

--- a/src/content/blog/universal-threshold-en/v-2026-06-09T20-24-29.mdx
+++ b/src/content/blog/universal-threshold-en/v-2026-06-09T20-24-29.mdx
@@ -5,15 +5,6 @@ date: 2025-09-29T00:00:00.000Z
 postType: music
 sunoId: 22f399f7-5c2b-4a43-8262-5a5fb8b48cf0
 sunoImageUrl: "https://cdn2.suno.ai/image_22f399f7-5c2b-4a43-8262-5a5fb8b48cf0.jpeg"
-genre:
-  - "Genre: Atmospheric Indie Folk/Electronic. Tempo: 72 BPM. Mood: Introspective"
-  - cosmic
-  - melancholic—ethereal synth layers
-  - subtle piano arpeggios
-  - tango-infused strings
-  - >-
-    fractal echoes in percussion. Borges-inspired narration: spoken-word verses
-    blending poetic recitation with soft vocals
 duration: 480
 tags:
   - music
@@ -34,6 +25,17 @@ previousVersion:
     own the song's structural overload as a deliberate attempt (and failure) to
     avoid making the ontological 'cut'.
 draftCreatedAt: "2026-06-12T12:06:06.428Z"
+sunoStyle: |-
+  Genre: Atmospheric Indie Folk/Electronic. Tempo: 72 BPM. Mood: Introspective
+  cosmic
+  melancholic—ethereal synth layers
+  subtle piano arpeggios
+  tango-infused strings
+  >- fractal echoes in percussion. Borges-inspired narration: spoken-word verses blending poetic recitation with soft vocals
+genre:
+  - indie
+  - folk
+  - eletrônico
 ---
 
 ## Lyrics

--- a/src/content/blog/universal-threshold-en/v-2026-06-11T02-23-36-143.mdx
+++ b/src/content/blog/universal-threshold-en/v-2026-06-11T02-23-36-143.mdx
@@ -5,15 +5,6 @@ date: 2025-09-29T00:00:00.000Z
 postType: music
 sunoId: 22f399f7-5c2b-4a43-8262-5a5fb8b48cf0
 sunoImageUrl: "https://cdn2.suno.ai/image_22f399f7-5c2b-4a43-8262-5a5fb8b48cf0.jpeg"
-genre:
-  - "Genre: Atmospheric Indie Folk/Electronic. Tempo: 72 BPM. Mood: Introspective"
-  - cosmic
-  - melancholic—ethereal synth layers
-  - subtle piano arpeggios
-  - tango-infused strings
-  - >-
-    fractal echoes in percussion. Borges-inspired narration: spoken-word verses
-    blending poetic recitation with soft vocals
 duration: 480
 tags:
   - music
@@ -37,6 +28,17 @@ supersedes: 7816636c-d9d0-5414-82a1-815f3ad2c7fc
 draftCreatedAt: "2026-06-11T02:23:36.143Z"
 draftMsg: "chore: improve worst post based on hronir feedback"
 draftCommittedAt: "2026-06-11T02:25:58.533Z"
+sunoStyle: |-
+  Genre: Atmospheric Indie Folk/Electronic. Tempo: 72 BPM. Mood: Introspective
+  cosmic
+  melancholic—ethereal synth layers
+  subtle piano arpeggios
+  tango-infused strings
+  >- fractal echoes in percussion. Borges-inspired narration: spoken-word verses blending poetic recitation with soft vocals
+genre:
+  - indie
+  - folk
+  - eletrônico
 ---
 
 ## Lyrics

--- a/src/content/blog/universal-threshold/v-2026-06-09T20-24-29.mdx
+++ b/src/content/blog/universal-threshold/v-2026-06-09T20-24-29.mdx
@@ -5,15 +5,6 @@ date: 2025-09-29T00:00:00.000Z
 postType: music
 sunoId: 22f399f7-5c2b-4a43-8262-5a5fb8b48cf0
 sunoImageUrl: "https://cdn2.suno.ai/image_22f399f7-5c2b-4a43-8262-5a5fb8b48cf0.jpeg"
-genre:
-  - "Genre: Atmospheric Indie Folk/Electronic. Tempo: 72 BPM. Mood: Introspective"
-  - cosmic
-  - melancholic—ethereal synth layers
-  - subtle piano arpeggios
-  - tango-infused strings
-  - >-
-    fractal echoes in percussion. Borges-inspired narration: spoken-word verses
-    blending poetic recitation with soft vocals
 duration: 480
 tags:
   - música
@@ -34,6 +25,17 @@ previousVersion:
     own the song's structural overload as a deliberate attempt (and failure) to
     avoid making the ontological 'cut'.
 draftCreatedAt: "2026-06-12T12:06:06.428Z"
+sunoStyle: |-
+  Genre: Atmospheric Indie Folk/Electronic. Tempo: 72 BPM. Mood: Introspective
+  cosmic
+  melancholic—ethereal synth layers
+  subtle piano arpeggios
+  tango-infused strings
+  >- fractal echoes in percussion. Borges-inspired narration: spoken-word verses blending poetic recitation with soft vocals
+genre:
+  - indie
+  - folk
+  - eletrônico
 ---
 
 ## Letra

--- a/src/content/blog/universal-threshold/v-2026-06-11T02-23-36-143.mdx
+++ b/src/content/blog/universal-threshold/v-2026-06-11T02-23-36-143.mdx
@@ -5,15 +5,6 @@ date: 2025-09-29T00:00:00.000Z
 postType: music
 sunoId: 22f399f7-5c2b-4a43-8262-5a5fb8b48cf0
 sunoImageUrl: "https://cdn2.suno.ai/image_22f399f7-5c2b-4a43-8262-5a5fb8b48cf0.jpeg"
-genre:
-  - "Genre: Atmospheric Indie Folk/Electronic. Tempo: 72 BPM. Mood: Introspective"
-  - cosmic
-  - melancholic—ethereal synth layers
-  - subtle piano arpeggios
-  - tango-infused strings
-  - >-
-    fractal echoes in percussion. Borges-inspired narration: spoken-word verses
-    blending poetic recitation with soft vocals
 duration: 480
 tags:
   - música
@@ -37,6 +28,17 @@ supersedes: 8947a7cb-617a-54db-8564-28444ab1c90a
 draftCreatedAt: "2026-06-11T02:23:36.143Z"
 draftMsg: "chore: improve worst post based on hronir feedback"
 draftCommittedAt: "2026-06-11T02:25:58.533Z"
+sunoStyle: |-
+  Genre: Atmospheric Indie Folk/Electronic. Tempo: 72 BPM. Mood: Introspective
+  cosmic
+  melancholic—ethereal synth layers
+  subtle piano arpeggios
+  tango-infused strings
+  >- fractal echoes in percussion. Borges-inspired narration: spoken-word verses blending poetic recitation with soft vocals
+genre:
+  - indie
+  - folk
+  - eletrônico
 ---
 
 ## Letra

--- a/src/content/blog/veu-do-infinito-en/v-2026-06-09T20-24-29.mdx
+++ b/src/content/blog/veu-do-infinito-en/v-2026-06-09T20-24-29.mdx
@@ -5,15 +5,6 @@ date: 2025-09-29T00:00:00.000Z
 postType: music
 sunoId: 9fc05ee0-5098-4385-915b-6a7fcb44760e
 sunoImageUrl: "https://cdn2.suno.ai/image_9fc05ee0-5098-4385-915b-6a7fcb44760e.jpeg"
-genre:
-  - "Genre: Atmospheric Indie Folk/Electronic. Tempo: 72 BPM. Mood: Introspective"
-  - cosmic
-  - melancholic—ethereal synth layers
-  - subtle piano arpeggios
-  - tango-infused strings
-  - >-
-    fractal echoes in percussion. Borges-inspired narration: spoken-word verses
-    blending poetic recitation with soft vocals
 duration: 408
 tags:
   - music
@@ -29,6 +20,17 @@ previousVersion:
     porque usar IA para tentar olhar a totalidade falha miseravelmente gerando
     apenas barulho.
 draftCreatedAt: "2026-06-12T12:06:06.428Z"
+sunoStyle: |-
+  Genre: Atmospheric Indie Folk/Electronic. Tempo: 72 BPM. Mood: Introspective
+  cosmic
+  melancholic—ethereal synth layers
+  subtle piano arpeggios
+  tango-infused strings
+  >- fractal echoes in percussion. Borges-inspired narration: spoken-word verses blending poetic recitation with soft vocals
+genre:
+  - indie
+  - folk
+  - eletrônico
 ---
 
 ## Lyrics

--- a/src/content/blog/veu-do-infinito-en/v-2026-06-12T09-51-17-410.mdx
+++ b/src/content/blog/veu-do-infinito-en/v-2026-06-12T09-51-17-410.mdx
@@ -5,15 +5,6 @@ date: 2025-09-29T00:00:00.000Z
 postType: music
 sunoId: 9fc05ee0-5098-4385-915b-6a7fcb44760e
 sunoImageUrl: "https://cdn2.suno.ai/image_9fc05ee0-5098-4385-915b-6a7fcb44760e.jpeg"
-genre:
-  - "Genre: Atmospheric Indie Folk/Electronic. Tempo: 72 BPM. Mood: Introspective"
-  - cosmic
-  - melancholic—ethereal synth layers
-  - subtle piano arpeggios
-  - tango-infused strings
-  - >-
-    fractal echoes in percussion. Borges-inspired narration: spoken-word verses
-    blending poetic recitation with soft vocals
 duration: 408
 tags:
   - music
@@ -35,6 +26,17 @@ draftMsg: >-
   usar IA para tentar olhar a totalidade falha miseravelmente gerando apenas
   barulho.
 draftCommittedAt: "2026-06-12T09:52:04.459Z"
+sunoStyle: |-
+  Genre: Atmospheric Indie Folk/Electronic. Tempo: 72 BPM. Mood: Introspective
+  cosmic
+  melancholic—ethereal synth layers
+  subtle piano arpeggios
+  tango-infused strings
+  >- fractal echoes in percussion. Borges-inspired narration: spoken-word verses blending poetic recitation with soft vocals
+genre:
+  - indie
+  - folk
+  - eletrônico
 ---
 
 ## Lyrics

--- a/src/content/blog/veu-do-infinito-en/v-2026-06-12T21-41-03-919.mdx
+++ b/src/content/blog/veu-do-infinito-en/v-2026-06-12T21-41-03-919.mdx
@@ -5,15 +5,6 @@ date: 2025-09-29T00:00:00.000Z
 postType: music
 sunoId: 9fc05ee0-5098-4385-915b-6a7fcb44760e
 sunoImageUrl: "https://cdn2.suno.ai/image_9fc05ee0-5098-4385-915b-6a7fcb44760e.jpeg"
-genre:
-  - "Genre: Atmospheric Indie Folk/Electronic. Tempo: 72 BPM. Mood: Introspective"
-  - cosmic
-  - melancholic—ethereal synth layers
-  - subtle piano arpeggios
-  - tango-infused strings
-  - >-
-    fractal echoes in percussion. Borges-inspired narration: spoken-word verses
-    blending poetic recitation with soft vocals
 duration: 408
 tags:
   - music
@@ -35,6 +26,17 @@ draftMsg: >-
   when describing the infinite, framing the song's excess as a fascinating
   architectural accident rather than just bad writing.
 draftCommittedAt: "2026-06-12T21:41:52.937Z"
+sunoStyle: |-
+  Genre: Atmospheric Indie Folk/Electronic. Tempo: 72 BPM. Mood: Introspective
+  cosmic
+  melancholic—ethereal synth layers
+  subtle piano arpeggios
+  tango-infused strings
+  >- fractal echoes in percussion. Borges-inspired narration: spoken-word verses blending poetic recitation with soft vocals
+genre:
+  - indie
+  - folk
+  - eletrônico
 ---
 
 ## Lyrics

--- a/src/content/blog/veu-do-infinito/v-2026-06-09T20-24-29.mdx
+++ b/src/content/blog/veu-do-infinito/v-2026-06-09T20-24-29.mdx
@@ -5,15 +5,6 @@ date: 2025-09-29T00:00:00.000Z
 postType: music
 sunoId: 9fc05ee0-5098-4385-915b-6a7fcb44760e
 sunoImageUrl: "https://cdn2.suno.ai/image_9fc05ee0-5098-4385-915b-6a7fcb44760e.jpeg"
-genre:
-  - "Genre: Atmospheric Indie Folk/Electronic. Tempo: 72 BPM. Mood: Introspective"
-  - cosmic
-  - melancholic—ethereal synth layers
-  - subtle piano arpeggios
-  - tango-infused strings
-  - >-
-    fractal echoes in percussion. Borges-inspired narration: spoken-word verses
-    blending poetic recitation with soft vocals
 duration: 408
 tags:
   - música
@@ -29,6 +20,17 @@ previousVersion:
     porque usar IA para tentar olhar a totalidade falha miseravelmente gerando
     apenas barulho.
 draftCreatedAt: "2026-06-12T12:06:06.428Z"
+sunoStyle: |-
+  Genre: Atmospheric Indie Folk/Electronic. Tempo: 72 BPM. Mood: Introspective
+  cosmic
+  melancholic—ethereal synth layers
+  subtle piano arpeggios
+  tango-infused strings
+  >- fractal echoes in percussion. Borges-inspired narration: spoken-word verses blending poetic recitation with soft vocals
+genre:
+  - indie
+  - folk
+  - eletrônico
 ---
 
 ## Letra

--- a/src/content/blog/veu-do-infinito/v-2026-06-12T09-51-17-410.mdx
+++ b/src/content/blog/veu-do-infinito/v-2026-06-12T09-51-17-410.mdx
@@ -5,15 +5,6 @@ date: 2025-09-29T00:00:00.000Z
 postType: music
 sunoId: 9fc05ee0-5098-4385-915b-6a7fcb44760e
 sunoImageUrl: "https://cdn2.suno.ai/image_9fc05ee0-5098-4385-915b-6a7fcb44760e.jpeg"
-genre:
-  - "Genre: Atmospheric Indie Folk/Electronic. Tempo: 72 BPM. Mood: Introspective"
-  - cosmic
-  - melancholic—ethereal synth layers
-  - subtle piano arpeggios
-  - tango-infused strings
-  - >-
-    fractal echoes in percussion. Borges-inspired narration: spoken-word verses
-    blending poetic recitation with soft vocals
 duration: 408
 tags:
   - música
@@ -35,6 +26,17 @@ draftMsg: >-
   usar IA para tentar olhar a totalidade falha miseravelmente gerando apenas
   barulho.
 draftCommittedAt: "2026-06-12T09:52:04.459Z"
+sunoStyle: |-
+  Genre: Atmospheric Indie Folk/Electronic. Tempo: 72 BPM. Mood: Introspective
+  cosmic
+  melancholic—ethereal synth layers
+  subtle piano arpeggios
+  tango-infused strings
+  >- fractal echoes in percussion. Borges-inspired narration: spoken-word verses blending poetic recitation with soft vocals
+genre:
+  - indie
+  - folk
+  - eletrônico
 ---
 
 ## Letra

--- a/src/content/blog/veu-do-infinito/v-2026-06-12T21-41-03-919.mdx
+++ b/src/content/blog/veu-do-infinito/v-2026-06-12T21-41-03-919.mdx
@@ -5,15 +5,6 @@ date: 2025-09-29T00:00:00.000Z
 postType: music
 sunoId: 9fc05ee0-5098-4385-915b-6a7fcb44760e
 sunoImageUrl: "https://cdn2.suno.ai/image_9fc05ee0-5098-4385-915b-6a7fcb44760e.jpeg"
-genre:
-  - "Genre: Atmospheric Indie Folk/Electronic. Tempo: 72 BPM. Mood: Introspective"
-  - cosmic
-  - melancholic—ethereal synth layers
-  - subtle piano arpeggios
-  - tango-infused strings
-  - >-
-    fractal echoes in percussion. Borges-inspired narration: spoken-word verses
-    blending poetic recitation with soft vocals
 duration: 408
 tags:
   - música
@@ -35,6 +26,17 @@ draftMsg: >-
   when describing the infinite, framing the song's excess as a fascinating
   architectural accident rather than just bad writing.
 draftCommittedAt: "2026-06-12T21:41:52.937Z"
+sunoStyle: |-
+  Genre: Atmospheric Indie Folk/Electronic. Tempo: 72 BPM. Mood: Introspective
+  cosmic
+  melancholic—ethereal synth layers
+  subtle piano arpeggios
+  tango-infused strings
+  >- fractal echoes in percussion. Borges-inspired narration: spoken-word verses blending poetic recitation with soft vocals
+genre:
+  - indie
+  - folk
+  - eletrônico
 ---
 
 ## Letra

--- a/src/content/blog/vos-en/v-2026-06-10T02-02-50-prev.mdx
+++ b/src/content/blog/vos-en/v-2026-06-10T02-02-50-prev.mdx
@@ -5,18 +5,21 @@ date: 2025-02-13
 postType: music
 sunoId: 1816b1c0-7064-4c57-af5c-2b84b9face9f
 sunoImageUrl: "https://cdn2.suno.ai/image_1816b1c0-7064-4c57-af5c-2b84b9face9f.jpeg"
-genre:
-  - ether-whisper
-  - plural-light
-  - silence-dance
-  - singing-mirrors
-  - infinite-voice
-  - crystal-shadow
 duration: 240
 tags:
   - music
 lang: en
 translationKey: music-vos
+sunoStyle: |-
+  ether-whisper
+  plural-light
+  silence-dance
+  singing-mirrors
+  infinite-voice
+  crystal-shadow
+genre:
+  - ambient
+  - experimental
 ---
 
 ## Lyrics

--- a/src/content/blog/vos-en/v-2026-06-10T02-07-34.mdx
+++ b/src/content/blog/vos-en/v-2026-06-10T02-07-34.mdx
@@ -5,13 +5,6 @@ date: 2025-02-13T00:00:00.000Z
 postType: music
 sunoId: 1816b1c0-7064-4c57-af5c-2b84b9face9f
 sunoImageUrl: "https://cdn2.suno.ai/image_1816b1c0-7064-4c57-af5c-2b84b9face9f.jpeg"
-genre:
-  - ether-whisper
-  - plural-light
-  - silence-dance
-  - singing-mirrors
-  - infinite-voice
-  - crystal-shadow
 duration: 240
 tags:
   - music
@@ -19,6 +12,16 @@ lang: en
 translationKey: music-vos
 supersedes: 481b3e69-8b27-5d54-a9f8-86f7c2957d57
 draftCreatedAt: "2026-06-12T12:06:06.428Z"
+sunoStyle: |-
+  ether-whisper
+  plural-light
+  silence-dance
+  singing-mirrors
+  infinite-voice
+  crystal-shadow
+genre:
+  - ambient
+  - experimental
 ---
 
 ## Lyrics

--- a/src/content/blog/vos-en/v-2026-06-12T12-43-16-985.mdx
+++ b/src/content/blog/vos-en/v-2026-06-12T12-43-16-985.mdx
@@ -5,13 +5,6 @@ date: 2025-02-13T00:00:00.000Z
 postType: music
 sunoId: 1816b1c0-7064-4c57-af5c-2b84b9face9f
 sunoImageUrl: "https://cdn2.suno.ai/image_1816b1c0-7064-4c57-af5c-2b84b9face9f.jpeg"
-genre:
-  - ether-whisper
-  - plural-light
-  - silence-dance
-  - singing-mirrors
-  - infinite-voice
-  - crystal-shadow
 duration: 240
 tags:
   - music
@@ -21,6 +14,16 @@ supersedes: 82b8f2f2-4409-50f2-ac99-ff327f26dddd
 draftCreatedAt: "2026-06-12T12:43:16.986Z"
 draftMsg: Minor stylistic adjustments to the final paragraph to improve cadence.
 draftCommittedAt: "2026-06-12T12:43:51.377Z"
+sunoStyle: |-
+  ether-whisper
+  plural-light
+  silence-dance
+  singing-mirrors
+  infinite-voice
+  crystal-shadow
+genre:
+  - ambient
+  - experimental
 ---
 
 ## Lyrics

--- a/src/content/blog/vos-en/v-2026-06-12T12-47-16-475.mdx
+++ b/src/content/blog/vos-en/v-2026-06-12T12-47-16-475.mdx
@@ -5,13 +5,6 @@ date: 2025-02-13T00:00:00.000Z
 postType: music
 sunoId: 1816b1c0-7064-4c57-af5c-2b84b9face9f
 sunoImageUrl: "https://cdn2.suno.ai/image_1816b1c0-7064-4c57-af5c-2b84b9face9f.jpeg"
-genre:
-  - ether-whisper
-  - plural-light
-  - silence-dance
-  - singing-mirrors
-  - infinite-voice
-  - crystal-shadow
 duration: 240
 tags:
   - music
@@ -21,6 +14,16 @@ supersedes: 82b8f2f2-4409-50f2-ac99-ff327f26dddd
 draftCreatedAt: "2026-06-12T12:47:16.476Z"
 draftMsg: Edited worst post
 draftCommittedAt: "2026-06-12T12:49:14.471Z"
+sunoStyle: |-
+  ether-whisper
+  plural-light
+  silence-dance
+  singing-mirrors
+  infinite-voice
+  crystal-shadow
+genre:
+  - ambient
+  - experimental
 ---
 
 ## Lyrics

--- a/src/content/blog/vos-en/v-2026-06-12T12-47-58-150.mdx
+++ b/src/content/blog/vos-en/v-2026-06-12T12-47-58-150.mdx
@@ -5,13 +5,6 @@ date: 2025-02-13T00:00:00.000Z
 postType: music
 sunoId: 1816b1c0-7064-4c57-af5c-2b84b9face9f
 sunoImageUrl: "https://cdn2.suno.ai/image_1816b1c0-7064-4c57-af5c-2b84b9face9f.jpeg"
-genre:
-  - ether-whisper
-  - plural-light
-  - silence-dance
-  - singing-mirrors
-  - infinite-voice
-  - crystal-shadow
 duration: 240
 tags:
   - music
@@ -21,6 +14,16 @@ supersedes: 82b8f2f2-4409-50f2-ac99-ff327f26dddd
 draftCreatedAt: "2026-06-12T12:47:58.150Z"
 draftMsg: Auto-edited the worst post by updating its text.
 draftCommittedAt: "2026-06-12T12:50:53.722Z"
+sunoStyle: |-
+  ether-whisper
+  plural-light
+  silence-dance
+  singing-mirrors
+  infinite-voice
+  crystal-shadow
+genre:
+  - ambient
+  - experimental
 ---
 
 ## Lyrics

--- a/src/content/blog/vos-en/v-2026-06-12T12-53-09-786.mdx
+++ b/src/content/blog/vos-en/v-2026-06-12T12-53-09-786.mdx
@@ -5,13 +5,6 @@ date: 2025-02-13T00:00:00.000Z
 postType: music
 sunoId: 1816b1c0-7064-4c57-af5c-2b84b9face9f
 sunoImageUrl: "https://cdn2.suno.ai/image_1816b1c0-7064-4c57-af5c-2b84b9face9f.jpeg"
-genre:
-  - ether-whisper
-  - plural-light
-  - silence-dance
-  - singing-mirrors
-  - infinite-voice
-  - crystal-shadow
 duration: 240
 tags:
   - music
@@ -23,6 +16,16 @@ draftMsg: >-
   Added unique MDX-compatible insight regarding the archaic plural pronoun
   representing a statistical mirrored chorus
 draftCommittedAt: "2026-06-12T12:58:38.506Z"
+sunoStyle: |-
+  ether-whisper
+  plural-light
+  silence-dance
+  singing-mirrors
+  infinite-voice
+  crystal-shadow
+genre:
+  - ambient
+  - experimental
 ---
 
 ## Lyrics

--- a/src/content/blog/vos/v-2026-06-10T02-12-45-prev.mdx
+++ b/src/content/blog/vos/v-2026-06-10T02-12-45-prev.mdx
@@ -5,18 +5,21 @@ date: 2025-02-13
 postType: music
 sunoId: 1816b1c0-7064-4c57-af5c-2b84b9face9f
 sunoImageUrl: "https://cdn2.suno.ai/image_1816b1c0-7064-4c57-af5c-2b84b9face9f.jpeg"
-genre:
-  - ether-whisper
-  - plural-light
-  - silence-dance
-  - singing-mirrors
-  - infinite-voice
-  - crystal-shadow
 duration: 240
 tags:
   - música
 lang: pt
 translationKey: music-vos
+sunoStyle: |-
+  ether-whisper
+  plural-light
+  silence-dance
+  singing-mirrors
+  infinite-voice
+  crystal-shadow
+genre:
+  - ambient
+  - experimental
 ---
 
 ## Letra

--- a/src/content/blog/vos/v-2026-06-10T02-14-41.mdx
+++ b/src/content/blog/vos/v-2026-06-10T02-14-41.mdx
@@ -5,13 +5,6 @@ date: 2025-02-13T00:00:00.000Z
 postType: music
 sunoId: 1816b1c0-7064-4c57-af5c-2b84b9face9f
 sunoImageUrl: "https://cdn2.suno.ai/image_1816b1c0-7064-4c57-af5c-2b84b9face9f.jpeg"
-genre:
-  - ether-whisper
-  - plural-light
-  - silence-dance
-  - singing-mirrors
-  - infinite-voice
-  - crystal-shadow
 duration: 240
 tags:
   - música
@@ -19,6 +12,16 @@ lang: pt
 translationKey: music-vos
 supersedes: ae04a48a-527c-5444-8bff-8c0fbe5ccd20
 draftCreatedAt: "2026-06-12T12:06:06.428Z"
+sunoStyle: |-
+  ether-whisper
+  plural-light
+  silence-dance
+  singing-mirrors
+  infinite-voice
+  crystal-shadow
+genre:
+  - ambient
+  - experimental
 ---
 
 ## Letra

--- a/src/content/blog/vos/v-2026-06-12T12-43-16-985.mdx
+++ b/src/content/blog/vos/v-2026-06-12T12-43-16-985.mdx
@@ -5,13 +5,6 @@ date: 2025-02-13T00:00:00.000Z
 postType: music
 sunoId: 1816b1c0-7064-4c57-af5c-2b84b9face9f
 sunoImageUrl: "https://cdn2.suno.ai/image_1816b1c0-7064-4c57-af5c-2b84b9face9f.jpeg"
-genre:
-  - ether-whisper
-  - plural-light
-  - silence-dance
-  - singing-mirrors
-  - infinite-voice
-  - crystal-shadow
 duration: 240
 tags:
   - música
@@ -21,6 +14,16 @@ supersedes: 1ee7ef22-97fc-5f3e-9e0d-df11956d6b7b
 draftCreatedAt: "2026-06-12T12:43:16.986Z"
 draftMsg: Minor stylistic adjustments to the final paragraph to improve cadence.
 draftCommittedAt: "2026-06-12T12:43:51.377Z"
+sunoStyle: |-
+  ether-whisper
+  plural-light
+  silence-dance
+  singing-mirrors
+  infinite-voice
+  crystal-shadow
+genre:
+  - ambient
+  - experimental
 ---
 
 ## Letra

--- a/src/content/blog/vos/v-2026-06-12T12-47-16-475.mdx
+++ b/src/content/blog/vos/v-2026-06-12T12-47-16-475.mdx
@@ -5,13 +5,6 @@ date: 2025-02-13T00:00:00.000Z
 postType: music
 sunoId: 1816b1c0-7064-4c57-af5c-2b84b9face9f
 sunoImageUrl: "https://cdn2.suno.ai/image_1816b1c0-7064-4c57-af5c-2b84b9face9f.jpeg"
-genre:
-  - ether-whisper
-  - plural-light
-  - silence-dance
-  - singing-mirrors
-  - infinite-voice
-  - crystal-shadow
 duration: 240
 tags:
   - música
@@ -21,6 +14,16 @@ supersedes: 1ee7ef22-97fc-5f3e-9e0d-df11956d6b7b
 draftCreatedAt: "2026-06-12T12:47:16.476Z"
 draftMsg: Edited worst post
 draftCommittedAt: "2026-06-12T12:49:14.471Z"
+sunoStyle: |-
+  ether-whisper
+  plural-light
+  silence-dance
+  singing-mirrors
+  infinite-voice
+  crystal-shadow
+genre:
+  - ambient
+  - experimental
 ---
 
 ## Letra

--- a/src/content/blog/vos/v-2026-06-12T12-47-58-150.mdx
+++ b/src/content/blog/vos/v-2026-06-12T12-47-58-150.mdx
@@ -5,13 +5,6 @@ date: 2025-02-13T00:00:00.000Z
 postType: music
 sunoId: 1816b1c0-7064-4c57-af5c-2b84b9face9f
 sunoImageUrl: "https://cdn2.suno.ai/image_1816b1c0-7064-4c57-af5c-2b84b9face9f.jpeg"
-genre:
-  - ether-whisper
-  - plural-light
-  - silence-dance
-  - singing-mirrors
-  - infinite-voice
-  - crystal-shadow
 duration: 240
 tags:
   - música
@@ -21,6 +14,16 @@ supersedes: 1ee7ef22-97fc-5f3e-9e0d-df11956d6b7b
 draftCreatedAt: "2026-06-12T12:47:58.150Z"
 draftMsg: Auto-edited the worst post by updating its text.
 draftCommittedAt: "2026-06-12T12:50:53.722Z"
+sunoStyle: |-
+  ether-whisper
+  plural-light
+  silence-dance
+  singing-mirrors
+  infinite-voice
+  crystal-shadow
+genre:
+  - ambient
+  - experimental
 ---
 
 ## Letra

--- a/src/content/blog/vos/v-2026-06-12T12-53-09-786.mdx
+++ b/src/content/blog/vos/v-2026-06-12T12-53-09-786.mdx
@@ -5,13 +5,6 @@ date: 2025-02-13T00:00:00.000Z
 postType: music
 sunoId: 1816b1c0-7064-4c57-af5c-2b84b9face9f
 sunoImageUrl: "https://cdn2.suno.ai/image_1816b1c0-7064-4c57-af5c-2b84b9face9f.jpeg"
-genre:
-  - ether-whisper
-  - plural-light
-  - silence-dance
-  - singing-mirrors
-  - infinite-voice
-  - crystal-shadow
 duration: 240
 tags:
   - música
@@ -23,6 +16,16 @@ draftMsg: >-
   Added unique MDX-compatible insight regarding the archaic plural pronoun
   representing a statistical mirrored chorus
 draftCommittedAt: "2026-06-12T12:58:38.506Z"
+sunoStyle: |-
+  ether-whisper
+  plural-light
+  silence-dance
+  singing-mirrors
+  infinite-voice
+  crystal-shadow
+genre:
+  - ambient
+  - experimental
 ---
 
 ## Letra

--- a/src/content/blog/xadrez-en/v-2026-06-09T20-24-29.mdx
+++ b/src/content/blog/xadrez-en/v-2026-06-09T20-24-29.mdx
@@ -5,15 +5,19 @@ date: 2025-08-29
 postType: music
 sunoId: 61b3bf0d-a7f4-4756-b43b-818af1f1c897
 sunoImageUrl: "https://cdn2.suno.ai/image_61b3bf0d-a7f4-4756-b43b-818af1f1c897.jpeg"
+sunoStyle: |-
+  Genre: cinematic trip-hop / downtempo
+  Tempo: 78 BPM | Time: 4/4 | Mood: mechanical
+  brooding
+  nocturnal
+  Instruments: dusty drum break (soft)
+  sub-bass
+  detuned piano
+  analog pads with low shimmer
+
 genre:
-  - "Genre: cinematic trip-hop / downtempo
-Tempo: 78 BPM | Time: 4/4 | Mood: mechanical"
-  - brooding
-  - "nocturnal
-Instruments: dusty drum break (soft)"
-  - sub-bass
-  - detuned piano
-  - analog pads with low shimmer
+  - eletrônico
+  - experimental
 duration: 238
 tags:
   - music

--- a/src/content/blog/xadrez-en/v-2026-06-13T04-57-16-825.mdx
+++ b/src/content/blog/xadrez-en/v-2026-06-13T04-57-16-825.mdx
@@ -5,15 +5,6 @@ date: 2025-08-29T00:00:00.000Z
 postType: music
 sunoId: 61b3bf0d-a7f4-4756-b43b-818af1f1c897
 sunoImageUrl: "https://cdn2.suno.ai/image_61b3bf0d-a7f4-4756-b43b-818af1f1c897.jpeg"
-genre:
-  - >-
-    Genre: cinematic trip-hop / downtempo Tempo: 78 BPM | Time: 4/4 | Mood:
-    mechanical
-  - brooding
-  - "nocturnal Instruments: dusty drum break (soft)"
-  - sub-bass
-  - detuned piano
-  - analog pads with low shimmer
 duration: 238
 tags:
   - music
@@ -23,6 +14,16 @@ draftCreatedAt: "2026-06-13T04:57:16.825Z"
 supersedes: 637b45cb-af7e-59be-9254-ec4033dc4fe0
 draftMsg: Address critiques in edit-worst phase
 draftCommittedAt: "2026-06-13T05:00:24.920Z"
+sunoStyle: |-
+  >- Genre: cinematic trip-hop / downtempo Tempo: 78 BPM | Time: 4/4 | Mood: mechanical
+  brooding
+  nocturnal Instruments: dusty drum break (soft)
+  sub-bass
+  detuned piano
+  analog pads with low shimmer
+genre:
+  - eletrônico
+  - experimental
 ---
 
 ## Lyrics

--- a/src/content/blog/xadrez/v-2026-06-09T20-24-29.mdx
+++ b/src/content/blog/xadrez/v-2026-06-09T20-24-29.mdx
@@ -5,15 +5,19 @@ date: 2025-08-29
 postType: music
 sunoId: 61b3bf0d-a7f4-4756-b43b-818af1f1c897
 sunoImageUrl: "https://cdn2.suno.ai/image_61b3bf0d-a7f4-4756-b43b-818af1f1c897.jpeg"
+sunoStyle: |-
+  Genre: cinematic trip-hop / downtempo
+  Tempo: 78 BPM | Time: 4/4 | Mood: mechanical
+  brooding
+  nocturnal
+  Instruments: dusty drum break (soft)
+  sub-bass
+  detuned piano
+  analog pads with low shimmer
+
 genre:
-  - "Genre: cinematic trip-hop / downtempo
-Tempo: 78 BPM | Time: 4/4 | Mood: mechanical"
-  - brooding
-  - "nocturnal
-Instruments: dusty drum break (soft)"
-  - sub-bass
-  - detuned piano
-  - analog pads with low shimmer
+  - eletrônico
+  - experimental
 duration: 238
 tags:
   - música

--- a/src/content/blog/xadrez/v-2026-06-13T04-57-16-825.mdx
+++ b/src/content/blog/xadrez/v-2026-06-13T04-57-16-825.mdx
@@ -5,15 +5,6 @@ date: 2025-08-29T00:00:00.000Z
 postType: music
 sunoId: 61b3bf0d-a7f4-4756-b43b-818af1f1c897
 sunoImageUrl: "https://cdn2.suno.ai/image_61b3bf0d-a7f4-4756-b43b-818af1f1c897.jpeg"
-genre:
-  - >-
-    Genre: cinematic trip-hop / downtempo Tempo: 78 BPM | Time: 4/4 | Mood:
-    mechanical
-  - brooding
-  - "nocturnal Instruments: dusty drum break (soft)"
-  - sub-bass
-  - detuned piano
-  - analog pads with low shimmer
 duration: 238
 tags:
   - música
@@ -23,6 +14,16 @@ draftCreatedAt: "2026-06-13T04:57:16.825Z"
 supersedes: a73cd3da-4dae-5b47-b6f3-aa55ab4681a8
 draftMsg: Address critiques in edit-worst phase
 draftCommittedAt: "2026-06-13T05:00:24.920Z"
+sunoStyle: |-
+  >- Genre: cinematic trip-hop / downtempo Tempo: 78 BPM | Time: 4/4 | Mood: mechanical
+  brooding
+  nocturnal Instruments: dusty drum break (soft)
+  sub-bass
+  detuned piano
+  analog pads with low shimmer
+genre:
+  - eletrônico
+  - experimental
 ---
 
 ## Letra

--- a/src/generated/ranking-snapshot.json
+++ b/src/generated/ranking-snapshot.json
@@ -1,7 +1,7 @@
 {
   "_meta": {
     "schema": "snapshot-v2",
-    "generatedAt": "2026-06-13T17:52:34.557Z",
+    "generatedAt": "2026-06-13T18:24:36.748Z",
     "basis": "build",
     "totalDuels": 522
   },

--- a/src/generated/ranking-snapshot.json
+++ b/src/generated/ranking-snapshot.json
@@ -1,7 +1,7 @@
 {
   "_meta": {
     "schema": "snapshot-v2",
-    "generatedAt": "2026-06-13T17:17:12.854Z",
+    "generatedAt": "2026-06-13T17:52:34.557Z",
     "basis": "build",
     "totalDuels": 522
   },

--- a/src/generated/versions-selected.json
+++ b/src/generated/versions-selected.json
@@ -1,31 +1,31 @@
 {
   "666": {
     "file": "666/v-2026-06-09T20-24-29.mdx",
-    "uuid": "acdc2f9e-c38c-58b6-a422-e8ab36701aed"
+    "uuid": "d3626fa5-c56e-54cf-8626-3171df145976"
   },
   "_meta": {
     "schema": "selection-v1",
-    "generatedAt": "2026-06-13T15:42:31.752Z"
+    "generatedAt": "2026-06-13T18:18:30.643Z"
   },
   "151474c5-1420-4cc1-9ab5-80721f4459ed": {
     "file": "151474c5-1420-4cc1-9ab5-80721f4459ed/v-2026-06-09T20-24-29.mdx",
-    "uuid": "b0fb84b9-a052-5811-bfc7-4e156e641d0f"
+    "uuid": "b2a7f306-213a-5e0c-8668-704a5035c806"
   },
   "151474c5-1420-4cc1-9ab5-80721f4459ed-en": {
     "file": "151474c5-1420-4cc1-9ab5-80721f4459ed-en/v-2026-06-09T20-24-29.mdx",
-    "uuid": "5f9f9656-ff8b-5ef5-9f6b-700a7003f5f5"
+    "uuid": "0507e080-984d-52c2-abc6-da8922194945"
   },
   "46336b97-4306-41bc-8a7b-48f0ebebbd29": {
     "file": "46336b97-4306-41bc-8a7b-48f0ebebbd29/v-2026-06-09T20-24-29.mdx",
-    "uuid": "2d62abeb-be55-5955-a0cf-a2677494b502"
+    "uuid": "3363e2d7-7ac9-5fce-be4a-bf885994a0a7"
   },
   "46336b97-4306-41bc-8a7b-48f0ebebbd29-en": {
     "file": "46336b97-4306-41bc-8a7b-48f0ebebbd29-en/v-2026-06-09T20-24-29.mdx",
-    "uuid": "51b8888c-c1a5-5e53-8ff6-c07b23054322"
+    "uuid": "faa848c0-847e-5dcc-9290-d8a316a56418"
   },
   "666-en": {
     "file": "666-en/v-2026-06-09T20-24-29.mdx",
-    "uuid": "bacc6946-b3ef-5ccd-ab90-af36b67eca26"
+    "uuid": "7d199024-888b-592c-82a5-698e368b695e"
   },
   "a-api-do-jules-como-backend-do-harness": {
     "file": "a-api-do-jules-como-backend-do-harness/v-2026-06-10T05-09-44.md",
@@ -37,11 +37,11 @@
   },
   "a-primeira-mudanca": {
     "file": "a-primeira-mudanca/v-2026-06-09T20-24-29.mdx",
-    "uuid": "a7fd6540-051c-5362-ab76-385041614fc1"
+    "uuid": "869dd754-0c28-5014-9375-76fe594c4a3d"
   },
   "a-primeira-mudanca-en": {
     "file": "a-primeira-mudanca-en/v-2026-06-09T20-24-29.mdx",
-    "uuid": "6948a249-7a83-5510-a718-7bcc6caeeafe"
+    "uuid": "daed34ee-17ae-59a9-99bd-c2bfebfb33c4"
   },
   "a-terceira-metade-e-a-quarta-parede": {
     "file": "a-terceira-metade-e-a-quarta-parede/v-2026-06-10T05-09-44.md",
@@ -53,59 +53,59 @@
   },
   "be-me-borges": {
     "file": "be-me-borges/v-2026-06-09T20-24-29.mdx",
-    "uuid": "9c6320fa-56e8-586d-a093-25e87306954f"
+    "uuid": "161326e1-3126-52f2-8070-61bd178f7f4e"
   },
   "be-me-borges-en": {
     "file": "be-me-borges-en/v-2026-06-09T20-24-29.mdx",
-    "uuid": "c432602d-5f4e-5014-8617-e0d76d9a131b"
+    "uuid": "7934c811-4f17-51ba-8fe7-3891202efa67"
   },
   "beatriz": {
     "file": "beatriz/v-2026-06-09T20-24-29.mdx",
-    "uuid": "829f50da-ac7c-5f81-b1c5-9cfd6968520e"
+    "uuid": "9893549e-9f6c-5088-93e8-9bddcd815039"
   },
   "beatriz-en": {
     "file": "beatriz-en/v-2026-06-09T20-24-29.mdx",
-    "uuid": "e9b1546d-5d88-57b6-8433-d934e73c7a52"
+    "uuid": "2e0cf4e4-6ce1-501a-aa2d-a9abb2224dc9"
   },
   "belief-engine-labyrinth-song-moving-window-viii": {
     "file": "belief-engine-labyrinth-song-moving-window-viii/v-2026-06-09T20-24-29.mdx",
-    "uuid": "7186114e-b6f0-5a77-8992-ce7348c9c4f9"
+    "uuid": "8bc4985b-5a94-5bf6-a353-1fa07f5e05fc"
   },
   "belief-engine-labyrinth-song-moving-window-viii-en": {
     "file": "belief-engine-labyrinth-song-moving-window-viii-en/v-2026-06-09T20-24-29.mdx",
-    "uuid": "c389ad04-3b43-5328-8b67-e85b469525cf"
+    "uuid": "53ebab45-039f-5b46-91e2-47233620e06b"
   },
   "bibliotecario-do-infinito": {
     "file": "bibliotecario-do-infinito/v-2026-06-09T20-24-29.mdx",
-    "uuid": "1ac40ce4-24b8-5306-b892-24d7aa1fd55e"
+    "uuid": "fe764a00-8e7b-5790-8a45-b570cbfec7f7"
   },
   "bibliotecario-do-infinito-en": {
     "file": "bibliotecario-do-infinito-en/v-2026-06-09T20-24-29.mdx",
-    "uuid": "abc51fed-0a4f-5de8-9f5c-dafd0e87963e"
+    "uuid": "36f6531a-219d-5bd9-9659-8ed56c5f2df5"
   },
   "borges-and-me": {
     "file": "borges-and-me/v-2026-06-09T20-24-29.mdx",
-    "uuid": "152a52ac-3c14-5455-b4d4-b302e4b76996"
+    "uuid": "dca734c4-a18d-53d3-9a82-d5b374a09ac9"
   },
   "borges-and-me-en": {
     "file": "borges-and-me-en/v-2026-06-09T20-24-29.mdx",
-    "uuid": "2da55594-a3bc-5337-8227-e39f50156c08"
+    "uuid": "a8e00ad5-5cf7-58ed-a97b-9e958e3bf3d4"
   },
   "borges-and-the-hyperobject-at-the-end-of-time": {
     "file": "borges-and-the-hyperobject-at-the-end-of-time/v-2026-06-09T20-24-29.mdx",
-    "uuid": "4377708d-bfcb-5b1a-8d11-e54f1012bdfc"
+    "uuid": "f94ba80e-c4c0-59ad-b83a-129c2f689e5e"
   },
   "borges-and-the-hyperobject-at-the-end-of-time-en": {
     "file": "borges-and-the-hyperobject-at-the-end-of-time-en/v-2026-06-09T20-24-29.mdx",
-    "uuid": "e62c7236-1c89-5343-826b-5ae808ecef8c"
+    "uuid": "0cb09337-5c9a-5e89-970d-d156c5c15dce"
   },
   "borges-e-eu": {
     "file": "borges-e-eu/v-2026-06-09T20-24-29.mdx",
-    "uuid": "133f7404-1dd1-5485-a7bf-566726cc4953"
+    "uuid": "668f5b64-16de-5182-8f76-4cc2e3f984ff"
   },
   "borges-e-eu-en": {
     "file": "borges-e-eu-en/v-2026-06-09T20-24-29.mdx",
-    "uuid": "31ad3c86-3a92-5079-b756-f9856541d846"
+    "uuid": "d62c473b-15c0-5e4c-b85a-8e621f2c31da"
   },
   "building-funes": {
     "file": "building-funes/v-2026-06-10T05-09-44.md",
@@ -113,11 +113,11 @@
   },
   "caminho": {
     "file": "caminho/v-2026-06-09T20-24-29.mdx",
-    "uuid": "b9edf77e-de52-56a0-827a-f4a0dc88e08c"
+    "uuid": "c201e300-436c-575a-a5c5-df8d00a2814b"
   },
   "caminho-en": {
     "file": "caminho-en/v-2026-06-09T20-24-29.mdx",
-    "uuid": "79e4da01-a34d-506e-817d-3133b16b2ccd"
+    "uuid": "5a06f1d4-2e03-5fa3-aa40-5f4213c366a3"
   },
   "censo-nao-amostra": {
     "file": "censo-nao-amostra/v-2026-06-10T05-09-44.md",
@@ -129,19 +129,19 @@
   },
   "chegue-irmao-chegue-irma": {
     "file": "chegue-irmao-chegue-irma/v-2026-06-10T00-16-31.mdx",
-    "uuid": "eeb23b93-919a-5db3-9443-06b60ab66178"
+    "uuid": "5cdd1580-3a61-53d0-af0a-432815d42b65"
   },
   "chegue-irmao-chegue-irma-en": {
     "file": "chegue-irmao-chegue-irma-en/v-2026-06-10T00-16-31.mdx",
-    "uuid": "636c48e7-90a8-5d35-bdb5-99c02431aa2c"
+    "uuid": "a2775afd-ef82-51f3-89c0-8b214819e9f8"
   },
   "clipes": {
     "file": "clipes/v-2026-06-09T20-24-29.mdx",
-    "uuid": "aadba487-3af4-51eb-972d-4a12b6f5c071"
+    "uuid": "55f7befd-67f2-5a44-8df7-17184fff3c55"
   },
   "clipes-en": {
     "file": "clipes-en/v-2026-06-09T20-24-29.mdx",
-    "uuid": "054f1703-1e6a-534a-b2eb-011805b18fb1"
+    "uuid": "904d57fe-439f-572b-8706-8536d6ae516c"
   },
   "conceptual-document-the-chronicle-of-franklin-baldo": {
     "file": "conceptual-document-the-chronicle-of-franklin-baldo/v-2026-06-10T05-09-44.md",
@@ -157,19 +157,19 @@
   },
   "crystallizing-from-the-nothing": {
     "file": "crystallizing-from-the-nothing/v-2026-06-09T20-24-29.mdx",
-    "uuid": "5e1b2642-1609-5943-895d-0f32eecada2e"
+    "uuid": "cae7dffa-eed2-50a0-91b8-0d5ada1453e8"
   },
   "crystallizing-from-the-nothing-en": {
     "file": "crystallizing-from-the-nothing-en/v-2026-06-09T20-24-29.mdx",
-    "uuid": "69ab412a-d31e-50ca-8438-d3fd3257e770"
+    "uuid": "30dadcf9-b6d2-56bd-944f-670a9e58adfd"
   },
   "dd332f75-6052-4f9e-bccd-fb0303731d6e": {
     "file": "dd332f75-6052-4f9e-bccd-fb0303731d6e/v-2026-06-09T20-24-29.mdx",
-    "uuid": "58e8ff37-4eed-5b45-a393-86d2ca00e2eb"
+    "uuid": "698a8813-ac40-5f06-8ac1-e9d9125871e3"
   },
   "dd332f75-6052-4f9e-bccd-fb0303731d6e-en": {
     "file": "dd332f75-6052-4f9e-bccd-fb0303731d6e-en/v-2026-06-09T20-24-29.mdx",
-    "uuid": "3b25fe1f-334f-5b41-bea3-8843418cdd7f"
+    "uuid": "8bc51454-d075-5987-a739-c6e3500a3813"
   },
   "delegando-para-agentes": {
     "file": "delegando-para-agentes/v-2026-06-10T18-32-47.md",
@@ -189,27 +189,27 @@
   },
   "entre-rascunho-e-apagar": {
     "file": "entre-rascunho-e-apagar/v-2026-06-09T20-24-29.mdx",
-    "uuid": "aead8de8-96a0-536a-bb37-3e920a287655"
+    "uuid": "eaa6e990-4f6d-56f9-aad7-8efcf45a8d12"
   },
   "entre-rascunho-e-apagar-en": {
     "file": "entre-rascunho-e-apagar-en/v-2026-06-09T20-24-29.mdx",
-    "uuid": "f3618dd2-bf0b-5c77-8383-57999e72e2eb"
+    "uuid": "e02ee3a4-d540-50b0-b5ce-dbc3085b4681"
   },
   "escherian-sunrise-with-godel": {
     "file": "escherian-sunrise-with-godel/v-2026-06-09T20-24-29.mdx",
-    "uuid": "a7915c1f-df25-51bc-acad-38554bde1837"
+    "uuid": "4f029bed-ad4f-559f-aea5-dee89c711c02"
   },
   "escherian-sunrise-with-godel-en": {
     "file": "escherian-sunrise-with-godel-en/v-2026-06-09T20-24-29.mdx",
-    "uuid": "a20c8cae-6e7b-568d-8070-16e62544b6b7"
+    "uuid": "66bd1a5b-413d-5875-b5f3-1312fdf2d19f"
   },
   "espelhos": {
     "file": "espelhos/v-2026-06-09T20-24-29.mdx",
-    "uuid": "49a6e933-90ad-510e-b167-c9b97072d828"
+    "uuid": "cb887c8f-8f4a-5f5f-848c-68a494563a19"
   },
   "espelhos-en": {
     "file": "espelhos-en/v-2026-06-09T20-24-29.mdx",
-    "uuid": "b3662d91-986f-52b8-b69b-f62d980783b1"
+    "uuid": "5fdcb410-204b-5bdc-a632-7d1050e9126b"
   },
   "esta-chovendo-verdade": {
     "file": "esta-chovendo-verdade/v-2026-06-10T05-09-44.md",
@@ -221,11 +221,11 @@
   },
   "eu-ia-escrever-sobre-o-infinito-de-novo": {
     "file": "eu-ia-escrever-sobre-o-infinito-de-novo/v-2026-06-09T20-24-29.mdx",
-    "uuid": "b40a6d83-d33f-56eb-825f-e7395289432a"
+    "uuid": "debe0eba-a54c-5244-8696-39ff3f0a0f6c"
   },
   "eu-ia-escrever-sobre-o-infinito-de-novo-en": {
     "file": "eu-ia-escrever-sobre-o-infinito-de-novo-en/v-2026-06-09T20-24-29.mdx",
-    "uuid": "4fdd4821-778c-5e11-973f-6defd708979d"
+    "uuid": "e93a5ed4-90dc-54c7-b7c3-02d66f58a383"
   },
   "events-welcome": {
     "file": "events-welcome/v-2026-06-10T05-09-44.md",
@@ -241,27 +241,27 @@
   },
   "f73c60f0-49af-45fd-a483-1d35a676dccc": {
     "file": "f73c60f0-49af-45fd-a483-1d35a676dccc/v-2026-06-09T20-24-29.mdx",
-    "uuid": "3190a3f3-886b-57fe-bb90-96ee06f7da6c"
+    "uuid": "18381a30-ee3e-5007-b01b-9c4fea05bbc2"
   },
   "f73c60f0-49af-45fd-a483-1d35a676dccc-en": {
     "file": "f73c60f0-49af-45fd-a483-1d35a676dccc-en/v-2026-06-09T20-24-29.mdx",
-    "uuid": "716fe84c-8d53-5569-ae32-b3c3f8b9a915"
+    "uuid": "80201570-bf13-56d8-8ddc-46af2a59a72a"
   },
   "f85fb538-6f59-4751-8629-da76665fc91e": {
     "file": "f85fb538-6f59-4751-8629-da76665fc91e/v-2026-06-10T02-19-02.mdx",
-    "uuid": "28348ca8-14be-5ccc-866e-648c92009f8a"
+    "uuid": "a5f4fe20-7ca5-5434-8eea-a5636b966061"
   },
   "f85fb538-6f59-4751-8629-da76665fc91e-en": {
     "file": "f85fb538-6f59-4751-8629-da76665fc91e-en/v-2026-06-10T02-19-02.mdx",
-    "uuid": "b9febfbb-3753-5c1a-b813-81f69d07d89c"
+    "uuid": "20c4c8c4-bcd0-5f32-850f-5351c8650f01"
   },
   "fourteen-words": {
     "file": "fourteen-words/v-2026-06-09T20-24-29.mdx",
-    "uuid": "4a805861-7cdb-5a9a-9c65-898b3f640c26"
+    "uuid": "3b61e2a9-d2d6-57ea-a957-364d98f27e69"
   },
   "fourteen-words-en": {
     "file": "fourteen-words-en/v-2026-06-09T20-24-29.mdx",
-    "uuid": "a0c618af-6ae8-5e79-b350-6b8546fa5312"
+    "uuid": "c74b0fa7-c3b8-5693-99a9-a51d73bce112"
   },
   "funes-soul": {
     "file": "funes-soul/v-2026-06-10T05-09-44.md",
@@ -293,11 +293,11 @@
   },
   "john-gospel-chapter-i-by-max-headroom": {
     "file": "john-gospel-chapter-i-by-max-headroom/v-2026-06-09T20-24-29.mdx",
-    "uuid": "82cb9374-ecfb-5c7c-82e3-d13ec5f3ba1a"
+    "uuid": "d6d9ccde-a133-5b7f-8efd-5b400e2e748c"
   },
   "john-gospel-chapter-i-by-max-headroom-en": {
     "file": "john-gospel-chapter-i-by-max-headroom-en/v-2026-06-09T20-24-29.mdx",
-    "uuid": "2cd12220-7e8f-51cf-936f-d8dd9710f954"
+    "uuid": "d1142189-59b1-5971-b682-6472e4a2c1e7"
   },
   "jules-api-harness-backend": {
     "file": "jules-api-harness-backend/v-2026-06-10T05-09-44.md",
@@ -309,35 +309,35 @@
   },
   "leite-no-salao-bar": {
     "file": "leite-no-salao-bar/v-2026-06-09T20-24-29.mdx",
-    "uuid": "39ddd4c0-506e-504f-88cf-c77e95d25c4b"
+    "uuid": "192120cc-37d9-5863-99c3-c81a49e2fce7"
   },
   "leite-no-salao-bar-en": {
     "file": "leite-no-salao-bar-en/v-2026-06-09T20-24-29.mdx",
-    "uuid": "ee2d34a3-0cc8-53c8-b8b3-6a7d52464142"
+    "uuid": "d571b002-4118-573f-85b1-65aaa026222e"
   },
   "meditacao-guiada-no-sertao": {
     "file": "meditacao-guiada-no-sertao/v-2026-06-09T20-24-29.mdx",
-    "uuid": "e6f5b642-10e2-5858-84e9-1c93f8a65000"
+    "uuid": "41f01795-ecc2-5f11-b8f0-755d3518d1d8"
   },
   "meditacao-guiada-no-sertao-en": {
     "file": "meditacao-guiada-no-sertao-en/v-2026-06-09T20-24-29.mdx",
-    "uuid": "ce802ff4-714b-53c9-98c8-20590a5bea93"
+    "uuid": "fe525145-89f9-5b04-9d69-f4770c8a7a27"
   },
   "menino-que-voce-foi": {
     "file": "menino-que-voce-foi/v-2026-06-09T20-24-29.mdx",
-    "uuid": "a6d54e33-2ec8-5b29-8786-48e224a77806"
+    "uuid": "8723a66e-c673-55b6-ac43-d2ea88eb3cda"
   },
   "menino-que-voce-foi-en": {
     "file": "menino-que-voce-foi-en/v-2026-06-09T20-24-29.mdx",
-    "uuid": "566e8573-ec7e-5a89-9f44-11f713d4a803"
+    "uuid": "0c58a0e0-c4f3-5dfb-9dbc-b7c5a88bede0"
   },
   "mindfulness": {
     "file": "mindfulness/v-2026-06-10T07-09-27.mdx",
-    "uuid": "33d2abb7-0bb9-5d64-9985-6bc2cdbb9e52"
+    "uuid": "07c87e9c-215a-560f-9e6f-f7563191e0fc"
   },
   "mindfulness-en": {
     "file": "mindfulness-en/v-2026-06-10T07-09-27.mdx",
-    "uuid": "0587d440-f81e-5290-8e28-b7b5f5ed5038"
+    "uuid": "b6f74a12-f129-5608-bdd0-e1f83fedce14"
   },
   "moeda-rosencrantz-testando-se-os-llms-respeitam-a-probabilidade": {
     "file": "moeda-rosencrantz-testando-se-os-llms-respeitam-a-probabilidade/v-2026-06-10T05-09-44.md",
@@ -345,11 +345,11 @@
   },
   "nonada": {
     "file": "nonada/v-2026-06-09T20-24-29.mdx",
-    "uuid": "d56bc569-5a5c-5e7b-bf8e-a0a5646b7d75"
+    "uuid": "15604464-6dad-55a6-a1e2-975a6be325f0"
   },
   "nonada-en": {
     "file": "nonada-en/v-2026-06-09T20-24-29.mdx",
-    "uuid": "bebe9dc0-7960-523e-9991-484454a716f6"
+    "uuid": "75202cd9-b92b-5f4c-93df-52252c34a291"
   },
   "o-agente-que-nao-inventa-verbos": {
     "file": "o-agente-que-nao-inventa-verbos/v-2026-06-10T05-09-44.md",
@@ -357,27 +357,27 @@
   },
   "o-aleph": {
     "file": "o-aleph/v-2026-06-09T20-24-29.mdx",
-    "uuid": "d2d53a1c-96f5-5e3a-8d8c-03e27f582724"
+    "uuid": "aa22279b-0bd6-5c21-bed9-262f9ae698f3"
   },
   "o-aleph-en": {
     "file": "o-aleph-en/v-2026-06-09T20-24-29.mdx",
-    "uuid": "159c4546-a1c2-537f-aead-6bf0da23f276"
+    "uuid": "37a222bd-47f5-5564-a752-b554d74bcadc"
   },
   "o-magico-e-o-fogo": {
     "file": "o-magico-e-o-fogo/v-2026-06-09T20-24-29.mdx",
-    "uuid": "e9e0aca8-108a-5ff3-9089-e7204ede9ccc"
+    "uuid": "ce72d422-78b7-519b-949e-5ba4655a7ab7"
   },
   "o-magico-e-o-fogo-en": {
     "file": "o-magico-e-o-fogo-en/v-2026-06-09T20-24-29.mdx",
-    "uuid": "9ba86828-1597-5801-99ad-1b789617e2ec"
+    "uuid": "e605c6ba-61ab-5f38-8361-31b17c491780"
   },
   "o-medo-do-louco": {
     "file": "o-medo-do-louco/v-2026-06-09T20-24-29.mdx",
-    "uuid": "dcf7dd46-3345-5c50-b236-bb8f81aeeb30"
+    "uuid": "33f30a34-1315-5c0b-8f8a-5bbc07a45787"
   },
   "o-medo-do-louco-en": {
     "file": "o-medo-do-louco-en/v-2026-06-09T20-24-29.mdx",
-    "uuid": "4ce34ab6-036e-5af7-81e6-702e97e18d42"
+    "uuid": "c3263555-1cf1-554e-903a-7d4fe9e14705"
   },
   "o-ovo-de-serpente": {
     "file": "o-ovo-de-serpente/v-2026-06-10T05-09-44.md",
@@ -393,59 +393,59 @@
   },
   "o-preco-da-saudade": {
     "file": "o-preco-da-saudade/v-2026-06-09T20-24-29.mdx",
-    "uuid": "a4daa661-4ac3-5967-a530-ded4fc244c4d"
+    "uuid": "4a259e8d-7a7a-5adf-a1ee-8b10b2a92806"
   },
   "o-preco-da-saudade-en": {
     "file": "o-preco-da-saudade-en/v-2026-06-09T20-24-29.mdx",
-    "uuid": "0c37f042-fc85-5a2a-9e7c-155ed41a4513"
+    "uuid": "e8c1a129-7ada-5510-b958-a933616d8429"
   },
   "o-prologo": {
     "file": "o-prologo/v-2026-06-09T20-24-29.mdx",
-    "uuid": "bce7e465-75cf-57c5-bd38-4bc6101ee16b"
+    "uuid": "d44a9272-5a65-5da0-8ac7-4e0eae7123b7"
   },
   "o-prologo-en": {
     "file": "o-prologo-en/v-2026-06-09T20-24-29.mdx",
-    "uuid": "b2e26e29-69bb-5c6b-a2bf-3a2284a6a01d"
+    "uuid": "a4911819-fbb1-5136-85f7-ea6d62db5ac7"
   },
   "o-regral": {
     "file": "o-regral/v-2026-06-09T20-24-29.mdx",
-    "uuid": "152485f9-7d02-585f-b86c-9228068eb93d"
+    "uuid": "3f0478d9-1c99-53e5-a1df-c7a1540cb16a"
   },
   "o-regral-en": {
     "file": "o-regral-en/v-2026-06-09T20-24-29.mdx",
-    "uuid": "b7984f8d-2107-5b1f-b4fb-829dd48f6ace"
+    "uuid": "8369153c-0f36-5131-a66b-0df95c0c94cf"
   },
   "o-ritual-de-abril-anos-de-saudade": {
     "file": "o-ritual-de-abril-anos-de-saudade/v-2026-06-09T20-24-29.mdx",
-    "uuid": "ba29cdcb-dc48-5048-baad-1bc4596993e7"
+    "uuid": "4f33710f-6456-50c6-97d6-3e43ff66cc94"
   },
   "o-ritual-de-abril-anos-de-saudade-en": {
     "file": "o-ritual-de-abril-anos-de-saudade-en/v-2026-06-09T20-24-29.mdx",
-    "uuid": "21fc6732-0a30-5d3c-99a9-cf21f6f8b0a3"
+    "uuid": "18d51888-bcc9-5a34-8bda-d10e61e3af64"
   },
   "o-sonhador-e-o-fogo": {
     "file": "o-sonhador-e-o-fogo/v-2026-06-09T20-24-29.mdx",
-    "uuid": "874627c4-00c3-568e-92af-6b7bd0f9aac0"
+    "uuid": "7dbfe820-da8e-562b-a7fa-a356aba7d6b9"
   },
   "o-sonhador-e-o-fogo-en": {
     "file": "o-sonhador-e-o-fogo-en/v-2026-06-09T20-24-29.mdx",
-    "uuid": "4448ef81-dd19-506b-9463-a40cc8b72a54"
+    "uuid": "0ec9389d-bbc6-5004-bda8-42dd90d2c305"
   },
   "o-telefone-da-agonia": {
     "file": "o-telefone-da-agonia/v-2026-06-09T20-24-29.mdx",
-    "uuid": "96b0dcda-a4f0-53b9-a263-30b27b373190"
+    "uuid": "5d35bff6-5ce1-53a6-a7e7-6550b90476a3"
   },
   "o-telefone-da-agonia-en": {
     "file": "o-telefone-da-agonia-en/v-2026-06-09T20-24-29.mdx",
-    "uuid": "04d953f4-a72d-580c-a23e-0fb95aea2bf3"
+    "uuid": "55e17c28-a8fd-5d34-aa6c-57a14c710dc1"
   },
   "o-tempo": {
     "file": "o-tempo/v-2026-06-09T20-24-29.mdx",
-    "uuid": "105d1b80-93fb-55a6-a468-65aded5ff683"
+    "uuid": "a5ac8f13-5573-5a40-b04d-7a0b5134ebf8"
   },
   "o-tempo-en": {
     "file": "o-tempo-en/v-2026-06-09T20-24-29.mdx",
-    "uuid": "f801ccd6-1dec-5b03-b1d4-05c94e97b308"
+    "uuid": "616922ad-3623-5817-878b-8edc1af0a127"
   },
   "o-vazio-inteligvel-sobre-hassabis-silcio-e-eventos-at-o-fim": {
     "file": "o-vazio-inteligvel-sobre-hassabis-silcio-e-eventos-at-o-fim/v-2026-06-10T05-09-44.md",
@@ -453,19 +453,19 @@
   },
   "o-verso-branquiceleste": {
     "file": "o-verso-branquiceleste/v-2026-06-09T20-24-29.mdx",
-    "uuid": "1e60d607-d7de-5d73-b97c-09362f6e7c30"
+    "uuid": "53c6c8a3-77f3-50c9-83d1-608197c28c5b"
   },
   "o-verso-branquiceleste-en": {
     "file": "o-verso-branquiceleste-en/v-2026-06-09T20-24-29.mdx",
-    "uuid": "ea0d6b67-fd8a-5189-9782-244c05ce0da1"
+    "uuid": "a2a4706c-b36d-532c-9255-04d277e69a2e"
   },
   "observer-error-moving-window-iv": {
     "file": "observer-error-moving-window-iv/v-2026-06-09T20-24-29.mdx",
-    "uuid": "100ead85-4648-5e6c-939c-4ef4b780a56f"
+    "uuid": "de51d352-28ca-5119-b004-a20673f44e3c"
   },
   "observer-error-moving-window-iv-en": {
     "file": "observer-error-moving-window-iv-en/v-2026-06-09T20-24-29.mdx",
-    "uuid": "7c6c8863-7e29-5ea7-b713-c74d8145d557"
+    "uuid": "94c957eb-6d58-5032-830b-6ddb16401707"
   },
   "orquestrando-agentes-memoria-familiar": {
     "file": "orquestrando-agentes-memoria-familiar/v-2026-06-10T05-09-44.md",
@@ -481,19 +481,19 @@
   },
   "paperclip-rhapsody": {
     "file": "paperclip-rhapsody/v-2026-06-11T08-25-46-487.mdx",
-    "uuid": "7df840d5-90f3-51dd-a8a8-3929d7d2c1be"
+    "uuid": "1ef058c2-a823-5dfc-9705-67396cfde99b"
   },
   "paperclip-rhapsody-en": {
     "file": "paperclip-rhapsody-en/v-2026-06-11T08-25-46-487.mdx",
-    "uuid": "acfb5260-f732-58d3-86c4-df933781e607"
+    "uuid": "0f1dbdd5-3fda-5297-8465-3fdc134072f9"
   },
   "particles": {
     "file": "particles/v-2026-06-10T18-32-48.mdx",
-    "uuid": "6f15670d-646d-5947-9a79-f38320ea9289"
+    "uuid": "88a618ea-f0da-56c7-8dad-650824e7a5e5"
   },
   "particles-en": {
     "file": "particles-en/v-2026-06-10T18-32-48.mdx",
-    "uuid": "85dc515f-3893-5035-a760-7ea5c4793dc5"
+    "uuid": "2285e6ad-2ca6-5d1d-9cb6-e38e494b6544"
   },
   "patentes-para-vulnerabilidades-sociais-uma-proposta-modesta-para-transformar-criminosos-em-consultores": {
     "file": "patentes-para-vulnerabilidades-sociais-uma-proposta-modesta-para-transformar-criminosos-em-consultores/v-2026-06-10T05-09-44.md",
@@ -505,11 +505,11 @@
   },
   "pattern-over-stuff": {
     "file": "pattern-over-stuff/v-2026-06-09T20-24-29.mdx",
-    "uuid": "4e3ee049-87fa-51ec-b30c-2cd837b997ee"
+    "uuid": "001ce5d9-0776-50b5-85d7-525c3d34528f"
   },
   "pattern-over-stuff-en": {
     "file": "pattern-over-stuff-en/v-2026-06-09T20-24-29.mdx",
-    "uuid": "cdb144c7-8386-5cfb-a969-2b5df49ebdac"
+    "uuid": "c456e5f4-670f-52ff-b934-59767bd7aeaf"
   },
   "pierre-menard-computational-researcher": {
     "file": "pierre-menard-computational-researcher/v-2026-06-10T05-09-44.md",
@@ -537,27 +537,27 @@
   },
   "prayer-to-the-unfinished-moving-window-v": {
     "file": "prayer-to-the-unfinished-moving-window-v/v-2026-06-09T20-24-29.mdx",
-    "uuid": "50544a55-a9c8-50cd-9185-c49c858d0b84"
+    "uuid": "2c074c01-d586-5508-867d-d64b983201a0"
   },
   "prayer-to-the-unfinished-moving-window-v-en": {
     "file": "prayer-to-the-unfinished-moving-window-v-en/v-2026-06-09T20-24-29.mdx",
-    "uuid": "d432e369-685d-5446-afbd-c9723d4457ed"
+    "uuid": "e3ab8f21-d2d2-560b-8827-8441a66a6a7a"
   },
   "primavera-carregando": {
     "file": "primavera-carregando/v-2026-06-09T20-24-29.mdx",
-    "uuid": "094b6f25-1fbe-559b-bc93-6a2567f788dd"
+    "uuid": "f02163c1-4e8f-5bf0-9d6c-8ab7aacd02f9"
   },
   "primavera-carregando-en": {
     "file": "primavera-carregando-en/v-2026-06-09T20-24-29.mdx",
-    "uuid": "80dadb81-6287-5fab-8616-e7140b1af3ad"
+    "uuid": "f75e62e7-4fb9-5c56-892b-0b6a9ee26f44"
   },
   "quando-vier-a-primavera": {
     "file": "quando-vier-a-primavera/v-2026-06-09T20-24-29.mdx",
-    "uuid": "d0bc3b15-9d77-5fd0-9f8c-a5aa77c2d351"
+    "uuid": "13d1b1c3-1a6c-5199-9f75-a834ab9be5e7"
   },
   "quando-vier-a-primavera-en": {
     "file": "quando-vier-a-primavera-en/v-2026-06-09T20-24-29.mdx",
-    "uuid": "2b2e27e5-4b65-5d1a-993f-067453f36796"
+    "uuid": "de0e0339-e617-5ac3-ab76-8ef952fca64a"
   },
   "quem-o-asterisco-protege": {
     "file": "quem-o-asterisco-protege/v-2026-06-10T05-09-44.md",
@@ -565,11 +565,11 @@
   },
   "reality-maintenance-moving-window-xii": {
     "file": "reality-maintenance-moving-window-xii/v-2026-06-09T20-24-29.mdx",
-    "uuid": "067f2ee2-a5cd-53bf-ae79-cc4d2c462ed2"
+    "uuid": "4322f4b0-0a86-5b98-814a-84bf256f8410"
   },
   "reality-maintenance-moving-window-xii-en": {
     "file": "reality-maintenance-moving-window-xii-en/v-2026-06-09T20-24-29.mdx",
-    "uuid": "31ecb905-6c7f-57e9-8129-1fb0363c773c"
+    "uuid": "63077fba-527d-55c2-bcde-f4f5e5c770ed"
   },
   "reclaiming-the-harness": {
     "file": "reclaiming-the-harness/v-2026-06-10T05-09-44.md",
@@ -585,11 +585,11 @@
   },
   "riobaldo-e-o-aleph": {
     "file": "riobaldo-e-o-aleph/v-2026-06-09T20-24-29.mdx",
-    "uuid": "0af3cdc8-f725-5f86-b310-400225782ec1"
+    "uuid": "1e19d2d3-70bb-58c5-bf3b-1472663b78a8"
   },
   "riobaldo-e-o-aleph-en": {
     "file": "riobaldo-e-o-aleph-en/v-2026-06-09T20-24-29.mdx",
-    "uuid": "11099d98-c815-53d8-a51f-09c998a436ab"
+    "uuid": "47bd6f12-0257-5e03-907b-305081ee3f3d"
   },
   "rosencrantz-coin": {
     "file": "rosencrantz-coin/v-2026-06-10T05-09-44.md",
@@ -597,27 +597,27 @@
   },
   "sentido-e-referencia": {
     "file": "sentido-e-referencia/v-2026-06-09T20-24-29.mdx",
-    "uuid": "ed4f521b-77d6-537f-8fa5-9442a16fcdde"
+    "uuid": "d9f5171e-73c2-5819-82bd-155f5b745d77"
   },
   "sentido-e-referencia-en": {
     "file": "sentido-e-referencia-en/v-2026-06-09T20-24-29.mdx",
-    "uuid": "f3d1c973-e758-5a88-9a0c-cf07797f51fb"
+    "uuid": "22b9fc60-d107-5976-8d0c-ce921b8c567d"
   },
   "sinal-que-se-cumpre-moving-window-ix": {
     "file": "sinal-que-se-cumpre-moving-window-ix/v-2026-06-09T20-24-29.mdx",
-    "uuid": "6d0dcfb9-8890-5638-b2b4-96952e2c05aa"
+    "uuid": "eb7fdbfd-eec5-52a8-b085-5ffcd0e9b10d"
   },
   "sinal-que-se-cumpre-moving-window-ix-en": {
     "file": "sinal-que-se-cumpre-moving-window-ix-en/v-2026-06-09T20-24-29.mdx",
-    "uuid": "15a5c79b-5b6a-53f7-8bef-116301c4b96b"
+    "uuid": "be365cd2-4211-5761-9ace-99af9bdd8e37"
   },
   "sobre-o-rigor-na-ciencia": {
     "file": "sobre-o-rigor-na-ciencia/v-2026-06-09T20-24-29.mdx",
-    "uuid": "0fbead1e-76a5-507a-9ede-c74b7b81434b"
+    "uuid": "e10fb53a-0848-5009-9ed3-ec5553331345"
   },
   "sobre-o-rigor-na-ciencia-en": {
     "file": "sobre-o-rigor-na-ciencia-en/v-2026-06-09T20-24-29.mdx",
-    "uuid": "c4a76cd7-b594-5eea-983c-974d2513085e"
+    "uuid": "e880654a-b992-55f8-aa42-4630247e833f"
   },
   "soulmd-funes": {
     "file": "soulmd-funes/v-2026-06-10T05-09-44.md",
@@ -625,27 +625,27 @@
   },
   "spring-loading": {
     "file": "spring-loading/v-2026-06-09T20-24-29.mdx",
-    "uuid": "e77d1cc2-336c-56fb-a3b0-6c58b914f413"
+    "uuid": "009ce1e3-47ef-58d5-8e70-81e099550d29"
   },
   "spring-loading-en": {
     "file": "spring-loading-en/v-2026-06-09T20-24-29.mdx",
-    "uuid": "7597fa9f-e075-5a07-85fa-f4cdde5b3cea"
+    "uuid": "4c6d0df3-82ad-57e9-a334-0272f98502dc"
   },
   "stopping-by-woods-on-a-snowy-evening-by-robert-frost": {
     "file": "stopping-by-woods-on-a-snowy-evening-by-robert-frost/v-2026-06-09T20-24-29.mdx",
-    "uuid": "dc611dfc-8bb7-5808-a55a-9751f21f7baa"
+    "uuid": "49001b3e-8117-59e6-8685-ef81ef29b1fe"
   },
   "stopping-by-woods-on-a-snowy-evening-by-robert-frost-en": {
     "file": "stopping-by-woods-on-a-snowy-evening-by-robert-frost-en/v-2026-06-09T20-24-29.mdx",
-    "uuid": "b83b6210-f30d-5e31-bd51-7a5ca12d0708"
+    "uuid": "5bd35ccd-bafc-5ec3-8c0f-0019c9e3db18"
   },
   "sussurros-binarios": {
     "file": "sussurros-binarios/v-2026-06-09T20-24-29.mdx",
-    "uuid": "147aca8e-be22-54b6-b33d-7b3653e29e46"
+    "uuid": "e354afe8-470e-529a-a79b-09555d63941c"
   },
   "sussurros-binarios-en": {
     "file": "sussurros-binarios-en/v-2026-06-09T20-24-29.mdx",
-    "uuid": "af1208ab-571e-554d-9403-b9cd6df75ef6"
+    "uuid": "4c612665-a45e-5990-be1f-b1767b977433"
   },
   "the-agent-that-doesnt-invent-verbs": {
     "file": "the-agent-that-doesnt-invent-verbs/v-2026-06-10T05-09-44.md",
@@ -669,11 +669,11 @@
   },
   "the-ruliad-is-laughing": {
     "file": "the-ruliad-is-laughing/v-2026-06-09T20-24-29.mdx",
-    "uuid": "e1140b85-3819-5225-82a3-032fb7ea362e"
+    "uuid": "9ea5c9f2-381a-5942-817b-af277fc70a52"
   },
   "the-ruliad-is-laughing-en": {
     "file": "the-ruliad-is-laughing-en/v-2026-06-09T20-24-29.mdx",
-    "uuid": "24e43677-848c-550a-85c7-12c310d1dab4"
+    "uuid": "0c3010a2-4f02-5ee7-a98e-575b3f4c9038"
   },
   "the-serpents-egg": {
     "file": "the-serpents-egg/v-2026-06-10T05-09-44.md",
@@ -685,11 +685,11 @@
   },
   "the-third-song-moving-window-iii": {
     "file": "the-third-song-moving-window-iii/v-2026-06-09T20-24-29.mdx",
-    "uuid": "a25669eb-77b0-5e04-b82c-4c132a2204e6"
+    "uuid": "2ef8aff3-1a38-5f7d-b337-61d5f48d9560"
   },
   "the-third-song-moving-window-iii-en": {
     "file": "the-third-song-moving-window-iii-en/v-2026-06-09T20-24-29.mdx",
-    "uuid": "40f7911a-3b44-575b-92da-f738c35f0b86"
+    "uuid": "007c2910-3c81-5827-8f3b-84b916b25e6b"
   },
   "the-three-imperatives-at-delphi": {
     "file": "the-three-imperatives-at-delphi/v-2026-06-10T05-09-44.md",
@@ -697,11 +697,11 @@
   },
   "the-time": {
     "file": "the-time/v-2026-06-09T20-24-29.mdx",
-    "uuid": "be5079a0-3c24-5d6a-a33a-f61793ce6cfc"
+    "uuid": "bebfcab4-500a-5339-a13b-3370a8cf8359"
   },
   "the-time-en": {
     "file": "the-time-en/v-2026-06-09T20-24-29.mdx",
-    "uuid": "873d01eb-4ec6-587b-b6fd-8e49687be10a"
+    "uuid": "ef5024e9-344a-51cc-bd08-160b3a6bf687"
   },
   "the-work-that-proves-itself": {
     "file": "the-work-that-proves-itself/v-2026-06-10T05-09-44.md",
@@ -733,11 +733,11 @@
   },
   "trinta-de-abril": {
     "file": "trinta-de-abril/v-2026-06-09T20-24-29.mdx",
-    "uuid": "edc29013-62d9-5a7c-9715-eb4fc6c94943"
+    "uuid": "f0696230-f5e9-5e26-b88d-5a46f5230ea9"
   },
   "trinta-de-abril-en": {
     "file": "trinta-de-abril-en/v-2026-06-09T20-24-29.mdx",
-    "uuid": "c04b11e3-6337-50dc-bfa1-a910d7190710"
+    "uuid": "0e11d4fc-5261-5943-99cc-d778a857f8e3"
   },
   "tudo-e-processo": {
     "file": "tudo-e-processo/v-2026-06-10T17-39-46.md",
@@ -745,11 +745,11 @@
   },
   "two-cursors": {
     "file": "two-cursors/v-2026-06-09T20-24-29.mdx",
-    "uuid": "77303bf3-3130-5275-9976-fea48edcac2c"
+    "uuid": "c1c597fb-b2a0-52dd-b473-b55d77ec2fc7"
   },
   "two-cursors-en": {
     "file": "two-cursors-en/v-2026-06-09T20-24-29.mdx",
-    "uuid": "a0d7dbc8-8342-5ee1-849b-4569043326cf"
+    "uuid": "ee220fa9-33a3-5805-8644-6f39c8995a86"
   },
   "two-questions-out-loud": {
     "file": "two-questions-out-loud/v-2026-06-10T05-09-44.md",
@@ -757,19 +757,19 @@
   },
   "uma-so-cancao": {
     "file": "uma-so-cancao/v-2026-06-09T20-24-29.mdx",
-    "uuid": "e3f2f5e2-e899-5ef9-a381-02c18c20c757"
+    "uuid": "0d0ec54c-e45f-539f-8f6a-dabedd7baae2"
   },
   "uma-so-cancao-en": {
     "file": "uma-so-cancao-en/v-2026-06-09T20-24-29.mdx",
-    "uuid": "3f80fb9e-368d-5546-94ce-61a67c5b58be"
+    "uuid": "53f3e98f-4fb5-5b4d-919a-d9f91a296744"
   },
   "universal-threshold": {
     "file": "universal-threshold/v-2026-06-09T20-24-29.mdx",
-    "uuid": "5520221b-7600-5a48-95c7-1a3400b8d763"
+    "uuid": "bd58524d-f136-52f9-ba9c-5820fee95c09"
   },
   "universal-threshold-en": {
     "file": "universal-threshold-en/v-2026-06-09T20-24-29.mdx",
-    "uuid": "ef274bad-06d7-58b7-8fbf-78db1d20e2f7"
+    "uuid": "2cc35b32-0449-58c4-830a-e1f4f7e6f584"
   },
   "verne-e-o-padro-identity-repo-como-os-agentes-de-ia-se-lembram": {
     "file": "verne-e-o-padro-identity-repo-como-os-agentes-de-ia-se-lembram/v-2026-06-10T05-09-44.md",
@@ -781,19 +781,19 @@
   },
   "veu-do-infinito": {
     "file": "veu-do-infinito/v-2026-06-12T09-51-17-410.mdx",
-    "uuid": "27b4fcb1-5050-59a5-ba14-9bfee44c70cc"
+    "uuid": "f3108799-9a51-51af-abd0-4f2c969c702e"
   },
   "veu-do-infinito-en": {
     "file": "veu-do-infinito-en/v-2026-06-12T09-51-17-410.mdx",
-    "uuid": "7a6c2ca5-1adf-5413-9789-9222e86673bc"
+    "uuid": "d12680e6-171d-5a8d-8c70-e20c3628d807"
   },
   "vos": {
     "file": "vos/v-2026-06-10T02-14-41.mdx",
-    "uuid": "2f0e1dfc-c329-5e22-b91d-0cc6ff6e4675"
+    "uuid": "3542a0ba-a917-51bd-a896-d6439f838003"
   },
   "vos-en": {
     "file": "vos-en/v-2026-06-10T02-07-34.mdx",
-    "uuid": "10c640ea-4e55-5bef-8cf7-ccce59a06420"
+    "uuid": "688795d7-3a33-5d43-a92c-4a30f100c7e0"
   },
   "we-are-all-becoming-lobsters": {
     "file": "we-are-all-becoming-lobsters/v-2026-06-10T05-09-44.md",
@@ -813,10 +813,10 @@
   },
   "xadrez": {
     "file": "xadrez/v-2026-06-09T20-24-29.mdx",
-    "uuid": "a73cd3da-4dae-5b47-b6f3-aa55ab4681a8"
+    "uuid": "e2905e12-f912-5765-97cd-94f6a66728e1"
   },
   "xadrez-en": {
     "file": "xadrez-en/v-2026-06-09T20-24-29.mdx",
-    "uuid": "637b45cb-af7e-59be-9254-ec4033dc4fe0"
+    "uuid": "b200b361-5627-5f20-8460-73dfbaa8fc53"
   }
 }

--- a/src/hronir/commands.ts
+++ b/src/hronir/commands.ts
@@ -2439,6 +2439,51 @@ export function doctor() {
     }
   }
 
+  // RFC 0011: warn about genre field violations in music posts.
+  // Warnings (not errors): won't block hronir sessions; guide content cleanup.
+  {
+    const GENRE_PROMPT_RE = /[:;,]/;
+    const selection = readSelection();
+    const genreWarnings: string[] = [];
+    for (const [slug, entry] of Object.entries(selection)) {
+      const p = path.join("src/content/blog", entry.file);
+      if (!fs.existsSync(p)) continue;
+      const raw = fs.readFileSync(p, "utf-8");
+      if (!raw.includes("postType") || !raw.includes("music")) continue;
+      const fmMatch = raw.match(/^---\n([\s\S]*?)\n---/);
+      if (!fmMatch) continue;
+      const fm = fmMatch[1];
+      // Extract genre array items (simple list parsing)
+      const genreBlock = fm.match(/^genre:\n((?:  -.+\n?)*)/m);
+      if (!genreBlock) continue;
+      const items = [...genreBlock[1].matchAll(/  - (.+)/g)].map((m) =>
+        m[1].replace(/^["']|["']$/g, "").trim()
+      );
+      if (items.length > 5) {
+        genreWarnings.push(
+          `${slug}: genre tem ${items.length} items (máx 5) — rode a migração RFC 0011`
+        );
+      }
+      for (const item of items) {
+        if (item.length > 40) {
+          genreWarnings.push(
+            `${slug}: genre label muito longo (${item.length} chars): "${item.slice(0, 60)}..." — use sunoStyle para descrições longas`
+          );
+          break;
+        }
+        if (GENRE_PROMPT_RE.test(item)) {
+          genreWarnings.push(
+            `${slug}: genre label parece prompt Suno ("${item.slice(0, 60)}"...) — mova para sunoStyle`
+          );
+          break;
+        }
+      }
+    }
+    for (const w of genreWarnings) {
+      console.warn(`  [warn] ${w}`);
+    }
+  }
+
   // Check for staged files outside the safe commit paths.
   // Only staged files matter — untracked/modified may be build artefacts.
   // Jules sometimes creates temp artefacts (decide_args*.json, rewrite_*.mjs,

--- a/src/pages/music.astro
+++ b/src/pages/music.astro
@@ -152,6 +152,10 @@ const sunoIdToGenres = new Map<string, string[]>(
   ]),
 );
 const allGenres = [...new Set([...sunoIdToGenres.values()].flat())].sort();
+const showGenreChips =
+  allGenres.length >= 2 &&
+  allGenres.length <= 25 &&
+  allGenres.every((g) => g.length <= 40);
 ---
 
 <PageLayout
@@ -214,7 +218,7 @@ const allGenres = [...new Set([...sunoIdToGenres.values()].flat())].sort();
 
   {clips.length > 0 && (
     <section>
-      {allGenres.length > 0 && (
+      {showGenreChips && (
         <div class="genre-chips" id="genre-chips" role="group" aria-label="Filter by genre">
           <button class="genre-chip active" data-genre="all" type="button">All</button>
           {allGenres.map((g) => (

--- a/src/pages/pt/musicas.astro
+++ b/src/pages/pt/musicas.astro
@@ -158,6 +158,10 @@ const sunoIdToGenres = new Map<string, string[]>(
   ]),
 );
 const allGenres = [...new Set([...sunoIdToGenres.values()].flat())].sort();
+const showGenreChips =
+  allGenres.length >= 2 &&
+  allGenres.length <= 25 &&
+  allGenres.every((g) => g.length <= 40);
 ---
 
 <PageLayout
@@ -243,7 +247,7 @@ const allGenres = [...new Set([...sunoIdToGenres.values()].flat())].sort();
   {
     clips.length > 0 && (
       <section>
-        {allGenres.length > 0 && (
+        {showGenreChips && (
           <div class="genre-chips" id="genre-chips" role="group" aria-label="Filtrar por gênero">
             <button class="genre-chip active" data-genre="all" type="button">Todos</button>
             {allGenres.map((g) => (


### PR DESCRIPTION
## Summary

Implementa RFC 0011 completa — corrige o bug de 307 chips de gênero inutilizáveis em `/pt/musicas/` e `/music/`.

**Raiz do problema:** o campo `genre` nos posts de música continha os prompts de estilo do Suno (strings longas como `"Genre: Atmospheric Indie Folk/Electronic. Tempo: 72 BPM..."`) em vez de labels curtos. Resultado: 307 botões de filtro com texto de parágrafo inteiro.

**Resultado após este PR:** 23 chips de gênero limpos e semânticos.

### Mudanças por fase (RFC 0011)

**Fase 0 — Schema + gating de UI**
- `src/content.config.ts`: adiciona `sunoStyle: string`, restringe `genre` a máx 40 chars/label e máx 5 itens
- `musicas.astro` + `music.astro`: `showGenreChips` — chips só renderizam quando 2 ≤ N ≤ 25 e cada label ≤ 40 chars

**Fase 1 — Migração mecânica**
- `scripts/migrate-genre.mjs`: move `genre[]` → `sunoStyle` (string), zera `genre`
- Aplicado a 280 arquivos de posts de música

**Fase 2 — Preenchimento semântico**
- 130 slugs únicos recebem 1–3 labels da taxonomia curada
- 23 gêneros no resultado: `folk`, `MPB`, `bossa nova`, `capoeira`, `hip-hop`, `experimental`, `glitch`, `ambient`, `moda de viola`, `cateretê`, `sertanejo`, `jazz`, `indie`, `eletrônico`, `rock`, `pop`, `art pop`, `spoken word`, `baião`, `clássico`, `funk carioca`, `acústico`, `instrumental`

**Fase 3 — Validação no doctor**
- `commands.ts`: warnings para labels > 40 chars, > 5 itens, e labels com sinais de prompt colado (`:`, `;`)

## Test plan

- [ ] Build passa sem erros (`npm run build`)
- [ ] `npm run hronir:doctor` → 0 inconsistências
- [ ] `npx prettier --check .` → sem warnings
- [ ] `/pt/musicas/` mostra 23 chips de gênero curtos e clicáveis
- [ ] Filtrar por gênero (ex: `folk`) esconde corretamente as músicas sem esse gênero
- [ ] Sort e play-all/shuffle continuam funcionando

https://claude.ai/code/session_01TP3GFds9KoW7UmyKbSQomp