### PR TITLE
RFC 0012 Fase 0 — tipos, fixtures e golden snapshot

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "hronir:doctor": "node --import tsx/esm scripts/hronir/index.js doctor",
     "hronir:detect-stuffing": "node scripts/hronir/detect-token-stuffing.mjs",
     "music:generate": "node scripts/generate-music-posts.mjs",
-    "test": "node --import tsx/esm --experimental-test-module-mocks --test src/hronir/__tests__/ranking.test.js"
+    "test": "node --import tsx/esm --experimental-test-module-mocks --test \"src/hronir/__tests__/*.test.js\""
   },
   "dependencies": {
     "@astrojs/mdx": "^5.0.4",

--- a/src/hronir/__tests__/fixtures/rate-files/version-stars-v3.md
+++ b/src/hronir/__tests__/fixtures/rate-files/version-stars-v3.md
@@ -1,0 +1,31 @@
+---
+# RFC 0012 fixture — stars-v3 VERSION duel: both sides share the same key but
+# carry distinct version UUIDs. kind === "version". Both sides are the same
+# linguistic version, so review_lang === content_lang (RFC 0012 §6, rule 3).
+prompt_version: stars-v3
+match_kind: version
+agent_id: fixture-agent
+run_at: 2026-06-21T01:00:00Z
+review_lang: en
+perspective_id: editorial-baseline
+post_a:
+  key: alpha-essay
+  path: src/content/blog/alpha-essay/v-2026-06-09T20-24-29.md
+  display_lang: en
+  content_lang: en
+  version: v-2026-06-09T20-24-29
+post_b:
+  key: alpha-essay
+  path: src/content/blog/alpha-essay/v-2026-06-11T08-25-46.md
+  display_lang: en
+  content_lang: en
+  version: v-2026-06-11T08-25-46
+winner: b
+rate_a: 3.25
+rate_b: 4.5
+review_a: Placeholder review of alpha-essay@v-2026-06-09T20-24-29.
+review_b: Placeholder review of alpha-essay@v-2026-06-11T08-25-46.
+clash: Placeholder clash between the two alpha-essay versions.
+---
+
+Fixture body — not parsed by ranking.

--- a/src/hronir/__tests__/fixtures/rate-files/work-stars-v1.md
+++ b/src/hronir/__tests__/fixtures/rate-files/work-stars-v1.md
@@ -1,0 +1,24 @@
+---
+# RFC 0012 fixture — historical stars-v1 WORK duel (different keys).
+# Classified `legacy` (no review_lang/match_kind); must stay readable.
+schema: stars-v1
+prompt_version: stars-v1
+agent_id: fixture-agent
+run_at: 2024-01-01T00:00:00Z
+post_a:
+  key: alpha-essay
+  path: src/content/blog/alpha-essay.md
+  display_lang: en
+post_b:
+  key: beta-essay
+  path: src/content/blog/beta-essay.md
+  display_lang: en
+winner: a
+rate_a: 4.5
+rate_b: 3
+review_a: Placeholder review of alpha-essay for fixtures.
+review_b: Placeholder review of beta-essay for fixtures.
+clash: Placeholder clash between alpha-essay and beta-essay.
+---
+
+Fixture body — not parsed by ranking.

--- a/src/hronir/__tests__/fixtures/rate-files/work-stars-v2.md
+++ b/src/hronir/__tests__/fixtures/rate-files/work-stars-v2.md
@@ -1,0 +1,29 @@
+---
+# RFC 0012 fixture — stars-v2 WORK duel with a perspective + mood (affective
+# chain era). No review_lang yet: normalizer falls back to eval_lang.
+prompt_version: stars-v2
+agent_id: fixture-agent
+run_at: 2024-02-01T00:00:00Z
+content_mode: inline
+eval_lang: en
+perspective_id: o-cetico
+post_a:
+  key: alpha-essay
+  path: src/content/blog/alpha-essay.md
+  display_lang: en
+post_b:
+  key: gamma-essay
+  path: src/content/blog/gamma-essay.md
+  display_lang: en
+winner: b
+rate_a: 2.75
+rate_b: 4
+evaluator_mood: Comecei curioso, meio cansado.
+evaluator_mood_after: Terminei inquieto, com vontade de reler.
+mood_glyph: "◷"
+review_a: Placeholder review of alpha-essay under o-cetico.
+review_b: Placeholder review of gamma-essay under o-cetico.
+clash: Placeholder clash between alpha-essay and gamma-essay.
+---
+
+Fixture body — not parsed by ranking.

--- a/src/hronir/__tests__/fixtures/rate-files/work-stars-v3.md
+++ b/src/hronir/__tests__/fixtures/rate-files/work-stars-v3.md
@@ -1,0 +1,29 @@
+---
+# RFC 0012 fixture — stars-v3 WORK duel across two languages. content_lang
+# differs per side; review_lang is the session language and is recorded
+# explicitly (RFC 0012 §6, rule 2/3).
+prompt_version: stars-v3
+match_kind: work
+agent_id: fixture-agent
+run_at: 2026-06-21T00:00:00Z
+review_lang: pt
+perspective_id: editorial-baseline
+post_a:
+  key: alpha-essay
+  path: src/content/blog/alpha-essay.md
+  display_lang: en
+  content_lang: en
+post_b:
+  key: delta-ensaio
+  path: src/content/blog/delta-ensaio.md
+  display_lang: pt
+  content_lang: pt
+winner: a
+rate_a: 4.25
+rate_b: 3.5
+review_a: Resenha placeholder de alpha-essay (crítica em PT).
+review_b: Resenha placeholder de delta-ensaio (crítica em PT).
+clash: Confronto placeholder entre alpha-essay e delta-ensaio.
+---
+
+Corpo de fixture — não lido pelo ranking.

--- a/src/hronir/__tests__/golden-ranking.test.js
+++ b/src/hronir/__tests__/golden-ranking.test.js
@@ -1,0 +1,194 @@
+import { describe, it, mock } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import matter from "gray-matter";
+
+// RFC 0012 Fase 0 — golden snapshot.
+//
+// This test freezes the *current* (pre-normalizer) behavior of the ranking
+// core so Fase 1 (the single normalizer + `getDuels({ kind })`) can prove it
+// is behavior-preserving: the assertions here must stay green unchanged after
+// consumers migrate to loadNormalizedMatches(). It also locks the structural
+// classification rule (kind = aKey === bKey ? "version" : "work") against the
+// on-disk rate-file fixtures the normalizer will consume.
+
+// Mock matches before importing ranking (same reason as ranking.test.js: avoid
+// pulling posts.ts → remark, which is only present after `npm ci`). The pure
+// _compute* functions under test take their raw array as an argument.
+await mock.module("../matches.js", {
+  namedExports: {
+    listMatchFiles: () => [],
+    readMatch: () => ({ data: {}, content: "" }),
+    writeMatch: () => {},
+    postKey: (side) => (side ? side.key || side.slug || null : null),
+    matchesDataVersion: () => 0,
+  },
+});
+
+const { _computeRatings, _computeVersionRatings } =
+  await import("../ranking.js");
+
+function match(overrides) {
+  return {
+    runAt: "2024-01-01T00:00:00Z",
+    filename: "match.md",
+    aKey: "alpha-essay",
+    bKey: "beta-essay",
+    aPath: "src/content/blog/alpha-essay.md",
+    bPath: "src/content/blog/beta-essay.md",
+    aVersion: null,
+    bVersion: null,
+    agentId: null,
+    perspectiveId: null,
+    winner: "a",
+    rateA: null,
+    rateB: null,
+    ...overrides,
+  };
+}
+
+// A fixed editorial (work) corpus: alpha > beta > gamma.
+const WORK_CORPUS = [
+  match({
+    runAt: "2024-01-01T00:00:00Z",
+    aKey: "alpha-essay",
+    bKey: "beta-essay",
+    winner: "a",
+  }),
+  match({
+    runAt: "2024-01-02T00:00:00Z",
+    aKey: "alpha-essay",
+    bKey: "beta-essay",
+    winner: "a",
+  }),
+  match({
+    runAt: "2024-01-03T00:00:00Z",
+    aKey: "beta-essay",
+    bKey: "gamma-essay",
+    winner: "a",
+  }),
+  match({
+    runAt: "2024-01-04T00:00:00Z",
+    aKey: "beta-essay",
+    bKey: "gamma-essay",
+    winner: "a",
+  }),
+  match({
+    runAt: "2024-01-05T00:00:00Z",
+    aKey: "alpha-essay",
+    bKey: "gamma-essay",
+    winner: "a",
+  }),
+];
+
+// The same corpus plus version duels of alpha-essay (same key both sides).
+const VERSION_DUELS = [
+  match({
+    runAt: "2024-01-06T00:00:00Z",
+    filename: "version-1.md",
+    aKey: "alpha-essay",
+    bKey: "alpha-essay",
+    aPath: "src/content/blog/alpha-essay/v-old.md",
+    bPath: "src/content/blog/alpha-essay/v-new.md",
+    aVersion: "v-old",
+    bVersion: "v-new",
+    winner: "b",
+    rateA: 3.25,
+    rateB: 4.5,
+  }),
+  match({
+    runAt: "2024-01-07T00:00:00Z",
+    filename: "version-2.md",
+    aKey: "alpha-essay",
+    bKey: "alpha-essay",
+    aPath: "src/content/blog/alpha-essay/v-old.md",
+    bPath: "src/content/blog/alpha-essay/v-new.md",
+    aVersion: "v-old",
+    bVersion: "v-new",
+    winner: "b",
+    rateA: 3,
+    rateB: 4.75,
+  }),
+];
+
+const orderOf = (rows) =>
+  [...rows].sort((a, b) => b.ordinal - a.ordinal).map((r) => r.key);
+
+describe("RFC 0012 golden — work/version separation", () => {
+  it("editorial ordering is alpha > beta > gamma", () => {
+    assert.deepEqual(orderOf(_computeRatings(WORK_CORPUS)), [
+      "alpha-essay",
+      "beta-essay",
+      "gamma-essay",
+    ]);
+  });
+
+  it("version duels never alter work ratings (the load-bearing invariant)", () => {
+    const withoutVersions = _computeRatings(WORK_CORPUS);
+    const withVersions = _computeRatings([...WORK_CORPUS, ...VERSION_DUELS]);
+    // Same keys, same ordinals, same appearance counts — a version duel must
+    // be invisible to the editorial ranking.
+    assert.deepEqual(withVersions, withoutVersions);
+  });
+
+  it("work duels never feed version ratings", () => {
+    assert.equal(_computeVersionRatings(WORK_CORPUS).size, 0);
+  });
+
+  it("version ratings rank the better-rated UUID higher, by key", () => {
+    const v = _computeVersionRatings([...WORK_CORPUS, ...VERSION_DUELS]);
+    assert.deepEqual([...v.keys()].sort(), ["v-new", "v-old"]);
+    assert.ok(v.get("v-new").stars > v.get("v-old").stars);
+    assert.equal(v.get("v-new").key, "alpha-essay");
+    assert.equal(v.get("v-old").key, "alpha-essay");
+  });
+});
+
+// Structural classification rule (RFC 0012 §4.1) against the on-disk fixtures.
+const FIXdir = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "fixtures",
+  "rate-files"
+);
+const readFixture = (name) =>
+  matter(fs.readFileSync(path.join(FIXdir, name), "utf8")).data;
+const kindOf = (data) =>
+  data.post_a.key === data.post_b.key ? "version" : "work";
+
+describe("RFC 0012 golden — fixture classification & schema", () => {
+  it("work fixtures classify as work; version fixture as version", () => {
+    assert.equal(kindOf(readFixture("work-stars-v1.md")), "work");
+    assert.equal(kindOf(readFixture("work-stars-v2.md")), "work");
+    assert.equal(kindOf(readFixture("work-stars-v3.md")), "work");
+    assert.equal(kindOf(readFixture("version-stars-v3.md")), "version");
+  });
+
+  it("persisted match_kind, when present, agrees with the derived rule", () => {
+    for (const f of ["work-stars-v3.md", "version-stars-v3.md"]) {
+      const data = readFixture(f);
+      assert.equal(data.match_kind, kindOf(data));
+    }
+  });
+
+  it("stars-v3 records review_lang and per-side content_lang", () => {
+    const work = readFixture("work-stars-v3.md");
+    assert.equal(work.review_lang, "pt");
+    assert.equal(work.post_a.content_lang, "en");
+    assert.equal(work.post_b.content_lang, "pt");
+
+    // Version duel: both sides are the same linguistic version, so the review
+    // is written in that language (RFC 0012 §6, rule 3).
+    const ver = readFixture("version-stars-v3.md");
+    assert.equal(ver.review_lang, ver.post_a.content_lang);
+    assert.equal(ver.post_a.content_lang, ver.post_b.content_lang);
+  });
+
+  it("legacy fixtures stay readable with no review_lang", () => {
+    assert.equal(readFixture("work-stars-v1.md").review_lang, undefined);
+    assert.equal(readFixture("work-stars-v2.md").review_lang, undefined);
+    // stars-v2 carries eval_lang, the legacy fallback the normalizer will use.
+    assert.equal(readFixture("work-stars-v2.md").eval_lang, "en");
+  });
+});

--- a/src/hronir/types.ts
+++ b/src/hronir/types.ts
@@ -8,11 +8,23 @@ export interface PostSide {
   path: string;
   display_lang?: "en" | "pt";
   version?: string;
+  /** RFC 0012 §4.2: language of this side's text. Written in stars-v3;
+   *  derived from the post frontmatter / `display_lang` for older files. */
+  content_lang?: "en" | "pt";
 }
 
 export interface RateFile {
+  // RFC 0012 §4.2: stars-v1/v2 stay valid and are classified `legacy`; new
+  // sessions write stars-v3. `schema` is historically only ever "stars-v1";
+  // the active marker is `prompt_version`.
   schema?: "stars-v1";
   prompt_version?: string;
+  /** RFC 0012 §4.1: redundant with `aKey === bKey`, validated against it,
+   *  never trusted in isolation. Written for human inspection in stars-v3. */
+  match_kind?: MatchKind;
+  /** RFC 0012 §6: language the review/clash was written in. Supersedes the
+   *  ambiguous `eval_lang` for stars-v3 files. */
+  review_lang?: "en" | "pt";
   agent_id?: string;
   run_at?: string | Date;
   season?: number;
@@ -34,6 +46,47 @@ export interface RateFile {
   margin?: number;
   confidence?: string;
   criterion?: string;
+}
+
+// ── Normalized match (RFC 0012) ─────────────────────────────────────────────
+
+// RFC 0012 §4.1: a match is `version` when both sides judge versions of the
+// same post (post_a.key === post_b.key) and `work` otherwise. The distinction
+// is structural — derivable from the rate file alone — not a regime of
+// evaluation (those live in RFC 0013). The classification is computed at load
+// time so every consumer (ranking, UI, snapshot, doctor) shares one source of
+// truth instead of re-deriving `aKey === bKey` ad hoc.
+export type MatchKind = "work" | "version";
+
+export interface NormalizedMatchSide {
+  key: string;
+  /** slug@uuid — the exact version judged. Null when no version is recorded. */
+  ref: string | null;
+  /** Cached file path; convenience for the UI, never an identity. */
+  path: string | null;
+  version: string | null;
+  contentLang: string | null;
+}
+
+// RFC 0012 §4.1. The single normalized shape the Fase 1 normalizer will emit;
+// declared here in Fase 0 so types land before any consumer migrates. It does
+// NOT carry an evaluation `mode` — regimes of evaluation are RFC 0013 and are
+// asserted (not derived), so they must not ride on this structural record.
+export interface NormalizedMatch {
+  id: string;
+  kind: MatchKind;
+  winnerSide: "a" | "b";
+  runAt: Date | null;
+  postA: NormalizedMatchSide;
+  postB: NormalizedMatchSide;
+  /** Language the review/clash was written in (RFC 0012 §6). */
+  reviewLang: string | null;
+  agentId: string | null;
+  perspectiveId: string | null;
+  rateA: number | null;
+  rateB: number | null;
+  evaluatorMood: string | null;
+  evaluatorMoodAfter: string | null;
 }
 
 // ── Ranking ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
**Stack:** PR 1 of 4 implementando a RFC 0012. Base = `claude/gifted-cray-zefxmx` (PR #608, docs). Merge bottom-up: #608 → esta → Fase 1 → Fase 2 → Fase 3.

## Fase 0 — Tipos, fixtures e golden snapshot

Base estrutural da RFC 0012 com **zero mudança de comportamento de produção**. Tudo aqui é tipo, fixture ou teste — nenhum consumidor (ranking, UI, doctor) é tocado ainda.

### O que entra
- **`types.ts`**: `MatchKind` e `NormalizedMatch` (a forma que o normalizador da Fase 1 vai emitir), declarados antes de qualquer consumidor migrar. Campos opcionais `match_kind`, `review_lang` (em `RateFile`) e `content_lang` (em `PostSide`) forward-declarados — todos opcionais, sem efeito em código existente. `NormalizedMatch` **não** carrega `mode` de avaliação: regimes são RFC 0013 e são *asserções*, não *derivações*, então não viajam neste registro estrutural.
- **Fixtures de rate file** (`__tests__/fixtures/rate-files/`): `stars-v1`, `stars-v2`, `stars-v3`, um duelo `work` e um duelo `version` — o acervo que o normalizador da Fase 1 vai consumir.
- **`golden-ranking.test.js`**: trava o invariante load-bearing — **um duelo `version` nunca altera o ranking `work`** (`_computeRatings` com e sem os duelos de versão produz resultado idêntico) — e a regra de classificação estrutural `kind = aKey === bKey ? "version" : "work"` contra as fixtures. Este golden é a rede de segurança contra a qual a Fase 1 prova ser behavior-preserving.
- **`package.json`**: o script `test` passa a varrer `src/hronir/__tests__/*.test.js` (antes nomeava só `ranking.test.js`, então o novo teste não rodaria).

### Gates (todos verdes)
- `npm test` — 29 testes, 7 suites, 0 falhas
- `npx prettier --check .` ✓
- `npx astro check` — 0 erros
- `npm run build` ✓
- `npm run check:hygiene` ✓

> A regeneração de `ranking-snapshot.json` durante o build mostrou drift **pré-existente** (54→74 duelos, chaves de música) não relacionado a esta fase — revertido para manter o PR limpo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PSUGMxdvYu34sJ3YHfScFm)_