### PR TITLE
docs(rfc): RFC 0013 — diagnóstico do corpus executado e incorporado

### DIFF
--- a/docs/rfcs/0013-regimes-de-avaliacao-evidencia-e-amostragem.md
+++ b/docs/rfcs/0013-regimes-de-avaliacao-evidencia-e-amostragem.md
@@ -2,10 +2,10 @@
 
 |                |                                                                                                                                                                                                                                 |
 | -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Status**     | Proposed — bloqueada em diagnóstico do corpus                                                                                                                                                                                   |
+| **Status**     | Proposed — diagnóstico executado; decisões editoriais pendentes                                                                                                                                                                 |
 | **Autor**      | Franklin Baldo (proposta assistida)                                                                                                                                                                                             |
 | **Criado em**  | 2026-06-21                                                                                                                                                                                                                      |
-| **Depende de** | RFC 0001 (qualidade absoluta), RFC 0002 (de-confounding e amostragem objetiva), RFC 0007 (UI/UX), RFC 0010 (versões como pares), **RFC 0012 (taxonomia de matches — pré-requisito estrutural)**                                 |
+| **Depende de** | RFC 0001 (qualidade absoluta), RFC 0002 (de-confounding e amostragem objetiva), RFC 0007 (UI/UX), RFC 0010 (versões como pares), **RFC 0012 (taxonomia de matches — mergeada)**                                                 |
 | **Afeta**      | `src/hronir/{matches,ranking,commands,types}.ts`, `src/lib/hronir-rank.ts`, `scripts/hronir/index.js`, `scripts/generate-ranking-snapshot.mjs`, `src/components/RankingView.astro`, `src/pages/ranking/**`, `CLAUDE.md`, testes |
 
 > Esta RFC é a **segunda metade** da antiga proposta 0012, fatiada por decisão
@@ -13,115 +13,192 @@
 > de leitura contam como evidência, como demonstrar a solidez de uma posição,
 > como amostrar o corpus e qual papel a cadeia afetiva deve ter no produto.
 >
-> **Ela não deve começar a ser implementada antes de a RFC 0012 estar concluída
-> e antes do diagnóstico do corpus descrito na §2.** Nenhum limiar numérico de
-> evidência pode ser fixado antes desse diagnóstico — esta RFC enumera as
-> decisões a tomar, não as respostas.
+> A RFC 0012 está **mergeada** (a fronteira estrutural existe). O diagnóstico do
+> corpus exigido pela §2 foi **executado** (`npm run hronir:diagnose-corpus`) e
+> seus resultados estão na §2.1. A conclusão muda a prioridade da RFC: **a
+> restrição que prende tudo não é de design, é de volume de dados.** Nenhum
+> limiar numérico de evidência é fixado aqui — e a §2.1 mostra que, no corpus
+> atual, qualquer limiar razoável classificaria ~zero obras como calibradas.
 
 ---
 
 ## Histórico de revisões
 
-| Data       | Mudança                                                                                                         |
-| ---------- | --------------------------------------------------------------------------------------------------------------- |
-| 2026-06-21 | Versão inicial, resultante do fatiamento da proposta 0012 original. Estado: bloqueada em diagnóstico do corpus. |
+| Data       | Mudança                                                                                                                                                                                                                                     |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 2026-06-21 | Versão inicial, resultante do fatiamento da proposta 0012 original. Estado: bloqueada em diagnóstico do corpus.                                                                                                                             |
+| 2026-06-21 | RFC 0012 mergeada. Diagnóstico do corpus executado e incorporado (§2.1). Prioridade reordenada: volume de dados é a restrição binding; estados de evidência são gated em crescimento do acervo. Script `hronir:diagnose-corpus` adicionado. |
 
 ---
 
 ## 1. Motivação
 
-A RFC 0012 separa estruturalmente duelos `work` de duelos `version` e estabiliza
-a proveniência linguística. Resta o problema mais difícil, que é **editorial e
-estatístico, não estrutural**:
+A RFC 0012 separou estruturalmente duelos `work` de duelos `version` e
+estabilizou a proveniência linguística. Resta o problema mais difícil, que é
+**editorial e estatístico, não estrutural**:
 
 - nem toda leitura tem o mesmo estatuto epistêmico — uma leitura editorial
   basal, uma leitura situada por perspectiva e uma cadeia afetiva encadeada
   respondem perguntas diferentes e não deveriam alimentar os mesmos agregados
   por acidente;
-- a posição no ranking é informativa desde os primeiros matches, mas a posição
-  isolada não mede a **solidez** da evidência (oponentes repetidos, perspectivas
-  concentradas, confrontos apertados, sigma alto);
-- a amostragem atual protege líderes de perspectiva de forma binária (com
-  fallback quando sobram poucos candidatos), o que pode ser refinado.
+- a posição no ranking é informativa, mas a posição isolada não mede a
+  **solidez** da evidência (oponentes repetidos, perspectivas concentradas,
+  confrontos apertados, sigma alto);
+- a amostragem atual protege líderes de perspectiva de forma binária
+  (`getProtectedPosts`, com fallback quando sobram <4 candidatos), o que pode
+  ser refinado.
 
-Estes são problemas de **decisão editorial sob dados reais**, não de correção de
-bug. Por isso esta RFC é deliberadamente aberta e condicionada a um diagnóstico.
-
----
-
-## 2. Pré-requisito: diagnóstico do corpus
-
-Antes de qualquer decisão de design ou limiar, produzir um relatório do acervo
-existente (script de leitura pura, sem alterar dados), contendo:
-
-1. quantidade de obras;
-2. quantidade de duelos entre obras (`work`) e entre versões (`version`);
-3. distribuição de aparições por obra;
-4. diversidade de oponentes por obra;
-5. distribuição de duelos por perspectiva e por agente;
-6. sigma do OpenSkill por obra;
-7. proporção dos dados históricos que poderiam satisfazer critérios de
-   calibração sob diferentes hipóteses de limiar.
-
-O relatório é insumo obrigatório para §3–§6. **Sem ele, esta RFC não avança.**
+Estes são problemas de **decisão editorial sob dados reais**, não de correção
+de bug. Por isso a RFC exigiu um diagnóstico antes de qualquer limiar — e o
+diagnóstico, agora executado, reordena o que vem primeiro.
 
 ---
 
-## 3. Decisões a tomar (em aberto)
+## 2. Diagnóstico do corpus
 
-Esta RFC deve decidir explicitamente, com base no diagnóstico:
+A §2 da versão original exigia um relatório de leitura pura antes de qualquer
+decisão. Ele agora existe como comando reproduzível:
 
-1. **Cadeia afetiva** (`affective-chain`): permanece fluxo principal, vira fluxo
-   paralelo, ou é arquivada como experimento? Hoje ela é o fluxo canônico
-   descrito em `CLAUDE.md` (perspectiva, mood, glifo, herança). Qualquer
-   rebaixamento é uma **mudança de identidade do produto** e deve ser tratado
-   como decisão editorial explícita, não como detalhe técnico.
-2. **Regimes de coleta**: quais modos existem (ex. `calibration`, `lens`,
-   `affective-chain`, além de `legacy`), como cada um é declarado e — ponto
-   crítico — **como sua proveniência será validada**, já que `mode` é uma
-   asserção de coleta, não uma propriedade derivável do dado como `kind`.
-3. **Quais dados alimentam o quê**: ranking editorial, seleção de versões e
-   leituras situadas. Em particular, se a seleção de versões da RFC 0010 passa a
-   exigir um regime específico de evidência para deslocar uma incumbente.
-4. **Estados de evidência**: como combinar **sigma do OpenSkill**, diversidade
-   de oponentes e diversidade de perspectivas num indicador de solidez.
-   Preferir o sigma — sinal de incerteza que o modelo já produz — a contagens
-   arbitrárias, salvo justificativa baseada no diagnóstico.
-5. **Objetivos de amostragem**: quais existem (ex. cobertura, refinar topo,
-   caçar pior, evidência de versão), como são persistidos como proveniência e
-   como a proteção binária de líderes é substituída por uma penalidade suave
-   (cooldown) que despriorize sem excluir.
-6. **Topologia de rotas**: se é necessária uma rota nova para leituras situadas
-   (`/ranking/readings/`), ou se filtros sobre as rotas existentes mais a rota
-   de testes de versão (já criada pela RFC 0012) bastam.
+```bash
+npm run hronir:diagnose-corpus
+```
+
+O script (`scripts/hronir/diagnose-corpus.mjs`) usa o normalizador único da
+RFC 0012 (`loadNormalizedMatches`) e o `computeRatings` — não altera dado
+nenhum.
+
+### 2.1. Resultados (2026-06-21)
+
+| Métrica                                  | Valor                                                  |
+| ---------------------------------------- | ------------------------------------------------------ |
+| Obras (`work`) ranqueadas                | **97**                                                 |
+| Duelos editoriais (`work`)               | **94** — menos de 1 por obra                           |
+| Duelos de versão (`version`)             | 47, em 31 chaves                                       |
+| Aparições por obra                       | mín 1 · **mediana 2** · p90 3 · **máx 4**              |
+| Oponentes distintos por obra             | mín 1 · mediana 2 · **máx 4**                          |
+| Sigma OpenSkill por obra                 | 8.08 – 8.26 (**prior ≈ 8.33**)                         |
+| Perspectivas                             | 12 (4–11 duelos cada)                                  |
+| Avaliadores (agentes)                    | 4 — todos modelos Claude; **nenhuma avaliação humana** |
+| Obras que passam `app≥4, opp≥3, persp≥1` | **3**                                                  |
+| Obras que passam `app≥6, opp≥4, persp≥2` | **0**                                                  |
+| Obras que passam `app≥8, opp≥5, persp≥3` | **0**                                                  |
+
+### 2.2. Interpretação
+
+Três fatos dominam todo o resto:
+
+1. **O acervo é raso.** 94 duelos para 97 obras; nenhuma obra passou de 4
+   aparições. A ordenação existe, mas é quase toda prior.
+2. **O sigma confirma isso.** Todas as obras têm sigma entre 8.08 e 8.26, ou
+   seja, praticamente coladas no prior (~8.33). Em termos de OpenSkill, **o
+   sistema mal começou a aprender**: o mu separou pouco e a incerteza quase não
+   caiu. Qualquer estado de evidência honesto baseado em sigma classificaria
+   **todas** as obras como "exploratórias" hoje — o que é a verdade.
+3. **Os limiares da proposta original eram inalcançáveis.** A tabela de
+   evidência cogitada (≥8 aparições, ≥5 oponentes, ≥3 perspectivas para
+   "calibrado") classificaria **zero** obras. Mesmo um patamar frouxo
+   (≥4/≥3/≥1) pega só 3. Fixar esses números agora produziria um rótulo
+   "Calibrated ranking" permanentemente vazio — exatamente o risco que a
+   alternativa D previu.
+
+Além disso: **não existe campo `mode` no acervo.** Todos os 94 duelos vêm do
+fluxo único atual (perspectiva + mood + glifo — o que a RFC chama de
+`affective-chain`), produzidos por modelos Claude. Não há `calibration` nem
+`lens` para separar; a distinção `legacy`/`calibration`/`affective-chain` só
+passa a existir **a partir de coletas futuras**.
+
+### 2.3. Consequência para a prioridade da RFC
+
+A restrição binding é **volume e diversidade de evidência**, não design de
+agregados. Logo, a ordem correta é:
+
+1. **Primeiro, coletar.** Uma campanha de amostragem com objetivo `coverage`
+   (e depois `refine-top`) para tirar o acervo do regime prior. Sem isso, todo
+   o resto da RFC é decoração sobre dados que não a sustentam.
+2. **Depois, reificar evidência.** Estados de evidência e a aba "Calibrated
+   ranking" só fazem sentido — e só devem ser publicados — quando o diagnóstico
+   mostrar uma rede mínima (ver §4).
 
 ---
 
-## 4. Restrições herdadas
+## 3. Decisões a tomar (em aberto, agora informadas)
 
-- **Não fixar limiares numéricos** (aparições, oponentes, perspectivas) antes do
-  diagnóstico da §2. Quando fixados, devem ser constantes nomeadas em
-  `ranking.ts`, não números espalhados pela UI, e justificados pelo tamanho real
-  do corpus.
-- **Não reescrever rate files históricos.** `legacy` permanece legível e
-  classificado com honestidade (herdado da RFC 0012).
-- **Subjetividade é dado, não ruído.** Perspectivas e humores são lentes de
-  leitura; a solução é declarar seu plano de validade, não neutralizá-los.
-- **Evidência antes de espetáculo.** A UI pode celebrar candidatos, mas não deve
-  chamar de "campeão" o que ainda é hipótese. A linguagem de pódio fica
-  condicionada aos estados de evidência decididos aqui.
-- A separação estrutural `work`/`version`, a normalização única e a proveniência
+Continuam sendo decisões editoriais do autor; o diagnóstico apenas as informa.
+
+1. **Cadeia afetiva** (`affective-chain`): permanece fluxo principal, vira
+   fluxo paralelo, ou é arquivada? **Dado relevante:** ela é hoje o **único**
+   fluxo — 100% do acervo. Rebaixá-la sem antes ter um fluxo `calibration`
+   alternativo deixaria o sistema sem nenhuma coleta. Recomendação: introduzir
+   `calibration` como modo paralelo primeiro; só reavaliar o papel da
+   `affective-chain` depois que houver dados dos dois.
+2. **Regimes de coleta**: quais modos existem (`calibration`, `lens`,
+   `affective-chain`, `legacy`) e — ponto crítico — **como sua proveniência é
+   validada**, já que `mode` é uma asserção de coleta, não derivável do dado
+   como `kind`. Todo dado atual entra como `legacy`/`affective-chain`.
+3. **Quais dados alimentam o quê**: ranking editorial, seleção de versões,
+   leituras situadas. Em especial, se a seleção de versões (RFC 0010) passa a
+   exigir evidência `calibration` para deslocar uma incumbente — **hoje
+   inviável**, pois não há duelos `calibration`; aplicar essa regra agora
+   congelaria todas as seleções.
+4. **Estados de evidência**: combinar **sigma** (sinal que o modelo já produz),
+   diversidade de oponentes e de perspectivas. Preferir sigma a contagens
+   arbitrárias. **Dado relevante:** com o sigma atual quase uniforme, o estado
+   seria "exploratório" para todos — então os estados só ganham poder
+   discriminante depois da campanha de coleta.
+5. **Objetivos de amostragem**: `coverage`, `refine-top`, `hunt-worst`,
+   `version-evidence`; persistidos como proveniência; e a proteção binária de
+   líderes (`getProtectedPosts`) substituída por uma penalidade suave
+   (cooldown) que despriorize sem excluir. **Este é o item de maior alavancagem
+   agora** (ver §2.3).
+6. **Topologia de rotas**: rota nova para leituras situadas
+   (`/ranking/readings/`) ou filtros sobre as rotas existentes + a rota de
+   testes de versão (já criada pela RFC 0012).
+
+---
+
+## 4. Restrições herdadas (reforçadas pelo diagnóstico)
+
+- **Limiares de evidência devem ser alcançáveis no corpus real.** Constantes
+  nomeadas em `ranking.ts`, derivadas da distribuição observada — não da
+  intuição. Concretamente: **não publicar "Calibrated ranking" enquanto o
+  diagnóstico mostrar mediana de aparições baixa e sigma ~prior.** Um gate
+  objetivo sugerido: revisitar quando a mediana de aparições das obras `work`
+  for ≥ um patamar a definir e o p90 de sigma tiver caído de forma mensurável
+  abaixo do prior.
+- **Não fixar limiares numéricos antes de a coleta acontecer.**
+- **Não reescrever rate files históricos.** `legacy` permanece legível.
+- **Subjetividade é dado, não ruído.** Perspectivas e humores são lentes; a
+  solução é declarar seu plano de validade, não neutralizá-los.
+- **Evidência antes de espetáculo.** A UI pode celebrar candidatos, mas não
+  chamar de "campeão" o que ainda é hipótese — e, dado o §2.1, **hoje tudo é
+  hipótese**.
+- A separação `work`/`version`, a normalização única e a proveniência
   linguística **já existem** (RFC 0012) e não são reabertas.
 
 ---
 
-## 5. Critério de conclusão
+## 5. Primeiro passo concreto
 
-A RFC 0013 estará cumprida quando, somada à 0012, um leitor puder responder sem
-ler código:
+Independente das decisões editoriais em aberto, há um passo sem
+ambiguidade e de maior alavancagem:
+
+1. **Já entregue nesta revisão:** `hronir:diagnose-corpus` — torna o estado do
+   acervo verificável a qualquer momento, e serve de gate para as fases
+   seguintes.
+2. **Próximo:** campanha de amostragem `coverage` (várias sessões) para tirar o
+   acervo do regime prior, re-rodando o diagnóstico entre rodadas. Só quando os
+   números melhorarem é que faz sentido implementar estados de evidência,
+   modos de coleta e a aba calibrada.
+
+---
+
+## 6. Critério de conclusão
+
+A RFC 0013 estará cumprida quando, somada à 0012, um leitor puder responder
+sem ler código:
 
 1. **Quão sólida é esta posição?** (estado de evidência derivado de sigma +
-   diversidade)
+   diversidade — só significativo após a coleta da §5)
 2. **Por que esta versão — e não sua rival — está publicada?** (regime de
    evidência exigido para deslocar uma incumbente)
 3. **Como leituras situadas e afetivas divergiram da avaliação editorial?**
@@ -132,18 +209,19 @@ A RFC 0012 já garante as perguntas estruturais ("isto é obra ou versão?",
 
 ---
 
-## 6. Alternativas consideradas
+## 7. Alternativas consideradas
 
 ### A. Não fatiar — manter tudo na proposta 0012 original
 
 Rejeitada. O problema estrutural (verificável, baixo risco) e o editorial
-(dependente de dados, alto risco de inconclusão) têm naturezas distintas.
-Empacotá-los criava uma RFC que dificilmente atingiria "todas as fases verdes".
+(dependente de dados) têm naturezas distintas. O diagnóstico confirma: o
+editorial dependia de dados que o acervo ainda não tem.
 
 ### B. Excluir subjetividade de todo o Hrönir
 
 Rejeitada. Perspectivas, humores e a cadeia afetiva são uma das melhores ideias
-do sistema. A solução é declarar seu plano de validade.
+do sistema — e, hoje, a única fonte de dados. A solução é declarar seu plano de
+validade.
 
 ### C. Fazer todo novo match contar para o ranking editorial
 
@@ -152,6 +230,12 @@ crítica situada e experimento afetivo.
 
 ### D. Fixar limiares de evidência por intuição, antes do diagnóstico
 
-Rejeitada explicitamente. Para um corpus pequeno, limiares mal calibrados podem
-tornar "calibrado" inatingível na prática. Os números seguem os dados, não o
-contrário.
+Rejeitada — e **agora confirmada pelos dados**: máximo de 4 aparições por obra,
+sigma ~prior em todas, 0 obras passando limiares moderados. Limiares fixados no
+escuro tornariam "calibrado" inatingível. Os números seguem os dados.
+
+### E. Implementar estados de evidência/modos agora
+
+Rejeitada por ora. Com sigma quase uniforme no prior, todo estado seria
+"exploratório" e todo painel de calibração ficaria vazio. Construir a máquina
+antes da coleta é esforço sobre dados que não a sustentam (§2.3).

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "hronir:end": "node --import tsx/esm scripts/hronir/index.js end",
     "hronir:migrate": "node --import tsx/esm scripts/hronir/index.js migrate",
     "hronir:doctor": "node --import tsx/esm scripts/hronir/index.js doctor",
+    "hronir:diagnose-corpus": "node --import tsx/esm scripts/hronir/diagnose-corpus.mjs",
     "hronir:detect-stuffing": "node scripts/hronir/detect-token-stuffing.mjs",
     "music:generate": "node scripts/generate-music-posts.mjs",
     "test": "node --import tsx/esm --experimental-test-module-mocks --test \"src/hronir/__tests__/*.test.js\""

--- a/scripts/hronir/diagnose-corpus.mjs
+++ b/scripts/hronir/diagnose-corpus.mjs
@@ -1,0 +1,113 @@
+#!/usr/bin/env node
+// RFC 0013 §2 — read-only corpus diagnosis. Prints the editorial state of the
+// Hrönir archive so the editorial decisions (regimes, evidence states,
+// sampling) can be grounded in real numbers. Touches no data.
+//
+//   node --import tsx/esm scripts/hronir/diagnose-corpus.mjs
+
+import { loadNormalizedMatches } from "../../src/hronir/matches.ts";
+import { computeRatings } from "../../src/hronir/ranking.ts";
+
+const matches = loadNormalizedMatches();
+const work = matches.filter((m) => m.kind === "work");
+const version = matches.filter((m) => m.kind === "version");
+
+// 1. works & duels
+const works = new Set();
+for (const m of work) {
+  works.add(m.postA.key);
+  works.add(m.postB.key);
+}
+
+// 3. appearances + 4. distinct opponents (work only)
+const appearances = new Map();
+const opponents = new Map();
+const bump = (k, opp) => {
+  appearances.set(k, (appearances.get(k) || 0) + 1);
+  if (!opponents.has(k)) opponents.set(k, new Set());
+  opponents.get(k).add(opp);
+};
+for (const m of work) {
+  bump(m.postA.key, m.postB.key);
+  bump(m.postB.key, m.postA.key);
+}
+
+// 5. duels per perspective / agent (work only)
+const byPerspective = new Map();
+const byAgent = new Map();
+const perspectivesPerWork = new Map();
+for (const m of work) {
+  const p = m.perspectiveId || "(none)";
+  byPerspective.set(p, (byPerspective.get(p) || 0) + 1);
+  const a = m.agentId || "(none)";
+  byAgent.set(a, (byAgent.get(a) || 0) + 1);
+  for (const key of [m.postA.key, m.postB.key]) {
+    if (!perspectivesPerWork.has(key)) perspectivesPerWork.set(key, new Set());
+    if (m.perspectiveId) perspectivesPerWork.get(key).add(m.perspectiveId);
+  }
+}
+
+// 6. sigma per work (OpenSkill)
+const ratings = computeRatings();
+const sigmas = ratings.map((r) => r.sigma).sort((a, b) => a - b);
+const quantile = (arr, q) =>
+  arr.length ? arr[Math.min(arr.length - 1, Math.floor(q * arr.length))] : NaN;
+
+// version trials per key
+const versionByKey = new Map();
+for (const m of version)
+  versionByKey.set(m.postA.key, (versionByKey.get(m.postA.key) || 0) + 1);
+
+// 7. how many works clear candidate "calibration" coverage thresholds
+const coverageAt = (minApp, minOpp, minPersp) =>
+  [...works].filter(
+    (k) =>
+      (appearances.get(k) || 0) >= minApp &&
+      (opponents.get(k)?.size || 0) >= minOpp &&
+      (perspectivesPerWork.get(k)?.size || 0) >= minPersp
+  ).length;
+
+const appVals = [...appearances.values()].sort((a, b) => a - b);
+const oppVals = [...works]
+  .map((k) => opponents.get(k)?.size || 0)
+  .sort((a, b) => a - b);
+
+const out = {
+  works: works.size,
+  ratedWorks: ratings.length,
+  workDuels: work.length,
+  versionDuels: version.length,
+  versionTrialsByKey: versionByKey.size,
+  appearances: {
+    min: appVals[0],
+    median: quantile(appVals, 0.5),
+    p90: quantile(appVals, 0.9),
+    max: appVals[appVals.length - 1],
+  },
+  distinctOpponents: {
+    min: oppVals[0],
+    median: quantile(oppVals, 0.5),
+    max: oppVals[oppVals.length - 1],
+  },
+  perspectives: byPerspective.size,
+  duelsPerPerspective: Object.fromEntries(
+    [...byPerspective.entries()].sort((a, b) => b[1] - a[1])
+  ),
+  agents: byAgent.size,
+  duelsPerAgent: Object.fromEntries(
+    [...byAgent.entries()].sort((a, b) => b[1] - a[1])
+  ),
+  sigma: {
+    min: sigmas[0],
+    median: quantile(sigmas, 0.5),
+    p90: quantile(sigmas, 0.9),
+    max: sigmas[sigmas.length - 1],
+  },
+  coverage: {
+    "app>=4,opp>=3,persp>=1": coverageAt(4, 3, 1),
+    "app>=6,opp>=4,persp>=2": coverageAt(6, 4, 2),
+    "app>=8,opp>=5,persp>=3": coverageAt(8, 5, 3),
+  },
+};
+
+console.log(JSON.stringify(out, null, 2));


### PR DESCRIPTION
## Contexto
Pedido: revisar a correção da RFC 0013 e, se boa, refazê-la.

## Verificação de correção
Conferi todas as afirmações factuais da RFC 0013 contra o `main` pós-RFC-0012 — **todas corretas**:
- separação `work`/`version` e normalizador único existem;
- proteção binária de líderes com fallback (`getProtectedPosts(2)`, `commands.ts:468`);
- `sigma` por obra disponível;
- cadeia afetiva (mood/glifo/`--after-mood`) é o fluxo canônico no `CLAUDE.md`;
- deps RFC 0002/0010 e rotas de versão existem.

A RFC é sólida. Como é boa, **refiz aterrando-a em dados reais.**

## O que muda
- **`scripts/hronir/diagnose-corpus.mjs`** (+ alias `npm run hronir:diagnose-corpus`): relatório **read-only** do acervo via `loadNormalizedMatches` + `computeRatings` — o artefato que a §2 exigia.
- **RFC 0013 reescrita** com o diagnóstico **executado**:

| Métrica | Valor |
|---|---|
| Obras `work` | 97 |
| Duelos `work` | **94** (<1 por obra) |
| Aparições/obra | mediana 2 · **máx 4** |
| Sigma/obra | 8.08–8.26 (**prior ≈ 8.33**) |
| Obras passando `app≥8,opp≥5,persp≥3` | **0** |
| Obras passando `app≥4,opp≥3` | 3 |

**Conclusão que reordena a RFC:** a restrição binding é **volume de dados, não design**. Com sigma ~prior em todas as obras, qualquer estado de evidência honesto leria "exploratório" para tudo, e os limiares cogitados (≥8 aparições) classificariam **zero** obras — confirmando com dados o risco que a própria RFC previu. Logo: estados de evidência / "Calibrated ranking" ficam **gated** em crescimento do acervo; o **primeiro passo** é uma campanha de amostragem `coverage`. As decisões editoriais (papel da `affective-chain`, modos de coleta) seguem em aberto — agora informadas (ex.: a `affective-chain` é hoje 100% do acervo, então não pode ser rebaixada antes de existir um fluxo `calibration`).

## CI (rodada localmente) — verde
`prettier --check .` · `check:hygiene` · `npm test` (39) · `hronir:doctor` (0) · `hronir:diagnose-corpus` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PSUGMxdvYu34sJ3YHfScFm)_