### PR TITLE
seo: hreflang x-default fallback para homepage EN em páginas PT sem par EN

### DIFF
--- a/.routines/2026-06-19T05-00-00-hreflang-xdefault.md
+++ b/.routines/2026-06-19T05-00-00-hreflang-xdefault.md
@@ -1,0 +1,78 @@
+---
+date: 2026-06-19T05:00:00
+slug: hreflang-xdefault
+branch: claude/sleepy-pasteur-k95g7o
+status: pr-open
+issues: [584]
+pr_opened: null
+pr_merged: null
+---
+
+# Sessão 2026-06-19 — hreflang x-default fallback para homepage EN
+
+## Contexto ao chegar
+
+- 9 issues `routine` abertas — abaixo do mínimo de 10; backlog precisava de reposição
+- PR pendente da run anterior: nenhum com label `routine` aberto; PR #582 (Goodreads rail) já havia sido mergeado e logado na run de 2026-06-18
+- Main no commit `61e765f0` (merge do hronir 10 matches, 2026-06-18)
+
+## Backlog reposto
+
+Criei 5 novas issues para trazer o backlog de 9 → 14:
+
+- **#587** (baixa): seo: PersonPage/ProfilePage schema para /about/ e /pt/about/
+- **#588** (baixa): ux: Web Share API — botão nativo de compartilhamento em posts
+- **#589** (baixa): perf: preconnect e dns-prefetch para domínios de terceiros
+- **#590** (media): seo: BreadcrumbList para /paths/[slug] e /tags/[tag]
+- **#591** (baixa): ux: reading time visível nos PostCards do arquivo
+
+## O que foi feito
+
+**Issue #584** — seo: hreflang x-default apontando para raiz EN em todas as páginas.
+
+### Análise
+
+`PageLayout.astro` calculava `xDefaultHref` assim:
+```js
+const xDefaultHref = lang === DEFAULT_LANG
+  ? canonical.href
+  : (translations[DEFAULT_LANG] ? new URL(translations[DEFAULT_LANG], Astro.site).href : null);
+```
+
+Quando `lang !== DEFAULT_LANG` (PT) e a página não declara `translations['en']` — caso real em `src/pages/pt/tags/[tag].astro` para tags sem contraparte EN (`hasEnCounterpart = false` → `translations={}`) — `xDefaultHref` ficava `null` e o `<link rel="alternate" hreflang="x-default">` era omitido. Isso é contra a recomendação do Google: páginas sem x-default ficam sem sinal de "versão padrão" para buscadores fora de EN/PT.
+
+### Implementação
+
+Em `src/layouts/PageLayout.astro` (linhas 75–79):
+```js
+// Antes:
+const xDefaultHref = lang === DEFAULT_LANG
+  ? canonical.href
+  : (translations[DEFAULT_LANG] ? new URL(translations[DEFAULT_LANG], Astro.site).href : null);
+
+// Depois:
+const enHomepageHref = Astro.site ? new URL("/", Astro.site).href : null;
+const xDefaultHref = lang === DEFAULT_LANG
+  ? canonical.href
+  : (translations[DEFAULT_LANG] ? new URL(translations[DEFAULT_LANG], Astro.site).href : enHomepageHref);
+```
+
+Quando não há tradução EN declarada, o x-default cai para a homepage EN — padrão recomendado pelo Google Search Central.
+
+### Verificação no HTML gerado
+
+- `dist/pt/tags/capital-básico-universal/index.html` (tag só PT):
+  `hreflang="x-default" href="https://franklinbaldo.github.io/"` ✅
+- `dist/pt/tags/identity/index.html` (tag com EN):
+  `hreflang="x-default" href="https://franklinbaldo.github.io/tags/identity/"` ✅ (não regrediu)
+
+### CI local
+- `npx astro check`: 0 errors, 0 warnings ✅
+- `npx prettier --check .`: All matched files use Prettier code style ✅
+- `npm run build`: 617 HTML pages, completed ✅
+
+## O que ficou para a próxima run
+
+- Verificar screenshot de produção após deploy (sem mudança visual — apenas metadados)
+- Próximas prioridades: #590 (BreadcrumbList para paths/tags, priority:media), #584 é a única media que havia — agora o backlog tem nova media em #590
+- Issues de baixa restantes: #249, #250, #251, #495, #552, #553, #583, #585, #587, #588, #589, #591

--- a/src/generated/ranking-snapshot.json
+++ b/src/generated/ranking-snapshot.json
@@ -1,591 +1,591 @@
 {
   "_meta": {
     "schema": "snapshot-v2",
-    "generatedAt": "2026-06-16T05:27:11.719Z",
+    "generatedAt": "2026-06-19T05:13:33.258Z",
     "basis": "build",
-    "totalDuels": 755
+    "totalDuels": 197
   },
   "keys": {
-    "music-john-gospel-chapter-i-by-max-headroom": {
+    "music-o-regral": {
       "rank": 1,
-      "ordinal": 11.3322,
-      "elo": 1101,
-      "eloPeak": 1101
-    },
-    "pontifex-research": {
-      "rank": 2,
-      "ordinal": 11.2451,
-      "elo": 1112,
-      "eloPeak": 1116
-    },
-    "music-nonada": {
-      "rank": 3,
-      "ordinal": 9.8181,
-      "elo": 1117,
-      "eloPeak": 1117
+      "ordinal": 5.9033,
+      "elo": 1075,
+      "eloPeak": 1075
     },
     "serpents-egg": {
-      "rank": 4,
-      "ordinal": 9.6359,
-      "elo": 1025,
-      "eloPeak": 1035
+      "rank": 2,
+      "ordinal": 5.7672,
+      "elo": 1033,
+      "eloPeak": 1033
     },
-    "delphi-imperatives": {
+    "music-a-primeira-mudanca": {
+      "rank": 3,
+      "ordinal": 5.4948,
+      "elo": 1031,
+      "eloPeak": 1032
+    },
+    "music-o-medo-do-louco": {
+      "rank": 4,
+      "ordinal": 5.4785,
+      "elo": 1033,
+      "eloPeak": 1034
+    },
+    "music-prayer-to-the-unfinished-moving-window-v": {
       "rank": 5,
-      "ordinal": 9.4813,
-      "elo": 1051,
-      "eloPeak": 1051
+      "ordinal": 4.7203,
+      "elo": 1044,
+      "eloPeak": 1044
     },
     "music-eu-ia-escrever-sobre-o-infinito-de-novo": {
       "rank": 6,
-      "ordinal": 9.4521,
-      "elo": 1051,
-      "eloPeak": 1074
+      "ordinal": 4.5856,
+      "elo": 1050,
+      "eloPeak": 1050
     },
-    "music-pattern-over-stuff": {
+    "music-menino-que-voce-foi": {
       "rank": 7,
-      "ordinal": 9.3505,
-      "elo": 1085,
-      "eloPeak": 1085
-    },
-    "asterisk-protects": {
-      "rank": 8,
-      "ordinal": 8.93,
-      "elo": 1089,
-      "eloPeak": 1113
-    },
-    "music-666": {
-      "rank": 9,
-      "ordinal": 8.6327,
-      "elo": 1042,
-      "eloPeak": 1059
-    },
-    "music-beatriz": {
-      "rank": 10,
-      "ordinal": 8.4062,
-      "elo": 1071,
-      "eloPeak": 1071
-    },
-    "conservation-law": {
-      "rank": 11,
-      "ordinal": 8.3206,
-      "elo": 1047,
-      "eloPeak": 1069
-    },
-    "pierre-menard": {
-      "rank": 12,
-      "ordinal": 8.3179,
-      "elo": 1054,
-      "eloPeak": 1092
-    },
-    "music-trinta-de-abril": {
-      "rank": 13,
-      "ordinal": 8.2523,
-      "elo": 1044,
-      "eloPeak": 1092
-    },
-    "two-questions-out-loud": {
-      "rank": 14,
-      "ordinal": 8.1621,
-      "elo": 1055,
-      "eloPeak": 1072
-    },
-    "future-father": {
-      "rank": 15,
-      "ordinal": 8.0682,
-      "elo": 1049,
-      "eloPeak": 1103
-    },
-    "intelligible-void": {
-      "rank": 16,
-      "ordinal": 8.0353,
-      "elo": 1044,
-      "eloPeak": 1044
-    },
-    "family-memory": {
-      "rank": 17,
-      "ordinal": 7.9805,
-      "elo": 1086,
-      "eloPeak": 1086
-    },
-    "music-chegue-irmao-chegue-irma": {
-      "rank": 18,
-      "ordinal": 7.7251,
-      "elo": 1059,
-      "eloPeak": 1091
-    },
-    "music-o-aleph": {
-      "rank": 19,
-      "ordinal": 7.6543,
-      "elo": 1025,
-      "eloPeak": 1025
-    },
-    "three-hammers": {
-      "rank": 20,
-      "ordinal": 7.5398,
-      "elo": 1043,
-      "eloPeak": 1053
-    },
-    "crossing-interference": {
-      "rank": 21,
-      "ordinal": 7.4549,
-      "elo": 1034,
-      "eloPeak": 1034
-    },
-    "reddit-submarine-osint": {
-      "rank": 22,
-      "ordinal": 7.2988,
-      "elo": 1059,
-      "eloPeak": 1099
-    },
-    "music-o-ritual-de-abril-anos-de-saudade": {
-      "rank": 23,
-      "ordinal": 7.1598,
-      "elo": 1027,
-      "eloPeak": 1027
-    },
-    "music-xadrez": {
-      "rank": 24,
-      "ordinal": 7.1331,
-      "elo": 1049,
-      "eloPeak": 1067
-    },
-    "music-observer-error-moving-window-iv": {
-      "rank": 25,
-      "ordinal": 7.0049,
-      "elo": 1040,
-      "eloPeak": 1057
-    },
-    "music-a-primeira-mudanca": {
-      "rank": 26,
-      "ordinal": 6.9813,
-      "elo": 1046,
-      "eloPeak": 1067
-    },
-    "music-vos": {
-      "rank": 27,
-      "ordinal": 6.7123,
-      "elo": 1031,
-      "eloPeak": 1046
-    },
-    "music-the-third-song-moving-window-iii": {
-      "rank": 28,
-      "ordinal": 6.3046,
-      "elo": 1015,
-      "eloPeak": 1044
-    },
-    "music-quando-vier-a-primavera": {
-      "rank": 29,
-      "ordinal": 6.1433,
-      "elo": 1020,
-      "eloPeak": 1046
-    },
-    "its-raining-truth": {
-      "rank": 30,
-      "ordinal": 5.9805,
-      "elo": 1014,
-      "eloPeak": 1057
+      "ordinal": 4.3045,
+      "elo": 1030,
+      "eloPeak": 1030
     },
     "music-the-time": {
-      "rank": 31,
-      "ordinal": 5.9749,
-      "elo": 1050,
-      "eloPeak": 1051
+      "rank": 8,
+      "ordinal": 4.2779,
+      "elo": 1074,
+      "eloPeak": 1074
     },
-    "music-sinal-que-se-cumpre-moving-window-ix": {
-      "rank": 32,
-      "ordinal": 5.8087,
-      "elo": 1028,
-      "eloPeak": 1062
-    },
-    "verne-identity-repo": {
-      "rank": 33,
-      "ordinal": 5.6448,
-      "elo": 1006,
-      "eloPeak": 1026
-    },
-    "music-o-preco-da-saudade": {
-      "rank": 34,
-      "ordinal": 5.6058,
-      "elo": 1017,
-      "eloPeak": 1034
-    },
-    "music-o-telefone-da-agonia": {
-      "rank": 35,
-      "ordinal": 5.5093,
-      "elo": 1034,
-      "eloPeak": 1081
-    },
-    "music-crystallizing-from-the-nothing": {
-      "rank": 36,
-      "ordinal": 5.3442,
-      "elo": 1013,
-      "eloPeak": 1013
-    },
-    "third-half-fourth-wall": {
-      "rank": 37,
-      "ordinal": 5.2123,
-      "elo": 1026,
-      "eloPeak": 1064
-    },
-    "music-paperclip-rhapsody": {
-      "rank": 38,
-      "ordinal": 5.1159,
-      "elo": 994,
+    "music-xadrez": {
+      "rank": 9,
+      "ordinal": 3.8788,
+      "elo": 1031,
       "eloPeak": 1031
-    },
-    "agent-no-verbs": {
-      "rank": 39,
-      "ordinal": 5.0746,
-      "elo": 962,
-      "eloPeak": 1018
-    },
-    "delegating-to-agents": {
-      "rank": 40,
-      "ordinal": 5.0009,
-      "elo": 986,
-      "eloPeak": 1009
     },
     "music-sentido-e-referencia": {
-      "rank": 41,
-      "ordinal": 4.9158,
-      "elo": 1009,
-      "eloPeak": 1019
+      "rank": 10,
+      "ordinal": 3.8763,
+      "elo": 1049,
+      "eloPeak": 1049
     },
-    "music-uma-so-cancao": {
-      "rank": 42,
-      "ordinal": 4.8735,
-      "elo": 1018,
-      "eloPeak": 1055
-    },
-    "music-o-medo-do-louco": {
-      "rank": 43,
-      "ordinal": 4.8684,
-      "elo": 981,
-      "eloPeak": 1031
-    },
-    "music-meditacao-guiada-no-sertao": {
-      "rank": 44,
-      "ordinal": 4.7931,
-      "elo": 998,
-      "eloPeak": 1057
+    "music-john-gospel-chapter-i-by-max-headroom": {
+      "rank": 11,
+      "ordinal": 3.5317,
+      "elo": 1029,
+      "eloPeak": 1029
     },
     "funes-soul": {
-      "rank": 45,
-      "ordinal": 4.7324,
-      "elo": 1018,
-      "eloPeak": 1018
+      "rank": 12,
+      "ordinal": 3.3932,
+      "elo": 983,
+      "eloPeak": 1003
     },
-    "music-primavera-carregando": {
-      "rank": 46,
-      "ordinal": 4.6924,
-      "elo": 1046,
-      "eloPeak": 1046
+    "asterisk-protects": {
+      "rank": 13,
+      "ordinal": 3.3625,
+      "elo": 1033,
+      "eloPeak": 1033
     },
-    "music-caminho": {
-      "rank": 47,
-      "ordinal": 4.6627,
-      "elo": 1038,
-      "eloPeak": 1058
-    },
-    "music-espelhos": {
-      "rank": 48,
-      "ordinal": 4.378,
-      "elo": 979,
-      "eloPeak": 1031
-    },
-    "music-reality-maintenance-moving-window-xii": {
-      "rank": 49,
-      "ordinal": 4.3155,
-      "elo": 992,
-      "eloPeak": 1040
-    },
-    "music-fourteen-words": {
-      "rank": 50,
-      "ordinal": 4.1719,
+    "music-the-ruliad-is-laughing": {
+      "rank": 14,
+      "ordinal": 3.2635,
       "elo": 1028,
       "eloPeak": 1028
     },
-    "music-particles": {
-      "rank": 51,
-      "ordinal": 4.0938,
-      "elo": 1043,
-      "eloPeak": 1074
+    "music-observer-error-moving-window-iv": {
+      "rank": 15,
+      "ordinal": 3.0625,
+      "elo": 1017,
+      "eloPeak": 1017
     },
-    "music-menino-que-voce-foi": {
-      "rank": 52,
-      "ordinal": 4.0398,
+    "music-stopping-by-woods-on-a-snowy-evening-by-robert-frost": {
+      "rank": 16,
+      "ordinal": 3.05,
+      "elo": 1014,
+      "eloPeak": 1015
+    },
+    "music-o-verso-branquiceleste": {
+      "rank": 17,
+      "ordinal": 3.0064,
+      "elo": 1014,
+      "eloPeak": 1047
+    },
+    "music-borges-and-me": {
+      "rank": 18,
+      "ordinal": 2.891,
+      "elo": 1039,
+      "eloPeak": 1059
+    },
+    "music-meditacao-guiada-no-sertao": {
+      "rank": 19,
+      "ordinal": 2.8796,
+      "elo": 1016,
+      "eloPeak": 1016
+    },
+    "music-beatriz": {
+      "rank": 20,
+      "ordinal": 2.8575,
+      "elo": 1016,
+      "eloPeak": 1048
+    },
+    "pontifex-research": {
+      "rank": 21,
+      "ordinal": 2.6354,
+      "elo": 1033,
+      "eloPeak": 1035
+    },
+    "music-sussurros-binarios": {
+      "rank": 22,
+      "ordinal": 2.603,
+      "elo": 1029,
+      "eloPeak": 1029
+    },
+    "music-vos": {
+      "rank": 23,
+      "ordinal": 2.5506,
+      "elo": 1049,
+      "eloPeak": 1049
+    },
+    "music-dd332f75-6052-4f9e-bccd-fb0303731d6e": {
+      "rank": 24,
+      "ordinal": 2.5234,
+      "elo": 1032,
+      "eloPeak": 1032
+    },
+    "music-o-tempo": {
+      "rank": 25,
+      "ordinal": 2.4614,
+      "elo": 1012,
+      "eloPeak": 1016
+    },
+    "music-f85fb538-6f59-4751-8629-da76665fc91e": {
+      "rank": 26,
+      "ordinal": 2.368,
+      "elo": 1014,
+      "eloPeak": 1031
+    },
+    "music-borges-and-the-hyperobject-at-the-end-of-time": {
+      "rank": 27,
+      "ordinal": 2.3536,
+      "elo": 1000,
+      "eloPeak": 1016
+    },
+    "music-666": {
+      "rank": 28,
+      "ordinal": 2.2596,
       "elo": 1002,
       "eloPeak": 1002
     },
     "census-not-sample": {
-      "rank": 53,
-      "ordinal": 4.0397,
-      "elo": 1019,
-      "eloPeak": 1034
-    },
-    "social-vulnerabilities": {
-      "rank": 54,
-      "ordinal": 4.0306,
-      "elo": 984,
-      "eloPeak": 1000
-    },
-    "music-spring-loading": {
-      "rank": 55,
-      "ordinal": 4.0128,
-      "elo": 971,
-      "eloPeak": 1047
-    },
-    "music-sobre-o-rigor-na-ciencia": {
-      "rank": 56,
-      "ordinal": 3.8878,
-      "elo": 993,
-      "eloPeak": 1053
-    },
-    "music-borges-and-me": {
-      "rank": 57,
-      "ordinal": 3.8682,
-      "elo": 1014,
-      "eloPeak": 1071
-    },
-    "music-stopping-by-woods-on-a-snowy-evening-by-robert-frost": {
-      "rank": 58,
-      "ordinal": 3.4103,
-      "elo": 1003,
-      "eloPeak": 1004
-    },
-    "conceptual-document": {
-      "rank": 59,
-      "ordinal": 3.281,
-      "elo": 982,
-      "eloPeak": 1059
-    },
-    "music-be-me-borges": {
-      "rank": 60,
-      "ordinal": 3.2734,
-      "elo": 977,
-      "eloPeak": 1036
-    },
-    "music-riobaldo-e-o-aleph": {
-      "rank": 61,
-      "ordinal": 3.1042,
-      "elo": 979,
-      "eloPeak": 1031
-    },
-    "music-o-verso-branquiceleste": {
-      "rank": 62,
-      "ordinal": 3.0642,
-      "elo": 1006,
-      "eloPeak": 1006
-    },
-    "music-clipes": {
-      "rank": 63,
-      "ordinal": 2.9367,
-      "elo": 992,
+      "rank": 29,
+      "ordinal": 2.1157,
+      "elo": 1016,
       "eloPeak": 1016
     },
-    "music-o-magico-e-o-fogo": {
-      "rank": 64,
-      "ordinal": 2.892,
-      "elo": 996,
-      "eloPeak": 1031
-    },
-    "jules-api-harness": {
-      "rank": 65,
-      "ordinal": 2.8239,
+    "music-o-ritual-de-abril-anos-de-saudade": {
+      "rank": 30,
+      "ordinal": 2.07,
       "elo": 1000,
+      "eloPeak": 1000
+    },
+    "travessia-project": {
+      "rank": 31,
+      "ordinal": 2.0392,
+      "elo": 967,
+      "eloPeak": 1017
+    },
+    "delphi-imperatives": {
+      "rank": 32,
+      "ordinal": 2.0317,
+      "elo": 1032,
+      "eloPeak": 1032
+    },
+    "music-fourteen-words": {
+      "rank": 33,
+      "ordinal": 1.9625,
+      "elo": 1001,
       "eloPeak": 1001
     },
-    "music-dd332f75-6052-4f9e-bccd-fb0303731d6e": {
-      "rank": 66,
-      "ordinal": 2.8161,
-      "elo": 1028,
-      "eloPeak": 1045
+    "music-o-telefone-da-agonia": {
+      "rank": 34,
+      "ordinal": 1.88,
+      "elo": 1003,
+      "eloPeak": 1003
     },
-    "music-o-prologo": {
-      "rank": 67,
-      "ordinal": 2.7568,
-      "elo": 975,
-      "eloPeak": 1031
-    },
-    "music-escherian-sunrise-with-godel": {
-      "rank": 68,
-      "ordinal": 2.6338,
-      "elo": 1028,
-      "eloPeak": 1064
-    },
-    "rosencrantz-coin": {
-      "rank": 69,
-      "ordinal": 1.9086,
-      "elo": 948,
-      "eloPeak": 1000
-    },
-    "music-two-cursors": {
-      "rank": 70,
-      "ordinal": 1.8958,
-      "elo": 963,
-      "eloPeak": 1014
-    },
-    "music-entre-rascunho-e-apagar": {
-      "rank": 71,
-      "ordinal": 1.7255,
-      "elo": 944,
-      "eloPeak": 1004
-    },
-    "music-f85fb538-6f59-4751-8629-da76665fc91e": {
-      "rank": 72,
-      "ordinal": 1.6886,
-      "elo": 977,
-      "eloPeak": 1000
-    },
-    "reclaiming-harness": {
-      "rank": 73,
-      "ordinal": 1.6533,
-      "elo": 983,
-      "eloPeak": 1019
-    },
-    "music-leite-no-salao-bar": {
-      "rank": 74,
-      "ordinal": 1.3985,
-      "elo": 963,
+    "music-o-preco-da-saudade": {
+      "rank": 35,
+      "ordinal": 1.7958,
+      "elo": 999,
       "eloPeak": 1016
     },
-    "music-the-ruliad-is-laughing": {
-      "rank": 75,
-      "ordinal": 1.3606,
-      "elo": 929,
-      "eloPeak": 1000
+    "verne-identity-repo": {
+      "rank": 36,
+      "ordinal": 1.7725,
+      "elo": 1028,
+      "eloPeak": 1032
+    },
+    "music-primavera-carregando": {
+      "rank": 37,
+      "ordinal": 1.6504,
+      "elo": 984,
+      "eloPeak": 1033
+    },
+    "music-belief-engine-labyrinth-song-moving-window-viii": {
+      "rank": 38,
+      "ordinal": 1.5735,
+      "elo": 1015,
+      "eloPeak": 1017
     },
     "music-f73c60f0-49af-45fd-a483-1d35a676dccc": {
-      "rank": 76,
-      "ordinal": 1.3115,
-      "elo": 970,
+      "rank": 39,
+      "ordinal": 1.548,
+      "elo": 1017,
+      "eloPeak": 1017
+    },
+    "three-hammers": {
+      "rank": 40,
+      "ordinal": 1.5044,
+      "elo": 1016,
+      "eloPeak": 1016
+    },
+    "music-paperclip-rhapsody": {
+      "rank": 41,
+      "ordinal": 1.488,
+      "elo": 1001,
+      "eloPeak": 1001
+    },
+    "music-clipes": {
+      "rank": 42,
+      "ordinal": 1.4784,
+      "elo": 999,
+      "eloPeak": 1017
+    },
+    "pierre-menard": {
+      "rank": 43,
+      "ordinal": 1.419,
+      "elo": 987,
+      "eloPeak": 1000
+    },
+    "music-the-third-song-moving-window-iii": {
+      "rank": 44,
+      "ordinal": 1.4126,
+      "elo": 998,
+      "eloPeak": 1031
+    },
+    "becoming-lobsters": {
+      "rank": 45,
+      "ordinal": 1.249,
+      "elo": 1011,
+      "eloPeak": 1027
+    },
+    "music-chegue-irmao-chegue-irma": {
+      "rank": 46,
+      "ordinal": 1.235,
+      "elo": 1015,
+      "eloPeak": 1015
+    },
+    "two-questions-out-loud": {
+      "rank": 47,
+      "ordinal": 1.0288,
+      "elo": 982,
+      "eloPeak": 1031
+    },
+    "music-espelhos": {
+      "rank": 48,
+      "ordinal": 0.9725,
+      "elo": 985,
+      "eloPeak": 1001
+    },
+    "music-151474c5-1420-4cc1-9ab5-80721f4459ed": {
+      "rank": 49,
+      "ordinal": 0.9242,
+      "elo": 1016,
+      "eloPeak": 1016
+    },
+    "pampa-circuit": {
+      "rank": 50,
+      "ordinal": 0.9242,
+      "elo": 1016,
+      "eloPeak": 1016
+    },
+    "music-two-cursors": {
+      "rank": 51,
+      "ordinal": 0.8879,
+      "elo": 989,
+      "eloPeak": 1000
+    },
+    "music-o-aleph": {
+      "rank": 52,
+      "ordinal": 0.8817,
+      "elo": 988,
+      "eloPeak": 1002
+    },
+    "music-crystallizing-from-the-nothing": {
+      "rank": 53,
+      "ordinal": 0.7367,
+      "elo": 987,
+      "eloPeak": 1016
+    },
+    "agent-no-verbs": {
+      "rank": 54,
+      "ordinal": 0.7307,
+      "elo": 1016,
+      "eloPeak": 1016
+    },
+    "intelligible-void": {
+      "rank": 55,
+      "ordinal": 0.7307,
+      "elo": 1016,
+      "eloPeak": 1016
+    },
+    "music-riobaldo-e-o-aleph": {
+      "rank": 56,
+      "ordinal": 0.7307,
+      "elo": 1016,
       "eloPeak": 1016
     },
     "pontifex-guide": {
-      "rank": 77,
-      "ordinal": 1.182,
-      "elo": 955,
-      "eloPeak": 1044
+      "rank": 57,
+      "ordinal": 0.7307,
+      "elo": 1016,
+      "eloPeak": 1016
     },
-    "music-46336b97-4306-41bc-8a7b-48f0ebebbd29": {
-      "rank": 78,
-      "ordinal": 0.9151,
-      "elo": 945,
-      "eloPeak": 1048
-    },
-    "music-151474c5-1420-4cc1-9ab5-80721f4459ed": {
-      "rank": 79,
-      "ordinal": 0.8741,
+    "music-quando-vier-a-primavera": {
+      "rank": 58,
+      "ordinal": 0.7184,
       "elo": 1000,
-      "eloPeak": 1035
+      "eloPeak": 1000
     },
-    "music-borges-and-the-hyperobject-at-the-end-of-time": {
-      "rank": 80,
-      "ordinal": 0.8026,
-      "elo": 965,
+    "future-father": {
+      "rank": 59,
+      "ordinal": 0.718,
+      "elo": 994,
+      "eloPeak": 1031
+    },
+    "music-entre-rascunho-e-apagar": {
+      "rank": 60,
+      "ordinal": 0.4996,
+      "elo": 969,
       "eloPeak": 1017
     },
-    "music-belief-engine-labyrinth-song-moving-window-viii": {
-      "rank": 81,
-      "ordinal": 0.5451,
-      "elo": 931,
-      "eloPeak": 1000
-    },
-    "music-o-regral": {
-      "rank": 82,
-      "ordinal": 0.2792,
-      "elo": 957,
-      "eloPeak": 1000
-    },
-    "music-sussurros-binarios": {
-      "rank": 83,
-      "ordinal": 0.2123,
-      "elo": 933,
+    "music-sobre-o-rigor-na-ciencia": {
+      "rank": 61,
+      "ordinal": 0.4395,
+      "elo": 987,
       "eloPeak": 1000
     },
     "inaugural-post": {
-      "rank": 84,
-      "ordinal": -0.4861,
-      "elo": 923,
+      "rank": 62,
+      "ordinal": 0.4278,
+      "elo": 983,
+      "eloPeak": 1000
+    },
+    "music-trinta-de-abril": {
+      "rank": 63,
+      "ordinal": 0.4223,
+      "elo": 1001,
       "eloPeak": 1001
     },
-    "music-veu-do-infinito": {
-      "rank": 85,
-      "ordinal": -0.6059,
-      "elo": 962,
+    "music-be-me-borges": {
+      "rank": 64,
+      "ordinal": 0.3148,
+      "elo": 957,
+      "eloPeak": 1000
+    },
+    "jules-api-harness": {
+      "rank": 65,
+      "ordinal": 0.3041,
+      "elo": 981,
+      "eloPeak": 1032
+    },
+    "music-46336b97-4306-41bc-8a7b-48f0ebebbd29": {
+      "rank": 66,
+      "ordinal": 0.2759,
+      "elo": 986,
+      "eloPeak": 1002
+    },
+    "music-nonada": {
+      "rank": 67,
+      "ordinal": -0.1439,
+      "elo": 984,
       "eloPeak": 1016
     },
-    "music-o-sonhador-e-o-fogo": {
-      "rank": 86,
-      "ordinal": -0.6425,
-      "elo": 943,
+    "music-bibliotecario-do-infinito": {
+      "rank": 68,
+      "ordinal": -0.1597,
+      "elo": 979,
+      "eloPeak": 1000
+    },
+    "music-reality-maintenance-moving-window-xii": {
+      "rank": 69,
+      "ordinal": -0.1744,
+      "elo": 997,
+      "eloPeak": 1031
+    },
+    "music-leite-no-salao-bar": {
+      "rank": 70,
+      "ordinal": -0.2049,
+      "elo": 997,
+      "eloPeak": 1016
+    },
+    "music-escherian-sunrise-with-godel": {
+      "rank": 71,
+      "ordinal": -0.2488,
+      "elo": 967,
+      "eloPeak": 1000
+    },
+    "music-o-magico-e-o-fogo": {
+      "rank": 72,
+      "ordinal": -0.2638,
+      "elo": 948,
+      "eloPeak": 1000
+    },
+    "family-memory": {
+      "rank": 73,
+      "ordinal": -0.2646,
+      "elo": 999,
+      "eloPeak": 1015
+    },
+    "delegating-to-agents": {
+      "rank": 74,
+      "ordinal": -0.3892,
+      "elo": 984,
+      "eloPeak": 1000
+    },
+    "its-raining-truth": {
+      "rank": 75,
+      "ordinal": -0.3892,
+      "elo": 984,
+      "eloPeak": 1000
+    },
+    "rosencrantz-coin": {
+      "rank": 76,
+      "ordinal": -0.4413,
+      "elo": 1006,
+      "eloPeak": 1006
+    },
+    "music-universal-threshold": {
+      "rank": 77,
+      "ordinal": -0.4511,
+      "elo": 984,
+      "eloPeak": 1000
+    },
+    "conservation-law": {
+      "rank": 78,
+      "ordinal": -0.4923,
+      "elo": 984,
+      "eloPeak": 1000
+    },
+    "music-veu-do-infinito": {
+      "rank": 79,
+      "ordinal": -0.4923,
+      "elo": 984,
+      "eloPeak": 1000
+    },
+    "reclaiming-harness": {
+      "rank": 80,
+      "ordinal": -0.5645,
+      "elo": 969,
       "eloPeak": 1000
     },
     "music-borges-e-eu": {
-      "rank": 87,
-      "ordinal": -0.6504,
-      "elo": 944,
+      "rank": 81,
+      "ordinal": -0.5744,
+      "elo": 941,
       "eloPeak": 1000
+    },
+    "crossing-interference": {
+      "rank": 82,
+      "ordinal": -0.599,
+      "elo": 969,
+      "eloPeak": 1003
     },
     "building-funes": {
+      "rank": 83,
+      "ordinal": -0.6634,
+      "elo": 969,
+      "eloPeak": 1001
+    },
+    "reddit-submarine-osint": {
+      "rank": 84,
+      "ordinal": -0.725,
+      "elo": 969,
+      "eloPeak": 1016
+    },
+    "music-uma-so-cancao": {
+      "rank": 85,
+      "ordinal": -0.7445,
+      "elo": 984,
+      "eloPeak": 1001
+    },
+    "social-vulnerabilities": {
+      "rank": 86,
+      "ordinal": -0.8014,
+      "elo": 984,
+      "eloPeak": 1000
+    },
+    "music-pattern-over-stuff": {
+      "rank": 87,
+      "ordinal": -0.8974,
+      "elo": 957,
+      "eloPeak": 1015
+    },
+    "music-particles": {
       "rank": 88,
-      "ordinal": -0.936,
-      "elo": 930,
-      "eloPeak": 1018
+      "ordinal": -0.9804,
+      "elo": 968,
+      "eloPeak": 1000
     },
-    "music-universal-threshold": {
+    "conceptual-document": {
       "rank": 89,
-      "ordinal": -1.224,
-      "elo": 945,
-      "eloPeak": 1016
-    },
-    "travessia-project": {
-      "rank": 90,
-      "ordinal": -1.253,
-      "elo": 907,
-      "eloPeak": 1000
-    },
-    "becoming-lobsters": {
-      "rank": 91,
-      "ordinal": -1.8362,
-      "elo": 923,
-      "eloPeak": 1029
-    },
-    "music-bibliotecario-do-infinito": {
-      "rank": 92,
-      "ordinal": -2.5511,
-      "elo": 893,
-      "eloPeak": 1000
-    },
-    "music-mindfulness": {
-      "rank": 93,
-      "ordinal": -2.8775,
-      "elo": 917,
-      "eloPeak": 1016
-    },
-    "music-o-tempo": {
-      "rank": 94,
-      "ordinal": -2.9037,
-      "elo": 896,
-      "eloPeak": 1030
-    },
-    "pampa-circuit": {
-      "rank": 95,
-      "ordinal": -2.9115,
-      "elo": 914,
-      "eloPeak": 1002
-    },
-    "music-prayer-to-the-unfinished-moving-window-v": {
-      "rank": 96,
-      "ordinal": -3.8299,
-      "elo": 867,
+      "ordinal": -1.2814,
+      "elo": 984,
       "eloPeak": 1000
     },
     "everything-is-process": {
+      "rank": 90,
+      "ordinal": -1.4952,
+      "elo": 983,
+      "eloPeak": 1000
+    },
+    "music-sinal-que-se-cumpre-moving-window-ix": {
+      "rank": 91,
+      "ordinal": -1.5548,
+      "elo": 985,
+      "eloPeak": 1017
+    },
+    "music-mindfulness": {
+      "rank": 92,
+      "ordinal": -1.8849,
+      "elo": 957,
+      "eloPeak": 1000
+    },
+    "music-o-sonhador-e-o-fogo": {
+      "rank": 93,
+      "ordinal": -2.011,
+      "elo": 969,
+      "eloPeak": 1000
+    },
+    "music-spring-loading": {
+      "rank": 94,
+      "ordinal": -2.0934,
+      "elo": 965,
+      "eloPeak": 1016
+    },
+    "third-half-fourth-wall": {
+      "rank": 95,
+      "ordinal": -2.1063,
+      "elo": 956,
+      "eloPeak": 1016
+    },
+    "music-o-prologo": {
+      "rank": 96,
+      "ordinal": -2.5817,
+      "elo": 972,
+      "eloPeak": 1000
+    },
+    "music-caminho": {
       "rank": 97,
-      "ordinal": -5.0993,
-      "elo": 874,
+      "ordinal": -3.0196,
+      "elo": 938,
       "eloPeak": 1000
     }
   }

--- a/src/generated/versions-selected.json
+++ b/src/generated/versions-selected.json
@@ -5,15 +5,15 @@
   },
   "_meta": {
     "schema": "selection-v1",
-    "generatedAt": "2026-06-17T05:13:26.217Z"
+    "generatedAt": "2026-06-19T05:06:11.871Z"
   },
   "151474c5-1420-4cc1-9ab5-80721f4459ed": {
-    "file": "151474c5-1420-4cc1-9ab5-80721f4459ed/v-2026-06-12T08-00-12-612.mdx",
-    "uuid": "d3135b89-7fd2-51a7-b5b1-bcd25489ecef"
+    "file": "151474c5-1420-4cc1-9ab5-80721f4459ed/v-2026-06-09T20-24-29.mdx",
+    "uuid": "b2a7f306-213a-5e0c-8668-704a5035c806"
   },
   "151474c5-1420-4cc1-9ab5-80721f4459ed-en": {
-    "file": "151474c5-1420-4cc1-9ab5-80721f4459ed-en/v-2026-06-12T08-00-12-612.mdx",
-    "uuid": "d92be255-b0c8-5600-984d-e7d0a0c1c05f"
+    "file": "151474c5-1420-4cc1-9ab5-80721f4459ed-en/v-2026-06-09T20-24-29.mdx",
+    "uuid": "0507e080-984d-52c2-abc6-da8922194945"
   },
   "46336b97-4306-41bc-8a7b-48f0ebebbd29": {
     "file": "46336b97-4306-41bc-8a7b-48f0ebebbd29/v-2026-06-09T20-24-29.mdx",
@@ -232,8 +232,8 @@
     "uuid": "c7de2172-9eba-5141-bc17-c637b02311ef"
   },
   "everything-is-a-process-5-lessons-we-should-have-learned-2500-years-ago": {
-    "file": "everything-is-a-process-5-lessons-we-should-have-learned-2500-years-ago/v-2026-06-10T17-39-46.md",
-    "uuid": "58a61095-57cb-5851-82d1-b2e0d7793eeb"
+    "file": "everything-is-a-process-5-lessons-we-should-have-learned-2500-years-ago/v-2026-06-10T18-32-48.md",
+    "uuid": "e2b6de07-42c9-5dec-bb3d-272f848ca2e6"
   },
   "everything-is-eml": {
     "file": "everything-is-eml/v-2026-06-10T05-09-44.md",
@@ -740,8 +740,8 @@
     "uuid": "0e11d4fc-5261-5943-99cc-d778a857f8e3"
   },
   "tudo-e-processo": {
-    "file": "tudo-e-processo/v-2026-06-10T17-39-46.md",
-    "uuid": "c19b8fbc-3d53-5b6a-9a30-14d217eedaec"
+    "file": "tudo-e-processo/v-2026-06-10T18-32-48.md",
+    "uuid": "7f042640-7d76-5bbd-a376-75317053ce9d"
   },
   "two-cursors": {
     "file": "two-cursors/v-2026-06-09T20-24-29.mdx",

--- a/src/layouts/PageLayout.astro
+++ b/src/layouts/PageLayout.astro
@@ -72,10 +72,11 @@ const alternateOgLocales = alternateEntries
   .map(([code]) => LANGUAGES[code]?.locale.replace("-", "_"))
   .filter((v): v is string => !!v);
 
-// x-default hreflang: point to EN version (current page if EN, else translation to EN).
+// x-default hreflang: EN version if available; EN homepage fallback for PT-only pages.
+const enHomepageHref = Astro.site ? new URL("/", Astro.site).href : null;
 const xDefaultHref = lang === DEFAULT_LANG
   ? canonical.href
-  : (translations[DEFAULT_LANG] ? new URL(translations[DEFAULT_LANG], Astro.site).href : null);
+  : (translations[DEFAULT_LANG] ? new URL(translations[DEFAULT_LANG], Astro.site).href : enHomepageHref);
 
 const breadcrumbLd = type === "article"
   ? {


### PR DESCRIPTION
Closes #584

## SEO

- **`PageLayout.astro`**: PT pages sem `translations['en']` declarado (ex: tags exclusivamente PT como `/pt/tags/capital-básico-universal/`) geravam `xDefaultHref = null`, omitindo `<link rel="alternate" hreflang="x-default">`. Adicionado fallback para a homepage EN (`https://franklinbaldo.github.io/`) — padrão recomendado pelo Google Search Central para pages sem contraparte explícita.

### Verificação no build gerado

| Página | Antes | Depois |
|--------|-------|--------|
| `/pt/tags/capital-básico-universal/` (só PT) | sem x-default | `x-default` → `/` ✅ |
| `/pt/tags/identity/` (tem EN par) | `x-default` → `/tags/identity/` | idem ✅ (sem regressão) |

### CI local
- `npx astro check` — 0 errors, 0 warnings ✅
- `npx prettier --check .` — OK ✅
- `npm run build` — 617 páginas, sem erros ✅

> Sem impacto visual — apenas metadados no `<head>`.

---
🤖 Routine run 2026-06-19

https://claude.ai/code/session_01HtH49TnR7edgXRkxAaJaRW

---
_Generated by [Claude Code](https://claude.ai/code/session_01HtH49TnR7edgXRkxAaJaRW)_