### PR TITLE
RFC 0012 Fase 2 — separação de superfícies work vs version

### DIFF
--- a/src/components/HronirReviews.astro
+++ b/src/components/HronirReviews.astro
@@ -1,5 +1,5 @@
 ---
-import { getAllDuels } from "../lib/hronir-rank";
+import { getDuels } from "../lib/hronir-rank";
 import { getCollection } from "astro:content";
 import { marked } from "marked";
 import { isPublished } from "../lib/publish";
@@ -11,7 +11,8 @@ interface Props {
 
 const { translationKey, lang = "en" } = Astro.props;
 
-const allDuels = getAllDuels();
+// RFC 0012 §6.1: a post's reviews are its editorial duels, not version trials.
+const allDuels = getDuels({ kind: "work" });
 
 const allPosts = await getCollection("blog");
 const postMeta = new Map<string, { title: string; slug: string; lang: string }>();
@@ -45,7 +46,7 @@ function fmtDate(iso: string): string {
 
 // Precompute card data and filter out duels with no review content
 type CardData = {
-  d: ReturnType<typeof getAllDuels>[number];
+  d: ReturnType<typeof getDuels>[number];
   myReview: string;
   myRate: number | undefined;
   won: boolean;

--- a/src/components/RankingView.astro
+++ b/src/components/RankingView.astro
@@ -390,7 +390,6 @@ function snapshotElo(key: string): { elo: number; peak: number } | null {
           >
             <div class="bcl-meta">
               <span class="bcl-date">{fmtDate(d.runAt)}</span>
-              {d.isVersionDuel && <span class="bcl-tag">version duel</span>}
               {d.perspectiveId && (
                 <span
                   class="bcl-tag bcl-tag-persp"

--- a/src/hronir/types.ts
+++ b/src/hronir/types.ts
@@ -131,6 +131,16 @@ export interface DuelEntry {
   season?: number;
   postAKey?: string;
   postBKey?: string;
+  /** RFC 0012 §6.2: slug@uuid of each side — the exact version judged. Equal
+   *  keys on both sides (a version duel) still resolve to two distinct refs. */
+  postARef?: string | null;
+  postBRef?: string | null;
+  postAVersion?: string | null;
+  postBVersion?: string | null;
+  /** Source file path of each side's version — used to build permalinks to the
+   *  exact content judged in a version trial. */
+  postAPath?: string | null;
+  postBPath?: string | null;
   perspectiveId?: string;
   rateA?: number;
   rateB?: number;

--- a/src/lib/hronir-rank.ts
+++ b/src/lib/hronir-rank.ts
@@ -139,6 +139,12 @@ function loadDuelData(): { stats: RankingStats; recent: DuelEntry[] } {
       season: typeof data.season === "number" ? data.season : undefined,
       postAKey: aKey,
       postBKey: bKey,
+      postARef: n.postA.ref,
+      postBRef: n.postB.ref,
+      postAVersion: n.postA.version,
+      postBVersion: n.postB.version,
+      postAPath: n.postA.path,
+      postBPath: n.postB.path,
       perspectiveId: data.perspective_id
         ? String(data.perspective_id)
         : undefined,
@@ -159,12 +165,15 @@ function loadDuelData(): { stats: RankingStats; recent: DuelEntry[] } {
 
   duels.sort((a, b) => b.runAt.localeCompare(a.runAt));
 
+  // RFC 0012 §6.1: editorial stats count only work duels. Version trials have
+  // their own surface and must not inflate "duels run".
+  const work = duels.filter((d) => !d.isVersionDuel);
   const rated = getRanking();
   const stats: RankingStats = {
-    totalDuels: duels.length,
+    totalDuels: work.length,
     totalRated: rated.length,
-    lastDuelAt: duels.length > 0 ? duels[0].runAt : null,
-    firstDuelAt: duels.length > 0 ? duels[duels.length - 1].runAt : null,
+    lastDuelAt: work.length > 0 ? work[0].runAt : null,
+    firstDuelAt: work.length > 0 ? work[work.length - 1].runAt : null,
   };
 
   _statsCache = { stats, recent: duels };
@@ -175,12 +184,25 @@ export function getRankingStats(): RankingStats {
   return loadDuelData().stats;
 }
 
+// RFC 0012 §6.1: "recent battles" on the ranking home are editorial only.
 export function getRecentDuels(limit = 8): DuelEntry[] {
-  return loadDuelData().recent.slice(0, limit);
+  return getDuels({ kind: "work" }).slice(0, limit);
 }
 
+// The raw archive (every duel, both kinds). Used by id resolution; public
+// listings should call getDuels({ kind }) with an explicit kind instead.
 export function getAllDuels(): DuelEntry[] {
   return loadDuelData().recent;
+}
+
+// RFC 0012 §6.2: all version trials, newest first.
+export function getVersionTrials(): DuelEntry[] {
+  return getDuels({ kind: "version" });
+}
+
+// Version trials for one post key (both sides share the key).
+export function getPostVersionTrials(key: string): DuelEntry[] {
+  return getDuels({ kind: "version" }).filter((d) => d.postAKey === key);
 }
 
 // RFC 0012 §6.4: the canonical duel accessor. `kind` is required — there is no
@@ -222,8 +244,12 @@ export function getDuelById(id: string): DuelEntry | undefined {
   return getAllDuels().find((d) => d.id === id);
 }
 
+// RFC 0012 §6.3: a post's editorial record is work duels only. Version trials
+// live in the dossier's "Edit history" section via getPostVersionTrials.
 export function getPostDuelHistory(key: string): DuelEntry[] {
-  return getAllDuels().filter((d) => d.postAKey === key || d.postBKey === key);
+  return getDuels({ kind: "work" }).filter(
+    (d) => d.postAKey === key || d.postBKey === key
+  );
 }
 
 const SNAPSHOT_PATH = path.join(

--- a/src/pages/ranking/battles/[id].astro
+++ b/src/pages/ranking/battles/[id].astro
@@ -1,7 +1,7 @@
 ---
 import PageLayout from "../../../layouts/PageLayout.astro";
 import { getCollection } from "astro:content";
-import { getAllDuels, getRankByKey } from "../../../lib/hronir-rank";
+import { getDuels, getRankByKey } from "../../../lib/hronir-rank";
 import { isPublished } from "../../../lib/publish";
 import { marked } from "marked";
 
@@ -17,27 +17,49 @@ export async function getStaticPaths() {
     if (!existing || lang === "en") byKey.set(key, { title: p.data.title, slug: p.id, lang });
   }
 
-  const duels = getAllDuels();
+  // RFC 0012: editorial (work) and version trials are distinct universes. Each
+  // duel detail navigates within its own kind, with its own archive backlink.
   const PER_PAGE = 20;
-  return duels.map((duel, i) => {
+  const work = getDuels({ kind: "work" });
+  const versions = getDuels({ kind: "version" });
+
+  const workPaths = work.map((duel, i) => {
     const archivePage = Math.floor(i / PER_PAGE) + 1;
     const archiveBase = archivePage === 1 ? "/ranking/battles/" : `/ranking/battles/page/${archivePage}/`;
-    const archiveHref = `${archiveBase}#${duel.id}`;
     return {
       params: { id: duel.id },
       props: {
         duel,
-        prevId: i + 1 < duels.length ? duels[i + 1].id : null,
-        nextId: i > 0 ? duels[i - 1].id : null,
-        archiveHref,
+        prevId: i + 1 < work.length ? work[i + 1].id : null,
+        nextId: i > 0 ? work[i - 1].id : null,
+        archiveHref: `${archiveBase}#${duel.id}`,
+        archiveLabel: "All battles",
         postAInfo: byKey.get(duel.postAKey ?? ""),
         postBInfo: byKey.get(duel.postBKey ?? ""),
       },
     };
   });
+
+  const versionPaths = versions.map((duel, i) => ({
+    params: { id: duel.id },
+    props: {
+      duel,
+      prevId: i + 1 < versions.length ? versions[i + 1].id : null,
+      nextId: i > 0 ? versions[i - 1].id : null,
+      archiveHref: `/ranking/versions/${duel.postAKey ?? ""}/`,
+      archiveLabel: "Version trials",
+      postAInfo: byKey.get(duel.postAKey ?? ""),
+      postBInfo: byKey.get(duel.postBKey ?? ""),
+    },
+  }));
+
+  return [...workPaths, ...versionPaths];
 }
 
-const { duel, prevId, nextId, archiveHref, postAInfo, postBInfo } = Astro.props;
+const { duel, prevId, nextId, archiveHref, archiveLabel, postAInfo, postBInfo } =
+  Astro.props;
+
+const isVersion = duel.isVersionDuel === true;
 
 function postHref(info: { slug: string; lang: string } | undefined) {
   if (!info) return null;
@@ -47,6 +69,11 @@ function postHref(info: { slug: string; lang: string } | undefined) {
 function dossierHref(key: string | undefined) {
   if (!key) return null;
   return `/ranking/posts/${key}/`;
+}
+
+const REPO = "https://github.com/franklinbaldo/franklinbaldo.github.io";
+function sourceHref(path: string | null | undefined) {
+  return path ? `${REPO}/blob/main/${path}` : null;
 }
 
 const winnerIsA = duel.winnerSide
@@ -60,6 +87,13 @@ const winnerTitle = winnerInfo?.title ?? winnerKey;
 const loserTitle = loserInfo?.title ?? loserKey;
 const winnerHref = postHref(winnerInfo);
 const loserHref = postHref(loserInfo);
+
+// Version trials: both sides share the post; the identity is the slug@uuid ref.
+const postTitle = postAInfo?.title ?? duel.postAKey ?? "";
+const winnerRef = winnerIsA ? duel.postARef : duel.postBRef;
+const loserRef = winnerIsA ? duel.postBRef : duel.postARef;
+const winnerSrc = sourceHref(winnerIsA ? duel.postAPath : duel.postBPath);
+const loserSrc = sourceHref(winnerIsA ? duel.postBPath : duel.postAPath);
 
 const rateWinner = winnerIsA ? duel.rateA : duel.rateB;
 const rateLoser = winnerIsA ? duel.rateB : duel.rateA;
@@ -78,12 +112,17 @@ function perspectiveHue(id: string): number {
   return Math.abs(h) % 360;
 }
 
-const pageTitle = `${winnerTitle} vs ${loserTitle}`;
-const pageDesc = `Hrönir duel: ${winnerTitle} beat ${loserTitle}${duel.perspectiveId ? ` under the ${duel.perspectiveId} perspective` : ""}.`;
+const pageTitle = isVersion
+  ? `Version trial — ${postTitle}`
+  : `${winnerTitle} vs ${loserTitle}`;
+const pageDesc = isVersion
+  ? `Hrönir version trial for "${postTitle}": ${winnerRef} beat ${loserRef}.`
+  : `Hrönir duel: ${winnerTitle} beat ${loserTitle}${duel.perspectiveId ? ` under the ${duel.perspectiveId} perspective` : ""}.`;
 
+// Global rank is editorial-only; a version trial never carries one.
 const rankByKey = getRankByKey();
-const winnerRank = rankByKey.get(winnerKey);
-const loserRank = rankByKey.get(loserKey);
+const winnerRank = isVersion ? undefined : rankByKey.get(winnerKey);
+const loserRank = isVersion ? undefined : rankByKey.get(loserKey);
 ---
 
 <PageLayout title={`${pageTitle} | Ranking Battles`} description={pageDesc} lang="en">
@@ -91,19 +130,23 @@ const loserRank = rankByKey.get(loserKey);
     <ol>
       <li><a href="/">Home</a></li>
       <li><a href="/ranking/">Ranking</a></li>
-      <li><a href="/ranking/battles/">All battles</a></li>
-      <li aria-current="page">{winnerTitle} vs {loserTitle}</li>
+      <li><a href={archiveHref}>{archiveLabel}</a></li>
+      <li aria-current="page">{pageTitle}</li>
     </ol>
   </nav>
 
   <hgroup>
-    <h1>Battle Report</h1>
+    <h1>{isVersion ? "Version Trial" : "Battle Report"}</h1>
     <p><small>{fmtDate(duel.runAt)}</small></p>
   </hgroup>
 
   <div class="battle-tags">
     {duel.season !== undefined && <span class="tag tag-season">Season {duel.season}</span>}
-    {duel.isVersionDuel && <span class="tag">version duel</span>}
+    {isVersion && (
+      <span class="tag">
+        <a href={`/ranking/versions/${duel.postAKey}/`}>version trial</a>
+      </span>
+    )}
     {duel.perspectiveId && (
       <span class="tag tag-perspective" style={`--ph:${perspectiveHue(duel.perspectiveId)}`}>
         <a href={`/ranking/perspectives/${duel.perspectiveId}/`}>{duel.perspectiveId.replace(/-/g, " ")}</a>
@@ -113,21 +156,34 @@ const loserRank = rankByKey.get(loserKey);
     {duel.confidence && <span class={`tag tag-confidence conf-${duel.confidence}`}>{duel.confidence} confidence</span>}
   </div>
 
+  {isVersion && (
+    <p class="version-note">
+      A revision trial of <a href={`/ranking/versions/${duel.postAKey}/`}>{postTitle}</a> —
+      two versions of the same post compared. This does not affect the editorial ranking.
+    </p>
+  )}
+
   <section class="versus-section" aria-label="Versus">
     <div class="versus-grid">
       <div class="versus-side winner">
         <div class="versus-label">Winner 🏆</div>
         <div class="versus-title">
-          {winnerHref
-            ? <a href={winnerHref}>{winnerTitle}</a>
-            : <span>{winnerTitle}</span>}
+          {isVersion
+            ? <code>{winnerRef}</code>
+            : winnerHref
+              ? <a href={winnerHref}>{winnerTitle}</a>
+              : <span>{winnerTitle}</span>}
         </div>
         {hasRates && <div class="versus-rate">{rateWinner!.toFixed(2)}</div>}
-        {winnerRank && (
-          <div class="versus-rank">
-            <a href={dossierHref(winnerKey) ?? "/ranking/"}>#{winnerRank.rank}/{winnerRank.total}</a>
-          </div>
-        )}
+        {isVersion
+          ? winnerSrc && (
+              <div class="versus-rank"><a href={winnerSrc}>read source →</a></div>
+            )
+          : winnerRank && (
+              <div class="versus-rank">
+                <a href={dossierHref(winnerKey) ?? "/ranking/"}>#{winnerRank.rank}/{winnerRank.total}</a>
+              </div>
+            )}
       </div>
 
       <div class="versus-center">
@@ -135,18 +191,24 @@ const loserRank = rankByKey.get(loserKey);
       </div>
 
       <div class="versus-side loser">
-        <div class="versus-label">Challenger</div>
+        <div class="versus-label">{isVersion ? "Challenger version" : "Challenger"}</div>
         <div class="versus-title">
-          {loserHref
-            ? <a href={loserHref}>{loserTitle}</a>
-            : <span>{loserTitle}</span>}
+          {isVersion
+            ? <code>{loserRef}</code>
+            : loserHref
+              ? <a href={loserHref}>{loserTitle}</a>
+              : <span>{loserTitle}</span>}
         </div>
         {hasRates && <div class="versus-rate loser-rate">{rateLoser!.toFixed(2)}</div>}
-        {loserRank && (
-          <div class="versus-rank">
-            <a href={dossierHref(loserKey) ?? "/ranking/"}>#{loserRank.rank}/{loserRank.total}</a>
-          </div>
-        )}
+        {isVersion
+          ? loserSrc && (
+              <div class="versus-rank"><a href={loserSrc}>read source →</a></div>
+            )
+          : loserRank && (
+              <div class="versus-rank">
+                <a href={dossierHref(loserKey) ?? "/ranking/"}>#{loserRank.rank}/{loserRank.total}</a>
+              </div>
+            )}
       </div>
     </div>
 
@@ -222,6 +284,8 @@ const loserRank = rankByKey.get(loserKey);
   .breadcrumb a:hover { text-decoration: underline; }
 
   .battle-tags { display: flex; flex-wrap: wrap; gap: 0.4rem; margin-bottom: 1.5rem; }
+  .version-note { font-size: 0.85rem; color: var(--pico-muted-color); margin: 0 0 1.5rem; }
+  .versus-title code { font-size: 0.82rem; word-break: break-all; }
   .tag {
     font-size: 0.68rem; text-transform: uppercase; letter-spacing: 0.05em;
     padding: 0.15rem 0.5rem; border-radius: 4px;

--- a/src/pages/ranking/battles/index.astro
+++ b/src/pages/ranking/battles/index.astro
@@ -1,7 +1,7 @@
 ---
 import PageLayout from "../../../layouts/PageLayout.astro";
 import { getCollection } from "astro:content";
-import { getAllDuels } from "../../../lib/hronir-rank";
+import { getDuels } from "../../../lib/hronir-rank";
 import { isPublished } from "../../../lib/publish";
 
 const allPosts = await getCollection("blog");
@@ -15,7 +15,8 @@ for (const p of allPosts) {
   if (!existing || lang === "en") byKey.set(key, { title: p.data.title, slug: p.id, lang });
 }
 
-const allDuels = getAllDuels();
+// RFC 0012 §6.1/§6.4: the archive is editorial (work) battles only.
+const allDuels = getDuels({ kind: "work" });
 const PER_PAGE = 20;
 const totalPages = Math.ceil(allDuels.length / PER_PAGE);
 const duels = allDuels.slice(0, PER_PAGE);
@@ -59,7 +60,8 @@ const agents = [...new Set(allDuels.map((d) => d.agentId).filter(Boolean) as str
 
   <hgroup>
     <h1>Battle Archive</h1>
-    <p><small>{allDuels.length} duels · click any battle to read the full analysis and verdict</small></p>
+    <p><small>{allDuels.length} editorial duels · click any battle to read the full analysis and verdict</small></p>
+    <p><small><a href="/ranking/version-trials/">→ Version trials</a> (revisions of a single post)</small></p>
   </hgroup>
 
   <div class="battle-filters" id="battle-filters">
@@ -136,7 +138,6 @@ const agents = [...new Set(allDuels.map((d) => d.agentId).filter(Boolean) as str
             <div class="battle-meta">
               <span class="battle-date">{fmtDate(d.runAt)}</span>
               {d.season !== undefined && <span class="tag tag-season">S{d.season}</span>}
-              {d.isVersionDuel && <span class="tag">version duel</span>}
               {d.perspectiveId && (
                 <span class="tag tag-perspective" style={`--ph:${perspectiveHue(d.perspectiveId)}`}>
                   {d.perspectiveId.replace(/-/g, " ")}

--- a/src/pages/ranking/battles/page/[n].astro
+++ b/src/pages/ranking/battles/page/[n].astro
@@ -1,11 +1,11 @@
 ---
 import PageLayout from "../../../../layouts/PageLayout.astro";
 import { getCollection } from "astro:content";
-import { getAllDuels } from "../../../../lib/hronir-rank";
+import { getDuels } from "../../../../lib/hronir-rank";
 import { isPublished } from "../../../../lib/publish";
 
 export function getStaticPaths() {
-  const allDuels = getAllDuels();
+  const allDuels = getDuels({ kind: "work" });
   const PER_PAGE = 20;
   const totalPages = Math.ceil(allDuels.length / PER_PAGE);
   // Only generate pages 2+ (page 1 is battles/index.astro)
@@ -148,7 +148,6 @@ const agents = [...new Set(duels.map((d) => d.agentId).filter(Boolean) as string
             <div class="battle-meta">
               <span class="battle-date">{fmtDate(d.runAt)}</span>
               {d.season !== undefined && <span class="tag tag-season">S{d.season}</span>}
-              {d.isVersionDuel && <span class="tag">version duel</span>}
               {d.perspectiveId && (
                 <span class="tag tag-perspective" style={`--ph:${perspectiveHue(d.perspectiveId)}`}>
                   {d.perspectiveId.replace(/-/g, " ")}

--- a/src/pages/ranking/posts/[key].astro
+++ b/src/pages/ranking/posts/[key].astro
@@ -4,6 +4,7 @@ import { getCollection } from "astro:content";
 import {
   getRanking,
   getPostDuelHistory,
+  getPostVersionTrials,
   getPerPerspectiveRankings,
   getPerspectives,
   getSnapshotDelta,
@@ -44,6 +45,7 @@ const postHref = postInfo
   : null;
 
 const duels = getPostDuelHistory(key);
+const versionTrials = getPostVersionTrials(key);
 
 // Per-perspective rankings
 const perPerspective = getPerPerspectiveRankings();
@@ -244,6 +246,34 @@ function fmtDate(iso: string): string {
       </ol>
     )}
   </section>
+
+  {versionTrials.length > 0 && (
+    <section class="edit-history">
+      <h2>Edit history <small>({versionTrials.length} version {versionTrials.length === 1 ? "trial" : "trials"})</small></h2>
+      <p class="edit-blurb">
+        Revisions of this post compared head-to-head. These trials decide which
+        version is published; they do not affect the editorial ranking above.
+        <a href={`/ranking/versions/${key}/`}>See full genealogy →</a>
+      </p>
+      <ol class="trial-list">
+        {versionTrials.slice(0, 5).map((t) => {
+          const wRef = t.winnerSide === "a" ? t.postARef : t.postBRef;
+          const lRef = t.winnerSide === "a" ? t.postBRef : t.postARef;
+          return (
+            <li>
+              <div class="trial-row">
+                <span class="trial-date">{fmtDate(t.runAt)}</span>
+                <code class="trial-win">{wRef}</code>
+                <span class="trial-beat">beat</span>
+                <code class="trial-lose">{lRef}</code>
+                {t.id && <a class="trial-link" href={`/ranking/battles/${t.id}/`}>analysis →</a>}
+              </div>
+            </li>
+          );
+        })}
+      </ol>
+    </section>
+  )}
 </PageLayout>
 
 <style>
@@ -512,5 +542,54 @@ function fmtDate(iso: string): string {
   .empty {
     color: var(--pico-muted-color);
     font-style: italic;
+  }
+  .edit-history {
+    margin-top: 2.5rem;
+  }
+  .edit-history h2 {
+    font-size: 1rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--pico-muted-color);
+  }
+  .edit-blurb {
+    font-size: 0.82rem;
+    color: var(--pico-muted-color);
+    margin: 0 0 0.75rem;
+  }
+  .trial-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+  }
+  .trial-row {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.4rem;
+    font-size: 0.82rem;
+  }
+  .trial-date {
+    font-family: var(--pico-font-family-monospace);
+    font-size: 0.7rem;
+    color: var(--pico-muted-color);
+  }
+  .trial-row code {
+    font-size: 0.74rem;
+    word-break: break-all;
+  }
+  .trial-win {
+    color: var(--pico-primary);
+  }
+  .trial-beat {
+    color: var(--pico-muted-color);
+    font-size: 0.72rem;
+  }
+  .trial-link {
+    margin-left: auto;
+    font-size: 0.78rem;
   }
 </style>

--- a/src/pages/ranking/version-trials/index.astro
+++ b/src/pages/ranking/version-trials/index.astro
@@ -1,0 +1,156 @@
+---
+import PageLayout from "../../../layouts/PageLayout.astro";
+import { getCollection } from "astro:content";
+import { getVersionTrials } from "../../../lib/hronir-rank";
+import { isPublished } from "../../../lib/publish";
+
+// RFC 0012 §6.2: the version-trial archive — revisions of a single post
+// compared head-to-head. Separate universe from the editorial battle archive.
+const allPosts = await getCollection("blog");
+const byKey = new Map<string, { title: string; slug: string; lang: string }>();
+for (const p of allPosts) {
+  if (!isPublished(p)) continue;
+  const key = p.data.translationKey;
+  if (!key) continue;
+  const lang = p.data.lang ?? "en";
+  const existing = byKey.get(key);
+  if (!existing || lang === "en")
+    byKey.set(key, { title: p.data.title, slug: p.id, lang });
+}
+
+const trials = getVersionTrials();
+
+// Group by post key: one genealogy entry per post that has been revised.
+const groups = new Map<
+  string,
+  { key: string; title: string; count: number; latest: string }
+>();
+for (const t of trials) {
+  const key = t.postAKey ?? "";
+  const existing = groups.get(key);
+  if (existing) {
+    existing.count += 1;
+  } else {
+    groups.set(key, {
+      key,
+      title: byKey.get(key)?.title ?? key,
+      count: 1,
+      latest: t.runAt,
+    });
+  }
+}
+const groupList = [...groups.values()].sort((a, b) =>
+  b.latest.localeCompare(a.latest)
+);
+
+function fmtDate(iso: string) {
+  return new Date(iso).toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}
+---
+
+<PageLayout
+  title="Version Trials | Ranking | Franklin Baldo"
+  description="Head-to-head trials between revisions of a single post — which version gets published."
+  lang="en"
+>
+  <nav class="breadcrumb" aria-label="Breadcrumb">
+    <ol>
+      <li><a href="/">Home</a></li>
+      <li><a href="/ranking/">Ranking</a></li>
+      <li aria-current="page">Version trials</li>
+    </ol>
+  </nav>
+
+  <hgroup>
+    <h1>Version Trials</h1>
+    <p>
+      <small>
+        {trials.length} trials across {groupList.length} posts · revisions of one
+        post compared to decide which version is published. These do not affect
+        the <a href="/ranking/battles/">editorial ranking</a>.
+      </small>
+    </p>
+  </hgroup>
+
+  {groupList.length === 0 ? (
+    <div class="empty-state"><em>No version trials yet.</em></div>
+  ) : (
+    <ul class="vt-list">
+      {groupList.map((g) => (
+        <li class="vt-item">
+          <a href={`/ranking/versions/${g.key}/`} class="vt-link">
+            <span class="vt-title">{g.title}</span>
+            <span class="vt-meta">
+              {g.count} {g.count === 1 ? "trial" : "trials"} · latest {fmtDate(g.latest)}
+            </span>
+          </a>
+        </li>
+      ))}
+    </ul>
+  )}
+</PageLayout>
+
+<style>
+  .breadcrumb ol {
+    list-style: none;
+    padding: 0;
+    margin: 0 0 1rem;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0;
+    font-size: 0.8rem;
+    color: var(--pico-muted-color);
+  }
+  .breadcrumb li + li::before {
+    content: " / ";
+    padding: 0 0.35em;
+  }
+  .breadcrumb a {
+    color: var(--pico-muted-color);
+    text-decoration: none;
+  }
+  .breadcrumb a:hover {
+    text-decoration: underline;
+  }
+  .vt-list {
+    list-style: none;
+    padding: 0;
+    margin: 1rem 0 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+  .vt-link {
+    display: flex;
+    flex-direction: column;
+    gap: 0.2rem;
+    padding: 0.8rem 1rem;
+    border: 1px solid var(--pico-muted-border-color);
+    border-radius: var(--pico-border-radius);
+    background: var(--pico-card-background-color);
+    text-decoration: none;
+    color: inherit;
+    transition: border-color 0.15s;
+  }
+  .vt-link:hover {
+    border-color: var(--pico-primary);
+  }
+  .vt-title {
+    font-weight: 600;
+  }
+  .vt-meta {
+    font-size: 0.78rem;
+    color: var(--pico-muted-color);
+  }
+  .empty-state {
+    padding: 2rem;
+    text-align: center;
+    color: var(--pico-muted-color);
+    border: 1px dashed var(--pico-muted-border-color);
+    border-radius: var(--pico-border-radius);
+  }
+</style>

--- a/src/pages/ranking/versions/[key].astro
+++ b/src/pages/ranking/versions/[key].astro
@@ -1,0 +1,253 @@
+---
+import PageLayout from "../../../layouts/PageLayout.astro";
+import { getCollection } from "astro:content";
+import {
+  getVersionTrials,
+  getPostVersionTrials,
+} from "../../../lib/hronir-rank";
+import { isPublished } from "../../../lib/publish";
+
+// RFC 0012 §6.2: genealogy of one post's revisions — every version trial, the
+// distinct versions seen, and permalinks to the exact content judged.
+export async function getStaticPaths() {
+  const keys = new Set(
+    getVersionTrials()
+      .map((t) => t.postAKey)
+      .filter((k): k is string => Boolean(k))
+  );
+
+  const allPosts = await getCollection("blog");
+  const byKey = new Map<string, { title: string; slug: string; lang: string }>();
+  for (const p of allPosts) {
+    if (!isPublished(p)) continue;
+    const key = p.data.translationKey;
+    if (!key) continue;
+    const lang = p.data.lang ?? "en";
+    const existing = byKey.get(key);
+    if (!existing || lang === "en")
+      byKey.set(key, { title: p.data.title, slug: p.id, lang });
+  }
+
+  return [...keys].map((key) => ({
+    params: { key },
+    props: { key, info: byKey.get(key) ?? null },
+  }));
+}
+
+const { key, info } = Astro.props;
+const trials = getPostVersionTrials(key);
+const title = info?.title ?? key;
+const postHref = info
+  ? info.lang === "pt"
+    ? `/pt/blog/${info.slug}/`
+    : `/blog/${info.slug}/`
+  : null;
+
+const REPO = "https://github.com/franklinbaldo/franklinbaldo.github.io";
+function sourceHref(path: string | null | undefined) {
+  return path ? `${REPO}/blob/main/${path}` : null;
+}
+
+// Distinct versions seen across all trials, with their source paths and a
+// win/loss tally — a lightweight genealogy.
+const versions = new Map<
+  string,
+  { ref: string; path: string | null; wins: number; losses: number }
+>();
+function note(
+  version: string | null | undefined,
+  ref: string | null | undefined,
+  path: string | null | undefined,
+  won: boolean
+) {
+  if (!version) return;
+  const v = versions.get(version) ?? {
+    ref: ref ?? version,
+    path: path ?? null,
+    wins: 0,
+    losses: 0,
+  };
+  if (won) v.wins += 1;
+  else v.losses += 1;
+  versions.set(version, v);
+}
+for (const t of trials) {
+  const aWon = t.winnerSide === "a";
+  note(t.postAVersion, t.postARef, t.postAPath, aWon);
+  note(t.postBVersion, t.postBRef, t.postBPath, !aWon);
+}
+const versionList = [...versions.values()].sort(
+  (a, b) => b.wins - a.wins || a.ref.localeCompare(b.ref)
+);
+
+function fmtDate(iso: string) {
+  return new Date(iso).toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}
+---
+
+<PageLayout
+  title={`${title} — Version genealogy | Franklin Baldo`}
+  description={`Version trials and revision genealogy for "${title}".`}
+  lang="en"
+>
+  <nav class="breadcrumb" aria-label="Breadcrumb">
+    <ol>
+      <li><a href="/">Home</a></li>
+      <li><a href="/ranking/">Ranking</a></li>
+      <li><a href="/ranking/version-trials/">Version trials</a></li>
+      <li aria-current="page">{title}</li>
+    </ol>
+  </nav>
+
+  <hgroup>
+    <h1>{title}</h1>
+    <p class="links">
+      {postHref && <a href={postHref}>Read published version →</a>}
+      <a href={`/ranking/posts/${key}/`}>Dossier →</a>
+    </p>
+  </hgroup>
+
+  <section class="genealogy">
+    <h2>Versions <small>({versionList.length})</small></h2>
+    <ul class="ver-list">
+      {versionList.map((v) => (
+        <li class="ver-item">
+          <code>{v.ref}</code>
+          <span class="ver-tally">{v.wins}W / {v.losses}L</span>
+          {sourceHref(v.path) && <a href={sourceHref(v.path)!}>source →</a>}
+        </li>
+      ))}
+    </ul>
+  </section>
+
+  <section class="trials">
+    <h2>Trials <small>({trials.length})</small></h2>
+    <ol class="trial-list">
+      {trials.map((t) => {
+        const wRef = t.winnerSide === "a" ? t.postARef : t.postBRef;
+        const lRef = t.winnerSide === "a" ? t.postBRef : t.postARef;
+        const wRate = t.winnerSide === "a" ? t.rateA : t.rateB;
+        const lRate = t.winnerSide === "a" ? t.rateB : t.rateA;
+        return (
+          <li>
+            <div class="trial-row">
+              <span class="trial-date">{fmtDate(t.runAt)}</span>
+              <code class="trial-win">{wRef}</code>
+              <span class="trial-beat">beat</span>
+              <code class="trial-lose">{lRef}</code>
+              {wRate != null && lRate != null && (
+                <span class="trial-rates">{wRate.toFixed(1)} / {lRate.toFixed(1)}</span>
+              )}
+              {t.id && <a class="trial-link" href={`/ranking/battles/${t.id}/`}>analysis →</a>}
+            </div>
+          </li>
+        );
+      })}
+    </ol>
+  </section>
+</PageLayout>
+
+<style>
+  .breadcrumb ol {
+    list-style: none;
+    padding: 0;
+    margin: 0 0 1rem;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0;
+    font-size: 0.8rem;
+    color: var(--pico-muted-color);
+  }
+  .breadcrumb li + li::before {
+    content: " / ";
+    padding: 0 0.35em;
+  }
+  .breadcrumb a {
+    color: var(--pico-muted-color);
+    text-decoration: none;
+  }
+  .breadcrumb a:hover {
+    text-decoration: underline;
+  }
+  .links {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+    font-size: 0.85rem;
+  }
+  .genealogy,
+  .trials {
+    margin-top: 2rem;
+  }
+  .genealogy h2,
+  .trials h2 {
+    font-size: 1rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--pico-muted-color);
+  }
+  .ver-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+  }
+  .ver-item {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.6rem;
+    font-size: 0.84rem;
+  }
+  .ver-item code {
+    font-size: 0.76rem;
+    word-break: break-all;
+  }
+  .ver-tally {
+    font-family: var(--pico-font-family-monospace);
+    font-size: 0.72rem;
+    color: var(--pico-muted-color);
+  }
+  .trial-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+  }
+  .trial-row {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.4rem;
+    font-size: 0.82rem;
+  }
+  .trial-date {
+    font-family: var(--pico-font-family-monospace);
+    font-size: 0.7rem;
+    color: var(--pico-muted-color);
+  }
+  .trial-row code {
+    font-size: 0.74rem;
+    word-break: break-all;
+  }
+  .trial-win {
+    color: var(--pico-primary);
+  }
+  .trial-beat,
+  .trial-rates {
+    color: var(--pico-muted-color);
+    font-size: 0.72rem;
+  }
+  .trial-link {
+    margin-left: auto;
+    font-size: 0.78rem;
+  }
+</style>


### PR DESCRIPTION
**Stack:** PR 3 of 4 implementando a RFC 0012. Base = `claude/rfc0012-fase1-normalizador` (PR #611). Merge bottom-up: #608 → #610 → #611 → **esta** → Fase 3.

## Fase 2 — Separação de superfícies work vs version

Agora cada superfície pública responde às perguntas estruturais da RFC 0012 §10.

### Editorial (work) apenas
- `getRankingStats().totalDuels`, `getRecentDuels`, `getPostDuelHistory` e os reviews por post (`HronirReviews`) contam/exibem **só duelos `work`**.
- Arquivo de batalhas (`/ranking/battles/` e `/page/[n]`) lista só `work`; some o selo morto "version duel" (e do card recente em `RankingView`).

### Testes de versão (novo)
- `DuelEntry` carrega `postARef`/`postBRef` (`slug@uuid`), versions e paths.
- **`/ranking/version-trials/`** — índice de posts com revisões.
- **`/ranking/versions/[key]/`** — genealogia: versões distintas (com **permalink para a fonte exata** no GitHub) e todos os trials.
- **`/ranking/battles/[id]`** renderiza duelo `version` como **"Version Trial"**: `winnerRef` beat `loserRef`, link para a fonte de cada versão, **sem `#rank` global, nunca "X venceu X"**. Navegação/breadcrumb por kind (work → archive; version → genealogia).
- Dossiê (`/ranking/posts/[key]`) ganha seção **"Edit history"** com os version trials do post.

### Verificação no build
- `74 editorial duels` no arquivo (== `totalDuels` work)
- 22 páginas de genealogia geradas; índice lista 22 posts
- **zero** selo "version duel" vazado em cards editoriais
- página de trial com `h1` = "Version Trial" + nota "does not affect the editorial ranking"
- **ranking inalterado** (snapshot idêntico — Fase 2 não toca o cálculo)

### Gates (todos verdes)
`npm test` (39) · `prettier --check .` · `astro check` (0 erros) · `npm run build` · `check:hygiene`

> Falta a **Fase 3** (idioma): `--review-lang`, `stars-v3`, chips de idioma, unificar `CLAUDE.md`+CLI. Drift pré-existente de `ranking-snapshot.json` revertido.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PSUGMxdvYu34sJ3YHfScFm)_