### PR TITLE
a11y: skip-link i18n + aria-label na navegação principal

### DIFF
--- a/.routines/2026-06-21T00-00-00-a11y-skip-link-nav-label.md
+++ b/.routines/2026-06-21T00-00-00-a11y-skip-link-nav-label.md
@@ -4,7 +4,7 @@ slug: a11y-skip-link-nav-label
 branch: claude/sleepy-pasteur-tw13in
 status: pr-open
 issues: [583, 495]
-pr_opened: null
+pr_opened: 601
 pr_merged: null
 ---
 

--- a/.routines/2026-06-21T00-00-00-a11y-skip-link-nav-label.md
+++ b/.routines/2026-06-21T00-00-00-a11y-skip-link-nav-label.md
@@ -1,0 +1,60 @@
+---
+date: 2026-06-21T00:00:00
+slug: a11y-skip-link-nav-label
+branch: claude/sleepy-pasteur-tw13in
+status: pr-open
+issues: [583, 495]
+pr_opened: null
+pr_merged: null
+---
+
+# Sessão 2026-06-21 — a11y: skip-link i18n + nav aria-label
+
+## Contexto ao chegar
+
+- Sem PR `routine` pendente da run anterior para mergear.
+- Backlog: 12 issues abertas com label `routine` — na faixa 10–20, sem necessidade de reabastecimento.
+- Branch designada: `claude/sleepy-pasteur-tw13in`, alinhada com `origin/main`.
+
+## O que foi feito
+
+### 1. Skip-link internacionalizado — `src/layouts/PageLayout.astro` (issue #583)
+
+O skip-link `<a href="#main">Skip to content</a>` era hardcoded em inglês. Em páginas PT-BR,
+screen readers liam "Skip to content" em inglês — violação de WCAG 2.1 SC 3.1.1 (idioma da página
+identificável). A correção é uma expressão condicional inline usando o prop `lang` já disponível:
+
+```astro
+{lang === 'pt' ? 'Ir para o conteúdo' : 'Skip to content'}
+```
+
+### 2. `aria-label` na navegação principal — `src/components/Header.astro` (issue #495)
+
+O `<nav>` do Header não tinha `aria-label`. Em páginas com TOC (que têm um segundo `<nav>`),
+screen readers não conseguiam distinguir os dois landmarks — WCAG 2.1 SC 4.1.2. O `<nav>` do
+TOC já tinha `aria-label` (confirmado na inspeção). O Header recebeu:
+
+```astro
+<nav aria-label={lang === 'pt' ? 'Navegação principal' : 'Main navigation'}>
+```
+
+Ambos os labels estão em PT em páginas PT e em EN em páginas EN — paridade i18n respeitada.
+
+## CI local
+
+- `npm run build` ✅ (0 erros, 206 páginas indexadas)
+- `npx prettier --check .` ✅
+- `npx astro check` ✅ (0 erros, 0 warnings novos)
+- `npm run hronir:doctor` ✅ (0 inconsistências)
+
+## Para a próxima run
+
+O screenshot de produção das páginas afetadas (`/`, `/pt/`) confirma o comportamento
+visual na próxima run após o merge. Não há impacto visual visível — o skip-link é
+oculto até Tab e o `aria-label` é invisível para usuários sem screen reader.
+
+Issues fechadas: #583, #495.
+Próximas candidatas no backlog (todas `priority:baixa`):
+- #249: preload Inter 400 WOFF2
+- #585: font-display Fira Code
+- #591: reading time nos PostCards

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -45,7 +45,7 @@ const isCurrent = (href: string) => {
 ---
 
 <header class="container">
-  <nav>
+  <nav aria-label={lang === 'pt' ? 'Navegação principal' : 'Main navigation'}>
     <ul>
       <li><strong><a href={homeHref} class="contrast" aria-current={here === homeHref ? 'page' : undefined}>Franklin Baldo</a></strong></li>
     </ul>

--- a/src/generated/ranking-snapshot.json
+++ b/src/generated/ranking-snapshot.json
@@ -1,591 +1,435 @@
 {
   "_meta": {
     "schema": "snapshot-v2",
-    "generatedAt": "2026-06-20T05:05:56.702Z",
+    "generatedAt": "2026-06-21T05:05:25.552Z",
     "basis": "build",
-    "totalDuels": 197
+    "totalDuels": 54
   },
   "keys": {
-    "music-o-regral": {
+    "three-hammers": {
       "rank": 1,
-      "ordinal": 5.9033,
-      "elo": 1075,
-      "eloPeak": 1075
+      "ordinal": 2.4203,
+      "elo": 1033,
+      "eloPeak": 1033
     },
-    "serpents-egg": {
+    "music-dd332f75-6052-4f9e-bccd-fb0303731d6e": {
       "rank": 2,
-      "ordinal": 5.7672,
-      "elo": 1033,
-      "eloPeak": 1033
-    },
-    "music-a-primeira-mudanca": {
-      "rank": 3,
-      "ordinal": 5.4948,
-      "elo": 1031,
-      "eloPeak": 1032
-    },
-    "music-o-medo-do-louco": {
-      "rank": 4,
-      "ordinal": 5.4785,
-      "elo": 1033,
-      "eloPeak": 1034
-    },
-    "music-prayer-to-the-unfinished-moving-window-v": {
-      "rank": 5,
-      "ordinal": 4.7203,
-      "elo": 1044,
-      "eloPeak": 1044
-    },
-    "music-eu-ia-escrever-sobre-o-infinito-de-novo": {
-      "rank": 6,
-      "ordinal": 4.5856,
-      "elo": 1050,
-      "eloPeak": 1050
-    },
-    "music-menino-que-voce-foi": {
-      "rank": 7,
-      "ordinal": 4.3045,
-      "elo": 1030,
-      "eloPeak": 1030
-    },
-    "music-the-time": {
-      "rank": 8,
-      "ordinal": 4.2779,
-      "elo": 1074,
-      "eloPeak": 1074
-    },
-    "music-xadrez": {
-      "rank": 9,
-      "ordinal": 3.8788,
-      "elo": 1031,
-      "eloPeak": 1031
-    },
-    "music-sentido-e-referencia": {
-      "rank": 10,
-      "ordinal": 3.8763,
-      "elo": 1049,
-      "eloPeak": 1049
-    },
-    "music-john-gospel-chapter-i-by-max-headroom": {
-      "rank": 11,
-      "ordinal": 3.5317,
-      "elo": 1029,
-      "eloPeak": 1029
-    },
-    "funes-soul": {
-      "rank": 12,
-      "ordinal": 3.3932,
-      "elo": 983,
-      "eloPeak": 1003
-    },
-    "asterisk-protects": {
-      "rank": 13,
-      "ordinal": 3.3625,
-      "elo": 1033,
-      "eloPeak": 1033
-    },
-    "music-the-ruliad-is-laughing": {
-      "rank": 14,
-      "ordinal": 3.2635,
-      "elo": 1028,
-      "eloPeak": 1028
-    },
-    "music-observer-error-moving-window-iv": {
-      "rank": 15,
-      "ordinal": 3.0625,
-      "elo": 1017,
-      "eloPeak": 1017
-    },
-    "music-stopping-by-woods-on-a-snowy-evening-by-robert-frost": {
-      "rank": 16,
-      "ordinal": 3.05,
-      "elo": 1014,
-      "eloPeak": 1015
-    },
-    "music-o-verso-branquiceleste": {
-      "rank": 17,
-      "ordinal": 3.0064,
-      "elo": 1014,
-      "eloPeak": 1047
-    },
-    "music-borges-and-me": {
-      "rank": 18,
-      "ordinal": 2.891,
-      "elo": 1039,
-      "eloPeak": 1059
-    },
-    "music-meditacao-guiada-no-sertao": {
-      "rank": 19,
-      "ordinal": 2.8796,
+      "ordinal": 2.2781,
       "elo": 1016,
       "eloPeak": 1016
     },
-    "music-beatriz": {
-      "rank": 20,
-      "ordinal": 2.8575,
-      "elo": 1016,
-      "eloPeak": 1048
-    },
-    "pontifex-research": {
-      "rank": 21,
-      "ordinal": 2.6354,
-      "elo": 1033,
-      "eloPeak": 1035
-    },
-    "music-sussurros-binarios": {
-      "rank": 22,
-      "ordinal": 2.603,
-      "elo": 1029,
-      "eloPeak": 1029
-    },
-    "music-vos": {
-      "rank": 23,
-      "ordinal": 2.5506,
-      "elo": 1049,
-      "eloPeak": 1049
-    },
-    "music-dd332f75-6052-4f9e-bccd-fb0303731d6e": {
-      "rank": 24,
-      "ordinal": 2.5234,
+    "pampa-circuit": {
+      "rank": 3,
+      "ordinal": 2.2205,
       "elo": 1032,
       "eloPeak": 1032
     },
-    "music-o-tempo": {
-      "rank": 25,
-      "ordinal": 2.4614,
-      "elo": 1012,
-      "eloPeak": 1016
-    },
-    "music-f85fb538-6f59-4751-8629-da76665fc91e": {
-      "rank": 26,
-      "ordinal": 2.368,
-      "elo": 1014,
-      "eloPeak": 1031
-    },
-    "music-borges-and-the-hyperobject-at-the-end-of-time": {
-      "rank": 27,
-      "ordinal": 2.3536,
-      "elo": 1000,
-      "eloPeak": 1016
-    },
-    "music-666": {
-      "rank": 28,
-      "ordinal": 2.2596,
-      "elo": 1002,
-      "eloPeak": 1002
-    },
-    "census-not-sample": {
-      "rank": 29,
-      "ordinal": 2.1157,
-      "elo": 1016,
-      "eloPeak": 1016
-    },
-    "music-o-ritual-de-abril-anos-de-saudade": {
-      "rank": 30,
-      "ordinal": 2.07,
-      "elo": 1000,
-      "eloPeak": 1000
-    },
-    "travessia-project": {
-      "rank": 31,
-      "ordinal": 2.0392,
-      "elo": 967,
-      "eloPeak": 1017
-    },
     "delphi-imperatives": {
-      "rank": 32,
+      "rank": 4,
       "ordinal": 2.0317,
       "elo": 1032,
       "eloPeak": 1032
     },
     "music-fourteen-words": {
-      "rank": 33,
-      "ordinal": 1.9625,
+      "rank": 5,
+      "ordinal": 1.8961,
       "elo": 1001,
       "eloPeak": 1001
     },
-    "music-o-telefone-da-agonia": {
-      "rank": 34,
-      "ordinal": 1.88,
-      "elo": 1003,
-      "eloPeak": 1003
-    },
-    "music-o-preco-da-saudade": {
-      "rank": 35,
-      "ordinal": 1.7958,
-      "elo": 999,
-      "eloPeak": 1016
-    },
-    "verne-identity-repo": {
-      "rank": 36,
-      "ordinal": 1.7725,
-      "elo": 1028,
+    "pontifex-guide": {
+      "rank": 6,
+      "ordinal": 1.8384,
+      "elo": 1032,
       "eloPeak": 1032
     },
-    "music-primavera-carregando": {
-      "rank": 37,
-      "ordinal": 1.6504,
-      "elo": 984,
-      "eloPeak": 1033
-    },
-    "music-belief-engine-labyrinth-song-moving-window-viii": {
-      "rank": 38,
-      "ordinal": 1.5735,
-      "elo": 1015,
-      "eloPeak": 1017
-    },
-    "music-f73c60f0-49af-45fd-a483-1d35a676dccc": {
-      "rank": 39,
-      "ordinal": 1.548,
-      "elo": 1017,
-      "eloPeak": 1017
-    },
-    "three-hammers": {
-      "rank": 40,
-      "ordinal": 1.5044,
+    "music-quando-vier-a-primavera": {
+      "rank": 7,
+      "ordinal": 1.6437,
       "elo": 1016,
       "eloPeak": 1016
     },
-    "music-paperclip-rhapsody": {
-      "rank": 41,
-      "ordinal": 1.488,
-      "elo": 1001,
-      "eloPeak": 1001
-    },
-    "music-clipes": {
-      "rank": 42,
-      "ordinal": 1.4784,
-      "elo": 999,
-      "eloPeak": 1017
-    },
-    "pierre-menard": {
-      "rank": 43,
-      "ordinal": 1.419,
-      "elo": 987,
-      "eloPeak": 1000
-    },
-    "music-the-third-song-moving-window-iii": {
-      "rank": 44,
-      "ordinal": 1.4126,
-      "elo": 998,
-      "eloPeak": 1031
-    },
-    "becoming-lobsters": {
-      "rank": 45,
-      "ordinal": 1.249,
-      "elo": 1011,
-      "eloPeak": 1027
-    },
-    "music-chegue-irmao-chegue-irma": {
-      "rank": 46,
-      "ordinal": 1.235,
+    "serpents-egg": {
+      "rank": 8,
+      "ordinal": 1.4807,
       "elo": 1015,
       "eloPeak": 1015
     },
-    "two-questions-out-loud": {
-      "rank": 47,
-      "ordinal": 1.0288,
-      "elo": 982,
-      "eloPeak": 1031
-    },
-    "music-espelhos": {
-      "rank": 48,
-      "ordinal": 0.9725,
-      "elo": 985,
-      "eloPeak": 1001
-    },
-    "music-151474c5-1420-4cc1-9ab5-80721f4459ed": {
-      "rank": 49,
-      "ordinal": 0.9242,
-      "elo": 1016,
-      "eloPeak": 1016
-    },
-    "pampa-circuit": {
-      "rank": 50,
-      "ordinal": 0.9242,
-      "elo": 1016,
-      "eloPeak": 1016
-    },
-    "music-two-cursors": {
-      "rank": 51,
-      "ordinal": 0.8879,
-      "elo": 989,
-      "eloPeak": 1000
-    },
-    "music-o-aleph": {
-      "rank": 52,
-      "ordinal": 0.8817,
-      "elo": 988,
-      "eloPeak": 1002
-    },
-    "music-crystallizing-from-the-nothing": {
-      "rank": 53,
-      "ordinal": 0.7367,
-      "elo": 987,
-      "eloPeak": 1016
-    },
-    "agent-no-verbs": {
-      "rank": 54,
-      "ordinal": 0.7307,
+    "music-eu-ia-escrever-sobre-o-infinito-de-novo": {
+      "rank": 9,
+      "ordinal": 1.3497,
       "elo": 1016,
       "eloPeak": 1016
     },
     "intelligible-void": {
-      "rank": 55,
-      "ordinal": 0.7307,
+      "rank": 10,
+      "ordinal": 1.348,
+      "elo": 1015,
+      "eloPeak": 1032
+    },
+    "asterisk-protects": {
+      "rank": 11,
+      "ordinal": 1.311,
       "elo": 1016,
       "eloPeak": 1016
     },
-    "music-riobaldo-e-o-aleph": {
-      "rank": 56,
-      "ordinal": 0.7307,
+    "music-the-time": {
+      "rank": 12,
+      "ordinal": 1.2877,
+      "elo": 999,
+      "eloPeak": 1016
+    },
+    "building-funes": {
+      "rank": 13,
+      "ordinal": 1.2814,
+      "elo": 1015,
+      "eloPeak": 1015
+    },
+    "verne-identity-repo": {
+      "rank": 14,
+      "ordinal": 1.2662,
+      "elo": 1032,
+      "eloPeak": 1032
+    },
+    "music-reality-maintenance-moving-window-xii": {
+      "rank": 15,
+      "ordinal": 1.1463,
+      "elo": 1017,
+      "eloPeak": 1017
+    },
+    "music-borges-and-me": {
+      "rank": 16,
+      "ordinal": 1.1176,
       "elo": 1016,
       "eloPeak": 1016
     },
-    "pontifex-guide": {
-      "rank": 57,
-      "ordinal": 0.7307,
+    "music-leite-no-salao-bar": {
+      "rank": 17,
+      "ordinal": 1.1176,
       "elo": 1016,
       "eloPeak": 1016
     },
-    "music-quando-vier-a-primavera": {
-      "rank": 58,
-      "ordinal": 0.7184,
+    "music-o-medo-do-louco": {
+      "rank": 18,
+      "ordinal": 1.1176,
+      "elo": 1016,
+      "eloPeak": 1016
+    },
+    "music-pattern-over-stuff": {
+      "rank": 19,
+      "ordinal": 1.1176,
+      "elo": 1016,
+      "eloPeak": 1016
+    },
+    "its-raining-truth": {
+      "rank": 20,
+      "ordinal": 1.1019,
       "elo": 1000,
       "eloPeak": 1000
     },
     "future-father": {
-      "rank": 59,
-      "ordinal": 0.718,
-      "elo": 994,
-      "eloPeak": 1031
-    },
-    "music-entre-rascunho-e-apagar": {
-      "rank": 60,
-      "ordinal": 0.4996,
-      "elo": 969,
-      "eloPeak": 1017
-    },
-    "music-sobre-o-rigor-na-ciencia": {
-      "rank": 61,
-      "ordinal": 0.4395,
-      "elo": 987,
-      "eloPeak": 1000
-    },
-    "inaugural-post": {
-      "rank": 62,
-      "ordinal": 0.4278,
-      "elo": 983,
-      "eloPeak": 1000
-    },
-    "music-trinta-de-abril": {
-      "rank": 63,
-      "ordinal": 0.4223,
-      "elo": 1001,
-      "eloPeak": 1001
-    },
-    "music-be-me-borges": {
-      "rank": 64,
-      "ordinal": 0.3148,
-      "elo": 957,
-      "eloPeak": 1000
-    },
-    "jules-api-harness": {
-      "rank": 65,
-      "ordinal": 0.3041,
-      "elo": 981,
-      "eloPeak": 1032
-    },
-    "music-46336b97-4306-41bc-8a7b-48f0ebebbd29": {
-      "rank": 66,
-      "ordinal": 0.2759,
-      "elo": 986,
-      "eloPeak": 1002
-    },
-    "music-nonada": {
-      "rank": 67,
-      "ordinal": -0.1439,
-      "elo": 984,
+      "rank": 21,
+      "ordinal": 0.9989,
+      "elo": 999,
       "eloPeak": 1016
     },
-    "music-bibliotecario-do-infinito": {
-      "rank": 68,
-      "ordinal": -0.1597,
-      "elo": 979,
-      "eloPeak": 1000
+    "music-primavera-carregando": {
+      "rank": 22,
+      "ordinal": 0.9628,
+      "elo": 1016,
+      "eloPeak": 1016
     },
-    "music-reality-maintenance-moving-window-xii": {
-      "rank": 69,
-      "ordinal": -0.1744,
-      "elo": 997,
-      "eloPeak": 1031
-    },
-    "music-leite-no-salao-bar": {
-      "rank": 70,
-      "ordinal": -0.2049,
-      "elo": 997,
+    "inaugural-post": {
+      "rank": 23,
+      "ordinal": 0.9242,
+      "elo": 1016,
       "eloPeak": 1016
     },
     "music-escherian-sunrise-with-godel": {
-      "rank": 71,
-      "ordinal": -0.2488,
-      "elo": 967,
-      "eloPeak": 1000
+      "rank": 24,
+      "ordinal": 0.9242,
+      "elo": 1016,
+      "eloPeak": 1016
+    },
+    "music-o-verso-branquiceleste": {
+      "rank": 25,
+      "ordinal": 0.9242,
+      "elo": 1016,
+      "eloPeak": 1016
+    },
+    "music-paperclip-rhapsody": {
+      "rank": 26,
+      "ordinal": 0.9242,
+      "elo": 1016,
+      "eloPeak": 1016
+    },
+    "music-sinal-que-se-cumpre-moving-window-ix": {
+      "rank": 27,
+      "ordinal": 0.9242,
+      "elo": 1016,
+      "eloPeak": 1016
+    },
+    "pontifex-research": {
+      "rank": 28,
+      "ordinal": 0.9242,
+      "elo": 1016,
+      "eloPeak": 1016
+    },
+    "agent-no-verbs": {
+      "rank": 29,
+      "ordinal": 0.8545,
+      "elo": 1015,
+      "eloPeak": 1016
+    },
+    "music-clipes": {
+      "rank": 30,
+      "ordinal": 0.7652,
+      "elo": 1017,
+      "eloPeak": 1017
+    },
+    "music-borges-and-the-hyperobject-at-the-end-of-time": {
+      "rank": 31,
+      "ordinal": 0.7542,
+      "elo": 1001,
+      "eloPeak": 1001
+    },
+    "music-meditacao-guiada-no-sertao": {
+      "rank": 32,
+      "ordinal": 0.7307,
+      "elo": 1016,
+      "eloPeak": 1016
     },
     "music-o-magico-e-o-fogo": {
-      "rank": 72,
-      "ordinal": -0.2638,
-      "elo": 948,
+      "rank": 33,
+      "ordinal": 0.7307,
+      "elo": 1016,
+      "eloPeak": 1016
+    },
+    "reddit-submarine-osint": {
+      "rank": 34,
+      "ordinal": 0.6382,
+      "elo": 1000,
+      "eloPeak": 1016
+    },
+    "music-veu-do-infinito": {
+      "rank": 35,
+      "ordinal": 0.6297,
+      "elo": 1001,
+      "eloPeak": 1001
+    },
+    "music-o-preco-da-saudade": {
+      "rank": 36,
+      "ordinal": 0.5373,
+      "elo": 1016,
+      "eloPeak": 1016
+    },
+    "music-the-third-song-moving-window-iii": {
+      "rank": 37,
+      "ordinal": 0.5373,
+      "elo": 1016,
+      "eloPeak": 1016
+    },
+    "music-beatriz": {
+      "rank": 38,
+      "ordinal": 0.3113,
+      "elo": 999,
+      "eloPeak": 1016
+    },
+    "music-151474c5-1420-4cc1-9ab5-80721f4459ed": {
+      "rank": 39,
+      "ordinal": 0.232,
+      "elo": 1000,
+      "eloPeak": 1016
+    },
+    "everything-is-process": {
+      "rank": 40,
+      "ordinal": 0.1028,
+      "elo": 999,
+      "eloPeak": 1016
+    },
+    "rosencrantz-coin": {
+      "rank": 41,
+      "ordinal": -0.0364,
+      "elo": 1001,
+      "eloPeak": 1001
+    },
+    "social-vulnerabilities": {
+      "rank": 42,
+      "ordinal": -0.0858,
+      "elo": 999,
+      "eloPeak": 1000
+    },
+    "music-particles": {
+      "rank": 43,
+      "ordinal": -0.1813,
+      "elo": 985,
+      "eloPeak": 1000
+    },
+    "reclaiming-harness": {
+      "rank": 44,
+      "ordinal": -0.2249,
+      "elo": 970,
       "eloPeak": 1000
     },
     "family-memory": {
-      "rank": 73,
+      "rank": 45,
       "ordinal": -0.2646,
       "elo": 999,
       "eloPeak": 1015
     },
-    "delegating-to-agents": {
-      "rank": 74,
-      "ordinal": -0.3892,
+    "music-belief-engine-labyrinth-song-moving-window-viii": {
+      "rank": 46,
+      "ordinal": -0.2862,
       "elo": 984,
       "eloPeak": 1000
     },
-    "its-raining-truth": {
-      "rank": 75,
-      "ordinal": -0.3892,
+    "music-o-aleph": {
+      "rank": 47,
+      "ordinal": -0.2862,
       "elo": 984,
       "eloPeak": 1000
     },
-    "rosencrantz-coin": {
-      "rank": 76,
-      "ordinal": -0.4413,
-      "elo": 1006,
-      "eloPeak": 1006
-    },
-    "music-universal-threshold": {
-      "rank": 77,
-      "ordinal": -0.4511,
+    "music-riobaldo-e-o-aleph": {
+      "rank": 48,
+      "ordinal": -0.3484,
       "elo": 984,
-      "eloPeak": 1000
-    },
-    "conservation-law": {
-      "rank": 78,
-      "ordinal": -0.4923,
-      "elo": 984,
-      "eloPeak": 1000
-    },
-    "music-veu-do-infinito": {
-      "rank": 79,
-      "ordinal": -0.4923,
-      "elo": 984,
-      "eloPeak": 1000
-    },
-    "reclaiming-harness": {
-      "rank": 80,
-      "ordinal": -0.5645,
-      "elo": 969,
-      "eloPeak": 1000
-    },
-    "music-borges-e-eu": {
-      "rank": 81,
-      "ordinal": -0.5744,
-      "elo": 941,
-      "eloPeak": 1000
-    },
-    "crossing-interference": {
-      "rank": 82,
-      "ordinal": -0.599,
-      "elo": 969,
-      "eloPeak": 1003
-    },
-    "building-funes": {
-      "rank": 83,
-      "ordinal": -0.6634,
-      "elo": 969,
-      "eloPeak": 1001
-    },
-    "reddit-submarine-osint": {
-      "rank": 84,
-      "ordinal": -0.725,
-      "elo": 969,
       "eloPeak": 1016
     },
-    "music-uma-so-cancao": {
-      "rank": 85,
-      "ordinal": -0.7445,
-      "elo": 984,
-      "eloPeak": 1001
-    },
-    "social-vulnerabilities": {
-      "rank": 86,
-      "ordinal": -0.8014,
+    "music-o-telefone-da-agonia": {
+      "rank": 49,
+      "ordinal": -0.3892,
       "elo": 984,
       "eloPeak": 1000
     },
-    "music-pattern-over-stuff": {
-      "rank": 87,
-      "ordinal": -0.8974,
-      "elo": 957,
-      "eloPeak": 1015
+    "music-uma-so-cancao": {
+      "rank": 50,
+      "ordinal": -0.3892,
+      "elo": 984,
+      "eloPeak": 1000
     },
-    "music-particles": {
-      "rank": 88,
-      "ordinal": -0.9804,
-      "elo": 968,
+    "music-666": {
+      "rank": 51,
+      "ordinal": -0.4923,
+      "elo": 984,
+      "eloPeak": 1000
+    },
+    "music-bibliotecario-do-infinito": {
+      "rank": 52,
+      "ordinal": -0.4923,
+      "elo": 984,
+      "eloPeak": 1000
+    },
+    "music-john-gospel-chapter-i-by-max-headroom": {
+      "rank": 53,
+      "ordinal": -0.4923,
+      "elo": 984,
+      "eloPeak": 1000
+    },
+    "music-mindfulness": {
+      "rank": 54,
+      "ordinal": -0.4923,
+      "elo": 984,
+      "eloPeak": 1000
+    },
+    "music-o-tempo": {
+      "rank": 55,
+      "ordinal": -0.4923,
+      "elo": 984,
+      "eloPeak": 1000
+    },
+    "music-observer-error-moving-window-iv": {
+      "rank": 56,
+      "ordinal": -0.4923,
+      "elo": 984,
+      "eloPeak": 1000
+    },
+    "music-xadrez": {
+      "rank": 57,
+      "ordinal": -0.4923,
+      "elo": 984,
+      "eloPeak": 1000
+    },
+    "music-menino-que-voce-foi": {
+      "rank": 58,
+      "ordinal": -0.5129,
+      "elo": 984,
       "eloPeak": 1000
     },
     "conceptual-document": {
-      "rank": 89,
-      "ordinal": -1.2814,
+      "rank": 59,
+      "ordinal": -0.5953,
       "elo": 984,
       "eloPeak": 1000
     },
-    "everything-is-process": {
-      "rank": 90,
-      "ordinal": -1.4952,
-      "elo": 983,
-      "eloPeak": 1000
-    },
-    "music-sinal-que-se-cumpre-moving-window-ix": {
-      "rank": 91,
-      "ordinal": -1.5548,
-      "elo": 985,
-      "eloPeak": 1017
-    },
-    "music-mindfulness": {
-      "rank": 92,
-      "ordinal": -1.8849,
-      "elo": 957,
-      "eloPeak": 1000
-    },
-    "music-o-sonhador-e-o-fogo": {
-      "rank": 93,
-      "ordinal": -2.011,
-      "elo": 969,
-      "eloPeak": 1000
-    },
-    "music-spring-loading": {
-      "rank": 94,
-      "ordinal": -2.0934,
-      "elo": 965,
-      "eloPeak": 1016
-    },
-    "third-half-fourth-wall": {
-      "rank": 95,
-      "ordinal": -2.1063,
-      "elo": 956,
-      "eloPeak": 1016
-    },
-    "music-o-prologo": {
-      "rank": 96,
-      "ordinal": -2.5817,
-      "elo": 972,
+    "music-46336b97-4306-41bc-8a7b-48f0ebebbd29": {
+      "rank": 60,
+      "ordinal": -0.5953,
+      "elo": 984,
       "eloPeak": 1000
     },
     "music-caminho": {
-      "rank": 97,
-      "ordinal": -3.0196,
-      "elo": 938,
+      "rank": 61,
+      "ordinal": -0.5953,
+      "elo": 984,
+      "eloPeak": 1000
+    },
+    "funes-soul": {
+      "rank": 62,
+      "ordinal": -0.6984,
+      "elo": 984,
+      "eloPeak": 1000
+    },
+    "music-be-me-borges": {
+      "rank": 63,
+      "ordinal": -0.719,
+      "elo": 984,
+      "eloPeak": 1000
+    },
+    "music-o-sonhador-e-o-fogo": {
+      "rank": 64,
+      "ordinal": -0.9044,
+      "elo": 984,
+      "eloPeak": 1000
+    },
+    "music-universal-threshold": {
+      "rank": 65,
+      "ordinal": -1.0573,
+      "elo": 967,
+      "eloPeak": 1000
+    },
+    "delegating-to-agents": {
+      "rank": 66,
+      "ordinal": -1.1851,
+      "elo": 968,
+      "eloPeak": 1000
+    },
+    "music-sussurros-binarios": {
+      "rank": 67,
+      "ordinal": -1.2135,
+      "elo": 984,
+      "eloPeak": 1000
+    },
+    "jules-api-harness": {
+      "rank": 68,
+      "ordinal": -1.2514,
+      "elo": 983,
+      "eloPeak": 1000
+    },
+    "travessia-project": {
+      "rank": 69,
+      "ordinal": -1.2559,
+      "elo": 969,
+      "eloPeak": 1000
+    },
+    "conservation-law": {
+      "rank": 70,
+      "ordinal": -1.2611,
+      "elo": 952,
+      "eloPeak": 1000
+    },
+    "crossing-interference": {
+      "rank": 71,
+      "ordinal": -1.3503,
+      "elo": 969,
       "eloPeak": 1000
     }
   }

--- a/src/layouts/PageLayout.astro
+++ b/src/layouts/PageLayout.astro
@@ -270,7 +270,7 @@ const personLd = {
     </script>
   </head>
   <body>
-    <a href="#main" class="skip-link">Skip to content</a>
+    <a href="#main" class="skip-link">{lang === 'pt' ? 'Ir para o conteúdo' : 'Skip to content'}</a>
     <Header lang={lang} />
 
     <main id="main" tabindex="-1" class="container">


### PR DESCRIPTION
Closes #583
Closes #495

## a11y

### Skip-link internacionalizado (`src/layouts/PageLayout.astro`)

O skip-link era hardcoded `Skip to content` em todas as páginas. Em PT-BR, screen readers liam em inglês — violação de WCAG 2.1 SC 3.1.1. Agora usa o `lang` prop já disponível:

```astro
{lang === 'pt' ? 'Ir para o conteúdo' : 'Skip to content'}
```

### `aria-label` no `<nav>` principal (`src/components/Header.astro`)

O `<nav>` do header não tinha `aria-label`. Páginas com TOC têm dois `<nav>`, e screen readers não conseguiam distingui-los — WCAG 2.1 SC 4.1.2. O TOC já tinha label; agora o header também:

```astro
<nav aria-label={lang === 'pt' ? 'Navegação principal' : 'Main navigation'}>
```

Ambos os labels respeitam paridade i18n (EN em páginas EN, PT em páginas PT).

## Outros

- `src/generated/ranking-snapshot.json` regenerado (sincronia com rate files atuais após remoção dos arquivos Jules).

---

**Para revisar:** nenhum impacto visual esperado — skip-link é oculto até Tab; `aria-label` é invisível. Screenshot de prod confirmado na próxima run.

---
_Generated by [Claude Code](https://claude.ai/code/session_018aaD5CvqAzG8PjQ7v4i7Wb)_