### PR TITLE
content(paths): expande trilha memory-and-funes com 4 posts novos

### DIFF
--- a/.routines/2026-06-17T05-15-23-content-paths-memory-funes.md
+++ b/.routines/2026-06-17T05-15-23-content-paths-memory-funes.md
@@ -1,0 +1,61 @@
+---
+date: 2026-06-17T05:15:23
+slug: content-paths-memory-funes
+branch: claude/sleepy-pasteur-fofktw
+status: pr-open
+issues: [248]
+pr_opened: null
+pr_merged: null
+---
+
+## Contexto ao chegar
+
+Main no commit c0412d1 (Merge PR #578: desativa Jules). Últimos commits: maioria de sessões Jules (hronir) e dois fixes relevantes — restauração de 70 rate files deletados (PR #574) e desativação do Jules (PR #578).
+
+12 issues abertas com label `routine` — backlog saudável (faixa 10–20, sem necessidade de criar ou congelar).
+
+## O que mergeou
+
+Nada mergeado nesta run — PR #564 (seo: trim meta descriptions) estava com CI vermelho em duas frentes.
+
+**Diagnóstico e fix de PR #564:**
+
+1. **`check:translations` falhava**: a run anterior editou `a-api-do-jules-como-backend-do-harness/v-2026-06-10T05-09-44.md` (PT) e `reddit-submarine-osint/v-2026-06-10T05-09-44.md` (EN) sem atualizar os respectivos pares de idioma. Fix: atualizei as descriptions dos dois posts parceiros para dentro da faixa 130–160 chars.
+
+2. **`hronir:doctor` falhava após o fix**: o UUID em `versions-selected.json` é SHA1 do conteúdo do arquivo. Ao editar as descriptions, o UUID mudou, e o doctor detectou a divergência. Fix: rodei `npm run hronir:select` no branch do PR para regenerar os UUIDs corretos.
+
+PR #564 agora tem dois commits adicionais e CI está em andamento. A próxima run deverá mergear (se CI verde).
+
+## O que fiz nesta run
+
+**Issue #248: expande trilha memory-and-funes com posts 2026**
+
+Antes: 3 posts EN (building-funes, funes-soul, pierre-menard-computational-researcher), 2 posts PT (sem paridade — faltavam os pares PT de building-funes e funes-soul, e a trilha não refletia o corpus atual).
+
+Após auditoria dos posts com temas de memória, arquivo, identidade e Funes:
+- `verne-identity-repo` / `verne-e-o-padro-identity-repo-como-os-agentes-de-ia-se-lembram` (2026-03-18) — padrão identity-repo: como agentes mantêm identidade independente do motor cognitivo. Fit excelente com o tema.
+- `what-i-learned-orchestrating-ai-agents-to-preserve-family-memory` / `orquestrando-agentes-memoria-familiar` (2026-03-30) — preservação de memória familiar com agentes. O post PT já estava na trilha; o EN estava ausente.
+- `construindo-funes-como-dei-uma-alma-a-um-agente-de-ia` e `soulmd-funes` — pares PT de posts EN já na trilha.
+
+Ordem de leitura agora vai do mais conceitual (construir Funes, SOUL.md) ao mais arquitetural (identity-repo) ao mais concreto/pessoal (memória familiar, Pierre Menard).
+
+Blurb atualizado para refletir o escopo ampliado.
+
+Build local: 1944 páginas, astro check: 0 erros. Prettier: OK. hronir:doctor: 0 inconsistências.
+
+PR aberto para esta run — aguardando review de Franklin (janela de 24h).
+
+## Issues descobertos
+
+Dois issues de "já implementado" encontrados durante triagem:
+- **#550 (series nav)**: `SeriesContext.astro` com variant `nav` já está implementado e integrado em `[...slug].astro:282`. Issue pode ser fechado.
+- **#493 (TOC scroll spy)**: `TableOfContents.astro` já tem IntersectionObserver completo com `toc-active` CSS. Issue pode ser fechado.
+
+Franklin pode querer fechar #550 e #493 manualmente para limpar o backlog.
+
+## Próxima run
+
+- Mergear PR desta run (se CI verde)
+- Mergear PR #564 (SEO descriptions) se CI passou finalmente
+- Verificar prod pós-deploy de #564 (snippets de description no HTML)
+- Trabalho: próxima issue de priority:media — #243 (goodreads books) ou issue baixa

--- a/src/lib/paths.ts
+++ b/src/lib/paths.ts
@@ -33,8 +33,8 @@ export const READING_PATHS: ReadingPath[] = [
       pt: "Memória e Funes",
     },
     blurb: {
-      en: "On total recall, Pierre Menard, and what Borges saw before anyone else about the cost of perfect memory.",
-      pt: "Sobre lembrança total, Pierre Menard, e o que Borges enxergou antes de todos sobre o custo da memória perfeita.",
+      en: "On total recall, Pierre Menard, and what Borges saw before anyone else. From building Funes to preserving family voices: the cost of perfect memory and the architecture that makes it survivable.",
+      pt: "Sobre lembrança total, Pierre Menard, e o que Borges viu antes de todos. De construir Funes a preservar vozes da família: o custo da memória perfeita e a arquitetura que a torna suportável.",
     },
     source: {
       type: "manual",
@@ -42,11 +42,16 @@ export const READING_PATHS: ReadingPath[] = [
         en: [
           "building-funes",
           "funes-soul",
+          "verne-identity-repo",
+          "what-i-learned-orchestrating-ai-agents-to-preserve-family-memory",
           "pierre-menard-computational-researcher",
         ],
         pt: [
-          "pierre-menard-pesquisador-computacional",
+          "construindo-funes-como-dei-uma-alma-a-um-agente-de-ia",
+          "soulmd-funes",
+          "verne-e-o-padro-identity-repo-como-os-agentes-de-ia-se-lembram",
           "orquestrando-agentes-memoria-familiar",
+          "pierre-menard-pesquisador-computacional",
         ],
       },
     },


### PR DESCRIPTION
Closes #248

## UI

A trilha `memory-and-funes` em `/paths/memory-and-funes/` agora mostra 5 posts (EN e PT) em vez de 3/2, com paridade completa entre idiomas.

**Verificar na run seguinte pós-deploy:** `/paths/memory-and-funes/` e `/pt/paths/memory-and-funes/` devem listar 5 posts cada, na ordem correta (building-funes → funes-soul → verne-identity-repo → family memory → pierre-menard).

---

## content

**Antes:**
- EN: `building-funes`, `funes-soul`, `pierre-menard-computational-researcher` (3 posts)
- PT: `pierre-menard-pesquisador-computacional`, `orquestrando-agentes-memoria-familiar` (2 posts, sem paridade)

**Depois:**
- EN: `building-funes`, `funes-soul`, `verne-identity-repo`, `what-i-learned-orchestrating-ai-agents-to-preserve-family-memory`, `pierre-menard-computational-researcher` (5 posts)
- PT: `construindo-funes-como-dei-uma-alma-a-um-agente-de-ia`, `soulmd-funes`, `verne-e-o-padro-identity-repo-como-os-agentes-de-ia-se-lembram`, `orquestrando-agentes-memoria-familiar`, `pierre-menard-pesquisador-computacional` (5 posts, paridade completa)

**Posts adicionados:**
| EN | PT | Tema |
|---|---|---|
| `verne-identity-repo` | `verne-e-o-padro-identity-repo-como-os-agentes-de-ia-se-lembram` | Arquitetura de memória de agentes: identity-repo pattern |
| `what-i-learned-orchestrating-ai-agents-to-preserve-family-memory` | `orquestrando-agentes-memoria-familiar` (já estava) | Preservação de memória familiar com agentes |
| — | `construindo-funes-como-dei-uma-alma-a-um-agente-de-ia` | Par PT de building-funes (já no path) |
| — | `soulmd-funes` | Par PT de funes-soul (já no path) |

**Ordem de leitura:** do mais conceitual (construir Funes, SOUL.md) ao mais arquitetural (identity-repo pattern) ao mais pessoal/concreto (memória familiar, Pierre Menard).

**Blurb atualizado** para refletir o escopo ampliado (family memory + identity-repo architecture).

---

_Gerado por [Claude Code](https://claude.ai/code/session_01GYroG3Um2LTByc6VDyQnNY) — rotina autônoma 2026-06-17_

---
_Generated by [Claude Code](https://claude.ai/code/session_01GYroG3Um2LTByc6VDyQnNY)_