### PR TITLE
RFC 0012 Fase 3a — proveniência linguística (chips, --review-lang, CLAUDE.md)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,7 @@ npm run hronir:init -- --agent-id <your-model-id> --matches 10 --skip-edit
 - `--agent-id` is **required** — use a stable identifier like `claude-opus-4-8` or `franklin`
 - `--matches` defaults to 10
 - `--skip-edit` skips the post-editing phase; use it for pure rating sessions
+- `--review-lang en|pt` — language the reviews/clash are written in (RFC 0012 §6); defaults to `--eval-lang`. Recorded as `review_lang` in each rate file
 - `--content-mode inline|path-only` — controls how post content is delivered:
   - `inline` (default): CLI prints the full post content in its output
   - `path-only`: CLI prints only the slug, file path, and Suno URLs; the agent reads the file directly. Recommended for agents with long sessions or context compression (e.g. Jules with 20 matches). The chosen mode is saved in `session.json` and recorded in each rate file as `content_mode`.
@@ -134,8 +135,13 @@ check derivam — veja RFC 0004.
 
 - **Código e identificadores**: inglês (variáveis, funções, comentários inline).
 - **Docs, RFCs, prosa de processo** (`docs/`, `CLAUDE.md`, mensagens de commit): português.
-- **Reviews e clash nos rate files**: o mesmo idioma do post avaliado (`lang` do frontmatter).
-  Posts em EN → review em EN. Posts em PT → review em PT.
+- **Reviews e clash nos rate files** (RFC 0012 §6): escritos na `review_lang`,
+  um campo explícito do rate file — não mais inferido do post. A `review_lang`
+  é a língua de avaliação da sessão (`--review-lang`, default = `--eval-lang`).
+  Em **duelo de versões** (mesma `key` dos dois lados) ambos os lados são a
+  mesma versão linguística, então `review_lang === content_lang`. Cada lado
+  grava sua própria `content_lang`. A UI exibe chips `content: EN/PT` e
+  `critique: PT`.
 - **`--after-mood`**: sempre português, primeira pessoa.
 
 ### Defaults de língua por tipo de conteúdo

--- a/scripts/hronir/index.js
+++ b/scripts/hronir/index.js
@@ -47,7 +47,7 @@ const [, , cmd, ...args] = process.argv;
 
 function usage() {
   console.error(
-    "Uso: hronir {next --agent-id <id> [init-opts]|init --agent-id <id> [--matches N] [--skip-edit] [--skip-rating] [--eval-lang <lang>] [--min-appearances N] [--pledge <text>] [--content-mode inline|path-only]|continue|first-impression-a <texto>|first-impression-b <texto>|decide --after-mood <text> --rate-a <1.00-5.00> --rate-b <1.00-5.00> --review-a <text> --review-b <text> --clash <text> [--clash-append <text>] [--review-a-append <text>] [--review-b-append <text>]|ranking|worst [--absolute]|diagnose|edit-worst|edit-commit --msg <text>|migrate [--dry-run]|doctor|end [--skip-edit] [--force] [--attest <text>]|select [--dry-run]|prune [--dry-run]}"
+    "Uso: hronir {next --agent-id <id> [init-opts]|init --agent-id <id> [--matches N] [--skip-edit] [--skip-rating] [--eval-lang <lang>] [--review-lang <lang>] [--min-appearances N] [--pledge <text>] [--content-mode inline|path-only]|continue|first-impression-a <texto>|first-impression-b <texto>|decide --after-mood <text> --rate-a <1.00-5.00> --rate-b <1.00-5.00> --review-a <text> --review-b <text> --clash <text> [--clash-append <text>] [--review-a-append <text>] [--review-b-append <text>]|ranking|worst [--absolute]|diagnose|edit-worst|edit-commit --msg <text>|migrate [--dry-run]|doctor|end [--skip-edit] [--force] [--attest <text>]|select [--dry-run]|prune [--dry-run]}"
   );
   process.exit(1);
 }
@@ -110,6 +110,10 @@ function parseInitOptions(args) {
     args.indexOf("--lang"),
   ]);
   const evalLang = evalLangRaw || "pt";
+  // RFC 0012 §6: language the review/clash is written in. Defaults to the
+  // evaluation language for back-compat; persisted explicitly.
+  const reviewLangRaw = readFlagValue(args, [args.indexOf("--review-lang")]);
+  const reviewLang = reviewLangRaw || undefined;
   const minAppRaw = readFlagValue(args, [
     args.indexOf("--min-appearances"),
     args.indexOf("--min-app"),
@@ -129,6 +133,7 @@ function parseInitOptions(args) {
     skipRating,
     agentId,
     evalLang,
+    reviewLang,
     minAppearances,
     pledge,
     contentMode,

--- a/src/hronir/commands.ts
+++ b/src/hronir/commands.ts
@@ -53,6 +53,7 @@ interface InitOptions {
   skipRating?: boolean;
   agentId?: string;
   evalLang?: string;
+  reviewLang?: string;
   minAppearances?: number;
   matches?: number;
   pledge?: string;
@@ -247,6 +248,8 @@ export function init(options: InitOptions = {}) {
     process.exit(1);
   }
   const evalLang = options.evalLang || "pt";
+  // RFC 0012 §6: review_lang defaults to the evaluation language when not given.
+  const reviewLang = options.reviewLang || evalLang;
   const sessionPath = SESSION_PATH;
 
   if (fs.existsSync(sessionPath)) {
@@ -272,6 +275,7 @@ export function init(options: InitOptions = {}) {
       completed: 0,
       agentId,
       evalLang,
+      reviewLang,
       state: "need_edit",
       skipEdit: false,
       skipRating: true,
@@ -301,6 +305,7 @@ export function init(options: InitOptions = {}) {
     completed: 0,
     agentId,
     evalLang,
+    reviewLang,
     state: "ready_for_next",
     skipEdit,
     skipRating: false,
@@ -599,6 +604,7 @@ function generateNextMatch() {
     key,
     path: p,
     display_lang: lang,
+    content_lang: lang, // RFC 0012 §6: explicit language of this side's text
     version: getPostUuid(p),
     ref: refFor(p),
   });
@@ -1325,6 +1331,19 @@ export function decide(args: string[]) {
   const bKey = currentMatch.post_b.key;
   const matchFile = path.join(RATES_DIR, `${runId}_${aKey}_x_${bKey}.md`);
 
+  // RFC 0012 §6: review_lang is the session language for editorial (work)
+  // duels; for a version duel both sides are the same linguistic version, so
+  // the critique is written in that content language (rule 3).
+  const evalLangValue = currentMatch.eval_lang || session.evalLang || "pt";
+  const contentLangA =
+    currentMatch.post_a.content_lang ||
+    currentMatch.post_a.display_lang ||
+    null;
+  const reviewLang =
+    aKey === bKey
+      ? contentLangA || session.reviewLang || evalLangValue
+      : session.reviewLang || evalLangValue;
+
   const data = {
     run_id: runId,
     run_at: runAt,
@@ -1333,7 +1352,8 @@ export function decide(args: string[]) {
     winner,
     agent_id: agentId,
     content_mode: session.contentMode ?? "inline",
-    eval_lang: currentMatch.eval_lang || session.evalLang || "pt",
+    eval_lang: evalLangValue,
+    review_lang: reviewLang,
     prompt_version: PROMPT_VERSION,
     season: 1,
     override: null,

--- a/src/hronir/types.ts
+++ b/src/hronir/types.ts
@@ -141,6 +141,10 @@ export interface DuelEntry {
    *  exact content judged in a version trial. */
   postAPath?: string | null;
   postBPath?: string | null;
+  /** RFC 0012 §6: languages, for the discrete UI chips (content / critique). */
+  reviewLang?: string | null;
+  postAContentLang?: string | null;
+  postBContentLang?: string | null;
   perspectiveId?: string;
   rateA?: number;
   rateB?: number;

--- a/src/lib/hronir-rank.ts
+++ b/src/lib/hronir-rank.ts
@@ -145,6 +145,9 @@ function loadDuelData(): { stats: RankingStats; recent: DuelEntry[] } {
       postBVersion: n.postB.version,
       postAPath: n.postA.path,
       postBPath: n.postB.path,
+      reviewLang: n.reviewLang,
+      postAContentLang: n.postA.contentLang,
+      postBContentLang: n.postB.contentLang,
       perspectiveId: data.perspective_id
         ? String(data.perspective_id)
         : undefined,

--- a/src/pages/ranking/battles/[id].astro
+++ b/src/pages/ranking/battles/[id].astro
@@ -112,6 +112,17 @@ function perspectiveHue(id: string): number {
   return Math.abs(h) % 360;
 }
 
+// RFC 0012 §6 rule 4: discrete language chips. Content can differ per side in
+// a work duel; collapse to one chip when both sides share a language.
+const contentLangs = [
+  ...new Set(
+    [duel.postAContentLang, duel.postBContentLang]
+      .filter((l): l is string => Boolean(l))
+      .map((l) => l.toUpperCase())
+  ),
+].join("/");
+const critiqueLang = duel.reviewLang ? duel.reviewLang.toUpperCase() : null;
+
 const pageTitle = isVersion
   ? `Version trial — ${postTitle}`
   : `${winnerTitle} vs ${loserTitle}`;
@@ -154,6 +165,8 @@ const loserRank = isVersion ? undefined : rankByKey.get(loserKey);
     )}
     {duel.agentId && <span class="tag tag-agent">{duel.agentId}</span>}
     {duel.confidence && <span class={`tag tag-confidence conf-${duel.confidence}`}>{duel.confidence} confidence</span>}
+    {contentLangs && <span class="tag tag-lang">content: {contentLangs}</span>}
+    {critiqueLang && <span class="tag tag-lang">critique: {critiqueLang}</span>}
   </div>
 
   {isVersion && (
@@ -285,6 +298,7 @@ const loserRank = isVersion ? undefined : rankByKey.get(loserKey);
 
   .battle-tags { display: flex; flex-wrap: wrap; gap: 0.4rem; margin-bottom: 1.5rem; }
   .version-note { font-size: 0.85rem; color: var(--pico-muted-color); margin: 0 0 1.5rem; }
+  .tag-lang { font-family: var(--pico-font-family-monospace); text-transform: none; letter-spacing: 0; }
   .versus-title code { font-size: 0.82rem; word-break: break-all; }
   .tag {
     font-size: 0.68rem; text-transform: uppercase; letter-spacing: 0.05em;


### PR DESCRIPTION
**Stack:** PR 4 of 5 implementando a RFC 0012. Base = `claude/rfc0012-fase2-superficies` (PR #613). Merge bottom-up: #608 → #610 → #611 → #613 → **esta** → Fase 3b.

## Fase 3a — Proveniência linguística (sem bump de schema)

Resolve a contradição **documentada vs implementada** de idioma (RFC 0012 §2.4), mantendo `prompt_version: stars-v2`. O bump para `stars-v3` + validação no `doctor` fica na **Fase 3b** (split pedido para reduzir risco no doctor por PR).

### Mudanças
- **CLI**: `--review-lang` no `init` (default = `--eval-lang`), persistido na sessão.
- **decide** grava `review_lang` e `content_lang` por lado. Política RFC 0012 §6:
  - duelo `work` → `review_lang` = língua da sessão;
  - duelo `version` → ambos os lados são a mesma versão linguística, então `review_lang === content_lang`.
  - `eval_lang` segue gravado para retrocompat.
- **`sideFor`** grava `content_lang` explícito por lado.
- **UI**: `DuelEntry` expõe `reviewLang`/`postAContentLang`/`postBContentLang`; `/ranking/battles/[id]` mostra chips `content: EN/PT` e `critique: PT` — funcionam em **todo o acervo** via fallback `display_lang`/`eval_lang` do normalizador (Fase 1).
- **CLAUDE.md**: política de idioma unificada — review na `review_lang` explícita, não mais inferida do post.

### CI rodada localmente (job `check` real) — tudo verde
`check:hygiene` ✓ · `prettier --check .` ✓ · `npm test` (39) ✓ · **`hronir:doctor` — 0 inconsistências** ✓ · `astro check` (0 erros) ✓ · `build` ✓ · chips confirmados no HTML gerado (`content: PT/EN`, `critique: PT`).

Acervo histórico intocado (sem reescrita de rate files).

### Falta (Fase 3b)
Bump `prompt_version: stars-v3` + validação de `review_lang`/`content_lang` no `doctor` (só stars-v3) + auditar os ramos `stars-v2`-específicos do doctor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PSUGMxdvYu34sJ3YHfScFm)_