### PR TITLE
perf(images): lazy loading para imagens em posts markdown

### DIFF
--- a/.routines/2026-06-14T05-00-00-lazy-images-perf.md
+++ b/.routines/2026-06-14T05-00-00-lazy-images-perf.md
@@ -1,0 +1,41 @@
+---
+date: 2026-06-14T05:00:00
+slug: lazy-images-perf
+branch: claude/sleepy-pasteur-caw01l
+status: pr-open
+issues: [492]
+pr_opened: null
+pr_merged: null
+---
+
+## Contexto ao chegar
+
+Run autônoma de 2026-06-14. PR #497 (`ux(print): CSS completo para impressão de ensaios`, fecha #246) estava fechado como merged (`2026-06-13T06:05:08Z`) — sem PR de rotina pendente para mergear.
+
+Backlog com 10 issues `routine` abertas — dentro da faixa 10–20. Nenhuma reposição necessária.
+
+Issues `priority:media` abertas: #493 (scroll spy TOC), #492 (lazy loading), #248 (reading path Memory and Funes), #243 (Goodreads rail), #242 (reading path Direito e IA).
+
+## O que fiz
+
+Implementei issue **#492 — perf: lazy loading de imagens em posts**.
+
+Auditoria mostrou:
+- Hero images e music covers em `src/pages/blog/[...slug].astro` já usam o `<Image>` do Astro com `loading="eager"` — corretos, não afetados.
+- Imagens renderizadas do corpo markdown (sintaxe `![alt](src)`) não tinham `loading` — eram `<img>` sem atributo, carregando todas no load inicial.
+
+Solução: rehype plugin inline `rehypeLazyImages` adicionado a `astro.config.mjs`, no bloco `markdown.rehypePlugins`, após `rehypeWrapTables`. O plugin percorre a hast tree recursivamente e injeta `loading="lazy"` em todo elemento `img` sem atributo `loading` já definido.
+
+A abordagem é zero-dependency (sem novo pacote), preserva `loading="eager"` onde explicitamente definido, e não tem impacto visual algum — só muda o comportamento de carregamento.
+
+Checks locais:
+- `npm run build`: 2417 páginas, 0 erros ✓
+- `npx astro check`: 0 errors ✓
+- `npx prettier --check .`: All matched files use Prettier code style ✓
+- Verificação no HTML gerado: hero images mantêm `loading="eager"`; imagens de conteúdo recebem `loading="lazy"` ✓
+
+## O que ficou para a próxima run
+
+- Mergear este PR se CI verde e sem comentário bloqueante de Franklin.
+- Continuar com issues de prioridade média: #493 (scroll spy TOC), #248, #243, #242.
+- Não há screenshot de prod a verificar desta run — mudança é de atributo HTML, sem impacto visual.

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -68,6 +68,26 @@ import { remarkGitModified } from "./src/lib/remark-git-modified.mjs";
 import { remarkHasMath } from "./src/lib/remark-has-math.mjs";
 import { rehypeWrapTables } from "./src/lib/rehype-wrap-tables.mjs";
 
+/** Adds loading="lazy" to all img elements rendered from markdown. */
+function rehypeLazyImages() {
+  /** @param {any} tree */
+  return function (tree) {
+    /** @param {any} node */
+    function visit(node) {
+      if (node.type === "element" && node.tagName === "img") {
+        node.properties ??= {};
+        if (!node.properties.loading) {
+          node.properties.loading = "lazy";
+        }
+      }
+      if (Array.isArray(node.children)) {
+        node.children.forEach(visit);
+      }
+    }
+    visit(tree);
+  };
+}
+
 // https://astro.build/config
 export default defineConfig({
   site: "https://franklinbaldo.github.io",
@@ -190,6 +210,7 @@ export default defineConfig({
         },
       ],
       rehypeWrapTables,
+      rehypeLazyImages,
     ],
   },
 });

--- a/src/generated/ranking-snapshot.json
+++ b/src/generated/ranking-snapshot.json
@@ -1,9 +1,9 @@
 {
   "_meta": {
     "schema": "snapshot-v2",
-    "generatedAt": "2026-06-13T21:49:24.596Z",
+    "generatedAt": "2026-06-14T05:06:34.551Z",
     "basis": "build",
-    "totalDuels": 490
+    "totalDuels": 571
   },
   "keys": {
     "pontifex-research": {
@@ -30,461 +30,461 @@
       "elo": 1054,
       "eloPeak": 1092
     },
-    "future-father": {
+    "music-eu-ia-escrever-sobre-o-infinito-de-novo": {
       "rank": 5,
+      "ordinal": 8.1433,
+      "elo": 1074,
+      "eloPeak": 1074
+    },
+    "future-father": {
+      "rank": 6,
       "ordinal": 8.0682,
       "elo": 1049,
       "eloPeak": 1103
     },
     "intelligible-void": {
-      "rank": 6,
+      "rank": 7,
       "ordinal": 8.0353,
       "elo": 1044,
       "eloPeak": 1044
     },
     "family-memory": {
-      "rank": 7,
+      "rank": 8,
       "ordinal": 7.9805,
       "elo": 1086,
       "eloPeak": 1086
     },
-    "music-trinta-de-abril": {
-      "rank": 8,
-      "ordinal": 7.9424,
-      "elo": 1092,
-      "eloPeak": 1092
+    "music-nonada": {
+      "rank": 9,
+      "ordinal": 7.8343,
+      "elo": 1085,
+      "eloPeak": 1085
     },
     "three-hammers": {
-      "rank": 9,
+      "rank": 10,
       "ordinal": 7.5398,
       "elo": 1043,
       "eloPeak": 1053
     },
     "crossing-interference": {
-      "rank": 10,
+      "rank": 11,
       "ordinal": 7.4549,
       "elo": 1034,
       "eloPeak": 1034
     },
-    "third-half-fourth-wall": {
-      "rank": 11,
-      "ordinal": 7.3062,
-      "elo": 1064,
-      "eloPeak": 1064
+    "asterisk-protects": {
+      "rank": 12,
+      "ordinal": 7.3433,
+      "elo": 1070,
+      "eloPeak": 1087
     },
     "reddit-submarine-osint": {
-      "rank": 12,
+      "rank": 13,
       "ordinal": 7.2988,
       "elo": 1059,
       "eloPeak": 1099
     },
-    "music-eu-ia-escrever-sobre-o-infinito-de-novo": {
-      "rank": 13,
-      "ordinal": 7.2906,
-      "elo": 1058,
-      "eloPeak": 1064
-    },
-    "music-pattern-over-stuff": {
+    "music-trinta-de-abril": {
       "rank": 14,
-      "ordinal": 6.9592,
-      "elo": 1054,
-      "eloPeak": 1058
+      "ordinal": 6.8874,
+      "elo": 1055,
+      "eloPeak": 1092
     },
-    "asterisk-protects": {
+    "music-the-third-song-moving-window-iii": {
       "rank": 15,
-      "ordinal": 6.9304,
-      "elo": 1073,
-      "eloPeak": 1073
+      "ordinal": 6.781,
+      "elo": 1043,
+      "eloPeak": 1044
+    },
+    "music-666": {
+      "rank": 16,
+      "ordinal": 6.6747,
+      "elo": 1044,
+      "eloPeak": 1044
     },
     "two-questions-out-loud": {
-      "rank": 16,
+      "rank": 17,
       "ordinal": 6.6393,
       "elo": 1027,
       "eloPeak": 1036
     },
+    "music-pattern-over-stuff": {
+      "rank": 18,
+      "ordinal": 6.594,
+      "elo": 1038,
+      "eloPeak": 1058
+    },
+    "music-o-telefone-da-agonia": {
+      "rank": 19,
+      "ordinal": 6.4601,
+      "elo": 1080,
+      "eloPeak": 1081
+    },
+    "music-a-primeira-mudanca": {
+      "rank": 20,
+      "ordinal": 6.219,
+      "elo": 1067,
+      "eloPeak": 1067
+    },
     "music-quando-vier-a-primavera": {
-      "rank": 17,
+      "rank": 21,
       "ordinal": 6.1433,
       "elo": 1020,
       "eloPeak": 1046
     },
-    "music-spring-loading": {
-      "rank": 18,
-      "ordinal": 6.0434,
-      "elo": 1047,
+    "music-john-gospel-chapter-i-by-max-headroom": {
+      "rank": 22,
+      "ordinal": 6.0156,
+      "elo": 1034,
       "eloPeak": 1047
     },
+    "third-half-fourth-wall": {
+      "rank": 23,
+      "ordinal": 5.9876,
+      "elo": 1043,
+      "eloPeak": 1064
+    },
     "its-raining-truth": {
-      "rank": 19,
+      "rank": 24,
       "ordinal": 5.9805,
       "elo": 1014,
       "eloPeak": 1057
     },
+    "music-beatriz": {
+      "rank": 25,
+      "ordinal": 5.7925,
+      "elo": 1039,
+      "eloPeak": 1060
+    },
     "serpents-egg": {
-      "rank": 20,
+      "rank": 26,
       "ordinal": 5.7151,
       "elo": 1017,
       "eloPeak": 1035
     },
     "verne-identity-repo": {
-      "rank": 21,
+      "rank": 27,
       "ordinal": 5.6448,
       "elo": 1006,
       "eloPeak": 1026
     },
-    "music-a-primeira-mudanca": {
-      "rank": 22,
-      "ordinal": 5.5643,
-      "elo": 1051,
-      "eloPeak": 1053
+    "music-sinal-que-se-cumpre-moving-window-ix": {
+      "rank": 28,
+      "ordinal": 5.6129,
+      "elo": 1047,
+      "eloPeak": 1066
     },
-    "music-nonada": {
-      "rank": 23,
-      "ordinal": 5.4129,
-      "elo": 1039,
-      "eloPeak": 1056
+    "music-uma-so-cancao": {
+      "rank": 29,
+      "ordinal": 5.3939,
+      "elo": 1027,
+      "eloPeak": 1044
+    },
+    "music-borges-and-me": {
+      "rank": 30,
+      "ordinal": 5.1038,
+      "elo": 1046,
+      "eloPeak": 1071
     },
     "agent-no-verbs": {
-      "rank": 24,
+      "rank": 31,
       "ordinal": 5.0746,
       "elo": 962,
       "eloPeak": 1018
     },
     "delegating-to-agents": {
-      "rank": 25,
+      "rank": 32,
       "ordinal": 5.0009,
       "elo": 986,
       "eloPeak": 1009
     },
-    "music-john-gospel-chapter-i-by-max-headroom": {
-      "rank": 26,
-      "ordinal": 4.7537,
-      "elo": 1014,
-      "eloPeak": 1047
+    "music-xadrez": {
+      "rank": 33,
+      "ordinal": 4.8964,
+      "elo": 1033,
+      "eloPeak": 1033
+    },
+    "music-reality-maintenance-moving-window-xii": {
+      "rank": 34,
+      "ordinal": 4.779,
+      "elo": 1006,
+      "eloPeak": 1040
     },
     "funes-soul": {
-      "rank": 27,
+      "rank": 35,
       "ordinal": 4.7324,
       "elo": 1018,
       "eloPeak": 1018
     },
-    "music-o-telefone-da-agonia": {
-      "rank": 28,
-      "ordinal": 4.6688,
-      "elo": 1050,
-      "eloPeak": 1050
-    },
-    "music-borges-and-me": {
-      "rank": 29,
-      "ordinal": 4.6136,
-      "elo": 1062,
-      "eloPeak": 1071
-    },
-    "music-beatriz": {
-      "rank": 30,
-      "ordinal": 4.5327,
-      "elo": 1039,
-      "eloPeak": 1060
+    "music-spring-loading": {
+      "rank": 36,
+      "ordinal": 4.4265,
+      "elo": 1003,
+      "eloPeak": 1047
     },
     "music-caminho": {
-      "rank": 31,
-      "ordinal": 4.4473,
-      "elo": 1032,
-      "eloPeak": 1032
+      "rank": 37,
+      "ordinal": 4.4188,
+      "elo": 1029,
+      "eloPeak": 1048
     },
-    "music-reality-maintenance-moving-window-xii": {
-      "rank": 32,
-      "ordinal": 4.4167,
-      "elo": 1020,
-      "eloPeak": 1040
+    "music-primavera-carregando": {
+      "rank": 38,
+      "ordinal": 4.3325,
+      "elo": 1031,
+      "eloPeak": 1031
     },
     "music-fourteen-words": {
-      "rank": 33,
+      "rank": 39,
       "ordinal": 4.1719,
       "elo": 1028,
       "eloPeak": 1028
     },
-    "music-crystallizing-from-the-nothing": {
-      "rank": 34,
-      "ordinal": 4.0471,
-      "elo": 1008,
-      "eloPeak": 1008
-    },
     "census-not-sample": {
-      "rank": 35,
+      "rank": 40,
       "ordinal": 4.0397,
       "elo": 1019,
       "eloPeak": 1034
     },
     "social-vulnerabilities": {
-      "rank": 36,
+      "rank": 41,
       "ordinal": 4.0306,
       "elo": 984,
       "eloPeak": 1000
     },
-    "music-sinal-que-se-cumpre-moving-window-ix": {
-      "rank": 37,
-      "ordinal": 3.7109,
-      "elo": 1022,
-      "eloPeak": 1022
-    },
-    "music-observer-error-moving-window-iv": {
-      "rank": 38,
-      "ordinal": 3.6031,
-      "elo": 1041,
-      "eloPeak": 1041
-    },
-    "music-the-third-song-moving-window-iii": {
-      "rank": 39,
-      "ordinal": 3.3746,
-      "elo": 1015,
-      "eloPeak": 1016
+    "music-the-time": {
+      "rank": 42,
+      "ordinal": 3.9723,
+      "elo": 1024,
+      "eloPeak": 1024
     },
     "music-chegue-irmao-chegue-irma": {
-      "rank": 40,
-      "ordinal": 3.3571,
-      "elo": 1027,
+      "rank": 43,
+      "ordinal": 3.564,
+      "elo": 1038,
+      "eloPeak": 1056
+    },
+    "music-o-aleph": {
+      "rank": 44,
+      "ordinal": 3.5287,
+      "elo": 1003,
+      "eloPeak": 1003
+    },
+    "music-46336b97-4306-41bc-8a7b-48f0ebebbd29": {
+      "rank": 45,
+      "ordinal": 3.4467,
+      "elo": 1007,
+      "eloPeak": 1048
+    },
+    "music-o-magico-e-o-fogo": {
+      "rank": 46,
+      "ordinal": 3.4335,
+      "elo": 1005,
       "eloPeak": 1031
     },
-    "music-666": {
-      "rank": 41,
-      "ordinal": 3.3284,
-      "elo": 1013,
-      "eloPeak": 1031
+    "music-sobre-o-rigor-na-ciencia": {
+      "rank": 47,
+      "ordinal": 3.4126,
+      "elo": 1022,
+      "eloPeak": 1039
+    },
+    "music-o-preco-da-saudade": {
+      "rank": 48,
+      "ordinal": 3.3839,
+      "elo": 999,
+      "eloPeak": 1018
     },
     "conceptual-document": {
-      "rank": 42,
+      "rank": 49,
       "ordinal": 3.281,
       "elo": 982,
       "eloPeak": 1059
     },
-    "music-o-prologo": {
-      "rank": 43,
-      "ordinal": 2.9542,
-      "elo": 1007,
+    "music-crystallizing-from-the-nothing": {
+      "rank": 50,
+      "ordinal": 3.262,
+      "elo": 994,
+      "eloPeak": 1008
+    },
+    "music-escherian-sunrise-with-godel": {
+      "rank": 51,
+      "ordinal": 3.0888,
+      "elo": 1045,
+      "eloPeak": 1064
+    },
+    "music-two-cursors": {
+      "rank": 52,
+      "ordinal": 2.9862,
+      "elo": 1014,
+      "eloPeak": 1014
+    },
+    "music-o-medo-do-louco": {
+      "rank": 53,
+      "ordinal": 2.9589,
+      "elo": 984,
       "eloPeak": 1031
     },
     "music-meditacao-guiada-no-sertao": {
-      "rank": 44,
+      "rank": 54,
       "ordinal": 2.8929,
       "elo": 991,
       "eloPeak": 1057
     },
     "jules-api-harness": {
-      "rank": 45,
+      "rank": 55,
       "ordinal": 2.8239,
       "elo": 1000,
       "eloPeak": 1001
     },
-    "music-particles": {
-      "rank": 46,
-      "ordinal": 2.7387,
-      "elo": 1042,
-      "eloPeak": 1074
+    "music-o-prologo": {
+      "rank": 56,
+      "ordinal": 2.6875,
+      "elo": 990,
+      "eloPeak": 1031
     },
-    "music-two-cursors": {
-      "rank": 47,
-      "ordinal": 2.5113,
+    "building-funes": {
+      "rank": 57,
+      "ordinal": 2.5086,
+      "elo": 1018,
+      "eloPeak": 1018
+    },
+    "music-clipes": {
+      "rank": 58,
+      "ordinal": 2.4973,
       "elo": 997,
       "eloPeak": 1000
     },
-    "music-riobaldo-e-o-aleph": {
-      "rank": 48,
-      "ordinal": 2.4151,
-      "elo": 991,
-      "eloPeak": 1031
+    "music-o-ritual-de-abril-anos-de-saudade": {
+      "rank": 59,
+      "ordinal": 2.4378,
+      "elo": 1007,
+      "eloPeak": 1023
     },
-    "music-46336b97-4306-41bc-8a7b-48f0ebebbd29": {
-      "rank": 49,
-      "ordinal": 2.3835,
-      "elo": 1029,
-      "eloPeak": 1048
+    "music-151474c5-1420-4cc1-9ab5-80721f4459ed": {
+      "rank": 60,
+      "ordinal": 2.1619,
+      "elo": 1035,
+      "eloPeak": 1035
     },
-    "music-vos": {
-      "rank": 50,
-      "ordinal": 2.3469,
+    "music-borges-and-the-hyperobject-at-the-end-of-time": {
+      "rank": 61,
+      "ordinal": 1.9356,
+      "elo": 988,
+      "eloPeak": 1000
+    },
+    "music-particles": {
+      "rank": 62,
+      "ordinal": 1.9119,
       "elo": 1010,
-      "eloPeak": 1046
-    },
-    "music-sobre-o-rigor-na-ciencia": {
-      "rank": 51,
-      "ordinal": 2.1959,
-      "elo": 1021,
-      "eloPeak": 1037
+      "eloPeak": 1074
     },
     "rosencrantz-coin": {
-      "rank": 52,
+      "rank": 63,
       "ordinal": 1.9086,
       "elo": 948,
       "eloPeak": 1000
     },
-    "music-xadrez": {
-      "rank": 53,
-      "ordinal": 1.8252,
-      "elo": 1002,
-      "eloPeak": 1016
+    "music-riobaldo-e-o-aleph": {
+      "rank": 64,
+      "ordinal": 1.7908,
+      "elo": 977,
+      "eloPeak": 1031
     },
     "music-be-me-borges": {
-      "rank": 54,
-      "ordinal": 1.8039,
-      "elo": 1000,
+      "rank": 65,
+      "ordinal": 1.7446,
+      "elo": 1004,
       "eloPeak": 1033
     },
-    "music-belief-engine-labyrinth-song-moving-window-viii": {
-      "rank": 55,
-      "ordinal": 1.7691,
-      "elo": 968,
-      "eloPeak": 1000
-    },
-    "music-escherian-sunrise-with-godel": {
-      "rank": 56,
-      "ordinal": 1.7496,
-      "elo": 1034,
-      "eloPeak": 1034
-    },
     "music-espelhos": {
-      "rank": 57,
+      "rank": 66,
       "ordinal": 1.6897,
       "elo": 994,
       "eloPeak": 1031
     },
     "reclaiming-harness": {
-      "rank": 58,
+      "rank": 67,
       "ordinal": 1.6533,
       "elo": 983,
       "eloPeak": 1019
     },
-    "music-f73c60f0-49af-45fd-a483-1d35a676dccc": {
-      "rank": 59,
-      "ordinal": 1.6086,
-      "elo": 1001,
-      "eloPeak": 1016
+    "music-observer-error-moving-window-iv": {
+      "rank": 68,
+      "ordinal": 1.6518,
+      "elo": 994,
+      "eloPeak": 1041
     },
-    "music-o-aleph": {
-      "rank": 60,
-      "ordinal": 1.443,
-      "elo": 972,
-      "eloPeak": 1000
-    },
-    "music-primavera-carregando": {
-      "rank": 61,
-      "ordinal": 1.4357,
-      "elo": 999,
-      "eloPeak": 1019
-    },
-    "building-funes": {
-      "rank": 62,
-      "ordinal": 1.4234,
-      "elo": 1000,
-      "eloPeak": 1017
-    },
-    "music-uma-so-cancao": {
-      "rank": 63,
-      "ordinal": 1.328,
-      "elo": 1000,
-      "eloPeak": 1032
+    "music-stopping-by-woods-on-a-snowy-evening-by-robert-frost": {
+      "rank": 69,
+      "ordinal": 1.279,
+      "elo": 954,
+      "eloPeak": 1003
     },
     "music-f85fb538-6f59-4751-8629-da76665fc91e": {
-      "rank": 64,
+      "rank": 70,
       "ordinal": 1.2716,
       "elo": 978,
       "eloPeak": 1000
     },
+    "music-o-verso-branquiceleste": {
+      "rank": 71,
+      "ordinal": 1.2329,
+      "elo": 983,
+      "eloPeak": 1002
+    },
     "pontifex-guide": {
-      "rank": 65,
+      "rank": 72,
       "ordinal": 1.182,
       "elo": 955,
       "eloPeak": 1044
     },
-    "music-the-ruliad-is-laughing": {
-      "rank": 66,
-      "ordinal": 1.1481,
-      "elo": 973,
-      "eloPeak": 1000
-    },
-    "music-o-medo-do-louco": {
-      "rank": 67,
-      "ordinal": 0.9088,
-      "elo": 963,
-      "eloPeak": 1031
-    },
-    "music-151474c5-1420-4cc1-9ab5-80721f4459ed": {
-      "rank": 68,
-      "ordinal": 0.7922,
-      "elo": 1003,
-      "eloPeak": 1003
-    },
-    "music-o-preco-da-saudade": {
-      "rank": 69,
-      "ordinal": 0.7907,
-      "elo": 986,
-      "eloPeak": 1016
-    },
     "music-veu-do-infinito": {
-      "rank": 70,
+      "rank": 73,
       "ordinal": 0.7839,
       "elo": 998,
       "eloPeak": 1016
     },
-    "music-o-tempo": {
-      "rank": 71,
-      "ordinal": 0.532,
-      "elo": 979,
-      "eloPeak": 1030
+    "music-vos": {
+      "rank": 74,
+      "ordinal": 0.7376,
+      "elo": 965,
+      "eloPeak": 1046
     },
     "music-paperclip-rhapsody": {
-      "rank": 72,
+      "rank": 75,
       "ordinal": 0.529,
       "elo": 966,
       "eloPeak": 1031
     },
-    "music-o-ritual-de-abril-anos-de-saudade": {
-      "rank": 73,
-      "ordinal": 0.5107,
-      "elo": 992,
-      "eloPeak": 1006
-    },
-    "music-o-verso-branquiceleste": {
-      "rank": 74,
-      "ordinal": 0.5034,
-      "elo": 985,
-      "eloPeak": 1002
-    },
-    "music-the-time": {
-      "rank": 75,
-      "ordinal": 0.3659,
-      "elo": 992,
-      "eloPeak": 1000
-    },
-    "music-bibliotecario-do-infinito": {
+    "music-belief-engine-labyrinth-song-moving-window-viii": {
       "rank": 76,
-      "ordinal": 0.1544,
-      "elo": 970,
+      "ordinal": 0.2017,
+      "elo": 945,
       "eloPeak": 1000
     },
-    "music-o-magico-e-o-fogo": {
+    "music-the-ruliad-is-laughing": {
       "rank": 77,
-      "ordinal": 0.1202,
-      "elo": 975,
-      "eloPeak": 1031
+      "ordinal": -0.0938,
+      "elo": 930,
+      "eloPeak": 1000
     },
-    "music-sentido-e-referencia": {
+    "music-leite-no-salao-bar": {
       "rank": 78,
-      "ordinal": 0.0238,
-      "elo": 1001,
-      "eloPeak": 1019
+      "ordinal": -0.1202,
+      "elo": 965,
+      "eloPeak": 1016
+    },
+    "music-o-tempo": {
+      "rank": 79,
+      "ordinal": -0.2614,
+      "elo": 944,
+      "eloPeak": 1030
     },
     "music-dd332f75-6052-4f9e-bccd-fb0303731d6e": {
-      "rank": 79,
-      "ordinal": -0.1469,
-      "elo": 995,
-      "eloPeak": 1031
-    },
-    "music-borges-e-eu": {
       "rank": 80,
-      "ordinal": -0.3576,
-      "elo": 974,
-      "eloPeak": 1000
+      "ordinal": -0.342,
+      "elo": 989,
+      "eloPeak": 1031
     },
     "inaugural-post": {
       "rank": 81,
@@ -492,94 +492,94 @@
       "elo": 923,
       "eloPeak": 1001
     },
-    "music-borges-and-the-hyperobject-at-the-end-of-time": {
+    "music-sentido-e-referencia": {
       "rank": 82,
-      "ordinal": -0.4937,
-      "elo": 957,
-      "eloPeak": 1000
+      "ordinal": -0.5807,
+      "elo": 969,
+      "eloPeak": 1019
     },
-    "music-leite-no-salao-bar": {
+    "music-f73c60f0-49af-45fd-a483-1d35a676dccc": {
       "rank": 83,
-      "ordinal": -0.5109,
-      "elo": 984,
+      "ordinal": -0.9188,
+      "elo": 954,
       "eloPeak": 1016
     },
-    "music-stopping-by-woods-on-a-snowy-evening-by-robert-frost": {
+    "music-entre-rascunho-e-apagar": {
       "rank": 84,
-      "ordinal": -0.5258,
-      "elo": 968,
-      "eloPeak": 1003
-    },
-    "music-clipes": {
-      "rank": 85,
-      "ordinal": -0.6708,
-      "elo": 964,
-      "eloPeak": 1000
+      "ordinal": -1.1195,
+      "elo": 926,
+      "eloPeak": 1004
     },
     "music-o-regral": {
-      "rank": 86,
+      "rank": 85,
       "ordinal": -1.2211,
       "elo": 940,
       "eloPeak": 1000
     },
     "travessia-project": {
-      "rank": 87,
+      "rank": 86,
       "ordinal": -1.253,
       "elo": 907,
       "eloPeak": 1000
     },
-    "music-o-sonhador-e-o-fogo": {
+    "music-bibliotecario-do-infinito": {
+      "rank": 87,
+      "ordinal": -1.2553,
+      "elo": 926,
+      "eloPeak": 1000
+    },
+    "music-mindfulness": {
       "rank": 88,
+      "ordinal": -1.3619,
+      "elo": 972,
+      "eloPeak": 1016
+    },
+    "music-sussurros-binarios": {
+      "rank": 89,
+      "ordinal": -1.3851,
+      "elo": 911,
+      "eloPeak": 1000
+    },
+    "music-o-sonhador-e-o-fogo": {
+      "rank": 90,
       "ordinal": -1.613,
       "elo": 959,
       "eloPeak": 1000
     },
-    "music-entre-rascunho-e-apagar": {
-      "rank": 89,
-      "ordinal": -1.753,
-      "elo": 921,
-      "eloPeak": 1004
+    "music-universal-threshold": {
+      "rank": 91,
+      "ordinal": -1.6859,
+      "elo": 940,
+      "eloPeak": 1016
     },
     "becoming-lobsters": {
-      "rank": 90,
+      "rank": 92,
       "ordinal": -1.8362,
       "elo": 923,
       "eloPeak": 1029
     },
-    "music-universal-threshold": {
-      "rank": 91,
-      "ordinal": -2.0395,
-      "elo": 936,
-      "eloPeak": 1016
+    "music-menino-que-voce-foi": {
+      "rank": 93,
+      "ordinal": -2.5962,
+      "elo": 944,
+      "eloPeak": 1000
     },
-    "music-mindfulness": {
-      "rank": 92,
-      "ordinal": -2.0424,
-      "elo": 955,
-      "eloPeak": 1016
+    "music-borges-e-eu": {
+      "rank": 94,
+      "ordinal": -2.6229,
+      "elo": 946,
+      "eloPeak": 1000
     },
     "pampa-circuit": {
-      "rank": 93,
+      "rank": 95,
       "ordinal": -2.9115,
       "elo": 914,
       "eloPeak": 1002
     },
     "music-prayer-to-the-unfinished-moving-window-v": {
-      "rank": 94,
-      "ordinal": -3.3786,
-      "elo": 909,
-      "eloPeak": 1000
-    },
-    "music-menino-que-voce-foi": {
-      "rank": 95,
-      "ordinal": -3.4455,
-      "elo": 928,
-      "eloPeak": 1000
-    },
-    "music-sussurros-binarios": {
       "rank": 96,
-      "ordinal": -4.3876,
-      "elo": 894,
+      "ordinal": -3.8185,
+      "elo": 892,
       "eloPeak": 1000
     },
     "everything-is-process": {


### PR DESCRIPTION
Closes #492

## perf

- Adiciona rehype plugin inline `rehypeLazyImages` a `astro.config.mjs`, na lista `markdown.rehypePlugins` (após `rehypeWrapTables`)
- O plugin percorre a hast tree recursivamente e injeta `loading="lazy"` em todo `<img>` sem atributo `loading` já definido
- Hero images e music covers — renderizados via `<Image loading="eager">` do Astro diretamente no template — **não são afetados**: vivem fora da árvore markdown e já têm `loading="eager"` explícito
- Implementação zero-dependency: sem novo pacote, sem import extra

### Por que importa

Posts com imagens no corpo (gráficos, screenshots) carregam todas as imagens de uma vez no load inicial. Com `loading="lazy"`, imagens abaixo do fold só são baixadas quando o usuário se aproxima delas — reduz payload inicial e melhora LCP.

### Verificação local

- `npm run build`: 2417 páginas, 0 erros ✓
- `npx astro check`: 0 errors ✓
- `npx prettier --check .`: all matched files ✓
- HTML gerado: hero images mantêm `loading="eager"`; imagens de conteúdo recebem `loading="lazy"` ✓

Mudança é de atributo HTML sem impacto visual — não há screenshot de prod a conferir.

---

_Rotina autônoma — janela de veto de 24h. A próxima run mergeia este PR se não houver comentário bloqueante._

https://claude.ai/code/session_01MTBtePk4ad7m2b1Jj5Q2CV

---
_Generated by [Claude Code](https://claude.ai/code/session_01MTBtePk4ad7m2b1Jj5Q2CV)_