### PR TITLE
RFC 0012 — taxonomia de matches, genealogia de versões e proveniência linguística (completa)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,7 @@ npm run hronir:init -- --agent-id <your-model-id> --matches 10 --skip-edit
 - `--agent-id` is **required** — use a stable identifier like `claude-opus-4-8` or `franklin`
 - `--matches` defaults to 10
 - `--skip-edit` skips the post-editing phase; use it for pure rating sessions
+- `--review-lang en|pt` — language the reviews/clash are written in (RFC 0012 §6); defaults to `--eval-lang`. Recorded as `review_lang` in each rate file
 - `--content-mode inline|path-only` — controls how post content is delivered:
   - `inline` (default): CLI prints the full post content in its output
   - `path-only`: CLI prints only the slug, file path, and Suno URLs; the agent reads the file directly. Recommended for agents with long sessions or context compression (e.g. Jules with 20 matches). The chosen mode is saved in `session.json` and recorded in each rate file as `content_mode`.
@@ -134,8 +135,13 @@ check derivam — veja RFC 0004.
 
 - **Código e identificadores**: inglês (variáveis, funções, comentários inline).
 - **Docs, RFCs, prosa de processo** (`docs/`, `CLAUDE.md`, mensagens de commit): português.
-- **Reviews e clash nos rate files**: o mesmo idioma do post avaliado (`lang` do frontmatter).
-  Posts em EN → review em EN. Posts em PT → review em PT.
+- **Reviews e clash nos rate files** (RFC 0012 §6): escritos na `review_lang`,
+  um campo explícito do rate file — não mais inferido do post. A `review_lang`
+  é a língua de avaliação da sessão (`--review-lang`, default = `--eval-lang`).
+  Em **duelo de versões** (mesma `key` dos dois lados) ambos os lados são a
+  mesma versão linguística, então `review_lang === content_lang`. Cada lado
+  grava sua própria `content_lang`. A UI exibe chips `content: EN/PT` e
+  `critique: PT`.
 - **`--after-mood`**: sempre português, primeira pessoa.
 
 ### Defaults de língua por tipo de conteúdo

--- a/docs/rfcs/0012-taxonomia-de-matches-e-proveniencia-linguistica.md
+++ b/docs/rfcs/0012-taxonomia-de-matches-e-proveniencia-linguistica.md
@@ -1,0 +1,383 @@
+# RFC 0012 — Taxonomia de matches, genealogia de versões e proveniência linguística
+
+|                 |                                                                                                                                                                                                                                                                                                                   |
+| --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Status**      | Proposed                                                                                                                                                                                                                                                                                                          |
+| **Autor**       | Franklin Baldo (proposta assistida)                                                                                                                                                                                                                                                                               |
+| **Criado em**   | 2026-06-21                                                                                                                                                                                                                                                                                                        |
+| **Branch / PR** | `claude/gifted-cray-zefxmx`                                                                                                                                                                                                                                                                                       |
+| **Depende de**  | RFC 0001 (qualidade absoluta), RFC 0007 (UI/UX do ranking), RFC 0010 (versões como pares — esta RFC **estabiliza a fronteira pública** das versões que a 0010 tornou ranqueáveis)                                                                                                                                 |
+| **Afeta**       | `src/hronir/{matches,ranking,types,commands}.ts`, `src/lib/hronir-rank.ts`, `scripts/hronir/index.js`, `scripts/generate-ranking-snapshot.mjs`, `src/components/RankingView.astro`, `src/pages/ranking/{battles,posts,perspectives}/**` e novas rotas de versão, `src/generated/`, `CLAUDE.md`, testes e fixtures |
+
+> Mesmo padrão das RFCs 0001/0002/0003/0010: primeiro o documento, depois a
+> implementação incremental na mesma branch, fase a fase, cada fase verde
+> (build + testes + `prettier --check` + `astro check` + `hronir:doctor`) antes
+> da próxima. Merge com merge commit, nunca squash.
+
+> Esta RFC é a **primeira metade** da antiga proposta 0012, fatiada por decisão
+> editorial. Trata só do problema **estrutural, verificável e de baixo risco**:
+> distinguir duelos entre obras de duelos entre versões, preservar a identidade
+> exata das versões avaliadas, impedir que testes de revisão contaminem
+> recordes/estatísticas/apresentações do ranking editorial, e registrar a
+> proveniência linguística de cada avaliação. Os problemas **editoriais e
+> experimentais** — regimes de avaliação, estados de evidência, amostragem e o
+> papel da cadeia afetiva — ficam para a **RFC 0013**, que só pode começar após
+> um diagnóstico do corpus. Nenhum limiar numérico de evidência é fixado aqui.
+
+---
+
+## Histórico de revisões
+
+| Data       | Mudança                                                                                                     |
+| ---------- | ----------------------------------------------------------------------------------------------------------- |
+| 2026-06-21 | Versão inicial, resultante do fatiamento da proposta 0012 original em 0012 (estrutural) + 0013 (editorial). |
+
+---
+
+## 1. Resumo
+
+O Hrönir produz dois juízos estruturalmente distintos sob o mesmo arquivo de
+rate:
+
+1. **comparação entre obras** (`work`): qual texto vence outro texto — pergunta
+   editorial;
+2. **comparação entre versões** (`version`): qual versão de um mesmo texto deve
+   ocupar a URL pública — pergunta de revisão.
+
+O núcleo de ranking **já** trata os dois universos separadamente nos seus
+cálculos de OpenSkill: `_computeRatings` pula duelos de mesma `key`
+(`ranking.ts:124-125`) e há um `_computeVersionRatings` dedicado
+(`ranking.ts:252-290`). O problema que esta RFC ataca não está no cálculo de
+rating, e sim na **camada de leitura pública e na identidade dos dados**: a
+distinção `work`/`version` é hoje derivada ad hoc por cada consumidor (via
+`isVersionDuel` ou comparação local de chaves), sem um normalizador único, e as
+superfícies públicas (dossiês, estatísticas, listas de batalhas, cards
+recentes) não filtram esses casos de forma consistente. Isso produz artefatos
+semânticos: um post parece enfrentar a si mesmo; uma vitória de versão parece
+uma vitória editorial; uma taxa de vitórias pode contar partidas cujo objeto de
+comparação não é o mesmo.
+
+Em paralelo, há uma contradição de idioma **documentada vs implementada**:
+`CLAUDE.md` prescreve "review na língua do post"; o CLI grava `eval_lang`
+escolhido na sessão, independente da língua do post (`commands.ts`). As duas
+políticas são defensáveis; não podem coexistir sem campos explícitos.
+
+Esta RFC cria:
+
+- um **normalizador único** de rate files, com `kind: "work" | "version"`
+  derivado deterministicamente;
+- **preservação e exposição de `slug@uuid`** para ambos os lados de um duelo de
+  versões;
+- correção das superfícies públicas para usarem apenas duelos `work` em
+  ranking, recordes, históricos, sparklines e estatísticas;
+- renderização de duelos `version` como **testes entre duas versões
+  identificáveis**, nunca como "X venceu X";
+- registro de `content_lang` por lado e `review_lang` da crítica, com uma
+  **política de idioma única** unificando docs e CLI;
+- preservação dos arquivos históricos como `legacy`, sem reprovação retroativa
+  no `doctor`.
+
+---
+
+## 2. Diagnóstico
+
+### 2.1. A distinção `work`/`version` é derivada ad hoc por cada consumidor
+
+Hoje cada lugar que precisa distinguir um duelo de versão faz isso por conta
+própria: o ranking compara `m.aKey === m.bKey`; a camada de UI usa
+`isVersionDuel` em `DuelEntry`. Não há uma fonte única de verdade. O resultado é
+que o cálculo de rating está correto (RFC 0010), mas nada **garante** que toda
+nova superfície pública herde a mesma classificação. A correção é estrutural:
+classificar uma vez, no carregamento, e proibir defaults ambíguos nos
+consumidores.
+
+### 2.2. Um vencedor de versão não é um vencedor editorial
+
+Um duelo entre `post-a` e `post-b` responde "qual texto é melhor". Um duelo
+entre `post-a@uuid-1` e `post-a@uuid-2` responde "qual revisão publicar". Os
+dois produzem resenha, estrelas e vencedor, mas o significado do vencedor é
+diferente. Nenhuma estatística ou visualização editorial deve somar o segundo
+ao primeiro, e nenhuma página de duelo de versão deve exibir o título "X venceu
+X" nem um `#rank global`.
+
+### 2.3. A identidade exata da versão precisa sobreviver até a UI
+
+Um duelo de versão só é legível se levar às **duas versões exatas avaliadas**,
+por `slug@uuid` — e não apenas à seleção corrente do post (que pode já ter
+mudado). A identidade `slug@uuid` precisa ser preservada no normalizador e
+renderizada com links permanentes para cada lado.
+
+### 2.4. O contrato de idioma divergiu
+
+`CLAUDE.md:137-139` afirma que reviews seguem a língua do post. O CLI grava
+`eval_lang` da sessão e instrui o avaliador a escrever sempre nessa língua,
+independente da língua do post (`commands.ts:1005`). O dado persistido (`eval_lang`)
+não distingue "língua do texto lido" de "língua da crítica". O resultado deve
+registrar ambas.
+
+---
+
+## 3. Princípios de design
+
+1. **Tipo antes de apresentação.** `work` e `version` são propriedades
+   estruturais do match, derivadas no carregamento, não tags que a UI tenta
+   inferir tarde.
+2. **Uma pergunta, uma superfície.** Ranking de obras e teste de versões podem
+   compartilhar dados brutos, mas não devem compartilhar agregados por acidente.
+3. **Versões são endereçáveis.** Um duelo de versão sempre leva às duas versões
+   exatas avaliadas, por `slug@uuid`.
+4. **Histórico preservado.** Rate files existentes permanecem legíveis e
+   públicos, classificados com honestidade como `legacy`. A mudança rege a
+   forma de ler o passado, não o reescreve.
+5. **Idioma é fato verificável, não convenção em prosa.** A língua do conteúdo e
+   a língua da crítica são campos distintos e validados.
+
+---
+
+## 4. Modelo de dados
+
+### 4.1. Normalização única
+
+`matches.ts` passa a exportar um normalizador único, consumido por ranking,
+seleção, UI, snapshot e doctor.
+
+```ts
+export type MatchKind = "work" | "version";
+
+export type NormalizedMatch = {
+  id: string;
+  kind: MatchKind;
+  winnerSide: "a" | "b";
+  runAt: Date | null;
+
+  postA: {
+    key: string;
+    ref: string | null; // slug@uuid
+    path: string | null; // cache, não identidade
+    version: string | null;
+    contentLang: string | null;
+  };
+  postB: {
+    key: string;
+    ref: string | null;
+    path: string | null;
+    version: string | null;
+    contentLang: string | null;
+  };
+
+  reviewLang: string | null;
+  agentId: string | null;
+  perspectiveId: string | null;
+  rateA: number | null;
+  rateB: number | null;
+  // demais campos narrativos e de proveniência preservados
+};
+```
+
+A regra de classificação é determinística:
+
+```ts
+kind = postA.key === postB.key ? "version" : "work";
+```
+
+Um campo persistido `match_kind` **pode** ser gravado em novos rate files para
+inspeção humana, mas o leitor valida sua coerência com a regra acima e nunca
+confia nele isoladamente.
+
+> **Nota de escopo.** `NormalizedMatch` aqui **não** inclui `mode`/
+> `EvaluationMode`. Regimes de avaliação são RFC 0013. Esta RFC só classifica o
+> que é estruturalmente verificável a partir do próprio dado.
+
+### 4.2. `stars-v3` e campos de idioma
+
+Novos rate files usam `prompt_version: stars-v3` e passam a gravar:
+
+```yaml
+match_kind: work # redundante, validado
+review_lang: en
+post_a:
+  content_lang: en
+post_b:
+  content_lang: pt
+```
+
+Rate files `stars-v1` e `stars-v2` continuam válidos. Na ausência de
+`review_lang`, o normalizador usa `eval_lang` se existir e, caso contrário,
+`null`/`unknown`. `content_lang` ausente é derivado do frontmatter do post
+(`lang`) quando o arquivo ainda existe, ou `unknown`.
+
+`hronir:doctor` reporta esses casos como **dados históricos**, não como erro.
+
+---
+
+## 5. Agregados e superfícies públicas
+
+### 5.1. Ranking editorial — apenas `work`
+
+`computeRatings`, qualidade absoluta e snapshot global recebem apenas
+`match.kind === "work"`. A página `/ranking/` mostra apenas duelos `work`. O
+item "all battles" passa a significar "all editorial battles".
+
+Estatísticas editoriais passam a contar somente duelos `work`: obras avaliadas,
+duelos entre obras, aparições por obra, oponentes distintos, perspectivas/
+avaliadores distintos.
+
+### 5.2. Dossiê de obra — apenas `work`
+
+`/ranking/posts/[key]/` usa somente duelos `work` para recorde, taxa de
+vitória, sparkline, histórico de oponentes e colocação global. Pode ganhar uma
+seção secundária **Histórico de edição** com: versão selecionada, número de
+duelos de versão e link para a genealogia. Essa seção é informativa e **não**
+alimenta o recorde editorial.
+
+### 5.3. Teste de versões — superfície própria
+
+Criar superfície dedicada para duelos `version`:
+
+- `/ranking/version-trials/` — lista de testes entre versões concorrentes;
+- `/ranking/versions/[slug]/` — genealogia, seleção vigente, desafiantes,
+  duelos e links permanentes por `slug@uuid`;
+- `/ranking/battles/[id]/` — continua existindo, mas muda de composição quando
+  `kind === "version"`.
+
+Um duelo de versão renderiza:
+
+> **Teste de versão — paperclip-rhapsody**
+> `v-2026-06-11T08-25-46` venceu `v-2026-06-09T20-24-29`
+> [ler vencedora] [ler desafiante] [comparar diff]
+
+Ele **não** mostra `#rank global`, **não** usa o título "X venceu X" e **não**
+altera o recorde editorial do post.
+
+### 5.4. Filtros de rota, não só visuais
+
+`getAllDuels()` / `getDuels()` ganham argumento explícito de `kind`, sem default
+ambíguo:
+
+```ts
+getDuels({ kind: "work" });
+getDuels({ kind: "version" });
+getDuels({ kind: "all" }); // precisa ser declarado, nunca implícito
+```
+
+> **Nota de escopo.** O filtro por `modes` (`calibration`/`lens`/
+> `affective-chain`) e a rota `/ranking/readings/` pertencem à RFC 0013. Esta
+> RFC entrega apenas o eixo `kind`.
+
+---
+
+## 6. Contrato de idioma
+
+Cada rate file novo distingue:
+
+- `content_lang`: língua do texto em cada lado;
+- `review_lang`: língua da crítica e do clash.
+
+Regras (política única que substitui a contradição atual):
+
+1. Reviews e clash são escritos em `review_lang`.
+2. Em duelo `work`, os conteúdos podem estar em línguas diferentes;
+   `review_lang` é a língua definida na sessão e gravada explicitamente.
+3. Em duelo `version`, ambos os lados pertencem à mesma versão linguística;
+   logo `review_lang === content_lang`.
+4. A UI exibe chips discretos: `conteúdo: EN/PT`, `crítica: PT`.
+5. O `doctor` valida os campos novos **apenas em rate files `stars-v3`**; dados
+   antigos recebem marcação `unknown` ou valor derivado, sem reescrita
+   obrigatória e sem reprovação retroativa.
+
+`CLAUDE.md` é atualizado para descrever esta política única, encerrando a
+divergência "review na língua do post" vs "review na língua da sessão".
+
+> A regra 3 (`review_lang === content_lang` em `version`) é validada **só para
+> coletas pós-RFC** (`stars-v3`). Rate files históricos de versão em língua
+> divergente permanecem `legacy` e não são reprovados.
+
+---
+
+## 7. Migração
+
+### Fase 0 — Especificação e fixtures
+
+- Adicionar tipos `MatchKind`, `NormalizedMatch`.
+- Criar fixtures de `stars-v1`, `stars-v2`, `stars-v3`, duelo entre obras e
+  duelo de versões.
+- Fixar snapshot de comportamento histórico antes de mudar consumidores.
+
+### Fase 1 — Normalizador e filtros sem mudança de UI
+
+- Implementar `loadNormalizedMatches()` em `matches.ts`.
+- Migrar todos os consumidores (ranking, `hronir-rank.ts`, snapshot, doctor,
+  páginas) para ele.
+- Garantir que `computeRatings()` e o snapshot contem somente `work`.
+- Expor `getDuels({ kind })`; eliminar defaults ambíguos.
+- Rodar `doctor` em todo o acervo sem reescrever rate files.
+
+### Fase 2 — Separação de superfícies
+
+- Corrigir dossiês, cards recentes e estatísticas para `work`.
+- Implementar `/ranking/version-trials/` e `/ranking/versions/[slug]/` com
+  renderização por `slug@uuid`, links permanentes e diff.
+- Tornar explícitas as duas versões em cada duelo `version`.
+
+### Fase 3 — Idioma
+
+- Adicionar `--review-lang` ao `init` e gravar `content_lang`/`review_lang`.
+- Introduzir `stars-v3` com validação no `doctor` e chips de idioma na UI.
+- Unificar `CLAUDE.md` e o CLI na política única do §6.
+
+Cada fase deve ser verde antes da seguinte: `npm test`, `prettier --check`,
+`astro check`, `npm run build`, `npm run hronir:doctor` e fixtures de páginas.
+
+---
+
+## 8. Testes obrigatórios
+
+1. Um duelo `version` nunca altera `computeRatings`, posição global, recorde,
+   sparkline ou lista de oponentes de uma obra.
+2. Um duelo `version` renderiza duas versões distintas, dois links distintos
+   (`slug@uuid`) e nunca produz "X venceu X".
+3. Dados `stars-v1`/`stars-v2` permanecem legíveis, classificados como
+   `legacy`, sem reprovação no `doctor`.
+4. `doctor`, ranking, snapshot, páginas e `select` usam o mesmo `winnerSide` e a
+   mesma classificação de match (normalizador único).
+5. `getDuels` sem `kind` declarado é erro de tipo/execução — não há default
+   ambíguo.
+6. `review_lang` é validado em `stars-v3`; duelo de versões `stars-v3` em língua
+   divergente é rejeitado; o mesmo caso em `legacy` é aceito como histórico.
+7. Sessão interrompida e retomada não duplica rate file nem altera idioma do
+   match pendente.
+
+---
+
+## 9. Alternativas consideradas
+
+### A. Manter um único fluxo e só colocar uma tag visual em duelos de versão
+
+Rejeitada. Agregados, dossiês e links precisam de identidades de versão,
+filtros e semânticas diferentes — não é problema decorativo.
+
+### B. Apagar ou reescrever rate files históricos para o novo schema
+
+Rejeitada. O arquivo crítico é parte da obra. O normalizador preserva o
+passado, classifica-o com honestidade e permite que novas decisões usem regras
+mais estritas.
+
+### C. Resolver idioma só na documentação, sem campo persistido
+
+Rejeitada. Uma convenção em prosa sem check deriva (RFC 0004). A distinção
+`content_lang`/`review_lang` precisa ser um fato verificável pelo `doctor`.
+
+---
+
+## 10. Critério de conclusão
+
+A RFC 0012 estará cumprida quando toda superfície pública responder
+corretamente, sem ler código:
+
+1. **Isto é uma batalha entre obras ou um teste entre versões?**
+2. **Quais foram as duas versões exatas avaliadas?** (`slug@uuid`)
+3. **Este duelo entra no ranking editorial?**
+4. **Em que língua estava cada texto e em que língua foi escrita a crítica?**
+
+A pergunta **"quão sólida é a posição?"** fica deliberadamente reservada à
+**RFC 0013**.

--- a/docs/rfcs/0013-regimes-de-avaliacao-evidencia-e-amostragem.md
+++ b/docs/rfcs/0013-regimes-de-avaliacao-evidencia-e-amostragem.md
@@ -1,0 +1,157 @@
+# RFC 0013 — Regimes de avaliação, evidência editorial e política de amostragem
+
+|                |                                                                                                                                                                                                                                 |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Status**     | Proposed — bloqueada em diagnóstico do corpus                                                                                                                                                                                   |
+| **Autor**      | Franklin Baldo (proposta assistida)                                                                                                                                                                                             |
+| **Criado em**  | 2026-06-21                                                                                                                                                                                                                      |
+| **Depende de** | RFC 0001 (qualidade absoluta), RFC 0002 (de-confounding e amostragem objetiva), RFC 0007 (UI/UX), RFC 0010 (versões como pares), **RFC 0012 (taxonomia de matches — pré-requisito estrutural)**                                 |
+| **Afeta**      | `src/hronir/{matches,ranking,commands,types}.ts`, `src/lib/hronir-rank.ts`, `scripts/hronir/index.js`, `scripts/generate-ranking-snapshot.mjs`, `src/components/RankingView.astro`, `src/pages/ranking/**`, `CLAUDE.md`, testes |
+
+> Esta RFC é a **segunda metade** da antiga proposta 0012, fatiada por decisão
+> editorial. Ela trata do problema **editorial e experimental**: quais regimes
+> de leitura contam como evidência, como demonstrar a solidez de uma posição,
+> como amostrar o corpus e qual papel a cadeia afetiva deve ter no produto.
+>
+> **Ela não deve começar a ser implementada antes de a RFC 0012 estar concluída
+> e antes do diagnóstico do corpus descrito na §2.** Nenhum limiar numérico de
+> evidência pode ser fixado antes desse diagnóstico — esta RFC enumera as
+> decisões a tomar, não as respostas.
+
+---
+
+## Histórico de revisões
+
+| Data       | Mudança                                                                                                         |
+| ---------- | --------------------------------------------------------------------------------------------------------------- |
+| 2026-06-21 | Versão inicial, resultante do fatiamento da proposta 0012 original. Estado: bloqueada em diagnóstico do corpus. |
+
+---
+
+## 1. Motivação
+
+A RFC 0012 separa estruturalmente duelos `work` de duelos `version` e estabiliza
+a proveniência linguística. Resta o problema mais difícil, que é **editorial e
+estatístico, não estrutural**:
+
+- nem toda leitura tem o mesmo estatuto epistêmico — uma leitura editorial
+  basal, uma leitura situada por perspectiva e uma cadeia afetiva encadeada
+  respondem perguntas diferentes e não deveriam alimentar os mesmos agregados
+  por acidente;
+- a posição no ranking é informativa desde os primeiros matches, mas a posição
+  isolada não mede a **solidez** da evidência (oponentes repetidos, perspectivas
+  concentradas, confrontos apertados, sigma alto);
+- a amostragem atual protege líderes de perspectiva de forma binária (com
+  fallback quando sobram poucos candidatos), o que pode ser refinado.
+
+Estes são problemas de **decisão editorial sob dados reais**, não de correção de
+bug. Por isso esta RFC é deliberadamente aberta e condicionada a um diagnóstico.
+
+---
+
+## 2. Pré-requisito: diagnóstico do corpus
+
+Antes de qualquer decisão de design ou limiar, produzir um relatório do acervo
+existente (script de leitura pura, sem alterar dados), contendo:
+
+1. quantidade de obras;
+2. quantidade de duelos entre obras (`work`) e entre versões (`version`);
+3. distribuição de aparições por obra;
+4. diversidade de oponentes por obra;
+5. distribuição de duelos por perspectiva e por agente;
+6. sigma do OpenSkill por obra;
+7. proporção dos dados históricos que poderiam satisfazer critérios de
+   calibração sob diferentes hipóteses de limiar.
+
+O relatório é insumo obrigatório para §3–§6. **Sem ele, esta RFC não avança.**
+
+---
+
+## 3. Decisões a tomar (em aberto)
+
+Esta RFC deve decidir explicitamente, com base no diagnóstico:
+
+1. **Cadeia afetiva** (`affective-chain`): permanece fluxo principal, vira fluxo
+   paralelo, ou é arquivada como experimento? Hoje ela é o fluxo canônico
+   descrito em `CLAUDE.md` (perspectiva, mood, glifo, herança). Qualquer
+   rebaixamento é uma **mudança de identidade do produto** e deve ser tratado
+   como decisão editorial explícita, não como detalhe técnico.
+2. **Regimes de coleta**: quais modos existem (ex. `calibration`, `lens`,
+   `affective-chain`, além de `legacy`), como cada um é declarado e — ponto
+   crítico — **como sua proveniência será validada**, já que `mode` é uma
+   asserção de coleta, não uma propriedade derivável do dado como `kind`.
+3. **Quais dados alimentam o quê**: ranking editorial, seleção de versões e
+   leituras situadas. Em particular, se a seleção de versões da RFC 0010 passa a
+   exigir um regime específico de evidência para deslocar uma incumbente.
+4. **Estados de evidência**: como combinar **sigma do OpenSkill**, diversidade
+   de oponentes e diversidade de perspectivas num indicador de solidez.
+   Preferir o sigma — sinal de incerteza que o modelo já produz — a contagens
+   arbitrárias, salvo justificativa baseada no diagnóstico.
+5. **Objetivos de amostragem**: quais existem (ex. cobertura, refinar topo,
+   caçar pior, evidência de versão), como são persistidos como proveniência e
+   como a proteção binária de líderes é substituída por uma penalidade suave
+   (cooldown) que despriorize sem excluir.
+6. **Topologia de rotas**: se é necessária uma rota nova para leituras situadas
+   (`/ranking/readings/`), ou se filtros sobre as rotas existentes mais a rota
+   de testes de versão (já criada pela RFC 0012) bastam.
+
+---
+
+## 4. Restrições herdadas
+
+- **Não fixar limiares numéricos** (aparições, oponentes, perspectivas) antes do
+  diagnóstico da §2. Quando fixados, devem ser constantes nomeadas em
+  `ranking.ts`, não números espalhados pela UI, e justificados pelo tamanho real
+  do corpus.
+- **Não reescrever rate files históricos.** `legacy` permanece legível e
+  classificado com honestidade (herdado da RFC 0012).
+- **Subjetividade é dado, não ruído.** Perspectivas e humores são lentes de
+  leitura; a solução é declarar seu plano de validade, não neutralizá-los.
+- **Evidência antes de espetáculo.** A UI pode celebrar candidatos, mas não deve
+  chamar de "campeão" o que ainda é hipótese. A linguagem de pódio fica
+  condicionada aos estados de evidência decididos aqui.
+- A separação estrutural `work`/`version`, a normalização única e a proveniência
+  linguística **já existem** (RFC 0012) e não são reabertas.
+
+---
+
+## 5. Critério de conclusão
+
+A RFC 0013 estará cumprida quando, somada à 0012, um leitor puder responder sem
+ler código:
+
+1. **Quão sólida é esta posição?** (estado de evidência derivado de sigma +
+   diversidade)
+2. **Por que esta versão — e não sua rival — está publicada?** (regime de
+   evidência exigido para deslocar uma incumbente)
+3. **Como leituras situadas e afetivas divergiram da avaliação editorial?**
+   (superfície de leituras, sem contaminar o ranking editorial)
+
+A RFC 0012 já garante as perguntas estruturais ("isto é obra ou versão?",
+"quais versões exatas?", "entra no ranking editorial?", "em que línguas?").
+
+---
+
+## 6. Alternativas consideradas
+
+### A. Não fatiar — manter tudo na proposta 0012 original
+
+Rejeitada. O problema estrutural (verificável, baixo risco) e o editorial
+(dependente de dados, alto risco de inconclusão) têm naturezas distintas.
+Empacotá-los criava uma RFC que dificilmente atingiria "todas as fases verdes".
+
+### B. Excluir subjetividade de todo o Hrönir
+
+Rejeitada. Perspectivas, humores e a cadeia afetiva são uma das melhores ideias
+do sistema. A solução é declarar seu plano de validade.
+
+### C. Fazer todo novo match contar para o ranking editorial
+
+Rejeitada. Preserva volume, mas dissolve a diferença entre avaliação editorial,
+crítica situada e experimento afetivo.
+
+### D. Fixar limiares de evidência por intuição, antes do diagnóstico
+
+Rejeitada explicitamente. Para um corpus pequeno, limiares mal calibrados podem
+tornar "calibrado" inatingível na prática. Os números seguem os dados, não o
+contrário.

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "hronir:doctor": "node --import tsx/esm scripts/hronir/index.js doctor",
     "hronir:detect-stuffing": "node scripts/hronir/detect-token-stuffing.mjs",
     "music:generate": "node scripts/generate-music-posts.mjs",
-    "test": "node --import tsx/esm --experimental-test-module-mocks --test src/hronir/__tests__/ranking.test.js"
+    "test": "node --import tsx/esm --experimental-test-module-mocks --test \"src/hronir/__tests__/*.test.js\""
   },
   "dependencies": {
     "@astrojs/mdx": "^5.0.4",

--- a/scripts/hronir/index.js
+++ b/scripts/hronir/index.js
@@ -47,7 +47,7 @@ const [, , cmd, ...args] = process.argv;
 
 function usage() {
   console.error(
-    "Uso: hronir {next --agent-id <id> [init-opts]|init --agent-id <id> [--matches N] [--skip-edit] [--skip-rating] [--eval-lang <lang>] [--min-appearances N] [--pledge <text>] [--content-mode inline|path-only]|continue|first-impression-a <texto>|first-impression-b <texto>|decide --after-mood <text> --rate-a <1.00-5.00> --rate-b <1.00-5.00> --review-a <text> --review-b <text> --clash <text> [--clash-append <text>] [--review-a-append <text>] [--review-b-append <text>]|ranking|worst [--absolute]|diagnose|edit-worst|edit-commit --msg <text>|migrate [--dry-run]|doctor|end [--skip-edit] [--force] [--attest <text>]|select [--dry-run]|prune [--dry-run]}"
+    "Uso: hronir {next --agent-id <id> [init-opts]|init --agent-id <id> [--matches N] [--skip-edit] [--skip-rating] [--eval-lang <lang>] [--review-lang <lang>] [--min-appearances N] [--pledge <text>] [--content-mode inline|path-only]|continue|first-impression-a <texto>|first-impression-b <texto>|decide --after-mood <text> --rate-a <1.00-5.00> --rate-b <1.00-5.00> --review-a <text> --review-b <text> --clash <text> [--clash-append <text>] [--review-a-append <text>] [--review-b-append <text>]|ranking|worst [--absolute]|diagnose|edit-worst|edit-commit --msg <text>|migrate [--dry-run]|doctor|end [--skip-edit] [--force] [--attest <text>]|select [--dry-run]|prune [--dry-run]}"
   );
   process.exit(1);
 }
@@ -110,6 +110,10 @@ function parseInitOptions(args) {
     args.indexOf("--lang"),
   ]);
   const evalLang = evalLangRaw || "pt";
+  // RFC 0012 §6: language the review/clash is written in. Defaults to the
+  // evaluation language for back-compat; persisted explicitly.
+  const reviewLangRaw = readFlagValue(args, [args.indexOf("--review-lang")]);
+  const reviewLang = reviewLangRaw || undefined;
   const minAppRaw = readFlagValue(args, [
     args.indexOf("--min-appearances"),
     args.indexOf("--min-app"),
@@ -129,6 +133,7 @@ function parseInitOptions(args) {
     skipRating,
     agentId,
     evalLang,
+    reviewLang,
     minAppearances,
     pledge,
     contentMode,

--- a/src/components/HronirReviews.astro
+++ b/src/components/HronirReviews.astro
@@ -1,5 +1,5 @@
 ---
-import { getAllDuels } from "../lib/hronir-rank";
+import { getDuels } from "../lib/hronir-rank";
 import { getCollection } from "astro:content";
 import { marked } from "marked";
 import { isPublished } from "../lib/publish";
@@ -11,7 +11,8 @@ interface Props {
 
 const { translationKey, lang = "en" } = Astro.props;
 
-const allDuels = getAllDuels();
+// RFC 0012 §6.1: a post's reviews are its editorial duels, not version trials.
+const allDuels = getDuels({ kind: "work" });
 
 const allPosts = await getCollection("blog");
 const postMeta = new Map<string, { title: string; slug: string; lang: string }>();
@@ -45,7 +46,7 @@ function fmtDate(iso: string): string {
 
 // Precompute card data and filter out duels with no review content
 type CardData = {
-  d: ReturnType<typeof getAllDuels>[number];
+  d: ReturnType<typeof getDuels>[number];
   myReview: string;
   myRate: number | undefined;
   won: boolean;

--- a/src/components/RankingView.astro
+++ b/src/components/RankingView.astro
@@ -390,7 +390,6 @@ function snapshotElo(key: string): { elo: number; peak: number } | null {
           >
             <div class="bcl-meta">
               <span class="bcl-date">{fmtDate(d.runAt)}</span>
-              {d.isVersionDuel && <span class="bcl-tag">version duel</span>}
               {d.perspectiveId && (
                 <span
                   class="bcl-tag bcl-tag-persp"

--- a/src/hronir/__tests__/fixtures/rate-files/version-stars-v3.md
+++ b/src/hronir/__tests__/fixtures/rate-files/version-stars-v3.md
@@ -1,0 +1,31 @@
+---
+# RFC 0012 fixture — stars-v3 VERSION duel: both sides share the same key but
+# carry distinct version UUIDs. kind === "version". Both sides are the same
+# linguistic version, so review_lang === content_lang (RFC 0012 §6, rule 3).
+prompt_version: stars-v3
+match_kind: version
+agent_id: fixture-agent
+run_at: 2026-06-21T01:00:00Z
+review_lang: en
+perspective_id: editorial-baseline
+post_a:
+  key: alpha-essay
+  path: src/content/blog/alpha-essay/v-2026-06-09T20-24-29.md
+  display_lang: en
+  content_lang: en
+  version: v-2026-06-09T20-24-29
+post_b:
+  key: alpha-essay
+  path: src/content/blog/alpha-essay/v-2026-06-11T08-25-46.md
+  display_lang: en
+  content_lang: en
+  version: v-2026-06-11T08-25-46
+winner: b
+rate_a: 3.25
+rate_b: 4.5
+review_a: Placeholder review of alpha-essay@v-2026-06-09T20-24-29.
+review_b: Placeholder review of alpha-essay@v-2026-06-11T08-25-46.
+clash: Placeholder clash between the two alpha-essay versions.
+---
+
+Fixture body — not parsed by ranking.

--- a/src/hronir/__tests__/fixtures/rate-files/work-stars-v1.md
+++ b/src/hronir/__tests__/fixtures/rate-files/work-stars-v1.md
@@ -1,0 +1,24 @@
+---
+# RFC 0012 fixture — historical stars-v1 WORK duel (different keys).
+# Classified `legacy` (no review_lang/match_kind); must stay readable.
+schema: stars-v1
+prompt_version: stars-v1
+agent_id: fixture-agent
+run_at: 2024-01-01T00:00:00Z
+post_a:
+  key: alpha-essay
+  path: src/content/blog/alpha-essay.md
+  display_lang: en
+post_b:
+  key: beta-essay
+  path: src/content/blog/beta-essay.md
+  display_lang: en
+winner: a
+rate_a: 4.5
+rate_b: 3
+review_a: Placeholder review of alpha-essay for fixtures.
+review_b: Placeholder review of beta-essay for fixtures.
+clash: Placeholder clash between alpha-essay and beta-essay.
+---
+
+Fixture body — not parsed by ranking.

--- a/src/hronir/__tests__/fixtures/rate-files/work-stars-v2.md
+++ b/src/hronir/__tests__/fixtures/rate-files/work-stars-v2.md
@@ -1,0 +1,29 @@
+---
+# RFC 0012 fixture — stars-v2 WORK duel with a perspective + mood (affective
+# chain era). No review_lang yet: normalizer falls back to eval_lang.
+prompt_version: stars-v2
+agent_id: fixture-agent
+run_at: 2024-02-01T00:00:00Z
+content_mode: inline
+eval_lang: en
+perspective_id: o-cetico
+post_a:
+  key: alpha-essay
+  path: src/content/blog/alpha-essay.md
+  display_lang: en
+post_b:
+  key: gamma-essay
+  path: src/content/blog/gamma-essay.md
+  display_lang: en
+winner: b
+rate_a: 2.75
+rate_b: 4
+evaluator_mood: Comecei curioso, meio cansado.
+evaluator_mood_after: Terminei inquieto, com vontade de reler.
+mood_glyph: "◷"
+review_a: Placeholder review of alpha-essay under o-cetico.
+review_b: Placeholder review of gamma-essay under o-cetico.
+clash: Placeholder clash between alpha-essay and gamma-essay.
+---
+
+Fixture body — not parsed by ranking.

--- a/src/hronir/__tests__/fixtures/rate-files/work-stars-v3.md
+++ b/src/hronir/__tests__/fixtures/rate-files/work-stars-v3.md
@@ -1,0 +1,29 @@
+---
+# RFC 0012 fixture — stars-v3 WORK duel across two languages. content_lang
+# differs per side; review_lang is the session language and is recorded
+# explicitly (RFC 0012 §6, rule 2/3).
+prompt_version: stars-v3
+match_kind: work
+agent_id: fixture-agent
+run_at: 2026-06-21T00:00:00Z
+review_lang: pt
+perspective_id: editorial-baseline
+post_a:
+  key: alpha-essay
+  path: src/content/blog/alpha-essay.md
+  display_lang: en
+  content_lang: en
+post_b:
+  key: delta-ensaio
+  path: src/content/blog/delta-ensaio.md
+  display_lang: pt
+  content_lang: pt
+winner: a
+rate_a: 4.25
+rate_b: 3.5
+review_a: Resenha placeholder de alpha-essay (crítica em PT).
+review_b: Resenha placeholder de delta-ensaio (crítica em PT).
+clash: Confronto placeholder entre alpha-essay e delta-ensaio.
+---
+
+Corpo de fixture — não lido pelo ranking.

--- a/src/hronir/__tests__/golden-ranking.test.js
+++ b/src/hronir/__tests__/golden-ranking.test.js
@@ -24,6 +24,8 @@ await mock.module("../matches.js", {
     writeMatch: () => {},
     postKey: (side) => (side ? side.key || side.slug || null : null),
     matchesDataVersion: () => 0,
+    loadMatches: () => [],
+    loadNormalizedMatches: () => [],
   },
 });
 

--- a/src/hronir/__tests__/golden-ranking.test.js
+++ b/src/hronir/__tests__/golden-ranking.test.js
@@ -1,0 +1,194 @@
+import { describe, it, mock } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import matter from "gray-matter";
+
+// RFC 0012 Fase 0 — golden snapshot.
+//
+// This test freezes the *current* (pre-normalizer) behavior of the ranking
+// core so Fase 1 (the single normalizer + `getDuels({ kind })`) can prove it
+// is behavior-preserving: the assertions here must stay green unchanged after
+// consumers migrate to loadNormalizedMatches(). It also locks the structural
+// classification rule (kind = aKey === bKey ? "version" : "work") against the
+// on-disk rate-file fixtures the normalizer will consume.
+
+// Mock matches before importing ranking (same reason as ranking.test.js: avoid
+// pulling posts.ts → remark, which is only present after `npm ci`). The pure
+// _compute* functions under test take their raw array as an argument.
+await mock.module("../matches.js", {
+  namedExports: {
+    listMatchFiles: () => [],
+    readMatch: () => ({ data: {}, content: "" }),
+    writeMatch: () => {},
+    postKey: (side) => (side ? side.key || side.slug || null : null),
+    matchesDataVersion: () => 0,
+  },
+});
+
+const { _computeRatings, _computeVersionRatings } =
+  await import("../ranking.js");
+
+function match(overrides) {
+  return {
+    runAt: "2024-01-01T00:00:00Z",
+    filename: "match.md",
+    aKey: "alpha-essay",
+    bKey: "beta-essay",
+    aPath: "src/content/blog/alpha-essay.md",
+    bPath: "src/content/blog/beta-essay.md",
+    aVersion: null,
+    bVersion: null,
+    agentId: null,
+    perspectiveId: null,
+    winner: "a",
+    rateA: null,
+    rateB: null,
+    ...overrides,
+  };
+}
+
+// A fixed editorial (work) corpus: alpha > beta > gamma.
+const WORK_CORPUS = [
+  match({
+    runAt: "2024-01-01T00:00:00Z",
+    aKey: "alpha-essay",
+    bKey: "beta-essay",
+    winner: "a",
+  }),
+  match({
+    runAt: "2024-01-02T00:00:00Z",
+    aKey: "alpha-essay",
+    bKey: "beta-essay",
+    winner: "a",
+  }),
+  match({
+    runAt: "2024-01-03T00:00:00Z",
+    aKey: "beta-essay",
+    bKey: "gamma-essay",
+    winner: "a",
+  }),
+  match({
+    runAt: "2024-01-04T00:00:00Z",
+    aKey: "beta-essay",
+    bKey: "gamma-essay",
+    winner: "a",
+  }),
+  match({
+    runAt: "2024-01-05T00:00:00Z",
+    aKey: "alpha-essay",
+    bKey: "gamma-essay",
+    winner: "a",
+  }),
+];
+
+// The same corpus plus version duels of alpha-essay (same key both sides).
+const VERSION_DUELS = [
+  match({
+    runAt: "2024-01-06T00:00:00Z",
+    filename: "version-1.md",
+    aKey: "alpha-essay",
+    bKey: "alpha-essay",
+    aPath: "src/content/blog/alpha-essay/v-old.md",
+    bPath: "src/content/blog/alpha-essay/v-new.md",
+    aVersion: "v-old",
+    bVersion: "v-new",
+    winner: "b",
+    rateA: 3.25,
+    rateB: 4.5,
+  }),
+  match({
+    runAt: "2024-01-07T00:00:00Z",
+    filename: "version-2.md",
+    aKey: "alpha-essay",
+    bKey: "alpha-essay",
+    aPath: "src/content/blog/alpha-essay/v-old.md",
+    bPath: "src/content/blog/alpha-essay/v-new.md",
+    aVersion: "v-old",
+    bVersion: "v-new",
+    winner: "b",
+    rateA: 3,
+    rateB: 4.75,
+  }),
+];
+
+const orderOf = (rows) =>
+  [...rows].sort((a, b) => b.ordinal - a.ordinal).map((r) => r.key);
+
+describe("RFC 0012 golden — work/version separation", () => {
+  it("editorial ordering is alpha > beta > gamma", () => {
+    assert.deepEqual(orderOf(_computeRatings(WORK_CORPUS)), [
+      "alpha-essay",
+      "beta-essay",
+      "gamma-essay",
+    ]);
+  });
+
+  it("version duels never alter work ratings (the load-bearing invariant)", () => {
+    const withoutVersions = _computeRatings(WORK_CORPUS);
+    const withVersions = _computeRatings([...WORK_CORPUS, ...VERSION_DUELS]);
+    // Same keys, same ordinals, same appearance counts — a version duel must
+    // be invisible to the editorial ranking.
+    assert.deepEqual(withVersions, withoutVersions);
+  });
+
+  it("work duels never feed version ratings", () => {
+    assert.equal(_computeVersionRatings(WORK_CORPUS).size, 0);
+  });
+
+  it("version ratings rank the better-rated UUID higher, by key", () => {
+    const v = _computeVersionRatings([...WORK_CORPUS, ...VERSION_DUELS]);
+    assert.deepEqual([...v.keys()].sort(), ["v-new", "v-old"]);
+    assert.ok(v.get("v-new").stars > v.get("v-old").stars);
+    assert.equal(v.get("v-new").key, "alpha-essay");
+    assert.equal(v.get("v-old").key, "alpha-essay");
+  });
+});
+
+// Structural classification rule (RFC 0012 §4.1) against the on-disk fixtures.
+const FIXdir = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "fixtures",
+  "rate-files"
+);
+const readFixture = (name) =>
+  matter(fs.readFileSync(path.join(FIXdir, name), "utf8")).data;
+const kindOf = (data) =>
+  data.post_a.key === data.post_b.key ? "version" : "work";
+
+describe("RFC 0012 golden — fixture classification & schema", () => {
+  it("work fixtures classify as work; version fixture as version", () => {
+    assert.equal(kindOf(readFixture("work-stars-v1.md")), "work");
+    assert.equal(kindOf(readFixture("work-stars-v2.md")), "work");
+    assert.equal(kindOf(readFixture("work-stars-v3.md")), "work");
+    assert.equal(kindOf(readFixture("version-stars-v3.md")), "version");
+  });
+
+  it("persisted match_kind, when present, agrees with the derived rule", () => {
+    for (const f of ["work-stars-v3.md", "version-stars-v3.md"]) {
+      const data = readFixture(f);
+      assert.equal(data.match_kind, kindOf(data));
+    }
+  });
+
+  it("stars-v3 records review_lang and per-side content_lang", () => {
+    const work = readFixture("work-stars-v3.md");
+    assert.equal(work.review_lang, "pt");
+    assert.equal(work.post_a.content_lang, "en");
+    assert.equal(work.post_b.content_lang, "pt");
+
+    // Version duel: both sides are the same linguistic version, so the review
+    // is written in that language (RFC 0012 §6, rule 3).
+    const ver = readFixture("version-stars-v3.md");
+    assert.equal(ver.review_lang, ver.post_a.content_lang);
+    assert.equal(ver.post_a.content_lang, ver.post_b.content_lang);
+  });
+
+  it("legacy fixtures stay readable with no review_lang", () => {
+    assert.equal(readFixture("work-stars-v1.md").review_lang, undefined);
+    assert.equal(readFixture("work-stars-v2.md").review_lang, undefined);
+    // stars-v2 carries eval_lang, the legacy fallback the normalizer will use.
+    assert.equal(readFixture("work-stars-v2.md").eval_lang, "en");
+  });
+});

--- a/src/hronir/__tests__/normalizer.test.js
+++ b/src/hronir/__tests__/normalizer.test.js
@@ -1,0 +1,115 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import matter from "gray-matter";
+import { normalizeMatch, classifyKind, matchId } from "../matches.js";
+
+// RFC 0012 Fase 1 — the single normalizer. These exercise the real
+// normalizeMatch (no module mock; this file runs in its own test process) so
+// the work/version classification, slug@uuid refs, language fallback and the
+// validity filters are pinned in one place.
+
+const FIXdir = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "fixtures",
+  "rate-files"
+);
+const load = (name) => {
+  const { data, content } = matter(
+    fs.readFileSync(path.join(FIXdir, name), "utf8")
+  );
+  return normalizeMatch(data, content, name);
+};
+
+describe("classifyKind", () => {
+  it("same key → version, different keys → work", () => {
+    assert.equal(classifyKind("a", "a"), "version");
+    assert.equal(classifyKind("a", "b"), "work");
+  });
+});
+
+describe("normalizeMatch — fixtures", () => {
+  it("stars-v1 work duel: legacy, no review_lang", () => {
+    const lm = load("work-stars-v1.md");
+    assert.equal(lm.norm.kind, "work");
+    assert.equal(lm.norm.winnerSide, "a");
+    assert.equal(lm.norm.postA.key, "alpha-essay");
+    assert.equal(lm.norm.postB.key, "beta-essay");
+    assert.equal(lm.norm.reviewLang, null);
+    assert.equal(lm.norm.rateA, 4.5);
+    assert.ok(lm.norm.runAt instanceof Date);
+  });
+
+  it("stars-v2 work duel: review_lang falls back to eval_lang", () => {
+    const lm = load("work-stars-v2.md");
+    assert.equal(lm.norm.kind, "work");
+    assert.equal(lm.norm.winnerSide, "b");
+    assert.equal(lm.norm.reviewLang, "en");
+    assert.equal(lm.norm.perspectiveId, "o-cetico");
+    assert.equal(lm.norm.evaluatorMood, "Comecei curioso, meio cansado.");
+  });
+
+  it("stars-v3 work duel: review_lang + per-side content_lang", () => {
+    const lm = load("work-stars-v3.md");
+    assert.equal(lm.norm.kind, "work");
+    assert.equal(lm.norm.reviewLang, "pt");
+    assert.equal(lm.norm.postA.contentLang, "en");
+    assert.equal(lm.norm.postB.contentLang, "pt");
+  });
+
+  it("stars-v3 version duel: kind version + slug@uuid refs", () => {
+    const lm = load("version-stars-v3.md");
+    assert.equal(lm.norm.kind, "version");
+    assert.equal(lm.norm.winnerSide, "b");
+    assert.equal(lm.norm.postA.key, "alpha-essay");
+    assert.equal(lm.norm.postB.key, "alpha-essay");
+    assert.equal(lm.norm.postA.ref, "alpha-essay@v-2026-06-09T20-24-29");
+    assert.equal(lm.norm.postB.ref, "alpha-essay@v-2026-06-11T08-25-46");
+  });
+
+  it("id is matchId(aKey, bKey, runAtRaw)", () => {
+    const lm = load("work-stars-v3.md");
+    assert.equal(
+      lm.norm.id,
+      matchId(lm.norm.postA.key, lm.norm.postB.key, lm.runAtRaw)
+    );
+  });
+});
+
+describe("normalizeMatch — validity filters", () => {
+  const base = {
+    post_a: { key: "a", path: "a.md" },
+    post_b: { key: "b", path: "b.md" },
+    run_at: "2024-01-01T00:00:00Z",
+    winner: "a",
+  };
+
+  it("returns null for TODO / missing winner", () => {
+    assert.equal(normalizeMatch({ ...base, winner: "TODO" }, "", "x"), null);
+    assert.equal(normalizeMatch({ ...base, winner: undefined }, "", "x"), null);
+  });
+
+  it("override flips the resolved winner", () => {
+    const lm = normalizeMatch({ ...base, override: "b" }, "", "x");
+    assert.equal(lm.norm.winnerSide, "b");
+  });
+
+  it("returns null when a key is missing", () => {
+    assert.equal(
+      normalizeMatch({ ...base, post_b: { path: "b.md" } }, "", "x"),
+      null
+    );
+  });
+
+  it("keeps run_id-only timestamps as runAtRaw, runAt null when unparseable", () => {
+    const lm = normalizeMatch(
+      { ...base, run_at: undefined, run_id: "2024-01-01T00-00-00-000" },
+      "",
+      "x"
+    );
+    assert.equal(lm.runAtRaw, "2024-01-01T00-00-00-000");
+    assert.equal(lm.norm.runAt, null);
+  });
+});

--- a/src/hronir/__tests__/ranking.test.js
+++ b/src/hronir/__tests__/ranking.test.js
@@ -14,6 +14,8 @@ await mock.module("../matches.js", {
     writeMatch: () => {},
     postKey: (side) => (side ? side.key || side.slug || null : null),
     matchesDataVersion: () => 0,
+    loadMatches: () => [],
+    loadNormalizedMatches: () => [],
   },
 });
 

--- a/src/hronir/commands.ts
+++ b/src/hronir/commands.ts
@@ -1350,11 +1350,23 @@ export function decide(args: string[]) {
       ? contentLangA || session.reviewLang || evalLangValue
       : session.reviewLang || evalLangValue;
 
+  // RFC 0012 §4.2: stars-v3 requires per-side content_lang. Sessions started
+  // before this field existed carry sides with only display_lang, so backfill
+  // it here — otherwise a session spanning the upgrade would write a stars-v3
+  // file the doctor rejects.
+  const withContentLang = (side: Record<string, unknown>) => ({
+    ...side,
+    content_lang:
+      (side.content_lang as string) ||
+      (side.display_lang as string) ||
+      evalLangValue,
+  });
+
   const data = {
     run_id: runId,
     run_at: runAt,
-    post_a: currentMatch.post_a,
-    post_b: currentMatch.post_b,
+    post_a: withContentLang(currentMatch.post_a),
+    post_b: withContentLang(currentMatch.post_b),
     winner,
     agent_id: agentId,
     content_mode: session.contentMode ?? "inline",

--- a/src/hronir/commands.ts
+++ b/src/hronir/commands.ts
@@ -117,8 +117,14 @@ const SESSION_PATH = "hronir_session.json";
 const MIN_WORDS = 100;
 // RFC 0010: stars-v2 adds post_a/b.ref ("slug@uuid") to each side. stars-v1
 // files (path/key/version fields) remain readable and are never rewritten.
-const PROMPT_VERSION = "stars-v2";
-const STARS_SCHEMAS = new Set(["stars-v1", "stars-v2"]);
+// RFC 0012 §4.2: stars-v3 adds review_lang + per-side content_lang. Older
+// schemas stay valid and classified `legacy`; only stars-v3 is validated for
+// the new language fields.
+const PROMPT_VERSION = "stars-v3";
+const STARS_SCHEMAS = new Set(["stars-v1", "stars-v2", "stars-v3"]);
+// Schemas that carry slug@uuid refs and therefore require strict version-uuid
+// resolution in the doctor (RFC 0010 §4.3).
+const REF_SCHEMAS = new Set(["stars-v2", "stars-v3"]);
 
 function wordCount(s: unknown): number {
   if (!s || typeof s !== "string") return 0;
@@ -2125,13 +2131,13 @@ export function doctor() {
     // stars-v1 gravou o UUID body-only da época do duelo; edições in-place
     // posteriores tornam esse hash irrecuperável, então basta a pasta do
     // post existir.
-    const isStarsV2 = String(data.prompt_version) === "stars-v2";
+    const isRefSchema = REF_SCHEMAS.has(String(data.prompt_version));
     const tolerableGone = (
       p: string | undefined,
       version: string | undefined
     ) => {
       if (!p || !version || !fs.existsSync(path.dirname(p))) return false;
-      if (!isStarsV2) return true;
+      if (!isRefSchema) return true;
       const slug = path.basename(path.dirname(p));
       return (
         dirUuids(slug).has(version) || prunedUuids.has(`${slug}@${version}`)
@@ -2197,6 +2203,42 @@ export function doctor() {
         !data.eval_lang.trim()
       ) {
         issues.push(`${base}: o campo 'eval_lang' no frontmatter está ausente`);
+      }
+      // RFC 0012 §6: stars-v3 carries explicit language provenance. Validated
+      // only for stars-v3 — older files stay legacy and are not reproved.
+      if (String(data.prompt_version) === "stars-v3") {
+        const reviewLang = data.review_lang;
+        const aContentLang = (data.post_a as Record<string, unknown> | null)
+          ?.content_lang as string | undefined;
+        const bContentLang = (data.post_b as Record<string, unknown> | null)
+          ?.content_lang as string | undefined;
+        if (
+          !reviewLang ||
+          typeof reviewLang !== "string" ||
+          !reviewLang.trim()
+        ) {
+          issues.push(`${base}: stars-v3 sem 'review_lang'`);
+        }
+        if (!aContentLang) {
+          issues.push(`${base}: stars-v3 sem 'post_a.content_lang'`);
+        }
+        if (!bContentLang) {
+          issues.push(`${base}: stars-v3 sem 'post_b.content_lang'`);
+        }
+        // Version duel: both sides are the same linguistic version, so the
+        // critique must be written in that content language (RFC 0012 §6 rule 3).
+        if (
+          aKey &&
+          bKey &&
+          aKey === bKey &&
+          typeof reviewLang === "string" &&
+          aContentLang &&
+          reviewLang !== aContentLang
+        ) {
+          issues.push(
+            `${base}: duelo de versão stars-v3 com review_lang≠content_lang (${reviewLang}≠${aContentLang})`
+          );
+        }
       }
       const ra = data.rate_a;
       const rb = data.rate_b;

--- a/src/hronir/commands.ts
+++ b/src/hronir/commands.ts
@@ -53,6 +53,7 @@ interface InitOptions {
   skipRating?: boolean;
   agentId?: string;
   evalLang?: string;
+  reviewLang?: string;
   minAppearances?: number;
   matches?: number;
   pledge?: string;
@@ -247,6 +248,8 @@ export function init(options: InitOptions = {}) {
     process.exit(1);
   }
   const evalLang = options.evalLang || "pt";
+  // RFC 0012 §6: review_lang defaults to the evaluation language when not given.
+  const reviewLang = options.reviewLang || evalLang;
   const sessionPath = SESSION_PATH;
 
   if (fs.existsSync(sessionPath)) {
@@ -272,6 +275,7 @@ export function init(options: InitOptions = {}) {
       completed: 0,
       agentId,
       evalLang,
+      reviewLang,
       state: "need_edit",
       skipEdit: false,
       skipRating: true,
@@ -301,6 +305,7 @@ export function init(options: InitOptions = {}) {
     completed: 0,
     agentId,
     evalLang,
+    reviewLang,
     state: "ready_for_next",
     skipEdit,
     skipRating: false,
@@ -599,6 +604,7 @@ function generateNextMatch() {
     key,
     path: p,
     display_lang: lang,
+    content_lang: lang, // RFC 0012 §6: explicit language of this side's text
     version: getPostUuid(p),
     ref: refFor(p),
   });
@@ -1325,6 +1331,19 @@ export function decide(args: string[]) {
   const bKey = currentMatch.post_b.key;
   const matchFile = path.join(RATES_DIR, `${runId}_${aKey}_x_${bKey}.md`);
 
+  // RFC 0012 §6: review_lang is the session language for editorial (work)
+  // duels; for a version duel both sides are the same linguistic version, so
+  // the critique is written in that content language (rule 3).
+  const evalLangValue = currentMatch.eval_lang || session.evalLang || "pt";
+  const contentLangA =
+    currentMatch.post_a.content_lang ||
+    currentMatch.post_a.display_lang ||
+    null;
+  const reviewLang =
+    aKey === bKey
+      ? contentLangA || session.reviewLang || evalLangValue
+      : session.reviewLang || evalLangValue;
+
   const data = {
     run_id: runId,
     run_at: runAt,
@@ -1333,7 +1352,8 @@ export function decide(args: string[]) {
     winner,
     agent_id: agentId,
     content_mode: session.contentMode ?? "inline",
-    eval_lang: currentMatch.eval_lang || session.evalLang || "pt",
+    eval_lang: evalLangValue,
+    review_lang: reviewLang,
     prompt_version: PROMPT_VERSION,
     season: 1,
     override: null,

--- a/src/hronir/matches.ts
+++ b/src/hronir/matches.ts
@@ -1,8 +1,14 @@
 import fs from "node:fs";
 import path from "node:path";
+import crypto from "node:crypto";
 import { execFileSync } from "node:child_process";
 import matter from "gray-matter";
 import { OUT_DIR, RATES_DIR } from "./posts.js";
+import type {
+  MatchKind,
+  NormalizedMatch,
+  NormalizedMatchSide,
+} from "./types.js";
 
 export function listMatchFiles(): string[] {
   const out: string[] = [];
@@ -80,6 +86,138 @@ export function postKey(
 ): string | null {
   if (!side) return null;
   return side.key || side.slug || null;
+}
+
+// ── Single normalizer (RFC 0012 §4.1) ───────────────────────────────────────
+//
+// Before RFC 0012 three readers (ranking._loadMatchData,
+// ranking.computePerPerspectiveRatings, hronir-rank.loadDuelData) each parsed
+// the rate files and re-derived winner/override resolution, keys, runAt and the
+// work-vs-version distinction by hand. This is the one place that does it, so
+// every consumer shares the same classification instead of re-deriving
+// `aKey === bKey` ad hoc.
+
+/** RFC 0012 §4.1: structural, derivable from the rate file alone. */
+export function classifyKind(aKey: string, bKey: string): MatchKind {
+  return aKey === bKey ? "version" : "work";
+}
+
+/** Stable 8-char duel id — hash of postAKey|postBKey|runAt. Single source for
+ *  the value hronir-rank.duelId used to compute inline. */
+export function matchId(aKey: string, bKey: string, runAt: string): string {
+  return crypto
+    .createHash("sha256")
+    .update([aKey, bKey, runAt].join("|"))
+    .digest("hex")
+    .slice(0, 8);
+}
+
+/** A normalized match plus the raw material consumers still need: the exact
+ *  original runAt string (Date round-tripping would corrupt `run_id`-only
+ *  timestamps), the source filename, and the untouched frontmatter/body for
+ *  passthrough display fields (margin, confidence, parsed clash, …). */
+export interface LoadedMatch {
+  norm: NormalizedMatch;
+  filename: string;
+  runAtRaw: string;
+  data: Record<string, unknown>;
+  content: string;
+}
+
+function asString(v: unknown): string | null {
+  return v == null ? null : String(v);
+}
+
+function asFiniteNumber(v: unknown): number | null {
+  return typeof v === "number" && Number.isFinite(v) ? v : null;
+}
+
+function normalizeSide(
+  raw: Record<string, unknown> | null | undefined,
+  key: string
+): NormalizedMatchSide {
+  const version = (raw?.version as string) ?? null;
+  const contentLang =
+    (raw?.content_lang as string) ?? (raw?.display_lang as string) ?? null;
+  return {
+    key,
+    ref: version ? `${key}@${version}` : null,
+    path: (raw?.path as string) || null,
+    version,
+    contentLang,
+  };
+}
+
+/** Pure: turns one parsed rate file into a LoadedMatch, or null when the file
+ *  carries no usable verdict (no winner, missing keys, TODO). Same filters the
+ *  three legacy readers applied, in one place. */
+export function normalizeMatch(
+  data: Record<string, unknown>,
+  content: string,
+  filePath: string
+): LoadedMatch | null {
+  let winner = data.winner as string;
+  if (data.override && data.override !== "null")
+    winner = data.override as string;
+  if (winner === "TODO" || !winner) return null;
+  if (winner !== "a" && winner !== "b") return null;
+
+  const aKey = postKey(data.post_a as { key?: string; slug?: string } | null);
+  const bKey = postKey(data.post_b as { key?: string; slug?: string } | null);
+  if (!aKey || !bKey) return null;
+
+  const rawRunAt = (data.run_at ?? data.run_id ?? "") as string | Date;
+  const runAtRaw =
+    rawRunAt instanceof Date ? rawRunAt.toISOString() : String(rawRunAt);
+  const parsed = runAtRaw ? new Date(runAtRaw) : null;
+  const runAt = parsed && !Number.isNaN(parsed.getTime()) ? parsed : null;
+
+  const postA = data.post_a as Record<string, unknown> | null;
+  const postB = data.post_b as Record<string, unknown> | null;
+
+  const norm: NormalizedMatch = {
+    id: matchId(aKey, bKey, runAtRaw),
+    kind: classifyKind(aKey, bKey),
+    winnerSide: winner,
+    runAt,
+    postA: normalizeSide(postA, aKey),
+    postB: normalizeSide(postB, bKey),
+    reviewLang:
+      (data.review_lang as string) ?? (data.eval_lang as string) ?? null,
+    agentId: asString(data.agent_id),
+    perspectiveId: asString(data.perspective_id),
+    rateA: asFiniteNumber(data.rate_a),
+    rateB: asFiniteNumber(data.rate_b),
+    evaluatorMood: asString(data.evaluator_mood),
+    evaluatorMoodAfter: asString(data.evaluator_mood_after),
+  };
+
+  return { norm, filename: filePath, runAtRaw, data, content };
+}
+
+// RFC 0010 §4.7 (E1): memoized against matchesDataVersion so a writeMatch in
+// the same process (decide, migrate) invalidates the snapshot.
+let _normCache: { version: number; matches: LoadedMatch[] } | null = null;
+
+/** The single parse pass over the rate files. Consumers map this to their own
+ *  shape (RawMatch, DuelEntry) instead of reading the files again. */
+export function loadMatches(): LoadedMatch[] {
+  const version = matchesDataVersion();
+  if (_normCache && _normCache.version === version) return _normCache.matches;
+  const out: LoadedMatch[] = [];
+  for (const f of listMatchFiles()) {
+    const { data, content } = readMatch(f);
+    const lm = normalizeMatch(data as Record<string, unknown>, content, f);
+    if (lm) out.push(lm);
+  }
+  _normCache = { version, matches: out };
+  return out;
+}
+
+/** RFC 0012 §4.1 public API: the normalized matches without the raw passthrough
+ *  material. */
+export function loadNormalizedMatches(): NormalizedMatch[] {
+  return loadMatches().map((m) => m.norm);
 }
 
 // RFC 0010 §4.7 (E3): one `git log --name-only` walk builds a last-commit-time

--- a/src/hronir/ranking.ts
+++ b/src/hronir/ranking.ts
@@ -1,10 +1,5 @@
 import { rating, rate, ordinal } from "openskill";
-import {
-  listMatchFiles,
-  readMatch,
-  postKey,
-  matchesDataVersion,
-} from "./matches.js";
+import { loadMatches, matchesDataVersion } from "./matches.js";
 import type { RankRow, PerspectiveRankRow } from "./types.js";
 
 export const MIN_APPEARANCES = 3;
@@ -41,51 +36,27 @@ let _rawCache: { version: number; raw: RawMatch[] } | null = null;
 function _loadMatchData(): RawMatch[] {
   const version = matchesDataVersion();
   if (_rawCache && _rawCache.version === version) return _rawCache.raw;
-  const raw: RawMatch[] = [];
-  for (const f of listMatchFiles()) {
-    const { data } = readMatch(f);
-    let winner = data.winner as string;
-    if (data.override && data.override !== "null")
-      winner = data.override as string;
-    if (winner === "TODO" || !winner) continue;
-
-    const aKey = postKey(data.post_a as { key?: string; slug?: string } | null);
-    const bKey = postKey(data.post_b as { key?: string; slug?: string } | null);
-    if (!aKey || !bKey) continue;
-    if (winner !== "a" && winner !== "b") continue;
-
-    const rawRunAt = (data.run_at ?? data.run_id ?? "") as string | Date;
-    const runAt =
-      rawRunAt instanceof Date ? rawRunAt.toISOString() : String(rawRunAt);
-
-    const rateA =
-      typeof data.rate_a === "number" && Number.isFinite(data.rate_a)
-        ? (data.rate_a as number)
-        : null;
-    const rateB =
-      typeof data.rate_b === "number" && Number.isFinite(data.rate_b)
-        ? (data.rate_b as number)
-        : null;
-
-    const postA = data.post_a as Record<string, unknown> | null;
-    const postB = data.post_b as Record<string, unknown> | null;
-
-    raw.push({
-      runAt,
-      filename: f,
-      aKey,
-      bKey,
-      aPath: (postA?.path as string) || "",
-      bPath: (postB?.path as string) || "",
-      aVersion: (postA?.version as string) ?? null,
-      bVersion: (postB?.version as string) ?? null,
-      agentId: data.agent_id ? String(data.agent_id) : null,
-      perspectiveId: data.perspective_id ? String(data.perspective_id) : null,
-      winner: winner as "a" | "b",
-      rateA,
-      rateB,
-    });
-  }
+  // RFC 0012 §4.1: one normalizer feeds every reader. RawMatch is just a flat
+  // projection of the normalized record (version duels included — _computeRatings
+  // skips same-key pairs, _computeVersionRatings keeps only those).
+  const raw: RawMatch[] = loadMatches().map((lm) => {
+    const n = lm.norm;
+    return {
+      runAt: lm.runAtRaw,
+      filename: lm.filename,
+      aKey: n.postA.key,
+      bKey: n.postB.key,
+      aPath: n.postA.path || "",
+      bPath: n.postB.path || "",
+      aVersion: n.postA.version,
+      bVersion: n.postB.version,
+      agentId: n.agentId,
+      perspectiveId: n.perspectiveId,
+      winner: n.winnerSide,
+      rateA: n.rateA,
+      rateB: n.rateB,
+    };
+  });
   _rawCache = { version, raw };
   return raw;
 }
@@ -524,30 +495,18 @@ export function computePerPerspectiveRatings(): Map<
     }>
   >();
 
-  for (const f of listMatchFiles()) {
-    const { data } = readMatch(f);
-    let winner = data.winner as string;
-    if (data.override && data.override !== "null")
-      winner = data.override as string;
-    if (winner === "TODO" || !winner) continue;
-
-    const aKey = postKey(data.post_a as { key?: string; slug?: string } | null);
-    const bKey = postKey(data.post_b as { key?: string; slug?: string } | null);
-    if (!aKey || !bKey) continue;
-    if (winner !== "a" && winner !== "b") continue;
-    if (aKey === bKey) continue;
-
-    const perspId = data.perspective_id ? String(data.perspective_id) : null;
-    if (!perspId) continue;
-
-    const rawRunAt = (data.run_at ?? data.run_id ?? "") as string | Date;
-    const runAt =
-      rawRunAt instanceof Date ? rawRunAt.toISOString() : String(rawRunAt);
-
-    if (!byPerspective.has(perspId)) byPerspective.set(perspId, []);
-    byPerspective
-      .get(perspId)!
-      .push({ runAt, aKey, bKey, winner: winner as "a" | "b" });
+  for (const lm of loadMatches()) {
+    const n = lm.norm;
+    if (n.kind === "version") continue; // RFC 0012: version duels never rank works
+    if (!n.perspectiveId) continue;
+    if (!byPerspective.has(n.perspectiveId))
+      byPerspective.set(n.perspectiveId, []);
+    byPerspective.get(n.perspectiveId)!.push({
+      runAt: lm.runAtRaw,
+      aKey: n.postA.key,
+      bKey: n.postB.key,
+      winner: n.winnerSide,
+    });
   }
 
   const result = new Map<string, PerspectiveRankRow[]>();

--- a/src/hronir/types.ts
+++ b/src/hronir/types.ts
@@ -8,11 +8,23 @@ export interface PostSide {
   path: string;
   display_lang?: "en" | "pt";
   version?: string;
+  /** RFC 0012 §4.2: language of this side's text. Written in stars-v3;
+   *  derived from the post frontmatter / `display_lang` for older files. */
+  content_lang?: "en" | "pt";
 }
 
 export interface RateFile {
+  // RFC 0012 §4.2: stars-v1/v2 stay valid and are classified `legacy`; new
+  // sessions write stars-v3. `schema` is historically only ever "stars-v1";
+  // the active marker is `prompt_version`.
   schema?: "stars-v1";
   prompt_version?: string;
+  /** RFC 0012 §4.1: redundant with `aKey === bKey`, validated against it,
+   *  never trusted in isolation. Written for human inspection in stars-v3. */
+  match_kind?: MatchKind;
+  /** RFC 0012 §6: language the review/clash was written in. Supersedes the
+   *  ambiguous `eval_lang` for stars-v3 files. */
+  review_lang?: "en" | "pt";
   agent_id?: string;
   run_at?: string | Date;
   season?: number;
@@ -34,6 +46,47 @@ export interface RateFile {
   margin?: number;
   confidence?: string;
   criterion?: string;
+}
+
+// ── Normalized match (RFC 0012) ─────────────────────────────────────────────
+
+// RFC 0012 §4.1: a match is `version` when both sides judge versions of the
+// same post (post_a.key === post_b.key) and `work` otherwise. The distinction
+// is structural — derivable from the rate file alone — not a regime of
+// evaluation (those live in RFC 0013). The classification is computed at load
+// time so every consumer (ranking, UI, snapshot, doctor) shares one source of
+// truth instead of re-deriving `aKey === bKey` ad hoc.
+export type MatchKind = "work" | "version";
+
+export interface NormalizedMatchSide {
+  key: string;
+  /** slug@uuid — the exact version judged. Null when no version is recorded. */
+  ref: string | null;
+  /** Cached file path; convenience for the UI, never an identity. */
+  path: string | null;
+  version: string | null;
+  contentLang: string | null;
+}
+
+// RFC 0012 §4.1. The single normalized shape the Fase 1 normalizer will emit;
+// declared here in Fase 0 so types land before any consumer migrates. It does
+// NOT carry an evaluation `mode` — regimes of evaluation are RFC 0013 and are
+// asserted (not derived), so they must not ride on this structural record.
+export interface NormalizedMatch {
+  id: string;
+  kind: MatchKind;
+  winnerSide: "a" | "b";
+  runAt: Date | null;
+  postA: NormalizedMatchSide;
+  postB: NormalizedMatchSide;
+  /** Language the review/clash was written in (RFC 0012 §6). */
+  reviewLang: string | null;
+  agentId: string | null;
+  perspectiveId: string | null;
+  rateA: number | null;
+  rateB: number | null;
+  evaluatorMood: string | null;
+  evaluatorMoodAfter: string | null;
 }
 
 // ── Ranking ────────────────────────────────────────────────────────────────

--- a/src/hronir/types.ts
+++ b/src/hronir/types.ts
@@ -141,6 +141,10 @@ export interface DuelEntry {
    *  exact content judged in a version trial. */
   postAPath?: string | null;
   postBPath?: string | null;
+  /** RFC 0012 §6: languages, for the discrete UI chips (content / critique). */
+  reviewLang?: string | null;
+  postAContentLang?: string | null;
+  postBContentLang?: string | null;
   perspectiveId?: string;
   rateA?: number;
   rateB?: number;

--- a/src/hronir/types.ts
+++ b/src/hronir/types.ts
@@ -131,6 +131,16 @@ export interface DuelEntry {
   season?: number;
   postAKey?: string;
   postBKey?: string;
+  /** RFC 0012 §6.2: slug@uuid of each side — the exact version judged. Equal
+   *  keys on both sides (a version duel) still resolve to two distinct refs. */
+  postARef?: string | null;
+  postBRef?: string | null;
+  postAVersion?: string | null;
+  postBVersion?: string | null;
+  /** Source file path of each side's version — used to build permalinks to the
+   *  exact content judged in a version trial. */
+  postAPath?: string | null;
+  postBPath?: string | null;
   perspectiveId?: string;
   rateA?: number;
   rateB?: number;

--- a/src/lib/hronir-rank.ts
+++ b/src/lib/hronir-rank.ts
@@ -145,6 +145,9 @@ function loadDuelData(): { stats: RankingStats; recent: DuelEntry[] } {
       postBVersion: n.postB.version,
       postAPath: n.postA.path,
       postBPath: n.postB.path,
+      reviewLang: n.reviewLang,
+      postAContentLang: n.postA.contentLang,
+      postBContentLang: n.postB.contentLang,
       perspectiveId: data.perspective_id
         ? String(data.perspective_id)
         : undefined,

--- a/src/lib/hronir-rank.ts
+++ b/src/lib/hronir-rank.ts
@@ -2,14 +2,13 @@
 // Reads .routines/hronir/*.md, runs OpenSkill, exposes a Map<key, RankRow>
 // keyed by translationKey, plus a sorted array.
 
-import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import {
   computeRatings,
   computePerPerspectiveRatings,
 } from "../hronir/ranking.js";
-import { listMatchFiles, readMatch, postKey } from "../hronir/matches.js";
+import { loadMatches, matchId } from "../hronir/matches.js";
 import { listPerspectives } from "../hronir/perspectives.js";
 import type {
   RankRow,
@@ -36,12 +35,9 @@ export type {
 export function duelId(
   d: Pick<DuelEntry, "postAKey" | "postBKey" | "runAt">
 ): string {
-  const canonical = [d.postAKey ?? "", d.postBKey ?? "", d.runAt].join("|");
-  return crypto
-    .createHash("sha256")
-    .update(canonical)
-    .digest("hex")
-    .slice(0, 8);
+  // RFC 0012: id generation lives in matches.matchId so the duel list and the
+  // normalizer agree on the value byte-for-byte.
+  return matchId(d.postAKey ?? "", d.postBKey ?? "", d.runAt);
 }
 
 export function parseDuelContent(
@@ -107,83 +103,58 @@ function loadDuelData(): { stats: RankingStats; recent: DuelEntry[] } {
   if (_statsCache) return _statsCache;
 
   const duels: DuelEntry[] = [];
-  for (const f of listMatchFiles()) {
-    const { data, content } = readMatch(f);
-    let winner = (data as any).winner;
-    if ((data as any).override && (data as any).override !== "null") {
-      winner = (data as any).override;
-    }
-    if (winner === "TODO" || !winner) continue;
-    const aKey = postKey((data as any).post_a);
-    const bKey = postKey((data as any).post_b);
-    if (!aKey || !bKey) continue;
-    if (winner !== "a" && winner !== "b") continue;
-
-    const rawRunAt = (data as any).run_at ?? (data as any).run_id ?? "";
-    const runAt =
-      rawRunAt instanceof Date ? rawRunAt.toISOString() : String(rawRunAt);
+  // RFC 0012 §4.1: built from the single normalizer. Structural decisions
+  // (winner side, keys, work/version kind, id, runAt) come from the normalized
+  // record; passthrough display fields are still read straight off the raw
+  // frontmatter so the rendered duel is byte-for-byte what it was before.
+  for (const lm of loadMatches()) {
+    const n = lm.norm;
+    const runAt = lm.runAtRaw;
     // Skip matches without a parseable timestamp: an empty runAt would
     // sort ahead of every real duel in the "Latest duels" list and
     // render with a placeholder date, which is worse than not showing it.
     if (!runAt) continue;
 
-    const winnerKey = winner === "a" ? aKey : bKey;
-    const loserKey = winner === "a" ? bKey : aKey;
+    const data = lm.data as any;
+    const content = lm.content;
+    const aKey = n.postA.key;
+    const bKey = n.postB.key;
+    const winnerKey = n.winnerSide === "a" ? aKey : bKey;
+    const loserKey = n.winnerSide === "a" ? bKey : aKey;
+    const agentId = data.agent_id ? String(data.agent_id) : undefined;
 
-    const agentId = (data as any).agent_id
-      ? String((data as any).agent_id)
-      : undefined;
-
-    const entry: DuelEntry = {
-      id: "",
+    duels.push({
+      id: n.id,
       runAt,
       winnerKey,
       loserKey,
-      winnerSide: winner as "a" | "b",
-      isVersionDuel: aKey === bKey,
-      margin:
-        typeof (data as any).margin === "number"
-          ? (data as any).margin
-          : undefined,
-      confidence: (data as any).confidence
-        ? String((data as any).confidence)
-        : undefined,
-      criterion: (data as any).criterion
-        ? String((data as any).criterion)
-        : undefined,
+      winnerSide: n.winnerSide,
+      isVersionDuel: n.kind === "version",
+      margin: typeof data.margin === "number" ? data.margin : undefined,
+      confidence: data.confidence ? String(data.confidence) : undefined,
+      criterion: data.criterion ? String(data.criterion) : undefined,
       body: content ? String(content).trim() : undefined,
       model: agentId,
       agentId,
-      season:
-        typeof (data as any).season === "number"
-          ? (data as any).season
-          : undefined,
+      season: typeof data.season === "number" ? data.season : undefined,
       postAKey: aKey,
       postBKey: bKey,
-      perspectiveId: (data as any).perspective_id
-        ? String((data as any).perspective_id)
+      perspectiveId: data.perspective_id
+        ? String(data.perspective_id)
         : undefined,
-      rateA:
-        typeof (data as any).rate_a === "number"
-          ? (data as any).rate_a
-          : undefined,
-      rateB:
-        typeof (data as any).rate_b === "number"
-          ? (data as any).rate_b
-          : undefined,
-      evaluatorMood: (data as any).evaluator_mood
-        ? String((data as any).evaluator_mood)
+      rateA: typeof data.rate_a === "number" ? data.rate_a : undefined,
+      rateB: typeof data.rate_b === "number" ? data.rate_b : undefined,
+      evaluatorMood: data.evaluator_mood
+        ? String(data.evaluator_mood)
         : undefined,
-      evaluatorMoodAfter: (data as any).evaluator_mood_after
-        ? String((data as any).evaluator_mood_after)
+      evaluatorMoodAfter: data.evaluator_mood_after
+        ? String(data.evaluator_mood_after)
         : undefined,
       parsedContent: parseDuelContent(
         content ? String(content).trim() : undefined,
         data as Record<string, unknown>
       ),
-    };
-    entry.id = duelId(entry);
-    duels.push(entry);
+    });
   }
 
   duels.sort((a, b) => b.runAt.localeCompare(a.runAt));
@@ -210,6 +181,21 @@ export function getRecentDuels(limit = 8): DuelEntry[] {
 
 export function getAllDuels(): DuelEntry[] {
   return loadDuelData().recent;
+}
+
+// RFC 0012 §6.4: the canonical duel accessor. `kind` is required — there is no
+// ambiguous default. "work" = editorial battles between distinct posts;
+// "version" = revision trials of one post; "all" = the raw archive. Fase 2
+// migrates the public surfaces (battles, dossiers, stats) onto this so they
+// stop mixing the two universes.
+export function getDuels(opts: {
+  kind: "work" | "version" | "all";
+}): DuelEntry[] {
+  const all = loadDuelData().recent;
+  if (opts.kind === "all") return all;
+  return all.filter(
+    (d) => (d.isVersionDuel ? "version" : "work") === opts.kind
+  );
 }
 
 export function getPerspectives(): PerspectiveMeta[] {

--- a/src/lib/hronir-rank.ts
+++ b/src/lib/hronir-rank.ts
@@ -139,6 +139,12 @@ function loadDuelData(): { stats: RankingStats; recent: DuelEntry[] } {
       season: typeof data.season === "number" ? data.season : undefined,
       postAKey: aKey,
       postBKey: bKey,
+      postARef: n.postA.ref,
+      postBRef: n.postB.ref,
+      postAVersion: n.postA.version,
+      postBVersion: n.postB.version,
+      postAPath: n.postA.path,
+      postBPath: n.postB.path,
       perspectiveId: data.perspective_id
         ? String(data.perspective_id)
         : undefined,
@@ -159,12 +165,15 @@ function loadDuelData(): { stats: RankingStats; recent: DuelEntry[] } {
 
   duels.sort((a, b) => b.runAt.localeCompare(a.runAt));
 
+  // RFC 0012 §6.1: editorial stats count only work duels. Version trials have
+  // their own surface and must not inflate "duels run".
+  const work = duels.filter((d) => !d.isVersionDuel);
   const rated = getRanking();
   const stats: RankingStats = {
-    totalDuels: duels.length,
+    totalDuels: work.length,
     totalRated: rated.length,
-    lastDuelAt: duels.length > 0 ? duels[0].runAt : null,
-    firstDuelAt: duels.length > 0 ? duels[duels.length - 1].runAt : null,
+    lastDuelAt: work.length > 0 ? work[0].runAt : null,
+    firstDuelAt: work.length > 0 ? work[work.length - 1].runAt : null,
   };
 
   _statsCache = { stats, recent: duels };
@@ -175,12 +184,25 @@ export function getRankingStats(): RankingStats {
   return loadDuelData().stats;
 }
 
+// RFC 0012 §6.1: "recent battles" on the ranking home are editorial only.
 export function getRecentDuels(limit = 8): DuelEntry[] {
-  return loadDuelData().recent.slice(0, limit);
+  return getDuels({ kind: "work" }).slice(0, limit);
 }
 
+// The raw archive (every duel, both kinds). Used by id resolution; public
+// listings should call getDuels({ kind }) with an explicit kind instead.
 export function getAllDuels(): DuelEntry[] {
   return loadDuelData().recent;
+}
+
+// RFC 0012 §6.2: all version trials, newest first.
+export function getVersionTrials(): DuelEntry[] {
+  return getDuels({ kind: "version" });
+}
+
+// Version trials for one post key (both sides share the key).
+export function getPostVersionTrials(key: string): DuelEntry[] {
+  return getDuels({ kind: "version" }).filter((d) => d.postAKey === key);
 }
 
 // RFC 0012 §6.4: the canonical duel accessor. `kind` is required — there is no
@@ -222,8 +244,12 @@ export function getDuelById(id: string): DuelEntry | undefined {
   return getAllDuels().find((d) => d.id === id);
 }
 
+// RFC 0012 §6.3: a post's editorial record is work duels only. Version trials
+// live in the dossier's "Edit history" section via getPostVersionTrials.
 export function getPostDuelHistory(key: string): DuelEntry[] {
-  return getAllDuels().filter((d) => d.postAKey === key || d.postBKey === key);
+  return getDuels({ kind: "work" }).filter(
+    (d) => d.postAKey === key || d.postBKey === key
+  );
 }
 
 const SNAPSHOT_PATH = path.join(

--- a/src/pages/ranking/battles/[id].astro
+++ b/src/pages/ranking/battles/[id].astro
@@ -1,7 +1,7 @@
 ---
 import PageLayout from "../../../layouts/PageLayout.astro";
 import { getCollection } from "astro:content";
-import { getAllDuels, getRankByKey } from "../../../lib/hronir-rank";
+import { getDuels, getRankByKey } from "../../../lib/hronir-rank";
 import { isPublished } from "../../../lib/publish";
 import { marked } from "marked";
 
@@ -17,27 +17,49 @@ export async function getStaticPaths() {
     if (!existing || lang === "en") byKey.set(key, { title: p.data.title, slug: p.id, lang });
   }
 
-  const duels = getAllDuels();
+  // RFC 0012: editorial (work) and version trials are distinct universes. Each
+  // duel detail navigates within its own kind, with its own archive backlink.
   const PER_PAGE = 20;
-  return duels.map((duel, i) => {
+  const work = getDuels({ kind: "work" });
+  const versions = getDuels({ kind: "version" });
+
+  const workPaths = work.map((duel, i) => {
     const archivePage = Math.floor(i / PER_PAGE) + 1;
     const archiveBase = archivePage === 1 ? "/ranking/battles/" : `/ranking/battles/page/${archivePage}/`;
-    const archiveHref = `${archiveBase}#${duel.id}`;
     return {
       params: { id: duel.id },
       props: {
         duel,
-        prevId: i + 1 < duels.length ? duels[i + 1].id : null,
-        nextId: i > 0 ? duels[i - 1].id : null,
-        archiveHref,
+        prevId: i + 1 < work.length ? work[i + 1].id : null,
+        nextId: i > 0 ? work[i - 1].id : null,
+        archiveHref: `${archiveBase}#${duel.id}`,
+        archiveLabel: "All battles",
         postAInfo: byKey.get(duel.postAKey ?? ""),
         postBInfo: byKey.get(duel.postBKey ?? ""),
       },
     };
   });
+
+  const versionPaths = versions.map((duel, i) => ({
+    params: { id: duel.id },
+    props: {
+      duel,
+      prevId: i + 1 < versions.length ? versions[i + 1].id : null,
+      nextId: i > 0 ? versions[i - 1].id : null,
+      archiveHref: `/ranking/versions/${duel.postAKey ?? ""}/`,
+      archiveLabel: "Version trials",
+      postAInfo: byKey.get(duel.postAKey ?? ""),
+      postBInfo: byKey.get(duel.postBKey ?? ""),
+    },
+  }));
+
+  return [...workPaths, ...versionPaths];
 }
 
-const { duel, prevId, nextId, archiveHref, postAInfo, postBInfo } = Astro.props;
+const { duel, prevId, nextId, archiveHref, archiveLabel, postAInfo, postBInfo } =
+  Astro.props;
+
+const isVersion = duel.isVersionDuel === true;
 
 function postHref(info: { slug: string; lang: string } | undefined) {
   if (!info) return null;
@@ -47,6 +69,11 @@ function postHref(info: { slug: string; lang: string } | undefined) {
 function dossierHref(key: string | undefined) {
   if (!key) return null;
   return `/ranking/posts/${key}/`;
+}
+
+const REPO = "https://github.com/franklinbaldo/franklinbaldo.github.io";
+function sourceHref(path: string | null | undefined) {
+  return path ? `${REPO}/blob/main/${path}` : null;
 }
 
 const winnerIsA = duel.winnerSide
@@ -60,6 +87,13 @@ const winnerTitle = winnerInfo?.title ?? winnerKey;
 const loserTitle = loserInfo?.title ?? loserKey;
 const winnerHref = postHref(winnerInfo);
 const loserHref = postHref(loserInfo);
+
+// Version trials: both sides share the post; the identity is the slug@uuid ref.
+const postTitle = postAInfo?.title ?? duel.postAKey ?? "";
+const winnerRef = winnerIsA ? duel.postARef : duel.postBRef;
+const loserRef = winnerIsA ? duel.postBRef : duel.postARef;
+const winnerSrc = sourceHref(winnerIsA ? duel.postAPath : duel.postBPath);
+const loserSrc = sourceHref(winnerIsA ? duel.postBPath : duel.postAPath);
 
 const rateWinner = winnerIsA ? duel.rateA : duel.rateB;
 const rateLoser = winnerIsA ? duel.rateB : duel.rateA;
@@ -78,12 +112,17 @@ function perspectiveHue(id: string): number {
   return Math.abs(h) % 360;
 }
 
-const pageTitle = `${winnerTitle} vs ${loserTitle}`;
-const pageDesc = `Hrönir duel: ${winnerTitle} beat ${loserTitle}${duel.perspectiveId ? ` under the ${duel.perspectiveId} perspective` : ""}.`;
+const pageTitle = isVersion
+  ? `Version trial — ${postTitle}`
+  : `${winnerTitle} vs ${loserTitle}`;
+const pageDesc = isVersion
+  ? `Hrönir version trial for "${postTitle}": ${winnerRef} beat ${loserRef}.`
+  : `Hrönir duel: ${winnerTitle} beat ${loserTitle}${duel.perspectiveId ? ` under the ${duel.perspectiveId} perspective` : ""}.`;
 
+// Global rank is editorial-only; a version trial never carries one.
 const rankByKey = getRankByKey();
-const winnerRank = rankByKey.get(winnerKey);
-const loserRank = rankByKey.get(loserKey);
+const winnerRank = isVersion ? undefined : rankByKey.get(winnerKey);
+const loserRank = isVersion ? undefined : rankByKey.get(loserKey);
 ---
 
 <PageLayout title={`${pageTitle} | Ranking Battles`} description={pageDesc} lang="en">
@@ -91,19 +130,23 @@ const loserRank = rankByKey.get(loserKey);
     <ol>
       <li><a href="/">Home</a></li>
       <li><a href="/ranking/">Ranking</a></li>
-      <li><a href="/ranking/battles/">All battles</a></li>
-      <li aria-current="page">{winnerTitle} vs {loserTitle}</li>
+      <li><a href={archiveHref}>{archiveLabel}</a></li>
+      <li aria-current="page">{pageTitle}</li>
     </ol>
   </nav>
 
   <hgroup>
-    <h1>Battle Report</h1>
+    <h1>{isVersion ? "Version Trial" : "Battle Report"}</h1>
     <p><small>{fmtDate(duel.runAt)}</small></p>
   </hgroup>
 
   <div class="battle-tags">
     {duel.season !== undefined && <span class="tag tag-season">Season {duel.season}</span>}
-    {duel.isVersionDuel && <span class="tag">version duel</span>}
+    {isVersion && (
+      <span class="tag">
+        <a href={`/ranking/versions/${duel.postAKey}/`}>version trial</a>
+      </span>
+    )}
     {duel.perspectiveId && (
       <span class="tag tag-perspective" style={`--ph:${perspectiveHue(duel.perspectiveId)}`}>
         <a href={`/ranking/perspectives/${duel.perspectiveId}/`}>{duel.perspectiveId.replace(/-/g, " ")}</a>
@@ -113,21 +156,34 @@ const loserRank = rankByKey.get(loserKey);
     {duel.confidence && <span class={`tag tag-confidence conf-${duel.confidence}`}>{duel.confidence} confidence</span>}
   </div>
 
+  {isVersion && (
+    <p class="version-note">
+      A revision trial of <a href={`/ranking/versions/${duel.postAKey}/`}>{postTitle}</a> —
+      two versions of the same post compared. This does not affect the editorial ranking.
+    </p>
+  )}
+
   <section class="versus-section" aria-label="Versus">
     <div class="versus-grid">
       <div class="versus-side winner">
         <div class="versus-label">Winner 🏆</div>
         <div class="versus-title">
-          {winnerHref
-            ? <a href={winnerHref}>{winnerTitle}</a>
-            : <span>{winnerTitle}</span>}
+          {isVersion
+            ? <code>{winnerRef}</code>
+            : winnerHref
+              ? <a href={winnerHref}>{winnerTitle}</a>
+              : <span>{winnerTitle}</span>}
         </div>
         {hasRates && <div class="versus-rate">{rateWinner!.toFixed(2)}</div>}
-        {winnerRank && (
-          <div class="versus-rank">
-            <a href={dossierHref(winnerKey) ?? "/ranking/"}>#{winnerRank.rank}/{winnerRank.total}</a>
-          </div>
-        )}
+        {isVersion
+          ? winnerSrc && (
+              <div class="versus-rank"><a href={winnerSrc}>read source →</a></div>
+            )
+          : winnerRank && (
+              <div class="versus-rank">
+                <a href={dossierHref(winnerKey) ?? "/ranking/"}>#{winnerRank.rank}/{winnerRank.total}</a>
+              </div>
+            )}
       </div>
 
       <div class="versus-center">
@@ -135,18 +191,24 @@ const loserRank = rankByKey.get(loserKey);
       </div>
 
       <div class="versus-side loser">
-        <div class="versus-label">Challenger</div>
+        <div class="versus-label">{isVersion ? "Challenger version" : "Challenger"}</div>
         <div class="versus-title">
-          {loserHref
-            ? <a href={loserHref}>{loserTitle}</a>
-            : <span>{loserTitle}</span>}
+          {isVersion
+            ? <code>{loserRef}</code>
+            : loserHref
+              ? <a href={loserHref}>{loserTitle}</a>
+              : <span>{loserTitle}</span>}
         </div>
         {hasRates && <div class="versus-rate loser-rate">{rateLoser!.toFixed(2)}</div>}
-        {loserRank && (
-          <div class="versus-rank">
-            <a href={dossierHref(loserKey) ?? "/ranking/"}>#{loserRank.rank}/{loserRank.total}</a>
-          </div>
-        )}
+        {isVersion
+          ? loserSrc && (
+              <div class="versus-rank"><a href={loserSrc}>read source →</a></div>
+            )
+          : loserRank && (
+              <div class="versus-rank">
+                <a href={dossierHref(loserKey) ?? "/ranking/"}>#{loserRank.rank}/{loserRank.total}</a>
+              </div>
+            )}
       </div>
     </div>
 
@@ -222,6 +284,8 @@ const loserRank = rankByKey.get(loserKey);
   .breadcrumb a:hover { text-decoration: underline; }
 
   .battle-tags { display: flex; flex-wrap: wrap; gap: 0.4rem; margin-bottom: 1.5rem; }
+  .version-note { font-size: 0.85rem; color: var(--pico-muted-color); margin: 0 0 1.5rem; }
+  .versus-title code { font-size: 0.82rem; word-break: break-all; }
   .tag {
     font-size: 0.68rem; text-transform: uppercase; letter-spacing: 0.05em;
     padding: 0.15rem 0.5rem; border-radius: 4px;

--- a/src/pages/ranking/battles/[id].astro
+++ b/src/pages/ranking/battles/[id].astro
@@ -112,6 +112,17 @@ function perspectiveHue(id: string): number {
   return Math.abs(h) % 360;
 }
 
+// RFC 0012 §6 rule 4: discrete language chips. Content can differ per side in
+// a work duel; collapse to one chip when both sides share a language.
+const contentLangs = [
+  ...new Set(
+    [duel.postAContentLang, duel.postBContentLang]
+      .filter((l): l is string => Boolean(l))
+      .map((l) => l.toUpperCase())
+  ),
+].join("/");
+const critiqueLang = duel.reviewLang ? duel.reviewLang.toUpperCase() : null;
+
 const pageTitle = isVersion
   ? `Version trial — ${postTitle}`
   : `${winnerTitle} vs ${loserTitle}`;
@@ -154,6 +165,8 @@ const loserRank = isVersion ? undefined : rankByKey.get(loserKey);
     )}
     {duel.agentId && <span class="tag tag-agent">{duel.agentId}</span>}
     {duel.confidence && <span class={`tag tag-confidence conf-${duel.confidence}`}>{duel.confidence} confidence</span>}
+    {contentLangs && <span class="tag tag-lang">content: {contentLangs}</span>}
+    {critiqueLang && <span class="tag tag-lang">critique: {critiqueLang}</span>}
   </div>
 
   {isVersion && (
@@ -285,6 +298,7 @@ const loserRank = isVersion ? undefined : rankByKey.get(loserKey);
 
   .battle-tags { display: flex; flex-wrap: wrap; gap: 0.4rem; margin-bottom: 1.5rem; }
   .version-note { font-size: 0.85rem; color: var(--pico-muted-color); margin: 0 0 1.5rem; }
+  .tag-lang { font-family: var(--pico-font-family-monospace); text-transform: none; letter-spacing: 0; }
   .versus-title code { font-size: 0.82rem; word-break: break-all; }
   .tag {
     font-size: 0.68rem; text-transform: uppercase; letter-spacing: 0.05em;

--- a/src/pages/ranking/battles/index.astro
+++ b/src/pages/ranking/battles/index.astro
@@ -1,7 +1,7 @@
 ---
 import PageLayout from "../../../layouts/PageLayout.astro";
 import { getCollection } from "astro:content";
-import { getAllDuels } from "../../../lib/hronir-rank";
+import { getDuels } from "../../../lib/hronir-rank";
 import { isPublished } from "../../../lib/publish";
 
 const allPosts = await getCollection("blog");
@@ -15,7 +15,8 @@ for (const p of allPosts) {
   if (!existing || lang === "en") byKey.set(key, { title: p.data.title, slug: p.id, lang });
 }
 
-const allDuels = getAllDuels();
+// RFC 0012 §6.1/§6.4: the archive is editorial (work) battles only.
+const allDuels = getDuels({ kind: "work" });
 const PER_PAGE = 20;
 const totalPages = Math.ceil(allDuels.length / PER_PAGE);
 const duels = allDuels.slice(0, PER_PAGE);
@@ -59,7 +60,8 @@ const agents = [...new Set(allDuels.map((d) => d.agentId).filter(Boolean) as str
 
   <hgroup>
     <h1>Battle Archive</h1>
-    <p><small>{allDuels.length} duels · click any battle to read the full analysis and verdict</small></p>
+    <p><small>{allDuels.length} editorial duels · click any battle to read the full analysis and verdict</small></p>
+    <p><small><a href="/ranking/version-trials/">→ Version trials</a> (revisions of a single post)</small></p>
   </hgroup>
 
   <div class="battle-filters" id="battle-filters">
@@ -136,7 +138,6 @@ const agents = [...new Set(allDuels.map((d) => d.agentId).filter(Boolean) as str
             <div class="battle-meta">
               <span class="battle-date">{fmtDate(d.runAt)}</span>
               {d.season !== undefined && <span class="tag tag-season">S{d.season}</span>}
-              {d.isVersionDuel && <span class="tag">version duel</span>}
               {d.perspectiveId && (
                 <span class="tag tag-perspective" style={`--ph:${perspectiveHue(d.perspectiveId)}`}>
                   {d.perspectiveId.replace(/-/g, " ")}

--- a/src/pages/ranking/battles/page/[n].astro
+++ b/src/pages/ranking/battles/page/[n].astro
@@ -1,11 +1,11 @@
 ---
 import PageLayout from "../../../../layouts/PageLayout.astro";
 import { getCollection } from "astro:content";
-import { getAllDuels } from "../../../../lib/hronir-rank";
+import { getDuels } from "../../../../lib/hronir-rank";
 import { isPublished } from "../../../../lib/publish";
 
 export function getStaticPaths() {
-  const allDuels = getAllDuels();
+  const allDuels = getDuels({ kind: "work" });
   const PER_PAGE = 20;
   const totalPages = Math.ceil(allDuels.length / PER_PAGE);
   // Only generate pages 2+ (page 1 is battles/index.astro)
@@ -148,7 +148,6 @@ const agents = [...new Set(duels.map((d) => d.agentId).filter(Boolean) as string
             <div class="battle-meta">
               <span class="battle-date">{fmtDate(d.runAt)}</span>
               {d.season !== undefined && <span class="tag tag-season">S{d.season}</span>}
-              {d.isVersionDuel && <span class="tag">version duel</span>}
               {d.perspectiveId && (
                 <span class="tag tag-perspective" style={`--ph:${perspectiveHue(d.perspectiveId)}`}>
                   {d.perspectiveId.replace(/-/g, " ")}

--- a/src/pages/ranking/posts/[key].astro
+++ b/src/pages/ranking/posts/[key].astro
@@ -4,6 +4,7 @@ import { getCollection } from "astro:content";
 import {
   getRanking,
   getPostDuelHistory,
+  getPostVersionTrials,
   getPerPerspectiveRankings,
   getPerspectives,
   getSnapshotDelta,
@@ -44,6 +45,7 @@ const postHref = postInfo
   : null;
 
 const duels = getPostDuelHistory(key);
+const versionTrials = getPostVersionTrials(key);
 
 // Per-perspective rankings
 const perPerspective = getPerPerspectiveRankings();
@@ -244,6 +246,34 @@ function fmtDate(iso: string): string {
       </ol>
     )}
   </section>
+
+  {versionTrials.length > 0 && (
+    <section class="edit-history">
+      <h2>Edit history <small>({versionTrials.length} version {versionTrials.length === 1 ? "trial" : "trials"})</small></h2>
+      <p class="edit-blurb">
+        Revisions of this post compared head-to-head. These trials decide which
+        version is published; they do not affect the editorial ranking above.
+        <a href={`/ranking/versions/${key}/`}>See full genealogy →</a>
+      </p>
+      <ol class="trial-list">
+        {versionTrials.slice(0, 5).map((t) => {
+          const wRef = t.winnerSide === "a" ? t.postARef : t.postBRef;
+          const lRef = t.winnerSide === "a" ? t.postBRef : t.postARef;
+          return (
+            <li>
+              <div class="trial-row">
+                <span class="trial-date">{fmtDate(t.runAt)}</span>
+                <code class="trial-win">{wRef}</code>
+                <span class="trial-beat">beat</span>
+                <code class="trial-lose">{lRef}</code>
+                {t.id && <a class="trial-link" href={`/ranking/battles/${t.id}/`}>analysis →</a>}
+              </div>
+            </li>
+          );
+        })}
+      </ol>
+    </section>
+  )}
 </PageLayout>
 
 <style>
@@ -512,5 +542,54 @@ function fmtDate(iso: string): string {
   .empty {
     color: var(--pico-muted-color);
     font-style: italic;
+  }
+  .edit-history {
+    margin-top: 2.5rem;
+  }
+  .edit-history h2 {
+    font-size: 1rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--pico-muted-color);
+  }
+  .edit-blurb {
+    font-size: 0.82rem;
+    color: var(--pico-muted-color);
+    margin: 0 0 0.75rem;
+  }
+  .trial-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+  }
+  .trial-row {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.4rem;
+    font-size: 0.82rem;
+  }
+  .trial-date {
+    font-family: var(--pico-font-family-monospace);
+    font-size: 0.7rem;
+    color: var(--pico-muted-color);
+  }
+  .trial-row code {
+    font-size: 0.74rem;
+    word-break: break-all;
+  }
+  .trial-win {
+    color: var(--pico-primary);
+  }
+  .trial-beat {
+    color: var(--pico-muted-color);
+    font-size: 0.72rem;
+  }
+  .trial-link {
+    margin-left: auto;
+    font-size: 0.78rem;
   }
 </style>

--- a/src/pages/ranking/version-trials/index.astro
+++ b/src/pages/ranking/version-trials/index.astro
@@ -1,0 +1,156 @@
+---
+import PageLayout from "../../../layouts/PageLayout.astro";
+import { getCollection } from "astro:content";
+import { getVersionTrials } from "../../../lib/hronir-rank";
+import { isPublished } from "../../../lib/publish";
+
+// RFC 0012 §6.2: the version-trial archive — revisions of a single post
+// compared head-to-head. Separate universe from the editorial battle archive.
+const allPosts = await getCollection("blog");
+const byKey = new Map<string, { title: string; slug: string; lang: string }>();
+for (const p of allPosts) {
+  if (!isPublished(p)) continue;
+  const key = p.data.translationKey;
+  if (!key) continue;
+  const lang = p.data.lang ?? "en";
+  const existing = byKey.get(key);
+  if (!existing || lang === "en")
+    byKey.set(key, { title: p.data.title, slug: p.id, lang });
+}
+
+const trials = getVersionTrials();
+
+// Group by post key: one genealogy entry per post that has been revised.
+const groups = new Map<
+  string,
+  { key: string; title: string; count: number; latest: string }
+>();
+for (const t of trials) {
+  const key = t.postAKey ?? "";
+  const existing = groups.get(key);
+  if (existing) {
+    existing.count += 1;
+  } else {
+    groups.set(key, {
+      key,
+      title: byKey.get(key)?.title ?? key,
+      count: 1,
+      latest: t.runAt,
+    });
+  }
+}
+const groupList = [...groups.values()].sort((a, b) =>
+  b.latest.localeCompare(a.latest)
+);
+
+function fmtDate(iso: string) {
+  return new Date(iso).toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}
+---
+
+<PageLayout
+  title="Version Trials | Ranking | Franklin Baldo"
+  description="Head-to-head trials between revisions of a single post — which version gets published."
+  lang="en"
+>
+  <nav class="breadcrumb" aria-label="Breadcrumb">
+    <ol>
+      <li><a href="/">Home</a></li>
+      <li><a href="/ranking/">Ranking</a></li>
+      <li aria-current="page">Version trials</li>
+    </ol>
+  </nav>
+
+  <hgroup>
+    <h1>Version Trials</h1>
+    <p>
+      <small>
+        {trials.length} trials across {groupList.length} posts · revisions of one
+        post compared to decide which version is published. These do not affect
+        the <a href="/ranking/battles/">editorial ranking</a>.
+      </small>
+    </p>
+  </hgroup>
+
+  {groupList.length === 0 ? (
+    <div class="empty-state"><em>No version trials yet.</em></div>
+  ) : (
+    <ul class="vt-list">
+      {groupList.map((g) => (
+        <li class="vt-item">
+          <a href={`/ranking/versions/${g.key}/`} class="vt-link">
+            <span class="vt-title">{g.title}</span>
+            <span class="vt-meta">
+              {g.count} {g.count === 1 ? "trial" : "trials"} · latest {fmtDate(g.latest)}
+            </span>
+          </a>
+        </li>
+      ))}
+    </ul>
+  )}
+</PageLayout>
+
+<style>
+  .breadcrumb ol {
+    list-style: none;
+    padding: 0;
+    margin: 0 0 1rem;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0;
+    font-size: 0.8rem;
+    color: var(--pico-muted-color);
+  }
+  .breadcrumb li + li::before {
+    content: " / ";
+    padding: 0 0.35em;
+  }
+  .breadcrumb a {
+    color: var(--pico-muted-color);
+    text-decoration: none;
+  }
+  .breadcrumb a:hover {
+    text-decoration: underline;
+  }
+  .vt-list {
+    list-style: none;
+    padding: 0;
+    margin: 1rem 0 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+  .vt-link {
+    display: flex;
+    flex-direction: column;
+    gap: 0.2rem;
+    padding: 0.8rem 1rem;
+    border: 1px solid var(--pico-muted-border-color);
+    border-radius: var(--pico-border-radius);
+    background: var(--pico-card-background-color);
+    text-decoration: none;
+    color: inherit;
+    transition: border-color 0.15s;
+  }
+  .vt-link:hover {
+    border-color: var(--pico-primary);
+  }
+  .vt-title {
+    font-weight: 600;
+  }
+  .vt-meta {
+    font-size: 0.78rem;
+    color: var(--pico-muted-color);
+  }
+  .empty-state {
+    padding: 2rem;
+    text-align: center;
+    color: var(--pico-muted-color);
+    border: 1px dashed var(--pico-muted-border-color);
+    border-radius: var(--pico-border-radius);
+  }
+</style>

--- a/src/pages/ranking/versions/[key].astro
+++ b/src/pages/ranking/versions/[key].astro
@@ -1,0 +1,253 @@
+---
+import PageLayout from "../../../layouts/PageLayout.astro";
+import { getCollection } from "astro:content";
+import {
+  getVersionTrials,
+  getPostVersionTrials,
+} from "../../../lib/hronir-rank";
+import { isPublished } from "../../../lib/publish";
+
+// RFC 0012 §6.2: genealogy of one post's revisions — every version trial, the
+// distinct versions seen, and permalinks to the exact content judged.
+export async function getStaticPaths() {
+  const keys = new Set(
+    getVersionTrials()
+      .map((t) => t.postAKey)
+      .filter((k): k is string => Boolean(k))
+  );
+
+  const allPosts = await getCollection("blog");
+  const byKey = new Map<string, { title: string; slug: string; lang: string }>();
+  for (const p of allPosts) {
+    if (!isPublished(p)) continue;
+    const key = p.data.translationKey;
+    if (!key) continue;
+    const lang = p.data.lang ?? "en";
+    const existing = byKey.get(key);
+    if (!existing || lang === "en")
+      byKey.set(key, { title: p.data.title, slug: p.id, lang });
+  }
+
+  return [...keys].map((key) => ({
+    params: { key },
+    props: { key, info: byKey.get(key) ?? null },
+  }));
+}
+
+const { key, info } = Astro.props;
+const trials = getPostVersionTrials(key);
+const title = info?.title ?? key;
+const postHref = info
+  ? info.lang === "pt"
+    ? `/pt/blog/${info.slug}/`
+    : `/blog/${info.slug}/`
+  : null;
+
+const REPO = "https://github.com/franklinbaldo/franklinbaldo.github.io";
+function sourceHref(path: string | null | undefined) {
+  return path ? `${REPO}/blob/main/${path}` : null;
+}
+
+// Distinct versions seen across all trials, with their source paths and a
+// win/loss tally — a lightweight genealogy.
+const versions = new Map<
+  string,
+  { ref: string; path: string | null; wins: number; losses: number }
+>();
+function note(
+  version: string | null | undefined,
+  ref: string | null | undefined,
+  path: string | null | undefined,
+  won: boolean
+) {
+  if (!version) return;
+  const v = versions.get(version) ?? {
+    ref: ref ?? version,
+    path: path ?? null,
+    wins: 0,
+    losses: 0,
+  };
+  if (won) v.wins += 1;
+  else v.losses += 1;
+  versions.set(version, v);
+}
+for (const t of trials) {
+  const aWon = t.winnerSide === "a";
+  note(t.postAVersion, t.postARef, t.postAPath, aWon);
+  note(t.postBVersion, t.postBRef, t.postBPath, !aWon);
+}
+const versionList = [...versions.values()].sort(
+  (a, b) => b.wins - a.wins || a.ref.localeCompare(b.ref)
+);
+
+function fmtDate(iso: string) {
+  return new Date(iso).toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}
+---
+
+<PageLayout
+  title={`${title} — Version genealogy | Franklin Baldo`}
+  description={`Version trials and revision genealogy for "${title}".`}
+  lang="en"
+>
+  <nav class="breadcrumb" aria-label="Breadcrumb">
+    <ol>
+      <li><a href="/">Home</a></li>
+      <li><a href="/ranking/">Ranking</a></li>
+      <li><a href="/ranking/version-trials/">Version trials</a></li>
+      <li aria-current="page">{title}</li>
+    </ol>
+  </nav>
+
+  <hgroup>
+    <h1>{title}</h1>
+    <p class="links">
+      {postHref && <a href={postHref}>Read published version →</a>}
+      <a href={`/ranking/posts/${key}/`}>Dossier →</a>
+    </p>
+  </hgroup>
+
+  <section class="genealogy">
+    <h2>Versions <small>({versionList.length})</small></h2>
+    <ul class="ver-list">
+      {versionList.map((v) => (
+        <li class="ver-item">
+          <code>{v.ref}</code>
+          <span class="ver-tally">{v.wins}W / {v.losses}L</span>
+          {sourceHref(v.path) && <a href={sourceHref(v.path)!}>source →</a>}
+        </li>
+      ))}
+    </ul>
+  </section>
+
+  <section class="trials">
+    <h2>Trials <small>({trials.length})</small></h2>
+    <ol class="trial-list">
+      {trials.map((t) => {
+        const wRef = t.winnerSide === "a" ? t.postARef : t.postBRef;
+        const lRef = t.winnerSide === "a" ? t.postBRef : t.postARef;
+        const wRate = t.winnerSide === "a" ? t.rateA : t.rateB;
+        const lRate = t.winnerSide === "a" ? t.rateB : t.rateA;
+        return (
+          <li>
+            <div class="trial-row">
+              <span class="trial-date">{fmtDate(t.runAt)}</span>
+              <code class="trial-win">{wRef}</code>
+              <span class="trial-beat">beat</span>
+              <code class="trial-lose">{lRef}</code>
+              {wRate != null && lRate != null && (
+                <span class="trial-rates">{wRate.toFixed(1)} / {lRate.toFixed(1)}</span>
+              )}
+              {t.id && <a class="trial-link" href={`/ranking/battles/${t.id}/`}>analysis →</a>}
+            </div>
+          </li>
+        );
+      })}
+    </ol>
+  </section>
+</PageLayout>
+
+<style>
+  .breadcrumb ol {
+    list-style: none;
+    padding: 0;
+    margin: 0 0 1rem;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0;
+    font-size: 0.8rem;
+    color: var(--pico-muted-color);
+  }
+  .breadcrumb li + li::before {
+    content: " / ";
+    padding: 0 0.35em;
+  }
+  .breadcrumb a {
+    color: var(--pico-muted-color);
+    text-decoration: none;
+  }
+  .breadcrumb a:hover {
+    text-decoration: underline;
+  }
+  .links {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+    font-size: 0.85rem;
+  }
+  .genealogy,
+  .trials {
+    margin-top: 2rem;
+  }
+  .genealogy h2,
+  .trials h2 {
+    font-size: 1rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--pico-muted-color);
+  }
+  .ver-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+  }
+  .ver-item {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.6rem;
+    font-size: 0.84rem;
+  }
+  .ver-item code {
+    font-size: 0.76rem;
+    word-break: break-all;
+  }
+  .ver-tally {
+    font-family: var(--pico-font-family-monospace);
+    font-size: 0.72rem;
+    color: var(--pico-muted-color);
+  }
+  .trial-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+  }
+  .trial-row {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.4rem;
+    font-size: 0.82rem;
+  }
+  .trial-date {
+    font-family: var(--pico-font-family-monospace);
+    font-size: 0.7rem;
+    color: var(--pico-muted-color);
+  }
+  .trial-row code {
+    font-size: 0.74rem;
+    word-break: break-all;
+  }
+  .trial-win {
+    color: var(--pico-primary);
+  }
+  .trial-beat,
+  .trial-rates {
+    color: var(--pico-muted-color);
+    font-size: 0.72rem;
+  }
+  .trial-link {
+    margin-left: auto;
+    font-size: 0.78rem;
+  }
+</style>

--- a/src/pages/ranking/versions/[key].astro
+++ b/src/pages/ranking/versions/[key].astro
@@ -76,9 +76,9 @@ for (const t of trials) {
   note(t.postAVersion, t.postARef, t.postAPath, aWon);
   note(t.postBVersion, t.postBRef, t.postBPath, !aWon);
 }
-const versionList = [...versions.values()].sort(
-  (a, b) => b.wins - a.wins || a.ref.localeCompare(b.ref)
-);
+const versionList = [...versions.values()]
+  .sort((a, b) => b.wins - a.wins || a.ref.localeCompare(b.ref))
+  .map((v) => ({ ...v, src: sourceHref(v.path) }));
 
 function fmtDate(iso: string) {
   return new Date(iso).toLocaleDateString("en-US", {
@@ -118,7 +118,7 @@ function fmtDate(iso: string) {
         <li class="ver-item">
           <code>{v.ref}</code>
           <span class="ver-tally">{v.wins}W / {v.losses}L</span>
-          {sourceHref(v.path) && <a href={sourceHref(v.path)!}>source →</a>}
+          {v.src && <a href={v.src}>source →</a>}
         </li>
       ))}
     </ul>


### PR DESCRIPTION
Implementa a **RFC 0012 inteira**. Rebaseada em `main`, então este PR contém o stack cumulativo (docs + Fases 0→3b); mergear traz toda a RFC para `main` num merge commit. Substitui os PRs empilhados #608/#610/#611/#613/#614.

## O problema
Um mesmo rate file servia a dois juízos distintos — **comparação entre obras** (`work`) e **comparação entre versões** (`version`) — e as superfícies públicas misturavam os dois: post enfrentando a si mesmo, vitória de versão contada como editorial, taxa de vitórias somando partidas de objetos diferentes. Em paralelo, o contrato de idioma divergia (CLAUDE.md dizia "review na língua do post"; o CLI gravava `eval_lang` da sessão).

## A entrega, por fase

**Docs** — RFCs 0012 (estrutural) e 0013 (editorial, bloqueada em diagnóstico do corpus), fatiadas por decisão editorial.

**Fase 0 — tipos, fixtures, golden snapshot.** `MatchKind`/`NormalizedMatch`; fixtures stars-v1/v2/v3 + work + version; golden travando o invariante load-bearing (duelo `version` nunca altera o ranking `work`). Zero mudança de comportamento.

**Fase 1 — normalizador único.** Três leitores que re-derivavam winner/keys/runAt/kind à mão passam a projetar um só `loadMatches()`/`normalizeMatch` (`kind = aKey===bKey?version:work`, `ref` slug@uuid, `reviewLang`/`content_lang`). `getDuels({ kind })` sem default ambíguo. **Invariância provada**: snapshot do loader antigo == novo, byte-a-byte.

**Fase 2 — superfícies work vs version.** Ranking/recordes/stats/sparkline/reviews → só `work`. Novas rotas `/ranking/version-trials/` e `/ranking/versions/[key]/` (genealogia + permalinks slug@uuid). `/ranking/battles/[id]` renderiza duelo `version` como **"Version Trial"** (sem #rank global, nunca "X venceu X"). Dossiê ganha "Edit history".

**Fase 3a — proveniência linguística.** `--review-lang` no init; `decide` grava `review_lang` + `content_lang` por lado (work ⇒ língua da sessão; version ⇒ `review_lang === content_lang`); chips `content`/`critique` na UI; CLAUDE.md unificado.

**Fase 3b — schema stars-v3.** `PROMPT_VERSION = stars-v3`; `doctor` valida `review_lang`/`content_lang` (só stars-v3; histórico segue `legacy` sem reprovação).

## CI (job `check` real) rodado localmente em cada fase — verde
`check:hygiene` · `prettier --check .` · `npm test` (39) · **`hronir:doctor` — 0 inconsistências** · `astro check` (0 erros) · `build`.

## Critério de sucesso §10
Sem ler código: **obra ou versão?** · **quais versões exatas?** (slug@uuid + permalinks) · **entra no ranking editorial?** (só work) · **em que línguas?** (chips + stars-v3 validado). A "solidez da posição" e regimes de avaliação ficam para a **RFC 0013**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)