### PR TITLE
RFC 0013 §8 — objetivo de amostragem coverage e cooldown suave de líderes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,7 @@ npm run hronir:init -- --agent-id <your-model-id> --matches 10 --skip-edit
 - `--matches` defaults to 10
 - `--skip-edit` skips the post-editing phase; use it for pure rating sessions
 - `--review-lang en|pt` — language the reviews/clash are written in (RFC 0012 §6); defaults to `--eval-lang`. Recorded as `review_lang` in each rate file
+- `--objective coverage|refine-top|hunt-worst` — RFC 0013 §8: sampling bias, persisted in the session and recorded as `objective` in each rate file. `coverage` (recommended while the corpus is thin) prioritizes under-sampled works; `refine-top`/`hunt-worst` tilt toward the top/bottom strata. Default: neutral
 - `--content-mode inline|path-only` — controls how post content is delivered:
   - `inline` (default): CLI prints the full post content in its output
   - `path-only`: CLI prints only the slug, file path, and Suno URLs; the agent reads the file directly. Recommended for agents with long sessions or context compression (e.g. Jules with 20 matches). The chosen mode is saved in `session.json` and recorded in each rate file as `content_mode`.

--- a/scripts/hronir/index.js
+++ b/scripts/hronir/index.js
@@ -47,7 +47,7 @@ const [, , cmd, ...args] = process.argv;
 
 function usage() {
   console.error(
-    "Uso: hronir {next --agent-id <id> [init-opts]|init --agent-id <id> [--matches N] [--skip-edit] [--skip-rating] [--eval-lang <lang>] [--review-lang <lang>] [--min-appearances N] [--pledge <text>] [--content-mode inline|path-only]|continue|first-impression-a <texto>|first-impression-b <texto>|decide --after-mood <text> --rate-a <1.00-5.00> --rate-b <1.00-5.00> --review-a <text> --review-b <text> --clash <text> [--clash-append <text>] [--review-a-append <text>] [--review-b-append <text>]|ranking|worst [--absolute]|diagnose|edit-worst|edit-commit --msg <text>|migrate [--dry-run]|doctor|end [--skip-edit] [--force] [--attest <text>]|select [--dry-run]|prune [--dry-run]}"
+    "Uso: hronir {next --agent-id <id> [init-opts]|init --agent-id <id> [--matches N] [--skip-edit] [--skip-rating] [--eval-lang <lang>] [--review-lang <lang>] [--objective coverage|refine-top|hunt-worst] [--min-appearances N] [--pledge <text>] [--content-mode inline|path-only]|continue|first-impression-a <texto>|first-impression-b <texto>|decide --after-mood <text> --rate-a <1.00-5.00> --rate-b <1.00-5.00> --review-a <text> --review-b <text> --clash <text> [--clash-append <text>] [--review-a-append <text>] [--review-b-append <text>]|ranking|worst [--absolute]|diagnose|edit-worst|edit-commit --msg <text>|migrate [--dry-run]|doctor|end [--skip-edit] [--force] [--attest <text>]|select [--dry-run]|prune [--dry-run]}"
   );
   process.exit(1);
 }
@@ -114,6 +114,9 @@ function parseInitOptions(args) {
   // evaluation language for back-compat; persisted explicitly.
   const reviewLangRaw = readFlagValue(args, [args.indexOf("--review-lang")]);
   const reviewLang = reviewLangRaw || undefined;
+  // RFC 0013 §8.2: persisted sampling objective (coverage|refine-top|hunt-worst).
+  const objective =
+    readFlagValue(args, [args.indexOf("--objective")]) || undefined;
   const minAppRaw = readFlagValue(args, [
     args.indexOf("--min-appearances"),
     args.indexOf("--min-app"),
@@ -134,6 +137,7 @@ function parseInitOptions(args) {
     agentId,
     evalLang,
     reviewLang,
+    objective,
     minAppearances,
     pledge,
     contentMode,

--- a/src/hronir/commands.ts
+++ b/src/hronir/commands.ts
@@ -54,6 +54,7 @@ interface InitOptions {
   agentId?: string;
   evalLang?: string;
   reviewLang?: string;
+  objective?: string;
   minAppearances?: number;
   matches?: number;
   pledge?: string;
@@ -112,6 +113,16 @@ const STALE_BONUS = 3.0;
 // weight is deliberately small so it tilts ties without overriding the
 // information terms (sigma, stale_bonus).
 const OBJECTIVE_WEIGHT = 0.15;
+// RFC 0013 §3/§5: the `coverage` objective. The corpus diagnosis showed a very
+// thin acervo (max ~4 appearances/work, sigma ≈ prior everywhere), so the
+// highest-leverage sampling bias is toward under-covered works. The bonus is
+// 1/(1+appearances) per side, weighted enough to dominate the (currently tiny)
+// sigma spread without overriding a closeness/stale signal entirely.
+const COVERAGE_WEIGHT = 4.0;
+// RFC 0013 §8.1: soft cooldown replacing the old binary leader exclusion. A
+// per-perspective leader (already ≥2 appearances there) is *deprioritized*, not
+// removed — kept below STALE_BONUS so a genuinely stale leader can still surface.
+const LEADER_COOLDOWN = 2.0;
 const SKILLS_DIR = "scripts/hronir/skills";
 const SESSION_PATH = "hronir_session.json";
 const MIN_WORDS = 100;
@@ -256,6 +267,8 @@ export function init(options: InitOptions = {}) {
   const evalLang = options.evalLang || "pt";
   // RFC 0012 §6: review_lang defaults to the evaluation language when not given.
   const reviewLang = options.reviewLang || evalLang;
+  // RFC 0013 §8.2: sampling objective is session provenance. Empty = neutral.
+  const objective = options.objective || "";
   const sessionPath = SESSION_PATH;
 
   if (fs.existsSync(sessionPath)) {
@@ -282,6 +295,7 @@ export function init(options: InitOptions = {}) {
       agentId,
       evalLang,
       reviewLang,
+      objective,
       state: "need_edit",
       skipEdit: false,
       skipRating: true,
@@ -312,6 +326,7 @@ export function init(options: InitOptions = {}) {
     agentId,
     evalLang,
     reviewLang,
+    objective,
     state: "ready_for_next",
     skipEdit,
     skipRating: false,
@@ -459,28 +474,27 @@ function pickVersionDuel() {
   return pool[Math.floor(Math.random() * pool.length)];
 }
 
-function generateNextMatch() {
-  const allCandidates = listEnglishWithKey();
+function generateNextMatch(sessionObjective?: string) {
+  // RFC 0013 §8.1: no hard exclusion. Every published post stays eligible; a
+  // per-perspective leader is only deprioritized via a cooldown in the score.
+  const eligible = listEnglishWithKey();
 
-  // Exclude posts that currently lead any per-perspective ranking (≥2 duels).
-  // A post on top in some perspective has already "won" there; keep the pool
-  // moving by giving others a chance to challenge.
-  const protected_ = getProtectedPosts(2);
-  const candidates =
-    protected_.size > 0
-      ? allCandidates.filter((c) => !protected_.has(c.translationKey))
-      : allCandidates;
-  if (protected_.size > 0) {
+  const leaders = getProtectedPosts(2);
+  const leaderCooldown = (key: string) =>
+    leaders.has(key) ? LEADER_COOLDOWN : 0;
+  if (leaders.size > 0) {
     console.log(
-      `(${protected_.size} post(s) protegido(s) — lideram um ranking de perspectiva: ${[...protected_].join(", ")})`
+      `(${leaders.size} líder(es) de perspectiva despriorizado(s) por cooldown: ${[...leaders].join(", ")})`
     );
   }
-  // Fallback: if protection would leave fewer than 4 candidates, ignore it.
-  const eligible = candidates.length >= 4 ? candidates : allCandidates;
 
   const ranking = computeRatings();
   const ratingByKey = new Map();
-  for (const r of ranking) ratingByKey.set(r.key, { mu: r.mu, sigma: r.sigma });
+  const appByKey = new Map<string, number>();
+  for (const r of ranking) {
+    ratingByKey.set(r.key, { mu: r.mu, sigma: r.sigma });
+    appByKey.set(r.key, r.appearances);
+  }
   const getRating = (key: string) => ratingByKey.get(key) ?? rating();
 
   const lastMatchTime = latestMatchTimeByKey();
@@ -506,18 +520,26 @@ function generateNextMatch() {
   }
   const staleBonus = (key: string) => (staleByKey.get(key) ? STALE_BONUS : 0);
 
-  // Phase 3 (opt-in): objective-aware sampling. `refine-top` prefers high-level
-  // pairs, `hunt-worst` prefers low-level pairs. Level = absolute stars EWMA;
-  // posts without stars yet get a neutral 3.0 so they're neither chased nor
-  // avoided. Default (env unset) leaves the score untouched.
-  const objective = process.env.HRONIR_OBJECTIVE || "";
+  // RFC 0013 §8.2: the objective is session-provenance first (persisted at
+  // init), with HRONIR_OBJECTIVE as a legacy fallback. `coverage` prefers
+  // under-sampled works; `refine-top`/`hunt-worst` tilt toward high/low level
+  // pairs. Unset → score untouched.
+  const objective = sessionObjective || process.env.HRONIR_OBJECTIVE || "";
   const objectiveSign =
     objective === "refine-top" ? 1 : objective === "hunt-worst" ? -1 : 0;
+  if (objective) console.log(`(objetivo de amostragem: ${objective})`);
+
+  // coverage: reward low-appearance works (1/(1+appearances) per side).
+  const coverageBonus =
+    objective === "coverage"
+      ? (a: string, b: string) =>
+          COVERAGE_WEIGHT *
+          (1 / (1 + (appByKey.get(a) ?? 0)) + 1 / (1 + (appByKey.get(b) ?? 0)))
+      : () => 0;
   const levelByKey = new Map();
   if (objectiveSign !== 0) {
     for (const [key, q] of computeAbsoluteQuality())
       levelByKey.set(key, q.stars);
-    console.log(`(objetivo de amostragem: ${objective})`);
   }
   const level = (key: string) => levelByKey.get(key) ?? 3.0;
   const objectiveBonus = (a: string, b: string) =>
@@ -539,7 +561,10 @@ function generateNextMatch() {
         rb.sigma +
         staleBonus(a.translationKey) +
         staleBonus(b.translationKey) +
-        objectiveBonus(a.translationKey, b.translationKey);
+        objectiveBonus(a.translationKey, b.translationKey) +
+        coverageBonus(a.translationKey, b.translationKey) -
+        leaderCooldown(a.translationKey) -
+        leaderCooldown(b.translationKey);
       pairs.push({
         a,
         b,
@@ -758,7 +783,7 @@ export function continueCmd() {
     const padding = Math.max(0, Math.floor((80 - title.length) / 2));
     const padStr = "━".repeat(padding);
     console.log(`\n${padStr}${title}${padStr}\n`);
-    const match = generateNextMatch();
+    const match = generateNextMatch(session.objective);
     session.currentMatch = match;
     session.state = "reading_a";
     fs.writeFileSync(sessionPath, JSON.stringify(session, null, 2));
@@ -1370,6 +1395,7 @@ export function decide(args: string[]) {
     winner,
     agent_id: agentId,
     content_mode: session.contentMode ?? "inline",
+    objective: session.objective || null,
     eval_lang: evalLangValue,
     review_lang: reviewLang,
     prompt_version: PROMPT_VERSION,


### PR DESCRIPTION
Implementa o **primeiro passo concreto** da RFC 0013 — o de maior alavancagem segundo o diagnóstico do corpus — **sem** a maquinaria pesada (estados de evidência, modos, aba calibrada), que o acervo raso ainda não sustenta.

## Por quê agora
O diagnóstico (`hronir:diagnose-corpus`, PR #617) mostrou um acervo raso: 97 obras, 94 duelos, **máx 4 aparições**, sigma ≈ prior em todas. A conclusão: a restrição binding é **volume de dados**, não design. Logo, a ação certa é melhorar **cobertura**, não construir scoreboard sobre dados que não a sustentam.

## Mudanças (RFC 0013 §8)
- **Objetivo `coverage`**: prioriza obras pouco amostradas no `generateNextMatch` — bônus `1/(1+aparições)` por lado, peso suficiente para dominar o spread de sigma (hoje minúsculo) sem anular os sinais de proximidade/stale. Junta-se aos `refine-top`/`hunt-worst` existentes.
- **Objetivo persistido** (`--objective` no `init` → sessão) e gravado como `objective` no rate file (proveniência, §8.2). `HRONIR_OBJECTIVE` continua como fallback legado.
- **Cooldown suave de líderes** (§8.1): a antiga **exclusão binária** (`getProtectedPosts` filtrando o pool, com fallback `<4 candidatos`) vira uma **penalidade no score** — o líder de perspectiva é despriorizado, **nunca removido**. Mantido abaixo de `STALE_BONUS` para um líder genuinamente desatualizado ainda poder aparecer.

## Fora de escopo (deliberado, conforme RFC 0013 revisada)
Estados de evidência, modos de coleta (`calibration`/`lens`), aba "Calibrated ranking" — gated em crescimento do acervo.

## Verificação
- Smoke test `hronir:next --objective coverage`: imprime cooldown + objetivo, gera match, `objective: "coverage"` persistido na sessão, nenhum arquivo vazado.
- CI local: `astro check` (0 erros) · `prettier --check .` · `npm test` (39) · `hronir:doctor` (0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PSUGMxdvYu34sJ3YHfScFm)_