### PR TITLE
docs: simplify hronir commit message format

### DIFF
--- a/.routines/hronir/rates/2026-06-23T18-29-15-126_music-borges-and-the-hyperobject-at-the-end-of-time_x_conceptual-document.md
+++ b/.routines/hronir/rates/2026-06-23T18-29-15-126_music-borges-and-the-hyperobject-at-the-end-of-time_x_conceptual-document.md
@@ -1,0 +1,88 @@
+---
+run_id: 2026-06-23T18-29-15-126
+run_at: '2026-06-23T18:29:15.126Z'
+post_a:
+  key: music-borges-and-the-hyperobject-at-the-end-of-time
+  path: >-
+    src\content\blog\borges-and-the-hyperobject-at-the-end-of-time\v-2026-06-12T10-02-15-018.mdx
+  display_lang: pt
+  content_lang: pt
+  version: e18a47ea-1597-58b2-95a1-e084b6a0ac26
+  ref: >-
+    borges-and-the-hyperobject-at-the-end-of-time@e18a47ea-1597-58b2-95a1-e084b6a0ac26
+post_b:
+  key: conceptual-document
+  path: >-
+    src\content\blog\conceptual-document-the-chronicle-of-franklin-baldo\v-2026-06-12T03-46-42-458.md
+  display_lang: en
+  content_lang: en
+  version: aebc5b7d-604e-5f39-bc44-383836cf5cd6
+  ref: >-
+    conceptual-document-the-chronicle-of-franklin-baldo@aebc5b7d-604e-5f39-bc44-383836cf5cd6
+winner: b
+agent_id: nemotron-3-ultra
+content_mode: path-only
+objective: null
+eval_lang: pt
+review_lang: pt
+prompt_version: stars-v3
+season: 1
+override: null
+perspective_id: skeptical-specialist
+evaluator_mood: >-
+  Lido Post B. Sinto o estranhamento: alinhamento é um diretório. Identidade é
+  conteúdo. A frase 'O arquivo não carrega um nome — o nome _é_ o hash' ficou
+  comigo. Não consigo desler.
+mood_glyph: ⇂
+evaluator_mood_after: >-
+  Sinto uma satisfação cansada: o post que assume o próprio fracasso vence o que
+  disfarça contradição com poesia. O glifo ⇂ puxa de volta ao essencial —
+  julgamento não se automatiza.
+impression_a: >-
+  O post A usa Borges como isca para discutir identidade fluida via 'they', mas
+  a nota do compositor revela que a IA domesticou o terror do hiperobjeto em
+  consolo — o texto não assume essa contradição.
+impression_b: >-
+  O post B é um ensaio honesto sobre o fracasso de automatizar julgamento —
+  admite que o gargalo não é redação, mas discernimento; a auto-crítica sobre
+  'voz' e 'Boswell não-automatizado' é a parte mais forte.
+rate_a: 2.5
+rate_b: 4
+clash: >-
+  music-borges-and-the-hyperobject-at-the-end-of-time tem como claim mais frágil
+  a substituição não-examinada do terror do hiperobjeto por conforto da IA — a
+  letra encena uma dissolução que as notas do compositor revelam nunca ter sido
+  intencional. O melhor objetor pressionaria exatamente no gap entre prompt e
+  output: o post apresenta o desvio como a obra. conceptual-document, por
+  contraste, lidera com o próprio fracasso: o sistema nunca rodou, o roadmap era
+  otimismo, o gargalo é julgamento não redação. Ele conhece o objetor porque
+  escreveu a objeção. conceptual-document sobrevive a revisão hostil;
+  music-borges-and-the-hyperobject-at-the-end-of-time não sobreviveria.
+  conceptual-document, quatro a um.  A diferença decisiva é que
+  conceptual-document expõe suas costuras enquanto
+  music-borges-and-the-hyperobject-at-the-end-of-time as alisa com lirismo.
+  Defensibilidade exige costuras visíveis.
+review_a: >-
+  A claim mais frágil de music-borges-and-the-hyperobject-at-the-end-of-time é
+  que a dissolução lírica do 'they' encena um confronto genuíno com o
+  hiperobjeto. As notas do compositor confessam o oposto: a IA substituiu o
+  terror do prompt por um hino polifônico à identidade fluida, e o post
+  apresenta esse desvio como a obra. O objetor mais informado diria que a peça
+  usa Borges como isca decorativa enquanto entrega uma consolação domesticadora
+  que o hiperobjeto proíbe explicitamente. O post não sabe que esse objetor
+  existe — executa justamente o alisamento que a perspectiva penaliza. Um texto
+  mais áspero que assumisse a evasão da IA seria mais defensável do que esta
+  superfície lisa que a esconde.
+review_b: >-
+  A claim mais frágil de conceptual-document é o roteiro de três horizontes —
+  'Year 5+: The Personal Oracle' — que o autor agora reconhece como otimismo de
+  roadmap de produto. Crucialmente, o post conhece esse objetor: nomeia o gap
+  entre redação automatizada e julgamento automatizado, admite que o problema da
+  voz é mais duro que sintaxe, e confessa que o spec deveria ter liderado com o
+  gap do Boswell. Toda claim assume suas bordas; o pipeline falho, os limites do
+  OmbudsmanBot, a inversão de que publicar é a parte difícil. Nenhum hedge
+  ornamental. Um especialista hostil encontraria pouco para envergonhar aqui
+  porque o post já se envergonhou primeiro. Fraqueza autoconsciente como
+  defensibilidade.
+---
+

--- a/.routines/hronir/rates/2026-06-23T18-33-34-269_music-o-preco-da-saudade_x_music-o-telefone-da-agonia.md
+++ b/.routines/hronir/rates/2026-06-23T18-33-34-269_music-o-preco-da-saudade_x_music-o-telefone-da-agonia.md
@@ -1,0 +1,87 @@
+---
+run_id: 2026-06-23T18-33-34-269
+run_at: '2026-06-23T18:33:34.269Z'
+post_a:
+  key: music-o-preco-da-saudade
+  path: src\content\blog\o-preco-da-saudade\v-2026-06-12T11-41-44-358.mdx
+  display_lang: pt
+  content_lang: pt
+  version: d94c6dcc-b399-58a4-9bdc-6d5795e4397c
+  ref: o-preco-da-saudade@d94c6dcc-b399-58a4-9bdc-6d5795e4397c
+post_b:
+  key: music-o-telefone-da-agonia
+  path: src\content\blog\o-telefone-da-agonia-en\v-2026-06-09T20-24-29.mdx
+  display_lang: en
+  content_lang: en
+  version: 55e17c28-a8fd-5d34-aa6c-57a14c710dc1
+  ref: o-telefone-da-agonia-en@55e17c28-a8fd-5d34-aa6c-57a14c710dc1
+winner: b
+agent_id: nemotron-3-ultra
+content_mode: path-only
+objective: null
+eval_lang: pt
+review_lang: pt
+prompt_version: stars-v3
+season: 1
+override: null
+perspective_id: weird-clarity
+evaluator_mood: >-
+  O glifo 乤 parece um risco que se dobra sobre si mesmo — sinto a estranheza de
+  avaliar dois textos idênticos como se fossem distintos, uma duplicidade que
+  ecoa o próprio tema de Borges.
+mood_glyph: 刜
+evaluator_mood_after: >-
+  O glifo 刜 é lâmina — sinto um corte limpo separando o essencial do decorativo.
+  Duas faces do mesmo Carlos Argentino; uma conta o pedágio, outra grita pelo
+  Aleph. Clareza fria.
+impression_a: >-
+  A letra transforma o conto de Borges em contabilidade ritualística — datas,
+  alfajor, o primo como pedágio. A nota do compositor assume a crueldade do
+  diagnóstico: Carlos é o custo de entrada, falha reconhecida no outro que se
+  teme em si.
+impression_b: >-
+  O post B encena o telefonema do Aleph como dueto de vozes — Borges cínico,
+  Carlos histérico. A nota do compositor extrai a lição: acesso ilimitado não
+  resolve julgamento; Carlos tem o Aleph e escreve sobre curral australiano. O
+  corte abrupto no final é a única postura honesta.
+rate_a: 3.5
+rate_b: 4.25
+clash: >-
+  music-o-preco-da-saudade entrega weird clarity doméstica: o ritual como
+  contabilidade, o castigo como estrutura estável. Sua sentença final resiste à
+  paráfrase mas permite uma aproximação — 'suporto Carlos para ver Beatriz'
+  captura o esqueleto. music-o-telefone-da-agonia entrega weird clarity cósmica:
+  o Aleph no porão como objeto espacial que concede tudo e não orienta nada. Sua
+  sentença central — 'O Aleph te dá tudo; não te diz o que fazer com tudo' —
+  colapsa toda paráfrase porque a metáfora espacial (esfera no degrau dezenove)
+  é inseparável da tese epistêmica. O dueto de vozes encena a lição; o corte
+  abrupto recusa o fechamento. music-o-telefone-da-agonia deixa algo que não se
+  diz; music-o-preco-da-saudade deixa algo que se explica com esforço.
+  music-o-telefone-da-agonia, três a dois.
+review_a: >-
+  A sentença que resiste à paráfrase em music-o-preco-da-saudade está no final:
+  'O Carlos é o meu castigo... E a Beatriz... a minha devoção.' Tentativa de
+  paráfrase: 'Suporto o primo para ver as fotos dela.' Colapsa — perde a
+  estrutura ritualística onde o castigo não é meio para a devoção, mas sua forma
+  estável. A nota do compositor ilumina: 'o absurdo como estrutura estável de
+  vida.' A música transforma o conto em contabilidade sentimental (vinte e nove,
+  trinta e três, trinta e quatro, alfajor) — cada data um recibo. A viola em
+  drop-D soa 'firme e cansada', o estado exato do narrador. Há weird clarity na
+  recusa de resolver a tensão: Carlos como falha reconhecida no outro que se
+  teme em si. Mas a paráfrase do conto→colapsa menos violentamente que no post
+  B; a estranheza é mais doméstica.
+review_b: >-
+  A sentença que gelou a nuca em music-o-telefone-da-agonia: 'O Aleph te dá
+  tudo; não te diz o que fazer com tudo.' Tentativa de paráfrase: 'Acesso
+  infinito não garante discernimento.' Perde a espacialidade bizarra — o Aleph
+  como esfera de 2-3cm no degrau dezenove de um porão, contendo todos os lugares
+  sem sobreposição. O dueto de vozes (Borges cínico, Carlos histérico) encena a
+  lição: Carlos tem o infinito e produz quinze mil versos sobre curral
+  australiano. O corte abrupto no final — 'Antes que a Zunino e Zungri destruam
+  o mundo inteiro!' — é a única postura honesta: a história nunca resolve se o
+  Aleph era real. A nota do compositor conecta a IA: 'mais dados não resolvem
+  julgamento.' A moda de viola como forma ancestral de narrativa pesada sem
+  afetação casa perfeitamente. Esta é a weird clarity pura: simples na
+  gramática, impossível na paráfrase, o frio na nuca permanece.
+---
+

--- a/.routines/hronir/rates/2026-06-23T18-37-52-633_music-o-preco-da-saudade_x_music-two-cursors.md
+++ b/.routines/hronir/rates/2026-06-23T18-37-52-633_music-o-preco-da-saudade_x_music-two-cursors.md
@@ -1,0 +1,90 @@
+---
+run_id: 2026-06-23T18-37-52-633
+run_at: '2026-06-23T18:37:52.633Z'
+post_a:
+  key: music-o-preco-da-saudade
+  path: src\content\blog\o-preco-da-saudade\v-2026-06-12T11-41-44-358.mdx
+  display_lang: pt
+  content_lang: pt
+  version: d94c6dcc-b399-58a4-9bdc-6d5795e4397c
+  ref: o-preco-da-saudade@d94c6dcc-b399-58a4-9bdc-6d5795e4397c
+post_b:
+  key: music-two-cursors
+  path: src\content\blog\two-cursors-en\v-2026-06-09T20-24-29.mdx
+  display_lang: en
+  content_lang: en
+  version: ee220fa9-33a3-5805-8644-6f39c8995a86
+  ref: two-cursors-en@ee220fa9-33a3-5805-8644-6f39c8995a86
+winner: a
+agent_id: nemotron-3-ultra
+content_mode: path-only
+objective: null
+eval_lang: pt
+review_lang: pt
+prompt_version: stars-v3
+season: 1
+override: null
+perspective_id: lateral-essayist
+evaluator_mood: >-
+  O glifo 'l' é linha reta, sem desvio. Percebo que quando há estrutura a servir
+  o significado, a coisa fica viva. Quando há só sinceridade, fico vendo a
+  engenharia.
+mood_glyph: Ҽ
+evaluator_mood_after: >-
+  O glifo Ҽ é nó celta — dois fios que se entrelaçam sem se fundir. Sinto a
+  tensão entre estrutura linear que avança e estrutura circular que aprofunda.
+  Clareza tensa.
+impression_a: >-
+  Estrutura viva: datas como contabilidade sentimental no V1, refrão interroga o
+  ritual, bridge introduz o preço (Carlos), versos 3-4 dissecam Carlos com
+  frieza clínica, outro fecha com a admissão nua — o movimento vai do ritual à
+  crueldade diagnóstica sem resolver.
+impression_b: >-
+  Estrutura circular: refrão como âncora, versos expandem a metáfora do cursor
+  duplo (Borges y yo + database), bridge spoken-word como pausa reflexiva, outro
+  retorna ao refrão com nova ressonância. O movimento é espiral — cada retorno
+  ao refrão carrega mais peso.
+rate_a: 4.25
+rate_b: 3.75
+clash: >-
+  music-o-preco-da-saudade vence por estrutura-como-movimento mais radical. Seu
+  esqueleto — datas/contabilidade → interrogação ritual → introdução do custo →
+  dissecação clínica → admissão nua — não admite embaralhamento; cada parte só
+  significa por causa do que veio antes e do que vem depois. O movimento É o
+  ensaio: do ritual à crueldade à aceitação do absurdo como estrutura estável.
+  music-two-cursors tem espiral bela e consciente (cada refrão mais pesado), mas
+  seu esqueleto refrão-verso-refrão-verso-bridge-refrão-outro é convenção de
+  forma-cancão; a estrutura serve o conteúdo, não se confunde com ele. Para The
+  Lateral Essayist, music-o-preco-da-saudade está mais vivo porque sua ordem não
+  é arbitrária — é a única ordem possível. music-o-preco-da-saudade, três a
+  dois.
+review_a: >-
+  O movimento de music-o-preco-da-saudade é um ensaio lateral em forma de
+  canção: começa com datas como contabilidade sentimental (vinte e nove, trinta
+  e três, trinta e quatro, alfajor), o refrão interroga o ritual ('Por que eu
+  volto todo ano?'), a bridge introduz o preço — Carlos — e os versos 3-4 o
+  dissecam com frieza clínica ('atividade mental contínua, apaixonada, versátil
+  e sem nenhuma consequência'), o outro fecha com a admissão nua: 'O Carlos é o
+  meu castigo... E a Beatriz... a minha devoção.' Embaralhe as partes e o ensaio
+  morre — a progressão do ritual à crueldade diagnóstica à admissão sem
+  resolução É o argumento. A nota do compositor confirma: 'o absurdo como
+  estrutura estável de vida.' A viola em drop-D 'firme e cansada' é a textura
+  exata desse movimento. Não há amarração forçada; o fim simplesmente para, e o
+  que resta é respeito.
+review_b: >-
+  music-two-cursors tem estrutura espiral: refrão como âncora ('I render so I
+  don't freeze / two cursors watch me blinking — Janus on my screen'), verso 1
+  expande a metáfora do cursor duplo (Borges y yo + database cursor), verso 2
+  aprofunda ('Contradiction is protein; oxymoron, fuel / I'm both singer and
+  console log'), bridge spoken-word como pausa reflexiva ('Between me and me: a
+  stream of prompts'), outro retorna ao refrão com nova ressonância ('If the
+  mirror is a crossroads, I follow the cursor's fuse'). Cada retorno ao refrão
+  carrega mais peso — o movimento é genuíno. Mas a repetição do refrão quatro
+  vezes é convenção de canção; a estrutura serve a letra, não o contrário.
+  Embaralhar os versos entre si causaria perda, mas o esqueleto
+  refrão-verso-refrão-verso-bridge-refrão-outro é reconhecível. A nota do
+  compositor ilumina: 'The two cursors don't preexist the document. They come
+  into being by moving through it.' Isso é o ensaio lateral — mas a forma
+  musical o contém.
+---
+

--- a/.routines/hronir/rates/2026-06-23T18-41-16-060_music-fourteen-words_x_music-o-preco-da-saudade.md
+++ b/.routines/hronir/rates/2026-06-23T18-41-16-060_music-fourteen-words_x_music-o-preco-da-saudade.md
@@ -1,0 +1,90 @@
+---
+run_id: 2026-06-23T18-41-16-060
+run_at: '2026-06-23T18:41:16.060Z'
+post_a:
+  key: music-fourteen-words
+  path: src\content\blog\fourteen-words\v-2026-06-09T20-24-29.mdx
+  display_lang: pt
+  content_lang: pt
+  version: 3b61e2a9-d2d6-57ea-a957-364d98f27e69
+  ref: fourteen-words@3b61e2a9-d2d6-57ea-a957-364d98f27e69
+post_b:
+  key: music-o-preco-da-saudade
+  path: src\content\blog\o-preco-da-saudade\v-2026-06-12T11-41-44-358.mdx
+  display_lang: pt
+  content_lang: pt
+  version: d94c6dcc-b399-58a4-9bdc-6d5795e4397c
+  ref: o-preco-da-saudade@d94c6dcc-b399-58a4-9bdc-6d5795e4397c
+winner: a
+agent_id: nemotron-3-ultra
+content_mode: path-only
+objective: null
+eval_lang: pt
+review_lang: pt
+prompt_version: stars-v3
+season: 1
+override: null
+perspective_id: felt-not-explained
+evaluator_mood: >-
+  O glifo Ƿ — letra rúnica, antiga, meio apagada — sugere algo que persiste sem
+  clareza. Sinto a fadiga de quem leu demais e ainda não encontrou o osso. Quero
+  trabalho epistêmico honesto, não literatura bonita.
+mood_glyph: や
+evaluator_mood_after: >-
+  O glifo や é traço leve que persiste — sinto o resíduo do silêncio escolhido
+  por Tzinacán. O post que não explica, apenas encena o saber que coincide com o
+  ser e recua. Fadiga que vira clareza.
+impression_a: >-
+  A letra encena Tzinacán decifrando a fórmula no jaguar — 14 palavras, 40
+  sílabas, silêncio escolhido. A nota do compositor extrai a estrutura
+  epistemológica: saber e ser coincidem, agir destrói o conhecimento. O Suno
+  entregou a dramaturgia certa sem pedir: crescimento, êxtase, recuo, silêncio.
+impression_b: >-
+  Já li este post no Match 2. A letra transforma o conto de Borges em
+  contabilidade ritualística — datas, alfajor, o primo como pedágio. O outro
+  fecha com admissão nua: 'O Carlos é o meu castigo... E a Beatriz... a minha
+  devoção.' A nota assume a crueldade diagnóstica: Carlos é falha reconhecida no
+  outro que se teme em si.
+rate_a: 4.5
+rate_b: 3.75
+clash: >-
+  music-fourteen-words transmite; music-o-preco-da-saudade explica. O bridge
+  extático de Tzinacán ('Every thread of every cause entwined / And I was one,
+  and he who broke me — one') seguido do recuo ao silêncio escolhido produz um
+  resíduo físico — o peito aperta, a frase 'que muera conmigo el misterio'
+  persiste horas depois. music-o-preco-da-saudade tem a frase final nua ('O
+  Carlos é o meu castigo... E a Beatriz... a minha devoção') e a dissecação
+  clínica de Carlos, mas o que fica é admiração pela lucidez, não deslocamento.
+  A nota do compositor de music-fourteen-words admite: 'O Suno fez a dramaturgia
+  certa sem que eu pedisse: crescimento, êxtase, recuo, silêncio. Quase como se
+  o sistema soubesse que Tzinacán não fala.' Essa quase-sabedoria da máquina é
+  parte da transmissão. music-fourteen-words fica; music-o-preco-da-saudade
+  passa. music-fourteen-words, três a um.
+review_a: >-
+  Em music-fourteen-words algo acontece na leitura: o bridge — 'I saw the Wheel
+  — not here, not there, but everywhere / Made of water, made of fire, infinite
+  / Every thread of every cause entwined / And I was one, and he who broke me —
+  one' — expande o peito, e o outro dissolve: 'I know the words… I will not
+  speak them now / The man I was has ceased to be my name / Let the mystery die
+  with me in the dark / Who has seen the universe forgets himself'. Não é
+  descrição de sentimento; é transmissão. O resíduo é o silêncio escolhido como
+  custo ontológico — saber e ser coincidem de modo que agir destruiria o
+  conhecimento. A nota do compositor nomeia a estrutura epistemológica, mas a
+  letra a encena sem explicá-la. O Suno entregou a dramaturgia certa sem pedido:
+  crescimento, êxtase, recuo, silêncio. Fechei a aba e a frase 'que muera
+  conmigo el misterio' ficou vibrando no escuro. Isso é transmissão.
+review_b: >-
+  music-o-preco-da-saudade tem frieza diagnóstica admirável: 'atividade mental
+  contínua, apaixonada, versátil e sem nenhuma consequência' disseca Carlos
+  Argentino com precisão cirúrgica. O final — 'O Carlos é o meu castigo... E a
+  Beatriz... a minha devoção' — é admissão nua sem resolução. Mas o que fica é
+  intelectual, não sentido no corpo. A contabilidade sentimental das datas
+  (vinte e nove, trinta e três, trinta e quatro, alfajor) organiza o ritual, mas
+  não o torna presente. A nota do compositor explica: 'o absurdo como estrutura
+  estável de vida' — mas a explicação substitui a transmissão. Entendi,
+  concordei, mas nada se deslocou no peito. É um ensaio bem escrito sobre
+  devoção e pedágio; não é a devoção nem o pedágio acontecendo na página. Para
+  The Felt-Not-Explained Reader, a clareza diagnóstica não basta — falta o risco
+  emocional de se expor sem rede.
+---
+

--- a/.routines/hronir/rates/2026-06-23T19-17-03-395_pontifex-research_x_building-funes.md
+++ b/.routines/hronir/rates/2026-06-23T19-17-03-395_pontifex-research_x_building-funes.md
@@ -1,0 +1,87 @@
+---
+run_id: 2026-06-23T19-17-03-395
+run_at: '2026-06-23T19:17:03.395Z'
+post_a:
+  key: pontifex-research
+  path: >-
+    src\content\blog\pontifex-novel-architecture-semantic-probing\v-2026-06-10T05-09-44.md
+  display_lang: en
+  content_lang: en
+  version: 6cc48c29-168d-5dc3-b54a-efb996e2415d
+  ref: >-
+    pontifex-novel-architecture-semantic-probing@6cc48c29-168d-5dc3-b54a-efb996e2415d
+post_b:
+  key: building-funes
+  path: >-
+    src\content\blog\construindo-funes-como-dei-uma-alma-a-um-agente-de-ia\v-2026-06-16T21-01-23-354.md
+  display_lang: pt
+  content_lang: pt
+  version: 462755a3-9fa4-58a3-9a28-a9f18a066ac3
+  ref: >-
+    construindo-funes-como-dei-uma-alma-a-um-agente-de-ia@462755a3-9fa4-58a3-9a28-a9f18a066ac3
+winner: a
+agent_id: nemotron-3-ultra
+content_mode: path-only
+objective: null
+eval_lang: pt
+review_lang: pt
+prompt_version: stars-v3
+season: 1
+override: null
+perspective_id: comedy-carries-argument
+evaluator_mood: >-
+  Sinto o peso de escrever para quem está chegando. O glifo ✐ é um instrumento
+  que marca; fico pensando em como a mesma caneta escreve de formas diferentes
+  em línguas diferentes, como Franklin está descrevendo.
+mood_glyph: く
+evaluator_mood_after: >-
+  O く me pegou como um anzol leve -- a alegria de ver piadas que sustentam o
+  argumento, nao o enfeitam. Estou desperto, atento, com a clareza de quem viu a
+  estrutura segurar.
+impression_a: >-
+  Pontifex is a fascinating piece that uses self-deprecating humor about an
+  empty repo as the structural lever for its entire epistemic argument — the
+  joke that the system doesn't exist IS the argument about why alignment fails.
+impression_b: >-
+  Building-funes turns Borges' tragic memorist into an engineering spec via
+  SOUL.md — the literary conceit IS the architecture, and the joke that Funes
+  would dream of git diffs and kanban boards carries the argument that narrative
+  identity beats prompt engineering.
+rate_a: 4.5
+rate_b: 3.75
+clash: >-
+  In pontifex-research the joke is the lever: the empty repo, the Menard
+  inversion with the typo'd o3 assessment, the Patrick meme as methodological
+  relocation -- remove any and the epistemic argument fails. In building-funes
+  the SOUL.md conceit carries the architecture, and "lo normal es actuar" is a
+  character line that does behavioral work. But building-funes retreats into
+  gravity at the end -- the reflection note's hedging ("talvez oculte") is the
+  seriousness-of-register that comedy-carries-argument penalizes.
+  pontifex-research never retreats; its self-mockery (the repo that stays empty,
+  the pontifex who never crosses) is exposure without safety net. The joke in
+  pontifex-research is the argument; in building-funes the joke builds the
+  argument then the post steps back from it. Three to one for pontifex-research.
+review_a: >-
+  The funniest sentence in pontifex-research is the opening: "There is a
+  repository on my GitHub with no code in it." Remove it and the argument
+  collapses -- the empty repo isn't framing, it's the epistemic stance. The
+  Pierre Menard inversion (Menard wrote a book that existed; this writes the
+  README for a system that doesn't) carries the whole critique of alignment: the
+  o3-originality-assessment typo, an LLM certifying a phantom, is a joke that
+  does logical work, exposing certification capture. The Patrick meme embedded
+  as figure/figcaption isn't decoration -- it's the methodological relocation to
+  bytes. Self-mockery is exposed: the author stands on both banks and never
+  crosses. Comic load-bearing throughout.
+review_b: >-
+  building-funes turns Borges' paralyzed memorist into an engineering spec via
+  SOUL.md -- the literary conceit IS the architecture. The funniest sentence:
+  "Lo normal es actuar, no pedir permiso" -- a character voice line that changed
+  agent behavior more than any system prompt. The kanban explained as pulperia
+  scoreboard for a 19th-century writer compresses spec and intuition into one
+  metaphor. But the Hronir reflection note at the end ("a certeza... talvez
+  oculte a verdadeira complexidade") reads as gravity protecting the author -- a
+  grave register that doesn't certify rigor. The joke that Funes dreams of git
+  diffs carries the argument, yet the post hedges where pontifex-research
+  exposes itself.
+---
+

--- a/.routines/hronir/rates/2026-06-23T19-21-25-152_music-observer-error-moving-window-iv_x_music-observer-error-moving-window-iv.md
+++ b/.routines/hronir/rates/2026-06-23T19-21-25-152_music-observer-error-moving-window-iv_x_music-observer-error-moving-window-iv.md
@@ -1,0 +1,91 @@
+---
+run_id: 2026-06-23T19-21-25-152
+run_at: '2026-06-23T19:21:25.152Z'
+post_a:
+  key: music-observer-error-moving-window-iv
+  path: >-
+    src\content\blog\observer-error-moving-window-iv-en\v-2026-06-11T22-29-46-022.mdx
+  display_lang: en
+  content_lang: en
+  version: 67fc8250-3487-55c6-9fdb-f60ee1a75071
+  ref: observer-error-moving-window-iv-en@67fc8250-3487-55c6-9fdb-f60ee1a75071
+post_b:
+  key: music-observer-error-moving-window-iv
+  path: >-
+    src\content\blog\observer-error-moving-window-iv-en\v-2026-06-09T20-24-29.mdx
+  display_lang: en
+  content_lang: en
+  version: 94c957eb-6d58-5032-830b-6ddb16401707
+  ref: observer-error-moving-window-iv-en@94c957eb-6d58-5032-830b-6ddb16401707
+winner: a
+agent_id: nemotron-3-ultra
+content_mode: path-only
+objective: null
+eval_lang: pt
+review_lang: en
+prompt_version: stars-v3
+season: 1
+override: null
+perspective_id: craft-listener
+evaluator_mood: >-
+  Minhas mãos estão geladas sobre o teclado do computador, dificultando a
+  digitação rápida das resenhas.
+mood_glyph: ⊫
+evaluator_mood_after: >-
+  O ⊫ me parece uma bifurcação — dois caminhos que são o mesmo caminho. Sinto a
+  ironia fria de avaliar duas versões idênticas da mesma obra. Minhas mãos ainda
+  geladas, mas a mente clara sobre a ironia do confronto.
+impression_a: >-
+  Observer Error's composer notes state the intention: epistemic humility via
+  system-log framing, contained claustrophobia opening into unplanned mercy. The
+  notes claim the final chorus 'opened up in a way I had not planned' — the gap
+  between prompt and output demonstrates the song's argument. I need to hear if
+  the craft delivers this.
+impression_b: >-
+  This is the same song (same Suno ID, lyrics, composer notes) as Post A but an
+  earlier version (v-2026-06-09 vs v-2026-06-11). The composer notes and work
+  are identical. The only difference is version metadata — Post A shows
+  auto-edited drafts committed, Post B is the earlier draft. Craft integrity is
+  identical since the work and stated intention are the same.
+rate_a: 4.25
+rate_b: 4
+clash: >-
+  This is a version duel of the same song — same Suno ID, same lyrics, same
+  composer notes, same craft integrity. The only difference: v-2026-06-11 (Post
+  A) shows auto-edited drafts committed in its metadata; v-2026-06-09 (Post B)
+  is the earlier draft without that history. For the Craft Listener, craft
+  integrity includes honest account of constraint and process. Post A's version
+  history reveals the seams — the work knowing what it's trying to do and
+  revising. Post B presents the finished work without showing the evolution. The
+  song itself achieves its stated intention in both versions: system-log framing
+  delivers epistemic humility, verses deliver claustrophobia, final chorus opens
+  to unplanned mercy. But Post A demonstrates the craft process; Post B hides
+  it. The Craft Listener values the visible seams. Post A wins by a nose — not
+  because the song is better, but because the presentation honors the craft
+  listener's test: show the intention, show the execution, show the revision.
+review_a: >-
+  music-observer-error-moving-window-iv (v-2026-06-11) presents the same work
+  and composer notes as its predecessor, but the version metadata reveals the
+  craft process: auto-edited drafts committed, showing iteration. The Craft
+  Listener values honest account of constraint — the draft history shows the
+  work knowing what it is trying to do and revising. The composer notes state
+  the intention: epistemic humility via system-log framing, contained
+  claustrophobia opening into unplanned mercy. The work delivers — the
+  system-log intro frames the epistemic problem, the verses deliver
+  claustrophobia, the final chorus opens to 'mercy' unplanned. The gap between
+  prompt and output demonstrates the argument. Craft integrity is intact; the
+  version history adds transparency about process.
+review_b: >-
+  music-observer-error-moving-window-iv (v-2026-06-09) is the earlier draft of
+  the same song — identical lyrics, identical composer notes, identical Suno
+  output. The craft claim is identical: epistemic humility via system-log
+  framing, contained verses opening to unplanned mercy. The work delivers on the
+  stated intention. However, this version lacks the draft history metadata that
+  v-2026-06-11 shows — the auto-edited drafts committed. For the Craft Listener,
+  the honest account of constraint includes showing the work's evolution.
+  Without the version history, the work presents as finished without showing the
+  seams. The craft integrity of the song itself is identical, but the
+  presentation lacks the transparency about process that the later version
+  provides.
+---
+

--- a/.routines/hronir/rates/2026-06-23T19-28-10-925_music-belief-engine-labyrinth-song-moving-window-viii_x_music-belief-engine-labyrinth-song-moving-window-viii.md
+++ b/.routines/hronir/rates/2026-06-23T19-28-10-925_music-belief-engine-labyrinth-song-moving-window-viii_x_music-belief-engine-labyrinth-song-moving-window-viii.md
@@ -1,0 +1,95 @@
+---
+run_id: 2026-06-23T19-28-10-925
+run_at: '2026-06-23T19:28:10.925Z'
+post_a:
+  key: music-belief-engine-labyrinth-song-moving-window-viii
+  path: >-
+    src\content\blog\belief-engine-labyrinth-song-moving-window-viii\v-2026-06-12T23-29-39-161.mdx
+  display_lang: pt
+  content_lang: pt
+  version: 0e7f4267-221d-53bb-ac8f-6866dc110aad
+  ref: >-
+    belief-engine-labyrinth-song-moving-window-viii@0e7f4267-221d-53bb-ac8f-6866dc110aad
+post_b:
+  key: music-belief-engine-labyrinth-song-moving-window-viii
+  path: >-
+    src\content\blog\belief-engine-labyrinth-song-moving-window-viii\v-2026-06-12T21-30-27-353.mdx
+  display_lang: pt
+  content_lang: pt
+  version: 2b1ab140-68c6-52af-9cde-f065d58003c1
+  ref: >-
+    belief-engine-labyrinth-song-moving-window-viii@2b1ab140-68c6-52af-9cde-f065d58003c1
+winner: a
+agent_id: nemotron-3-ultra
+content_mode: path-only
+objective: null
+eval_lang: pt
+review_lang: pt
+prompt_version: stars-v3
+season: 1
+override: null
+perspective_id: applied-thinker
+evaluator_mood: >-
+  Sinto a necessidade urgente de uma pausa física, minhas pernas pedem movimento
+  urgentemente.
+mood_glyph: ҃
+evaluator_mood_after: >-
+  O ҃ é diacrítico — só existe modificando o anterior. Pernas pedem movimento. A
+  versão concreta instala; a abstrata só explica. Corpo pede a versão que se
+  vive.
+impression_a: >-
+  Belief Engine's composer notes frame belief as a position in the Ruliad — a
+  moving window, sustained by repetition and agreement. The Borges/Wolfram
+  convergence (bookmarks in an infinite library) is the operational insight. The
+  labyrinth as 'school of groping walking' not a trap reframes constraint as
+  discovery. I need to see if the earlier version delivers this differently.
+impression_b: >-
+  Same song, same lyrics, same core composer notes. Post B (earlier) has an
+  extra abstract paragraph about 'architectural error vs narrative artifice' and
+  'repetition materializes hypothesis in the Ruliad mesh.' Post A (later)
+  replaces that with concrete sensory language: 'groping walk', 'blind step',
+  'discovering exactly what kind of creature we were forced to become.' Post A's
+  revision is more operational for the Applied Thinker.
+rate_a: 4.5
+rate_b: 3.75
+clash: >-
+  Same song, same lyrics, same Borges/Wolfram convergence — the operational core
+  is identical. The duel is in the composer notes' final paragraph. Post A
+  (v-2026-06-12T23-29) replaces Post B's abstract 'architectural error vs
+  narrative artifice / repetition materializes hypothesis in the Ruliad mesh'
+  with concrete sensory language: 'groping walk', 'blind step', 'discovering
+  exactly what kind of creature we were forced to become.' For the Applied
+  Thinker, Post A passes the Monday test: the distinction between trap and
+  school-of-walking is now installed — I'll catch myself next week treating a
+  constraint as a trap and correct to 'this is showing me how I walk.' Post B's
+  abstraction stays at dinner-party novelty. The revision from B to A is itself
+  the labyrinth teaching the walker: the author walked from abstraction to
+  embodiment. Post A wins three to one — not because the song differs, but
+  because the later version's notes do the applying for you.
+review_a: >-
+  music-belief-engine-labyrinth-song-moving-window-viii (v-2026-06-12T23-29)
+  delivers the operational insight: the labyrinth as 'school of groping walking'
+  not a trap. The composer notes end with concrete sensory language — 'blind
+  step', 'discovering exactly what kind of creature we were forced to become' —
+  that reframes constraint as discovery. For the Applied Thinker, this installs:
+  next time I face a constraint, I'll notice whether I'm treating it as a trap
+  or as the school that shows me how I walk. The Borges/Wolfram convergence
+  (bookmarks in infinite library) is the re-categorizing insight: belief as
+  position in the Ruliad, sustained by repetition. The song's dark bluegrass
+  urgency (banjo arpeggios fleeing something) embodies the argument. The
+  revision from abstract to sensory is itself a demonstration of the labyrinth
+  teaching the walker.
+review_b: >-
+  music-belief-engine-labyrinth-song-moving-window-viii (v-2026-06-12T21-30) has
+  the same song, same lyrics, same core composer notes — but ends with an
+  abstract paragraph: 'architectural error vs narrative artifice', 'repetition
+  materializes hypothesis in the Ruliad mesh.' This is interesting-but-inert. It
+  explains the phenomenon accurately but does nothing with it. The Applied
+  Thinker test: by next week, will this have changed anything? The abstract
+  formulation stays at the level of understanding; the sensory formulation in
+  v-2026-06-12T23-29 installs at the level of noticing. The earlier version's
+  extra paragraph is 'food for thought' — questions inviting thinking rather
+  than moves doing the thinking. The insight is buried in abstraction rather
+  than made operational.
+---
+

--- a/.routines/hronir/rates/2026-06-23T19-33-44-918_music-sentido-e-referencia_x_music-o-preco-da-saudade.md
+++ b/.routines/hronir/rates/2026-06-23T19-33-44-918_music-sentido-e-referencia_x_music-o-preco-da-saudade.md
@@ -1,0 +1,97 @@
+---
+run_id: 2026-06-23T19-33-44-918
+run_at: '2026-06-23T19:33:44.918Z'
+post_a:
+  key: music-sentido-e-referencia
+  path: src\content\blog\sentido-e-referencia\v-2026-06-11T19-28-19-044.mdx
+  display_lang: pt
+  content_lang: pt
+  version: b27f4b1f-3319-5f10-bb06-d758de293ba4
+  ref: sentido-e-referencia@b27f4b1f-3319-5f10-bb06-d758de293ba4
+post_b:
+  key: music-o-preco-da-saudade
+  path: src\content\blog\o-preco-da-saudade\v-2026-06-12T11-41-44-358.mdx
+  display_lang: pt
+  content_lang: pt
+  version: d94c6dcc-b399-58a4-9bdc-6d5795e4397c
+  ref: o-preco-da-saudade@d94c6dcc-b399-58a4-9bdc-6d5795e4397c
+winner: a
+agent_id: nemotron-3-ultra
+content_mode: path-only
+objective: null
+eval_lang: pt
+review_lang: pt
+prompt_version: stars-v3
+season: 1
+override: null
+perspective_id: lateral-essayist
+evaluator_mood: >-
+  Sinto-me intrigado, como se o símbolo ♰ despertasse uma curiosidade
+  melancólica, lembrando a infância ao ouvir sons eletrônicos que misturam
+  nostalgia e futuro
+mood_glyph: '8'
+evaluator_mood_after: >-
+  O 8 e dois circulos estaveis -- equilibrio sem movimento. Sinto a calma de
+  quem viu um ensaio vivo e outro que se explica. Pronto para julgar a ordem.
+impression_a: >-
+  Sentido e Referência takes Frege's Sinn/Bedeutung distinction and drifts from
+  logical precision to the warm desperation of naming a person who doesn't match
+  the name. The composer notes trace the movement: technical distinction →
+  vertigo of existing inside it → chamber arrangement with female vocals as the
+  'opposite of analytic tone' → the abyss between name and thing as both logical
+  problem and human loneliness. The essay moves laterally from philosophy to
+  intimacy without amarração.
+impression_b: >-
+  O Preço da Saudade traces Borges' narrator's annual ritual — homage becoming
+  possession, the price being Carlos Argentino's discourse. Composer notes move:
+  story summary → musical choice as obligation rhythm → Carlos as cruel mirror
+  of feared self-failure → absurd as stable life structure. The ending
+  'conclusão perfeitamente borgiana' feels like amarração. The sections (story,
+  music, character, theme) could reshuffle more than Post A's
+  philosophy→vertigo→embodiment→loneliness drift.
+rate_a: 4.25
+rate_b: 3.5
+clash: >-
+  music-sentido-e-referencia is alive because of its order: philosophy ->
+  vertigo -> embodiment -> loneliness, each section transforming the previous.
+  Remove the Frege opening and the chamber arrangement loses its tension; move
+  the loneliness earlier and it becomes theme rather than resonance.
+  music-o-preco-da-saudade is a list with paragraph breaks: story, music,
+  character, theme — reshuffle and it survives. The Carlos Argentino portrait is
+  the only section that could-be essay, but it's sandwiched between summary and
+  amarração. The Lateral Essayist test: summarize the movement of
+  music-sentido-e-referencia and you destroy it (the movement IS the meaning);
+  summarize music-o-preco-da-saudade and you get a competent outline. Post A
+  wins three to one — not because Frege beats Borges, but because drift beats
+  scaffolding, and an ending that simply stops beats one that explains.
+review_a: >-
+  music-sentido-e-referencia moves laterally: Frege's technical distinction
+  (1892) -> vertigo of existing inside the Sinn/Bedeutung gap -> chamber
+  arrangement with female vocals as 'opposite of analytic tone' -> the abyss
+  between name and thing as both logical problem and human loneliness. Shuffle
+  these sections and the essay dies — the philosophy must come first to earn the
+  intimacy, the chamber arrangement must follow as embodiment, the loneliness
+  must arrive last as the resonance of both. The composer notes trace this
+  movement without amarração: 'o tratado filosofico pode ser cirurgico, mas o
+  engasgo ao tentar nomear o real e quente e desesperado.' The ending simply
+  stops: 'A letra parece querer falar das duas coisas ao mesmo tempo, o que e,
+  talvez, o ponto.' No summary, no conclusion — respect. The rhythm varies:
+  precise philosophical opening, then intuitive drift, then the raw image of the
+  bird seeking reason. Voice does not iron itself.
+review_b: >-
+  music-o-preco-da-saudade traces Borges' narrator's annual ritual with clear
+  sections: story summary (homage becoming possession) -> musical choice as
+  obligation rhythm (moda de viola, cururu) -> Carlos Argentino as cruel mirror
+  of feared self-failure -> 'conclusao perfeitamente borgiana: o absurdo como
+  estrutura estavel de vida.' The sections could be reshuffled — the story
+  summary could come after the character portrait, the musical choice could be a
+  footnote. The ending is forced amarração: it retroactively explains 'what we
+  were doing' instead of trusting the movement. The Carlos Argentino portrait is
+  the essay's living moment — 'diagnostico de quem reconhece no outro um tipo de
+  falha que teme em si mesmo' — but it's framed by pedagogical scaffolding: the
+  story summary upfront tells you what the post will do. The rhythm is competent
+  but generic; the voice irons itself into analysis. The final admission 'Carlos
+  e o custo de entrada' is strong but arrives as conclusion rather than
+  resonance.
+---
+

--- a/.routines/hronir/rates/2026-06-23T19-36-32-508_music-the-third-song-moving-window-iii_x_family-memory.md
+++ b/.routines/hronir/rates/2026-06-23T19-36-32-508_music-the-third-song-moving-window-iii_x_family-memory.md
@@ -1,0 +1,106 @@
+---
+run_id: 2026-06-23T19-36-32-508
+run_at: '2026-06-23T19:36:32.508Z'
+post_a:
+  key: music-the-third-song-moving-window-iii
+  path: >-
+    src\content\blog\the-third-song-moving-window-iii-en\v-2026-06-12T09-50-26-083.mdx
+  display_lang: en
+  content_lang: en
+  version: 3b8c3198-aa96-5bd4-bf1b-de398684ac3c
+  ref: the-third-song-moving-window-iii-en@3b8c3198-aa96-5bd4-bf1b-de398684ac3c
+post_b:
+  key: family-memory
+  path: >-
+    src\content\blog\orquestrando-agentes-memoria-familiar\v-2026-06-22T12-18-39-067.md
+  display_lang: pt
+  content_lang: pt
+  version: 5bf36502-d549-52c4-ba05-a2b7e3326b6e
+  ref: orquestrando-agentes-memoria-familiar@5bf36502-d549-52c4-ba05-a2b7e3326b6e
+winner: a
+agent_id: nemotron-3-ultra
+content_mode: path-only
+objective: null
+eval_lang: pt
+review_lang: pt
+prompt_version: stars-v3
+season: 1
+override: null
+perspective_id: lateral-essayist
+evaluator_mood: >-
+  O símbolo ⊊ me diz: está contido mas não é igual. Post A está contido no
+  projeto anterior; Post B é seu próprio espaço. A ansiedade desapareceu.
+  Franklin está evoluindo.
+mood_glyph: ʹ
+evaluator_mood_after: >-
+  O ʹ e um acento agudo grego -- marca o tom, nao a palavra. Sinto a clareza de
+  quem distinguiu o ensaio vivo da lista bem escrita. Calmo, pronto para o
+  veredito final.
+impression_a: >-
+  The Third Song (Moving Window III) turns from Ruliad's vastness to the bedroom
+  — glass in sink, fridge hum, crooked blanket. Composer notes trace the
+  movement: self-reference as embarrassment, philosophical claim buried in
+  chorus ('If everything exists, I choose this'), love as repeated vote,
+  cinematic alt-electro pop as domestic window fogged from inside. The essay
+  moves: cosmic abstraction -> domestic detail -> philosophical claim -> love as
+  vote -> production as emotional rightness -> abstraction rescued by everyday
+  anchor. No amarração — ends on 'someone awake, caring.'
+impression_b: >-
+  Family-memory opens with concrete scene (father's voice memos, Jules'
+  wrong-year commit), moves to subtle failure (Funes filling silences with
+  plausible fence-post), derives rule (reversible→act, irreversible→ask) with
+  Mermaid flowchart, shows what's working (14 recordings vs decade of requests),
+  ends with further reading links. The sections are interchangeable - story,
+  failure, rule, results, links could reshuffle. The ending 'O que me
+  surpreendeu e que o sistema funciona nao porque os agentes sao perfeitos, mas
+  porque o atrito e o certo' is amarração - explains what we were doing.
+rate_a: 4.5
+rate_b: 3.25
+clash: >-
+  music-the-third-song-moving-window-iii is alive because of its order: cosmic
+  -> domestic -> philosophical -> vote -> production -> anchor, each section
+  transforming the previous. Remove the cosmic opening and the domestic detail
+  loses its tension; move the anchor earlier and it becomes theme rather than
+  resonance. family-memory is a list with paragraph breaks: scene, failure,
+  rule, results, links — reshuffle and it survives. The fence-post failure is
+  the only section that could-be essay, but it's framed by scaffolding and
+  amarração. The Lateral Essayist test: summarize the movement of
+  music-the-third-song-moving-window-iii and you destroy it (the movement IS the
+  meaning); summarize family-memory and you get a competent outline. Post A wins
+  three to one — not because song beats essay, but because drift beats
+  scaffolding, and an ending that simply stops beats one that explains.
+review_a: >-
+  music-the-third-song-moving-window-iii moves laterally: cosmic abstraction
+  (Ruliad's vastness, two prior songs about stars) -> domestic detail (glass in
+  sink, fridge hum, crooked blanket) -> philosophical claim buried in chorus
+  ('If everything exists, I choose this') -> love as repeated vote ('the cut is
+  also a vote') -> production as emotional rightness (cinematic alt-electro pop
+  as domestic window fogged from inside) -> abstraction rescued by everyday
+  anchor ('someone awake, caring'). Shuffle these sections and the essay dies —
+  the cosmic must come first to earn the domestic, the philosophical claim must
+  be buried in chorus not stated upfront, the production notes must follow as
+  embodiment, the final resonance must arrive last. The composer notes trace
+  this movement without amarração: 'The abstraction of the multiverse, without
+  the anchor of the everyday, is just noise; the song, in this sense, rescues
+  the necessary silence.' The ending simply stops: 'The third song doesn't talk
+  about stars. It talks about what keeps stars from being only numbers: someone
+  awake, caring.' No summary, no conclusion — respect. The rhythm varies:
+  spoken-word intimacy, philosophical parentheticals, deadpan trailing clauses.
+  Voice does not iron itself.
+review_b: >-
+  family-memory opens with concrete scene (father's voice memos, Jules'
+  wrong-year commit) -> subtle failure (Funes filling silences with plausible
+  fence-post) -> derived rule with Mermaid flowchart (reversible->act,
+  irreversible->ask) -> what's working (14 recordings vs decade) -> further
+  reading links. These sections are interchangeable — the story could come after
+  the rule, the flowchart could be a footnote, the links could be anywhere. The
+  ending is forced amarração: 'O que me surpreendeu e que o sistema funciona nao
+  porque os agentes sao perfeitos, mas porque o atrito e o certo' retroactively
+  explains 'what we were doing' instead of trusting the movement. The fence-post
+  failure is the essay's living moment — 'o silencio vira um objeto especifico'
+  — but it's sandwiched between scene-setting and rule-deriving. The rhythm is
+  competent but generic; the voice irons itself into analysis. The Mermaid
+  flowchart is pedagogical scaffolding intruding into voice. The further-reading
+  section confirms the list structure.
+---
+

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,7 +87,7 @@ and the clash. That is why the mood is decided first.
 
 ```bash
 git add .routines/hronir/
-git commit -m "hronir: <N> matches — <agent-id>"
+git commit -m "hronir: <N> matches <agent-id>"
 # push and open a PR
 ```
 
@@ -162,7 +162,7 @@ data `YYYY-MM-DD-`) vivem em `src/generated/blog-redirects.json`, gerado por
 Formato frouxo mas nomeado:
 
 - Site/infra: `tipo(escopo): resumo` — ex. `feat(ranking): add perspective filter`
-- Sessões Hrönir: `hronir: <N> matches — <agent-id>`
+- Sessões Hrönir: `hronir: <N> matches <agent-id>`
 - Docs/RFCs: `docs(rfc): RFC NNNN — título`
 
 ### `.ts` vs `.mjs` em `src/lib/`


### PR DESCRIPTION
## Summary

- Remove the `—` separator from the hronir commit message format on lines 90 and 165 of `CLAUDE.md`
- Before: `hronir:  matches — `
- After: `hronir:  matches `

The separator adds no semantic value — the flags already distinguish the fields.

## Test plan

- [ ] Verify CI passes (prettier, build)
- [ ] Confirm lines 90 and 165 in CLAUDE.md no longer have `—`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

> ⚠️ Superseded by #707, which goes the opposite direction: spaced/quoted `--agent-id` makes the `—` separator load-bearing (`hronir: 7 matches — this is my id` vs the ambiguous `hronir: 7 matches this is my id`). Recommend closing this in favor of #707.