### PR TITLE
RFC 0012 Fase 1 — normalizador único e getDuels({ kind })

### DIFF
--- a/src/hronir/__tests__/golden-ranking.test.js
+++ b/src/hronir/__tests__/golden-ranking.test.js
@@ -24,6 +24,8 @@ await mock.module("../matches.js", {
     writeMatch: () => {},
     postKey: (side) => (side ? side.key || side.slug || null : null),
     matchesDataVersion: () => 0,
+    loadMatches: () => [],
+    loadNormalizedMatches: () => [],
   },
 });
 

--- a/src/hronir/__tests__/normalizer.test.js
+++ b/src/hronir/__tests__/normalizer.test.js
@@ -1,0 +1,115 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import matter from "gray-matter";
+import { normalizeMatch, classifyKind, matchId } from "../matches.js";
+
+// RFC 0012 Fase 1 — the single normalizer. These exercise the real
+// normalizeMatch (no module mock; this file runs in its own test process) so
+// the work/version classification, slug@uuid refs, language fallback and the
+// validity filters are pinned in one place.
+
+const FIXdir = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "fixtures",
+  "rate-files"
+);
+const load = (name) => {
+  const { data, content } = matter(
+    fs.readFileSync(path.join(FIXdir, name), "utf8")
+  );
+  return normalizeMatch(data, content, name);
+};
+
+describe("classifyKind", () => {
+  it("same key → version, different keys → work", () => {
+    assert.equal(classifyKind("a", "a"), "version");
+    assert.equal(classifyKind("a", "b"), "work");
+  });
+});
+
+describe("normalizeMatch — fixtures", () => {
+  it("stars-v1 work duel: legacy, no review_lang", () => {
+    const lm = load("work-stars-v1.md");
+    assert.equal(lm.norm.kind, "work");
+    assert.equal(lm.norm.winnerSide, "a");
+    assert.equal(lm.norm.postA.key, "alpha-essay");
+    assert.equal(lm.norm.postB.key, "beta-essay");
+    assert.equal(lm.norm.reviewLang, null);
+    assert.equal(lm.norm.rateA, 4.5);
+    assert.ok(lm.norm.runAt instanceof Date);
+  });
+
+  it("stars-v2 work duel: review_lang falls back to eval_lang", () => {
+    const lm = load("work-stars-v2.md");
+    assert.equal(lm.norm.kind, "work");
+    assert.equal(lm.norm.winnerSide, "b");
+    assert.equal(lm.norm.reviewLang, "en");
+    assert.equal(lm.norm.perspectiveId, "o-cetico");
+    assert.equal(lm.norm.evaluatorMood, "Comecei curioso, meio cansado.");
+  });
+
+  it("stars-v3 work duel: review_lang + per-side content_lang", () => {
+    const lm = load("work-stars-v3.md");
+    assert.equal(lm.norm.kind, "work");
+    assert.equal(lm.norm.reviewLang, "pt");
+    assert.equal(lm.norm.postA.contentLang, "en");
+    assert.equal(lm.norm.postB.contentLang, "pt");
+  });
+
+  it("stars-v3 version duel: kind version + slug@uuid refs", () => {
+    const lm = load("version-stars-v3.md");
+    assert.equal(lm.norm.kind, "version");
+    assert.equal(lm.norm.winnerSide, "b");
+    assert.equal(lm.norm.postA.key, "alpha-essay");
+    assert.equal(lm.norm.postB.key, "alpha-essay");
+    assert.equal(lm.norm.postA.ref, "alpha-essay@v-2026-06-09T20-24-29");
+    assert.equal(lm.norm.postB.ref, "alpha-essay@v-2026-06-11T08-25-46");
+  });
+
+  it("id is matchId(aKey, bKey, runAtRaw)", () => {
+    const lm = load("work-stars-v3.md");
+    assert.equal(
+      lm.norm.id,
+      matchId(lm.norm.postA.key, lm.norm.postB.key, lm.runAtRaw)
+    );
+  });
+});
+
+describe("normalizeMatch — validity filters", () => {
+  const base = {
+    post_a: { key: "a", path: "a.md" },
+    post_b: { key: "b", path: "b.md" },
+    run_at: "2024-01-01T00:00:00Z",
+    winner: "a",
+  };
+
+  it("returns null for TODO / missing winner", () => {
+    assert.equal(normalizeMatch({ ...base, winner: "TODO" }, "", "x"), null);
+    assert.equal(normalizeMatch({ ...base, winner: undefined }, "", "x"), null);
+  });
+
+  it("override flips the resolved winner", () => {
+    const lm = normalizeMatch({ ...base, override: "b" }, "", "x");
+    assert.equal(lm.norm.winnerSide, "b");
+  });
+
+  it("returns null when a key is missing", () => {
+    assert.equal(
+      normalizeMatch({ ...base, post_b: { path: "b.md" } }, "", "x"),
+      null
+    );
+  });
+
+  it("keeps run_id-only timestamps as runAtRaw, runAt null when unparseable", () => {
+    const lm = normalizeMatch(
+      { ...base, run_at: undefined, run_id: "2024-01-01T00-00-00-000" },
+      "",
+      "x"
+    );
+    assert.equal(lm.runAtRaw, "2024-01-01T00-00-00-000");
+    assert.equal(lm.norm.runAt, null);
+  });
+});

--- a/src/hronir/__tests__/ranking.test.js
+++ b/src/hronir/__tests__/ranking.test.js
@@ -14,6 +14,8 @@ await mock.module("../matches.js", {
     writeMatch: () => {},
     postKey: (side) => (side ? side.key || side.slug || null : null),
     matchesDataVersion: () => 0,
+    loadMatches: () => [],
+    loadNormalizedMatches: () => [],
   },
 });
 

--- a/src/hronir/matches.ts
+++ b/src/hronir/matches.ts
@@ -1,8 +1,14 @@
 import fs from "node:fs";
 import path from "node:path";
+import crypto from "node:crypto";
 import { execFileSync } from "node:child_process";
 import matter from "gray-matter";
 import { OUT_DIR, RATES_DIR } from "./posts.js";
+import type {
+  MatchKind,
+  NormalizedMatch,
+  NormalizedMatchSide,
+} from "./types.js";
 
 export function listMatchFiles(): string[] {
   const out: string[] = [];
@@ -80,6 +86,138 @@ export function postKey(
 ): string | null {
   if (!side) return null;
   return side.key || side.slug || null;
+}
+
+// ── Single normalizer (RFC 0012 §4.1) ───────────────────────────────────────
+//
+// Before RFC 0012 three readers (ranking._loadMatchData,
+// ranking.computePerPerspectiveRatings, hronir-rank.loadDuelData) each parsed
+// the rate files and re-derived winner/override resolution, keys, runAt and the
+// work-vs-version distinction by hand. This is the one place that does it, so
+// every consumer shares the same classification instead of re-deriving
+// `aKey === bKey` ad hoc.
+
+/** RFC 0012 §4.1: structural, derivable from the rate file alone. */
+export function classifyKind(aKey: string, bKey: string): MatchKind {
+  return aKey === bKey ? "version" : "work";
+}
+
+/** Stable 8-char duel id — hash of postAKey|postBKey|runAt. Single source for
+ *  the value hronir-rank.duelId used to compute inline. */
+export function matchId(aKey: string, bKey: string, runAt: string): string {
+  return crypto
+    .createHash("sha256")
+    .update([aKey, bKey, runAt].join("|"))
+    .digest("hex")
+    .slice(0, 8);
+}
+
+/** A normalized match plus the raw material consumers still need: the exact
+ *  original runAt string (Date round-tripping would corrupt `run_id`-only
+ *  timestamps), the source filename, and the untouched frontmatter/body for
+ *  passthrough display fields (margin, confidence, parsed clash, …). */
+export interface LoadedMatch {
+  norm: NormalizedMatch;
+  filename: string;
+  runAtRaw: string;
+  data: Record<string, unknown>;
+  content: string;
+}
+
+function asString(v: unknown): string | null {
+  return v == null ? null : String(v);
+}
+
+function asFiniteNumber(v: unknown): number | null {
+  return typeof v === "number" && Number.isFinite(v) ? v : null;
+}
+
+function normalizeSide(
+  raw: Record<string, unknown> | null | undefined,
+  key: string
+): NormalizedMatchSide {
+  const version = (raw?.version as string) ?? null;
+  const contentLang =
+    (raw?.content_lang as string) ?? (raw?.display_lang as string) ?? null;
+  return {
+    key,
+    ref: version ? `${key}@${version}` : null,
+    path: (raw?.path as string) || null,
+    version,
+    contentLang,
+  };
+}
+
+/** Pure: turns one parsed rate file into a LoadedMatch, or null when the file
+ *  carries no usable verdict (no winner, missing keys, TODO). Same filters the
+ *  three legacy readers applied, in one place. */
+export function normalizeMatch(
+  data: Record<string, unknown>,
+  content: string,
+  filePath: string
+): LoadedMatch | null {
+  let winner = data.winner as string;
+  if (data.override && data.override !== "null")
+    winner = data.override as string;
+  if (winner === "TODO" || !winner) return null;
+  if (winner !== "a" && winner !== "b") return null;
+
+  const aKey = postKey(data.post_a as { key?: string; slug?: string } | null);
+  const bKey = postKey(data.post_b as { key?: string; slug?: string } | null);
+  if (!aKey || !bKey) return null;
+
+  const rawRunAt = (data.run_at ?? data.run_id ?? "") as string | Date;
+  const runAtRaw =
+    rawRunAt instanceof Date ? rawRunAt.toISOString() : String(rawRunAt);
+  const parsed = runAtRaw ? new Date(runAtRaw) : null;
+  const runAt = parsed && !Number.isNaN(parsed.getTime()) ? parsed : null;
+
+  const postA = data.post_a as Record<string, unknown> | null;
+  const postB = data.post_b as Record<string, unknown> | null;
+
+  const norm: NormalizedMatch = {
+    id: matchId(aKey, bKey, runAtRaw),
+    kind: classifyKind(aKey, bKey),
+    winnerSide: winner,
+    runAt,
+    postA: normalizeSide(postA, aKey),
+    postB: normalizeSide(postB, bKey),
+    reviewLang:
+      (data.review_lang as string) ?? (data.eval_lang as string) ?? null,
+    agentId: asString(data.agent_id),
+    perspectiveId: asString(data.perspective_id),
+    rateA: asFiniteNumber(data.rate_a),
+    rateB: asFiniteNumber(data.rate_b),
+    evaluatorMood: asString(data.evaluator_mood),
+    evaluatorMoodAfter: asString(data.evaluator_mood_after),
+  };
+
+  return { norm, filename: filePath, runAtRaw, data, content };
+}
+
+// RFC 0010 §4.7 (E1): memoized against matchesDataVersion so a writeMatch in
+// the same process (decide, migrate) invalidates the snapshot.
+let _normCache: { version: number; matches: LoadedMatch[] } | null = null;
+
+/** The single parse pass over the rate files. Consumers map this to their own
+ *  shape (RawMatch, DuelEntry) instead of reading the files again. */
+export function loadMatches(): LoadedMatch[] {
+  const version = matchesDataVersion();
+  if (_normCache && _normCache.version === version) return _normCache.matches;
+  const out: LoadedMatch[] = [];
+  for (const f of listMatchFiles()) {
+    const { data, content } = readMatch(f);
+    const lm = normalizeMatch(data as Record<string, unknown>, content, f);
+    if (lm) out.push(lm);
+  }
+  _normCache = { version, matches: out };
+  return out;
+}
+
+/** RFC 0012 §4.1 public API: the normalized matches without the raw passthrough
+ *  material. */
+export function loadNormalizedMatches(): NormalizedMatch[] {
+  return loadMatches().map((m) => m.norm);
 }
 
 // RFC 0010 §4.7 (E3): one `git log --name-only` walk builds a last-commit-time

--- a/src/hronir/ranking.ts
+++ b/src/hronir/ranking.ts
@@ -1,10 +1,5 @@
 import { rating, rate, ordinal } from "openskill";
-import {
-  listMatchFiles,
-  readMatch,
-  postKey,
-  matchesDataVersion,
-} from "./matches.js";
+import { loadMatches, matchesDataVersion } from "./matches.js";
 import type { RankRow, PerspectiveRankRow } from "./types.js";
 
 export const MIN_APPEARANCES = 3;
@@ -41,51 +36,27 @@ let _rawCache: { version: number; raw: RawMatch[] } | null = null;
 function _loadMatchData(): RawMatch[] {
   const version = matchesDataVersion();
   if (_rawCache && _rawCache.version === version) return _rawCache.raw;
-  const raw: RawMatch[] = [];
-  for (const f of listMatchFiles()) {
-    const { data } = readMatch(f);
-    let winner = data.winner as string;
-    if (data.override && data.override !== "null")
-      winner = data.override as string;
-    if (winner === "TODO" || !winner) continue;
-
-    const aKey = postKey(data.post_a as { key?: string; slug?: string } | null);
-    const bKey = postKey(data.post_b as { key?: string; slug?: string } | null);
-    if (!aKey || !bKey) continue;
-    if (winner !== "a" && winner !== "b") continue;
-
-    const rawRunAt = (data.run_at ?? data.run_id ?? "") as string | Date;
-    const runAt =
-      rawRunAt instanceof Date ? rawRunAt.toISOString() : String(rawRunAt);
-
-    const rateA =
-      typeof data.rate_a === "number" && Number.isFinite(data.rate_a)
-        ? (data.rate_a as number)
-        : null;
-    const rateB =
-      typeof data.rate_b === "number" && Number.isFinite(data.rate_b)
-        ? (data.rate_b as number)
-        : null;
-
-    const postA = data.post_a as Record<string, unknown> | null;
-    const postB = data.post_b as Record<string, unknown> | null;
-
-    raw.push({
-      runAt,
-      filename: f,
-      aKey,
-      bKey,
-      aPath: (postA?.path as string) || "",
-      bPath: (postB?.path as string) || "",
-      aVersion: (postA?.version as string) ?? null,
-      bVersion: (postB?.version as string) ?? null,
-      agentId: data.agent_id ? String(data.agent_id) : null,
-      perspectiveId: data.perspective_id ? String(data.perspective_id) : null,
-      winner: winner as "a" | "b",
-      rateA,
-      rateB,
-    });
-  }
+  // RFC 0012 §4.1: one normalizer feeds every reader. RawMatch is just a flat
+  // projection of the normalized record (version duels included — _computeRatings
+  // skips same-key pairs, _computeVersionRatings keeps only those).
+  const raw: RawMatch[] = loadMatches().map((lm) => {
+    const n = lm.norm;
+    return {
+      runAt: lm.runAtRaw,
+      filename: lm.filename,
+      aKey: n.postA.key,
+      bKey: n.postB.key,
+      aPath: n.postA.path || "",
+      bPath: n.postB.path || "",
+      aVersion: n.postA.version,
+      bVersion: n.postB.version,
+      agentId: n.agentId,
+      perspectiveId: n.perspectiveId,
+      winner: n.winnerSide,
+      rateA: n.rateA,
+      rateB: n.rateB,
+    };
+  });
   _rawCache = { version, raw };
   return raw;
 }
@@ -524,30 +495,18 @@ export function computePerPerspectiveRatings(): Map<
     }>
   >();
 
-  for (const f of listMatchFiles()) {
-    const { data } = readMatch(f);
-    let winner = data.winner as string;
-    if (data.override && data.override !== "null")
-      winner = data.override as string;
-    if (winner === "TODO" || !winner) continue;
-
-    const aKey = postKey(data.post_a as { key?: string; slug?: string } | null);
-    const bKey = postKey(data.post_b as { key?: string; slug?: string } | null);
-    if (!aKey || !bKey) continue;
-    if (winner !== "a" && winner !== "b") continue;
-    if (aKey === bKey) continue;
-
-    const perspId = data.perspective_id ? String(data.perspective_id) : null;
-    if (!perspId) continue;
-
-    const rawRunAt = (data.run_at ?? data.run_id ?? "") as string | Date;
-    const runAt =
-      rawRunAt instanceof Date ? rawRunAt.toISOString() : String(rawRunAt);
-
-    if (!byPerspective.has(perspId)) byPerspective.set(perspId, []);
-    byPerspective
-      .get(perspId)!
-      .push({ runAt, aKey, bKey, winner: winner as "a" | "b" });
+  for (const lm of loadMatches()) {
+    const n = lm.norm;
+    if (n.kind === "version") continue; // RFC 0012: version duels never rank works
+    if (!n.perspectiveId) continue;
+    if (!byPerspective.has(n.perspectiveId))
+      byPerspective.set(n.perspectiveId, []);
+    byPerspective.get(n.perspectiveId)!.push({
+      runAt: lm.runAtRaw,
+      aKey: n.postA.key,
+      bKey: n.postB.key,
+      winner: n.winnerSide,
+    });
   }
 
   const result = new Map<string, PerspectiveRankRow[]>();

--- a/src/lib/hronir-rank.ts
+++ b/src/lib/hronir-rank.ts
@@ -2,14 +2,13 @@
 // Reads .routines/hronir/*.md, runs OpenSkill, exposes a Map<key, RankRow>
 // keyed by translationKey, plus a sorted array.
 
-import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import {
   computeRatings,
   computePerPerspectiveRatings,
 } from "../hronir/ranking.js";
-import { listMatchFiles, readMatch, postKey } from "../hronir/matches.js";
+import { loadMatches, matchId } from "../hronir/matches.js";
 import { listPerspectives } from "../hronir/perspectives.js";
 import type {
   RankRow,
@@ -36,12 +35,9 @@ export type {
 export function duelId(
   d: Pick<DuelEntry, "postAKey" | "postBKey" | "runAt">
 ): string {
-  const canonical = [d.postAKey ?? "", d.postBKey ?? "", d.runAt].join("|");
-  return crypto
-    .createHash("sha256")
-    .update(canonical)
-    .digest("hex")
-    .slice(0, 8);
+  // RFC 0012: id generation lives in matches.matchId so the duel list and the
+  // normalizer agree on the value byte-for-byte.
+  return matchId(d.postAKey ?? "", d.postBKey ?? "", d.runAt);
 }
 
 export function parseDuelContent(
@@ -107,83 +103,58 @@ function loadDuelData(): { stats: RankingStats; recent: DuelEntry[] } {
   if (_statsCache) return _statsCache;
 
   const duels: DuelEntry[] = [];
-  for (const f of listMatchFiles()) {
-    const { data, content } = readMatch(f);
-    let winner = (data as any).winner;
-    if ((data as any).override && (data as any).override !== "null") {
-      winner = (data as any).override;
-    }
-    if (winner === "TODO" || !winner) continue;
-    const aKey = postKey((data as any).post_a);
-    const bKey = postKey((data as any).post_b);
-    if (!aKey || !bKey) continue;
-    if (winner !== "a" && winner !== "b") continue;
-
-    const rawRunAt = (data as any).run_at ?? (data as any).run_id ?? "";
-    const runAt =
-      rawRunAt instanceof Date ? rawRunAt.toISOString() : String(rawRunAt);
+  // RFC 0012 §4.1: built from the single normalizer. Structural decisions
+  // (winner side, keys, work/version kind, id, runAt) come from the normalized
+  // record; passthrough display fields are still read straight off the raw
+  // frontmatter so the rendered duel is byte-for-byte what it was before.
+  for (const lm of loadMatches()) {
+    const n = lm.norm;
+    const runAt = lm.runAtRaw;
     // Skip matches without a parseable timestamp: an empty runAt would
     // sort ahead of every real duel in the "Latest duels" list and
     // render with a placeholder date, which is worse than not showing it.
     if (!runAt) continue;
 
-    const winnerKey = winner === "a" ? aKey : bKey;
-    const loserKey = winner === "a" ? bKey : aKey;
+    const data = lm.data as any;
+    const content = lm.content;
+    const aKey = n.postA.key;
+    const bKey = n.postB.key;
+    const winnerKey = n.winnerSide === "a" ? aKey : bKey;
+    const loserKey = n.winnerSide === "a" ? bKey : aKey;
+    const agentId = data.agent_id ? String(data.agent_id) : undefined;
 
-    const agentId = (data as any).agent_id
-      ? String((data as any).agent_id)
-      : undefined;
-
-    const entry: DuelEntry = {
-      id: "",
+    duels.push({
+      id: n.id,
       runAt,
       winnerKey,
       loserKey,
-      winnerSide: winner as "a" | "b",
-      isVersionDuel: aKey === bKey,
-      margin:
-        typeof (data as any).margin === "number"
-          ? (data as any).margin
-          : undefined,
-      confidence: (data as any).confidence
-        ? String((data as any).confidence)
-        : undefined,
-      criterion: (data as any).criterion
-        ? String((data as any).criterion)
-        : undefined,
+      winnerSide: n.winnerSide,
+      isVersionDuel: n.kind === "version",
+      margin: typeof data.margin === "number" ? data.margin : undefined,
+      confidence: data.confidence ? String(data.confidence) : undefined,
+      criterion: data.criterion ? String(data.criterion) : undefined,
       body: content ? String(content).trim() : undefined,
       model: agentId,
       agentId,
-      season:
-        typeof (data as any).season === "number"
-          ? (data as any).season
-          : undefined,
+      season: typeof data.season === "number" ? data.season : undefined,
       postAKey: aKey,
       postBKey: bKey,
-      perspectiveId: (data as any).perspective_id
-        ? String((data as any).perspective_id)
+      perspectiveId: data.perspective_id
+        ? String(data.perspective_id)
         : undefined,
-      rateA:
-        typeof (data as any).rate_a === "number"
-          ? (data as any).rate_a
-          : undefined,
-      rateB:
-        typeof (data as any).rate_b === "number"
-          ? (data as any).rate_b
-          : undefined,
-      evaluatorMood: (data as any).evaluator_mood
-        ? String((data as any).evaluator_mood)
+      rateA: typeof data.rate_a === "number" ? data.rate_a : undefined,
+      rateB: typeof data.rate_b === "number" ? data.rate_b : undefined,
+      evaluatorMood: data.evaluator_mood
+        ? String(data.evaluator_mood)
         : undefined,
-      evaluatorMoodAfter: (data as any).evaluator_mood_after
-        ? String((data as any).evaluator_mood_after)
+      evaluatorMoodAfter: data.evaluator_mood_after
+        ? String(data.evaluator_mood_after)
         : undefined,
       parsedContent: parseDuelContent(
         content ? String(content).trim() : undefined,
         data as Record<string, unknown>
       ),
-    };
-    entry.id = duelId(entry);
-    duels.push(entry);
+    });
   }
 
   duels.sort((a, b) => b.runAt.localeCompare(a.runAt));
@@ -210,6 +181,21 @@ export function getRecentDuels(limit = 8): DuelEntry[] {
 
 export function getAllDuels(): DuelEntry[] {
   return loadDuelData().recent;
+}
+
+// RFC 0012 §6.4: the canonical duel accessor. `kind` is required — there is no
+// ambiguous default. "work" = editorial battles between distinct posts;
+// "version" = revision trials of one post; "all" = the raw archive. Fase 2
+// migrates the public surfaces (battles, dossiers, stats) onto this so they
+// stop mixing the two universes.
+export function getDuels(opts: {
+  kind: "work" | "version" | "all";
+}): DuelEntry[] {
+  const all = loadDuelData().recent;
+  if (opts.kind === "all") return all;
+  return all.filter(
+    (d) => (d.isVersionDuel ? "version" : "work") === opts.kind
+  );
 }
 
 export function getPerspectives(): PerspectiveMeta[] {


### PR DESCRIPTION
**Stack:** PR 2 of 4 implementando a RFC 0012. Base = `claude/rfc0012-fase0-tipos-fixtures` (PR #610). Merge bottom-up: #608 → #610 → **esta** → Fase 2 → Fase 3.

## Fase 1 — Normalizador único e `getDuels({ kind })`

A fase de maior risco do stack, entregue **com comportamento preservado e provado**.

### Problema
Três leitores de rate files re-derivavam, cada um à mão, resolução de winner/override, chaves, `runAt` e a distinção work/version:
- `ranking._loadMatchData`
- `ranking.computePerPerspectiveRatings`
- `hronir-rank.loadDuelData`

Nada garantia que herdassem a mesma classificação (RFC 0012 §2.1).

### Solução
- **`matches.ts`**: um normalizador único.
  - `normalizeMatch()` (puro, testável) → `LoadedMatch | null` com os mesmos filtros de validade que os três leitores aplicavam.
  - `loadMatches()` — o **único** parse memoizado dos arquivos; `loadNormalizedMatches()` expõe a forma limpa (RFC §4.1).
  - `classifyKind()` (`aKey === bKey ? "version" : "work"`), `matchId()` (id de duelo, fonte única), `ref` `slug@uuid` por lado, `reviewLang` com fallback `eval_lang`, `content_lang` por lado.
- **`ranking.ts`**: `_loadMatchData` e `computePerPerspectiveRatings` projetam `loadMatches()` — sem reler arquivos. `runAt` preservado via `runAtRaw` (round-trip de `Date` corromperia timestamps `run_id`-only com hífens).
- **`hronir-rank.ts`**: `loadDuelData` idem; `duelId` delega a `matchId`; **`getDuels({ kind })`** — acessor canônico **sem default ambíguo** (`work` | `version` | `all`). Decisões estruturais vêm do normalizador; campos de exibição (margin, confidence, clash, mood) seguem lidos do frontmatter byte-a-byte.

### Escopo deliberado
As **superfícies públicas** (battles/dossiês/stats ainda chamam `getAllDuels`, comportamento intacto) migram para `getDuels` na **Fase 2**. O CLI `commands.ts`/doctor (escreve/draft, não é leitor de superfície) adota o normalizador depois — `doctor` segue verde sem reescrita.

### Prova de invariância
Gerei o `ranking-snapshot.json` com o loader **antigo** e com o **novo** sobre o mesmo acervo: `keys`/ordinais/elo/ranks **byte-idênticos**, `totalDuels` 74 nos dois. O golden da Fase 0 segue verde sem alteração.

### Gates (todos verdes)
- `npm test` — **39 testes** (golden + novo `normalizer.test.js` + suite existente), 0 falhas
- `npx prettier --check .` ✓ · `npx astro check` — 0 erros · `npm run build` ✓ · `npm run check:hygiene` ✓

> Drift pré-existente de `ranking-snapshot.json` revertido novamente (não relacionado).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PSUGMxdvYu34sJ3YHfScFm)_