### PR TITLE
ux: livros recentes do Goodreads no HomeAuthorRail

### DIFF
--- a/.routines/2026-06-18T05-00-00-goodreads-rail.md
+++ b/.routines/2026-06-18T05-00-00-goodreads-rail.md
@@ -1,0 +1,65 @@
+---
+date: 2026-06-18T05:00:00
+slug: goodreads-rail
+branch: claude/sleepy-pasteur-iwdjxc
+status: pr-open
+issues: [243]
+pr_opened: null
+pr_merged: 564
+---
+
+# Sessão 2026-06-18 — Goodreads books no HomeAuthorRail
+
+## Contexto ao chegar
+
+- 11 issues `routine` abertas (faixa saudável 10–20)
+- PR pendente: #564 (seo: trim 22 meta descriptions para 130–160 chars) — CI verde, sem review bloqueante
+- Main avançou bastante desde o base do PR: conflito em `ranking-snapshot.json` e `versions-selected.json` (arquivos gerados)
+
+## O que mergeou
+
+**PR #564** — rebaseou sobre main, resolvendo conflito nos arquivos gerados tomando a versão de main (que reflete as sessões hronir posteriores). CI rerun: verde. Merge com merge commit.
+
+## Limpeza de backlog
+
+Ao inspecionar os issues "open" com label `routine`, descobri que 3 deles já estavam implementados no codebase:
+
+- **#550** (ux: prev/next series navigation): `SeriesContext.astro` já tem `variant='nav'` com prev/next, chamado em ambos os layouts de post (EN e PT, linha 282 e 279 respectivamente). Fechado como completed.
+- **#493** (ux: TOC scroll spy): `TableOfContents.astro` já tem IntersectionObserver completo com classe `toc-active` e fallback para último heading acima do viewport. Fechado como completed.
+- **#494** (seo: JSON-LD wordCount e timeRequired): `PageLayout.astro` já injeta `wordCount` e `timeRequired: PT${n}M` no JSON-LD do BlogPosting. Fechado como completed.
+
+## O que foi feito
+
+**Issue #243** — Goodreads RSS books no HomeAuthorRail.
+
+### Análise
+
+`BooksPage.astro` tinha toda a lógica de fetch do Goodreads RSS inline (90+ linhas). O issue pedia extrair isso para `src/lib/goodreads.ts` e usar no rail da homepage.
+
+### Implementação
+
+1. **`src/lib/goodreads.ts`** — novo utilitário com:
+   - `fetchGoodreadsBooks()`: faz o fetch do RSS, parseia com `fast-xml-parser` (já dependência existente), retorna `GoodreadsBook[]`, lança em caso de erro (quem chama decide o fallback)
+   - `recentBooks(books, n)`: ordena por `user_read_at` desc e retorna os N primeiros
+
+2. **`src/components/BooksPage.astro`** — refatorado para importar do lib; comportamento idêntico (try/catch com display de erro para o usuário)
+
+3. **`src/components/HomeAuthorRail.astro`** — adicionada seção "Recently read" / "Lendo recentemente":
+   - Capas de livros (40×60px) como links para o Goodreads, com `title` sendo `${livro} — ${autor}`
+   - Fallback emoji 📖 se a URL da capa estiver vazia
+   - Link "All books →" / "Ver todos os livros →" para a página de livros
+   - Seção só aparece se `recent.length > 0` (quando o Goodreads estiver offline, o rail não quebra)
+   - I18n: texto "Recently read" em EN, "Lendo recentemente" em PT (feed é o mesmo para ambos)
+
+### Verificação
+
+- `npm run build`: ✅ 1992 páginas
+- `npx astro check`: ✅ 0 errors, 0 warnings
+- `npx prettier --check .`: ✅ OK
+- `npm run hronir:doctor`: ✅ 0 inconsistências
+- `npm run check:hygiene`: ✅ OK
+
+## O que ficou para a próxima run
+
+- Verificar screenshot de produção da homepage após merge (capas de livros, layout do rail em desktop e mobile)
+- Issues restantes de baixa prioridade: #249 (preload Inter), #250 (OG image paths), #251 (skip-to-content PT), #252, #495 (aria-label nav), #552 (focus-visible), #553 (CLS imagens)

--- a/src/components/BooksPage.astro
+++ b/src/components/BooksPage.astro
@@ -2,7 +2,7 @@
 import PageLayout from "../layouts/PageLayout.astro";
 import { pick } from "../lib/i18n";
 import type { Lang } from "../lib/i18n";
-import { XMLParser } from "fast-xml-parser";
+import { fetchGoodreadsBooks } from "../lib/goodreads";
 
 interface Props {
   lang: Lang;
@@ -63,56 +63,14 @@ const translations: Record<string, string> =
   lang === "en" ? { pt: "/pt/livros/" } : { en: "/books/" };
 const ogImage = lang === "en" ? "/og/books.png" : "/og/books-pt.png";
 
-const GOODREADS_RSS = "https://www.goodreads.com/review/list_rss/5942034?shelf=read";
 const GOODREADS_PROFILE = "https://www.goodreads.com/user/show/5942034";
 
-interface GoodreadsItem {
-  title: string;
-  link: string;
-  author_name: string;
-  book_image_url: string;
-  user_rating: number;
-  user_read_at: string;
-  book_published: string | number;
-}
-
-let books: GoodreadsItem[] = [];
 let error: string | null = null;
+let books: Awaited<ReturnType<typeof fetchGoodreadsBooks>> = [];
 
 try {
-  const res = await fetch(GOODREADS_RSS);
-  if (!res.ok) throw new Error(`HTTP ${res.status}`);
-  const xml = await res.text();
-
-  const parser = new XMLParser({
-    ignoreAttributes: false,
-    cdataPropName: "__cdata",
-    isArray: (name) => name === "item",
-  });
-  const parsed = parser.parse(xml);
-  const items: Record<string, unknown>[] = parsed?.rss?.channel?.item ?? [];
-
-  books = items.map((item) => {
-    const str = (v: unknown) =>
-      typeof v === "object" && v !== null && "__cdata" in v
-        ? String((v as Record<string, unknown>)["__cdata"])
-        : String(v ?? "");
-
-    const imageUrl = str(item["book_image_url"]);
-    const coverUrl = imageUrl.replace("._SY75_.", "._SX200_.").replace("._SX98_.", "._SX200_.");
-
-    return {
-      title: str(item["title"]),
-      link: str(item["link"]),
-      author_name: str(item["author_name"]),
-      book_image_url: coverUrl || imageUrl,
-      user_rating: Number(item["user_rating"]) || 0,
-      user_read_at: str(item["user_read_at"]),
-      book_published: str(item["book_published"]),
-    };
-  });
-
-  books.sort((a, b) => {
+  const raw = await fetchGoodreadsBooks();
+  books = raw.sort((a, b) => {
     if (b.user_rating !== a.user_rating) return b.user_rating - a.user_rating;
     return a.title.localeCompare(b.title);
   });

--- a/src/components/HomeAuthorRail.astro
+++ b/src/components/HomeAuthorRail.astro
@@ -1,5 +1,6 @@
 ---
 import { t, urlPrefix } from '../lib/i18n';
+import { fetchGoodreadsBooks, recentBooks } from '../lib/goodreads';
 
 interface Props {
   lang?: string;
@@ -9,6 +10,9 @@ const { lang } = Astro.props;
 const homeAbout = `${urlPrefix(lang)}/about/`;
 const homeSearch = `${urlPrefix(lang)}/search/`;
 const rssHref = lang === "pt" ? "/pt/rss.xml" : "/rss.xml";
+const booksHref = lang === "pt" ? "/pt/livros/" : "/books/";
+
+const recent = await fetchGoodreadsBooks().then((b) => recentBooks(b, 3)).catch(() => []);
 ---
 
 <aside class="home-author-rail" aria-label={t(lang, 'author.aboutEyebrow')}>
@@ -21,6 +25,26 @@ const rssHref = lang === "pt" ? "/pt/rss.xml" : "/rss.xml";
   <p class="rail-more">
     <a href={homeAbout}>{t(lang, 'author.aboutMore')}</a>
   </p>
+
+  {recent.length > 0 && (
+    <>
+      <hr class="rail-divider" />
+      <p class="rail-eyebrow"><small>{lang === 'pt' ? 'Lendo recentemente' : 'Recently read'}</small></p>
+      <ul class="rail-books">
+        {recent.map((book) => (
+          <li>
+            <a href={book.link} target="_blank" rel="noopener noreferrer" title={`${book.title} — ${book.author_name}`}>
+              {book.book_image_url
+                ? <img src={book.book_image_url} alt={book.title} width="40" height="60" loading="lazy" decoding="async" />
+                : <span class="rail-book-fallback" aria-hidden="true">📖</span>
+              }
+            </a>
+          </li>
+        ))}
+      </ul>
+      <p class="rail-books-more"><a href={booksHref}><small>{lang === 'pt' ? 'Ver todos os livros →' : 'All books →'}</small></a></p>
+    </>
+  )}
 
   <hr class="rail-divider" />
 
@@ -111,6 +135,51 @@ const rssHref = lang === "pt" ? "/pt/rss.xml" : "/rss.xml";
     color: var(--pico-primary);
     flex-shrink: 0;
   }
+
+  .rail-books {
+    list-style: none;
+    padding: 0;
+    margin: 0 0 0.5rem;
+    display: flex;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+  }
+  .rail-books li { margin: 0; }
+  .rail-books a {
+    display: block;
+    border-radius: 2px;
+    overflow: hidden;
+    border: 1px solid var(--pico-muted-border-color);
+    transition: transform 0.15s, border-color 0.15s;
+  }
+  .rail-books a:hover {
+    transform: translateY(-2px);
+    border-color: var(--pico-primary);
+  }
+  .rail-books img {
+    display: block;
+    width: 40px;
+    height: 60px;
+    object-fit: cover;
+  }
+  .rail-book-fallback {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 40px;
+    height: 60px;
+    font-size: 1.25rem;
+    background: var(--pico-card-background-color);
+  }
+  .rail-books-more {
+    margin: 0 0 0;
+    font-size: 0.82rem;
+  }
+  .rail-books-more a {
+    color: var(--pico-muted-color);
+    text-decoration: none;
+  }
+  .rail-books-more a:hover { color: var(--pico-primary); }
 
   /* Compact horizontal layout on mobile/tablet */
   @media (max-width: 1099px) {

--- a/src/lib/goodreads.ts
+++ b/src/lib/goodreads.ts
@@ -1,0 +1,63 @@
+import { XMLParser } from "fast-xml-parser";
+
+export interface GoodreadsBook {
+  title: string;
+  link: string;
+  author_name: string;
+  book_image_url: string;
+  user_rating: number;
+  user_read_at: string;
+  book_published: string;
+}
+
+const GOODREADS_RSS =
+  "https://www.goodreads.com/review/list_rss/5942034?shelf=read";
+
+export async function fetchGoodreadsBooks(): Promise<GoodreadsBook[]> {
+  const res = await fetch(GOODREADS_RSS);
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  const xml = await res.text();
+
+  const parser = new XMLParser({
+    ignoreAttributes: false,
+    cdataPropName: "__cdata",
+    isArray: (name) => name === "item",
+  });
+  const parsed = parser.parse(xml);
+  const items: Record<string, unknown>[] = parsed?.rss?.channel?.item ?? [];
+
+  const str = (v: unknown) =>
+    typeof v === "object" && v !== null && "__cdata" in v
+      ? String((v as Record<string, unknown>)["__cdata"])
+      : String(v ?? "");
+
+  return items.map((item) => {
+    const imageUrl = str(item["book_image_url"]);
+    const coverUrl = imageUrl
+      .replace("._SY75_.", "._SX200_.")
+      .replace("._SX98_.", "._SX200_.");
+    return {
+      title: str(item["title"]),
+      link: str(item["link"]),
+      author_name: str(item["author_name"]),
+      book_image_url: coverUrl || imageUrl,
+      user_rating: Number(item["user_rating"]) || 0,
+      user_read_at: str(item["user_read_at"]),
+      book_published: str(item["book_published"]),
+    };
+  });
+}
+
+export function recentBooks(books: GoodreadsBook[], n = 3): GoodreadsBook[] {
+  return [...books]
+    .sort((a, b) => {
+      const da = a.user_read_at
+        ? new Date(a.user_read_at.replace(/\//g, "-")).valueOf()
+        : 0;
+      const db = b.user_read_at
+        ? new Date(b.user_read_at.replace(/\//g, "-")).valueOf()
+        : 0;
+      return db - da;
+    })
+    .slice(0, n);
+}


### PR DESCRIPTION
Closes #243

## UI

Adiciona uma seção "Recently read" / "Lendo recentemente" no rail do autor na homepage — as 3 capas de livros mais recentes do Goodreads, cada uma como link para o Goodreads com tooltip `título — autor`.

**Verificar na run seguinte pós-deploy:**
- Homepage EN (`/`) e PT (`/pt/`) — rail do autor: seção de livros aparece abaixo da bio?
- Capas carregam (40×60px), hover sobe levemente, border fica primária?
- Em mobile (< 1100px) a seção segue o layout compacto horizontal do rail?
- Link "All books →" / "Ver todos os livros →" aponta corretamente para `/books/` e `/pt/livros/`?

## perf / resiliência

Fallback silencioso: se o Goodreads RSS estiver offline, `recent = []` e a seção simplesmente não é renderizada — o build não quebra e o rail continua funcionando.

## Refactor

`src/lib/goodreads.ts` — novo utilitário com `fetchGoodreadsBooks()` (lança em erro) e `recentBooks(books, n)` (ordena por data de leitura). `BooksPage.astro` refatorado para importar do lib compartilhado; comportamento idêntico ao anterior.

---
_Generated by [Claude Code](https://claude.ai/code/session_01B59jChCvAvhrLRaDBD6sPo)_