### PR TITLE
seo: BreadcrumbList structured data para /paths/ e /tags/

### DIFF
--- a/.routines/2026-06-20T05-00-00-breadcrumb-paths-tags.md
+++ b/.routines/2026-06-20T05-00-00-breadcrumb-paths-tags.md
@@ -1,0 +1,69 @@
+---
+date: 2026-06-20T05:00:00
+slug: breadcrumb-paths-tags
+branch: claude/sleepy-pasteur-mojyai
+status: pr-open
+issues: [590]
+pr_opened: null
+pr_merged: 592
+---
+
+# Sessão 2026-06-20 — BreadcrumbList para /paths/ e /tags/
+
+## Contexto ao chegar
+
+- 13 issues `routine` abertas (faixa saudável 10–20)
+- PR da run anterior: #592 (seo: hreflang x-default) já havia sido mergeado pelo Franklin na run de 2026-06-19. Nenhum PR `routine` pendente para mergear.
+- Main no commit `f45d1ee` (merge do PR #592)
+
+## O que mergeou
+
+PR #592 (hreflang x-default fallback para homepage EN) — mergeado pelo Franklin ainda durante a run de 2026-06-19.
+
+## O que foi feito
+
+**Issue #590** (priority:media) — seo: BreadcrumbList structured data para /paths/[slug] e /tags/[tag]
+
+### Análise
+
+`PageLayout.astro` já emitia `BreadcrumbList` para posts (`type="article"`), com hierarquia fixa: Home → Blog → título do post. Mas as páginas `/paths/[slug]/`, `/pt/paths/[slug]/`, `/tags/[tag]/` e `/pt/tags/[tag]/` não tinham nenhuma BreadcrumbList — ficavam com apenas o schema `WebSite` (para navegação não-artigo) ou o `CollectionPage` inline (para tags).
+
+### Implementação
+
+1. **`src/layouts/PageLayout.astro`** — adicionado prop `breadcrumb?: Array<{ name: string; item: string }>`. Quando passado, emite um `BreadcrumbList` JSON-LD adicional no `<head>`, separado do breadcrumb de artigos. O prop coexiste sem conflito com o `breadcrumbLd` existente (que só ativa para `type="article"`).
+
+2. **`src/pages/paths/[slug].astro`** — breadcrumb 2 níveis:
+   - EN: Home (`/`) → {path.title.en} (`/paths/{slug}/`)
+   - (sem nível intermediário `/paths/` pois não há index page)
+
+3. **`src/pages/pt/paths/[slug].astro`** — breadcrumb 2 níveis:
+   - PT: Início (`/pt/`) → {path.title.pt} (`/pt/paths/{slug}/`)
+
+4. **`src/pages/tags/[tag].astro`** — breadcrumb 3 níveis:
+   - EN: Home (`/`) → Tags (`/tags/`) → `#{tag}` (`/tags/{tag}/`)
+   - `/tags/` index existe → hierarquia completa
+
+5. **`src/pages/pt/tags/[tag].astro`** — breadcrumb 3 níveis:
+   - PT: Início (`/pt/`) → Etiquetas (`/pt/tags/`) → `#{tag}` (`/pt/tags/{tag}/`)
+
+### Verificação no HTML gerado
+
+| Página | BreadcrumbList |
+|--------|---------------|
+| `/tags/AI/` | Home → Tags → #AI ✅ |
+| `/pt/tags/ia/` | Início → Etiquetas → #ia ✅ |
+| `/paths/agency-and-constraint/` | Home → Agency and Constraint ✅ |
+| `/pt/paths/memory-and-funes/` | Início → Memória e Funes ✅ |
+
+### CI local
+
+- `npm run build` — 2003 páginas, sem erros ✅
+- `npx prettier --check .` — OK ✅
+- `npm run hronir:doctor` — 0 inconsistências ✅
+- `npm run check:hygiene` — OK ✅
+
+## O que ficou para a próxima run
+
+- Verificar screenshot de produção pós-deploy (sem impacto visual — só metadados `<head>`)
+- Próximas prioridades: #583 (a11y: skip-link PT), #495 (aria-label nav), #552 (focus-visible), #553 (CLS imagens), #585 (font-display Fira Code)
+- Issues de baixa restantes: #249, #250, #251, #495, #552, #553, #583, #585, #587, #588, #589, #591

--- a/.routines/2026-06-20T05-00-00-breadcrumb-paths-tags.md
+++ b/.routines/2026-06-20T05-00-00-breadcrumb-paths-tags.md
@@ -4,7 +4,7 @@ slug: breadcrumb-paths-tags
 branch: claude/sleepy-pasteur-mojyai
 status: pr-open
 issues: [590]
-pr_opened: null
+pr_opened: 594
 pr_merged: 592
 ---
 

--- a/src/generated/ranking-snapshot.json
+++ b/src/generated/ranking-snapshot.json
@@ -1,7 +1,7 @@
 {
   "_meta": {
     "schema": "snapshot-v2",
-    "generatedAt": "2026-06-19T05:13:33.258Z",
+    "generatedAt": "2026-06-20T05:05:56.702Z",
     "basis": "build",
     "totalDuels": 197
   },

--- a/src/layouts/PageLayout.astro
+++ b/src/layouts/PageLayout.astro
@@ -24,6 +24,10 @@ interface Props {
   canonicalOverride?: string;
   /** Emit robots noindex,follow — for archive/version pages. */
   noindex?: boolean;
+  /** BreadcrumbList items for list/taxonomy pages (paths, tags). Each item becomes
+   *  a ListItem in a BreadcrumbList JSON-LD block. Does not affect article pages
+   *  (those use the built-in breadcrumb derived from type="article"). */
+  breadcrumb?: Array<{ name: string; item: string }>;
 }
 
 const SITE_NAME = "Franklin Baldo";
@@ -44,6 +48,7 @@ const {
   wordCount,
   canonicalOverride,
   noindex,
+  breadcrumb,
 } = source;
 // Language-aware fallback description: derive lang first so PT pages without
 // an explicit description don't fall back to the English copy.
@@ -87,6 +92,19 @@ const breadcrumbLd = type === "article"
         { "@type": "ListItem", position: 2, name: lang === "pt" ? "Arquivo" : "Blog", item: Astro.site ? new URL(lang === "pt" ? "/pt/archive/" : "/archive/", Astro.site).href : "/archive/" },
         { "@type": "ListItem", position: 3, name: title, item: canonical.href },
       ],
+    }
+  : null;
+
+const listBreadcrumbLd = breadcrumb?.length
+  ? {
+      "@context": "https://schema.org",
+      "@type": "BreadcrumbList",
+      itemListElement: breadcrumb.map((crumb, i) => ({
+        "@type": "ListItem",
+        position: i + 1,
+        name: crumb.name,
+        item: crumb.item,
+      })),
     }
   : null;
 
@@ -212,6 +230,7 @@ const personLd = {
     <script type="application/ld+json" set:html={JSON.stringify(jsonLd)} is:inline />
     <script type="application/ld+json" set:html={JSON.stringify(personLd)} is:inline />
     {breadcrumbLd && <script type="application/ld+json" set:html={JSON.stringify(breadcrumbLd)} is:inline />}
+    {listBreadcrumbLd && <script type="application/ld+json" set:html={JSON.stringify(listBreadcrumbLd)} is:inline />}
     <slot name="head" />
 
     <script is:inline>

--- a/src/pages/paths/[slug].astro
+++ b/src/pages/paths/[slug].astro
@@ -21,6 +21,10 @@ const translations: Record<string, string> = ptHasPosts ? { pt: `/pt/paths/${pat
   description={path.blurb.en}
   lang="en"
   translations={translations}
+  breadcrumb={[
+    { name: "Home", item: Astro.site ? new URL("/", Astro.site).href : "https://franklinbaldo.github.io/" },
+    { name: path.title.en, item: Astro.site ? new URL(`/paths/${path.slug}/`, Astro.site).href : `https://franklinbaldo.github.io/paths/${path.slug}/` },
+  ]}
 >
   <hgroup>
     <p><small><a href="/">← Home</a> · <em>Reading path</em></small></p>

--- a/src/pages/pt/paths/[slug].astro
+++ b/src/pages/pt/paths/[slug].astro
@@ -21,6 +21,10 @@ const translations: Record<string, string> = enHasPosts ? { en: `/paths/${path.s
   description={path.blurb.pt}
   lang="pt"
   translations={translations}
+  breadcrumb={[
+    { name: "Início", item: Astro.site ? new URL("/pt/", Astro.site).href : "https://franklinbaldo.github.io/pt/" },
+    { name: path.title.pt, item: Astro.site ? new URL(`/pt/paths/${path.slug}/`, Astro.site).href : `https://franklinbaldo.github.io/pt/paths/${path.slug}/` },
+  ]}
 >
   <hgroup>
     <p><small><a href="/pt/">← Início</a> · <em>Caminho de leitura</em></small></p>

--- a/src/pages/pt/tags/[tag].astro
+++ b/src/pages/pt/tags/[tag].astro
@@ -70,6 +70,11 @@ const collectionLd = {
   description={description}
   lang="pt"
   translations={hasEnCounterpart ? { en: `/tags/${tag}/` } : {}}
+  breadcrumb={[
+    { name: "Início", item: Astro.site ? new URL("/pt/", Astro.site).href : "https://franklinbaldo.github.io/pt/" },
+    { name: "Etiquetas", item: Astro.site ? new URL("/pt/tags/", Astro.site).href : "https://franklinbaldo.github.io/pt/tags/" },
+    { name: `#${tag}`, item: Astro.site ? new URL(`/pt/tags/${tag}/`, Astro.site).href : `https://franklinbaldo.github.io/pt/tags/${tag}/` },
+  ]}
 >
   <script type="application/ld+json" set:html={JSON.stringify(collectionLd)} is:inline slot="head" />
   <article>

--- a/src/pages/tags/[tag].astro
+++ b/src/pages/tags/[tag].astro
@@ -70,6 +70,11 @@ const collectionLd = {
   description={description}
   lang="en"
   translations={hasPtCounterpart ? { pt: `/pt/tags/${tag}/` } : {}}
+  breadcrumb={[
+    { name: "Home", item: Astro.site ? new URL("/", Astro.site).href : "https://franklinbaldo.github.io/" },
+    { name: "Tags", item: Astro.site ? new URL("/tags/", Astro.site).href : "https://franklinbaldo.github.io/tags/" },
+    { name: `#${tag}`, item: Astro.site ? new URL(`/tags/${tag}/`, Astro.site).href : `https://franklinbaldo.github.io/tags/${tag}/` },
+  ]}
 >
   <script type="application/ld+json" set:html={JSON.stringify(collectionLd)} is:inline slot="head" />
   <article>


### PR DESCRIPTION
Closes #590

## SEO

- **`PageLayout.astro`**: novo prop `breadcrumb?: Array<{ name: string; item: string }>`. Quando presente, emite um bloco `BreadcrumbList` JSON-LD separado no `<head>` — coexiste com o breadcrumb existente de posts (`type="article"`) sem conflito.

- **`/paths/[slug].astro`** e **`/pt/paths/[slug].astro`**: breadcrumb 2 níveis — Home (Início PT) → título da trilha. Sem nível intermediário `/paths/` pois não existe index page.

- **`/tags/[tag].astro`** e **`/pt/tags/[tag].astro`**: breadcrumb 3 níveis — Home (Início PT) → Tags (Etiquetas PT) → `#tag`. `/tags/` index page existe, então a hierarquia é completa.

### Paridade i18n

| Nível | EN | PT |
|-------|----|----|
| Raiz | `Home` → `/` | `Início` → `/pt/` |
| Tags index | `Tags` → `/tags/` | `Etiquetas` → `/pt/tags/` |
| Tag/path | `#tag` / path title | idem |

### Verificação no HTML gerado

| Página | Hierarquia emitida |
|--------|-------------------|
| `/tags/AI/` | Home → Tags → #AI ✅ |
| `/pt/tags/ia/` | Início → Etiquetas → #ia ✅ |
| `/paths/agency-and-constraint/` | Home → Agency and Constraint ✅ |
| `/pt/paths/memory-and-funes/` | Início → Memória e Funes ✅ |

> Sem impacto visual — apenas metadados no `<head>`. Screenshot de produção na próxima run.

---
🤖 Routine run 2026-06-20

https://claude.ai/code/session_017UAMJ2cpMGYDSFmUv9S3Gt

---
_Generated by [Claude Code](https://claude.ai/code/session_017UAMJ2cpMGYDSFmUv9S3Gt)_