### PR TITLE
chore(hronir): desativa Jules — substituído por outro agente

### DIFF
--- a/.github/workflows/hronir-autopilot.yml
+++ b/.github/workflows/hronir-autopilot.yml
@@ -139,11 +139,13 @@ jobs:
           echo "Merged PR #$PR."
           echo "merged=$PR" >> "$GITHUB_OUTPUT"
 
-      - name: Respawn session after merge
-        if: steps.merge.outputs.merged != ''
-        env:
-          JULES_API_KEY: ${{ secrets.JULES_API_KEY }}
-        run: |
-          set -euo pipefail
-          echo "Spawning replacement session for merged PR #${{ steps.merge.outputs.merged }}..."
-          bash scripts/hronir/spawn-session.sh
+      # Respawn disabled — Jules substituído por outro agente.
+      # Para reativar: descomentar o step abaixo e restaurar JULES_API_KEY.
+      # - name: Respawn session after merge
+      #   if: steps.merge.outputs.merged != ''
+      #   env:
+      #     JULES_API_KEY: ${{ secrets.JULES_API_KEY }}
+      #   run: |
+      #     set -euo pipefail
+      #     echo "Spawning replacement session..."
+      #     bash scripts/hronir/spawn-session.sh

--- a/.github/workflows/hronir-heartbeat.yml
+++ b/.github/workflows/hronir-heartbeat.yml
@@ -15,14 +15,18 @@ name: Hrönir Heartbeat
 # The autopilot (hronir-autopilot.yml) also spawns one session after each merge.
 # Between the two, the pool stays full continuously.
 
+# Heartbeat desabilitado — Jules substituído por outro agente.
+# Para reativar: restaurar o bloco `on:` original abaixo.
+# on:
+#   schedule:
+#     - cron: "*/15 * * * *"
+#   workflow_dispatch:
+#   push:
+#     branches:
+#       - claude/lucid-goodall-3t7aqc
+#       - claude/vibrant-albattani-znjq7z
 on:
-  schedule:
-    - cron: "*/15 * * * *" # every 15 minutes
   workflow_dispatch:
-  push:
-    branches:
-      - claude/lucid-goodall-3t7aqc
-      - claude/vibrant-albattani-znjq7z
 
 permissions:
   contents: read


### PR DESCRIPTION
Desativa o Jules como avaliador do Hrönir para dar lugar a outro agente.

## Mudanças

**`hronir-heartbeat.yml`** — remove os triggers automáticos:
- Remove `schedule` (cron `*/15 * * * *`) — heartbeat não vai mais disparar a cada 15 min
- Remove `push` triggers das branches Claude
- Mantém apenas `workflow_dispatch` para poder rodar manualmente se necessário

**`hronir-autopilot.yml`** — desativa o respawn:
- Comenta o step `Respawn session after merge`
- O autopilot continua funcionando normalmente para mergear PRs de sessões que ainda estejam abertas
- Não vai spawnar sessões Jules novas

## Para reativar Jules

Descomentar os blocos indicados nos dois arquivos e restaurar o secret `JULES_API_KEY`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018ftJQohVjMvL5xLULL1iCd

---
_Generated by [Claude Code](https://claude.ai/code/session_018ftJQohVjMvL5xLULL1iCd)_