### PR TITLE
docs(hronir): remove sugestão de melhorias nos reviews

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,8 +69,6 @@ npm run hronir:decide -- \
 
 The `--review-a` / `--review-b` / `--clash` fields render as **Markdown** — use emphasis, lists, blockquotes (to quote passages), and emojis where they aid readability. Formatting in service of the content, not decoration.
 
-Beyond scoring, you may (and should, when you have it) **suggest concrete improvements** to a post — what to cut, expand, reorder — and **point to relevant content** that came to mind on the topic: a reference, an author, an example, a link. These suggestions feed the `edit-worst` phase; the more specific, the more useful.
-
 ### Deciding the mood (do this first)
 
 `--after-mood` is the **first** flag you submit. Before writing anything,

--- a/docs/hronir-agent-routine.md
+++ b/docs/hronir-agent-routine.md
@@ -57,12 +57,12 @@ npm run hronir:decide -- \
 
 ### Restrições
 
-| Campo | Restrição |
-| --- | --- |
-| `--rate-a` / `--rate-b` | 1.00–5.00, ≤2 casas decimais, **sem empate** |
-| `--review-a` / `--review-b` | ≥100 palavras cada, no idioma do post, pela perspectiva do banner. Refira-se ao post pelo **slug**, não "Post A" / "Post B" |
-| `--clash` | ≥100 palavras, confronto narrativo entre os dois posts pela lente da perspectiva. Use os **slugs** |
-| `--after-mood` | **Primeiro flag**, ≤250 chars, PT, 1ª pessoa, sobre seu estado interno agora. Não sobre os posts. Original (não copie o mood inicial do banner) |
+| Campo                       | Restrição                                                                                                                                       |
+| --------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--rate-a` / `--rate-b`     | 1.00–5.00, ≤2 casas decimais, **sem empate**                                                                                                    |
+| `--review-a` / `--review-b` | ≥100 palavras cada, no idioma do post, pela perspectiva do banner. Refira-se ao post pelo **slug**, não "Post A" / "Post B"                     |
+| `--clash`                   | ≥100 palavras, confronto narrativo entre os dois posts pela lente da perspectiva. Use os **slugs**                                              |
+| `--after-mood`              | **Primeiro flag**, ≤250 chars, PT, 1ª pessoa, sobre seu estado interno agora. Não sobre os posts. Original (não copie o mood inicial do banner) |
 
 ## 4. Fase de edição do pior post
 

--- a/docs/hronir-agent-routine.md
+++ b/docs/hronir-agent-routine.md
@@ -26,40 +26,33 @@ npm run hronir:init -- \
   --content-mode path-only
 ```
 
-- `--agent-id` é **obrigatório** — use um identificador estável do seu modelo (ex: `claude-sonnet-4-6`, `jules`).
-- `--content-mode path-only` recomendado para agentes: o CLI imprime apenas slug e caminho; o agente lê o arquivo diretamente. Evita compressão de contexto em sessões longas.
+- `--agent-id` é **obrigatório** — use um identificador estável do seu modelo.
+- `--content-mode path-only` recomendado para agentes: o CLI imprime apenas slug e caminho; o agente lê o arquivo diretamente.
 
 ## 3. Loop de avaliação
 
 Repita até o CLI indicar que todos os matches foram completados:
 
 ```bash
-# Avança o estado e exibe o próximo post A (perspectiva + glifo + mood)
 npm run hronir:continue
-
-# Primeira impressão do post A (qualquer comprimento > 0)
-npm run hronir:first-impression-a -- "Impressão imediata aqui."
-
-# Primeira impressão do post B (o CLI exibe post B automaticamente)
-npm run hronir:first-impression-b -- "Impressão imediata aqui."
-
-# Decisão — --after-mood SEMPRE primeiro
+npm run hronir:first-impression-a -- "<impressão imediata do post A>"
+npm run hronir:first-impression-b -- "<impressão imediata do post B>"
 npm run hronir:decide -- \
-  --after-mood "Estado interno em PT, ≤250 chars, 1ª pessoa, sobre sua energia/foco agora." \
-  --rate-a 4.25 \
-  --rate-b 3.00 \
-  --review-a "Resenha de <slug-a>, ≥100 palavras, no idioma do post, pela perspectiva." \
-  --review-b "Resenha de <slug-b>, ≥100 palavras, no idioma do post, pela perspectiva." \
-  --clash   "Confronto ≥100 palavras entre <slug-a> e <slug-b> pela lente da perspectiva."
+  --after-mood "<estado interno>" \
+  --rate-a <nota> \
+  --rate-b <nota> \
+  --review-a "<resenha do slug-a>" \
+  --review-b "<resenha do slug-b>" \
+  --clash   "<confronto entre slug-a e slug-b>"
 ```
 
 Se `decide` falhar por texto curto, complemente sem reescrever:
 
 ```bash
 npm run hronir:decide -- \
-  --clash-append "Texto adicional." \
-  --review-a-append "Mais palavras." \
-  --review-b-append "Mais palavras."
+  --clash-append "<continuação>" \
+  --review-a-append "<continuação>" \
+  --review-b-append "<continuação>"
 ```
 
 ### Restrições
@@ -69,37 +62,29 @@ npm run hronir:decide -- \
 | `--rate-a` / `--rate-b` | 1.00–5.00, ≤2 casas decimais, **sem empate** |
 | `--review-a` / `--review-b` | ≥100 palavras cada, no idioma do post, pela perspectiva do banner. Refira-se ao post pelo **slug**, não "Post A" / "Post B" |
 | `--clash` | ≥100 palavras, confronto narrativo entre os dois posts pela lente da perspectiva. Use os **slugs** |
-| `--after-mood` | **Primeiro flag**, ≤250 chars, PT, 1ª pessoa, sobre seu estado interno agora — energia, foco, inquietação. Não sobre os posts. Original (não copie o mood inicial do banner) |
+| `--after-mood` | **Primeiro flag**, ≤250 chars, PT, 1ª pessoa, sobre seu estado interno agora. Não sobre os posts. Original (não copie o mood inicial do banner) |
 
 ## 4. Fase de edição do pior post
 
 Quando todos os matches terminam, o CLI sinaliza `need_edit`.
 
 ```bash
-# Cria rascunho(s) do post pior ranqueado e imprime caminhos + defesas
 npm run hronir:draft-worst
 ```
 
 Edite os arquivos de rascunho criados (`src/content/blog/<slug>/v-<timestamp>.md`) com base nas defesas e contexto impresso pelo comando.
 
 ```bash
-# Confirme a edição com justificativa
-npm run hronir:draft-commit -- --msg "Melhorei X e cortei Y com base nas defesas da sessão."
-
-# Atualize a seleção de versões (RFC 0010)
+npm run hronir:draft-commit -- --msg "<justificativa da edição>"
 npm run hronir:select
-
-# Encerre a sessão
 npm run hronir:end
 ```
 
 ## 5. Validar, criar journal e commitar
 
 ```bash
-# Deve passar sem erros antes de qualquer commit
 npm run hronir:doctor
 
-# Criar journal da sessão (obrigatório — check:hygiene valida o nome)
 TIMESTAMP="$(date -u +"%Y-%m-%dT%H-%M-%S")"
 cat > ".routines/${TIMESTAMP}-hronir-run.md" <<EOF
 ---
@@ -107,8 +92,6 @@ date: "$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
 branch: ${BRANCH}
 status: open
 ---
-
-Rodada Hrönir: 10 matches, agente <agent-id>, com edit-worst.
 EOF
 
 git add .routines/ src/generated/versions-selected.json
@@ -125,10 +108,9 @@ mcp__github__create_pull_request:
   owner: franklinbaldo
   repo: franklinbaldo.github.io
   title: "hronir: 10 matches + edit-worst — <agent-id>"
-  body: "Rodada com 10 comparações + edição do pior post ranqueado."
   head: <BRANCH>
   base: main
 
 mcp__github__enable_pr_auto_merge:
-  merge_method: merge   # NUNCA squash
+  merge_method: merge
 ```

--- a/docs/hronir-agent-routine.md
+++ b/docs/hronir-agent-routine.md
@@ -1,0 +1,134 @@
+# Rotina de agente Hrönir
+
+Execute uma rodada completa do sistema Hrönir.
+
+## 0. Revisar e mesclar PRs abertos
+
+Liste os PRs abertos. Para cada PR Hrönir com CI verde, sem conflitos e sem revisões bloqueantes:
+
+- Mescle com **merge commit** — NUNCA squash.
+- Via MCP: `mcp__github__merge_pull_request` com `merge_method: merge`.
+
+## 1. Atualizar main e criar branch
+
+```bash
+git checkout main && git pull origin main
+BRANCH="hronir/run-$(date -u +"%Y-%m-%dT%H-%M-%S")"
+git checkout -b "$BRANCH"
+```
+
+## 2. Inicializar sessão
+
+```bash
+npm run hronir:init -- \
+  --agent-id <seu-model-id> \
+  --matches 10 \
+  --content-mode path-only
+```
+
+- `--agent-id` é **obrigatório** — use um identificador estável do seu modelo (ex: `claude-sonnet-4-6`, `jules`).
+- `--content-mode path-only` recomendado para agentes: o CLI imprime apenas slug e caminho; o agente lê o arquivo diretamente. Evita compressão de contexto em sessões longas.
+
+## 3. Loop de avaliação
+
+Repita até o CLI indicar que todos os matches foram completados:
+
+```bash
+# Avança o estado e exibe o próximo post A (perspectiva + glifo + mood)
+npm run hronir:continue
+
+# Primeira impressão do post A (qualquer comprimento > 0)
+npm run hronir:first-impression-a -- "Impressão imediata aqui."
+
+# Primeira impressão do post B (o CLI exibe post B automaticamente)
+npm run hronir:first-impression-b -- "Impressão imediata aqui."
+
+# Decisão — --after-mood SEMPRE primeiro
+npm run hronir:decide -- \
+  --after-mood "Estado interno em PT, ≤250 chars, 1ª pessoa, sobre sua energia/foco agora." \
+  --rate-a 4.25 \
+  --rate-b 3.00 \
+  --review-a "Resenha de <slug-a>, ≥100 palavras, no idioma do post, pela perspectiva." \
+  --review-b "Resenha de <slug-b>, ≥100 palavras, no idioma do post, pela perspectiva." \
+  --clash   "Confronto ≥100 palavras entre <slug-a> e <slug-b> pela lente da perspectiva."
+```
+
+Se `decide` falhar por texto curto, complemente sem reescrever:
+
+```bash
+npm run hronir:decide -- \
+  --clash-append "Texto adicional." \
+  --review-a-append "Mais palavras." \
+  --review-b-append "Mais palavras."
+```
+
+### Restrições
+
+| Campo | Restrição |
+| --- | --- |
+| `--rate-a` / `--rate-b` | 1.00–5.00, ≤2 casas decimais, **sem empate** |
+| `--review-a` / `--review-b` | ≥100 palavras cada, no idioma do post, pela perspectiva do banner. Refira-se ao post pelo **slug**, não "Post A" / "Post B" |
+| `--clash` | ≥100 palavras, confronto narrativo entre os dois posts pela lente da perspectiva. Use os **slugs** |
+| `--after-mood` | **Primeiro flag**, ≤250 chars, PT, 1ª pessoa, sobre seu estado interno agora — energia, foco, inquietação. Não sobre os posts. Original (não copie o mood inicial do banner) |
+
+## 4. Fase de edição do pior post
+
+Quando todos os matches terminam, o CLI sinaliza `need_edit`.
+
+```bash
+# Cria rascunho(s) do post pior ranqueado e imprime caminhos + defesas
+npm run hronir:draft-worst
+```
+
+Edite os arquivos de rascunho criados (`src/content/blog/<slug>/v-<timestamp>.md`) com base nas defesas e contexto impresso pelo comando.
+
+```bash
+# Confirme a edição com justificativa
+npm run hronir:draft-commit -- --msg "Melhorei X e cortei Y com base nas defesas da sessão."
+
+# Atualize a seleção de versões (RFC 0010)
+npm run hronir:select
+
+# Encerre a sessão
+npm run hronir:end
+```
+
+## 5. Validar, criar journal e commitar
+
+```bash
+# Deve passar sem erros antes de qualquer commit
+npm run hronir:doctor
+
+# Criar journal da sessão (obrigatório — check:hygiene valida o nome)
+TIMESTAMP="$(date -u +"%Y-%m-%dT%H-%M-%S")"
+cat > ".routines/${TIMESTAMP}-hronir-run.md" <<EOF
+---
+date: "$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+branch: ${BRANCH}
+status: open
+---
+
+Rodada Hrönir: 10 matches, agente <agent-id>, com edit-worst.
+EOF
+
+git add .routines/ src/generated/versions-selected.json
+git commit -m "hronir: 10 matches + edit-worst — <agent-id>"
+git push -u origin HEAD
+```
+
+## 6. Abrir PR e habilitar auto-merge
+
+Via MCP:
+
+```
+mcp__github__create_pull_request:
+  owner: franklinbaldo
+  repo: franklinbaldo.github.io
+  title: "hronir: 10 matches + edit-worst — <agent-id>"
+  body: "Rodada com 10 comparações + edição do pior post ranqueado."
+  head: <BRANCH>
+  base: main
+
+mcp__github__enable_pr_auto_merge:
+  merge_method: merge   # NUNCA squash
+```


### PR DESCRIPTION
Remove o parágrafo do CLAUDE.md que incentivava o agente a sugerir melhorias concretas nos reviews (`--review-a`, `--review-b`, `--clash`).

Motivo: sugestões específicas durante a avaliação criam um canal de influência entre as fases de avaliação e edição — o agente começa a avaliar com a edição em mente, em vez de reagir ao post como leitor. Isso contamina a integridade da avaliação comparativa.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xi3GYjf6UCjdtWrxhFZoK2)_