### PR TITLE
feat(hronir): defer --agent-id to submit-eval

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,13 +35,19 @@ npx hronir init --agent-id 'this is my id' --matches 10 --skip-edit  # via node_
 single match without the `init` / `continue` / `first-impression-*` ceremony:
 
 ```bash
-npx hronir generate-match --agent-id 'this is my id'  # starts a 1-match session, prints BOTH posts + glyph + decide prompt
+npx hronir generate-match                             # starts a 1-match session, prints BOTH posts + glyph + decide prompt
 npx hronir get-glipho                                 # re-read the glyph (also shown by generate-match)
-npx hronir submit-eval --after-mood "..." --rate-a 4.25 --rate-b 3.00 \
+npx hronir submit-eval --agent-id 'this is my id' \
+  --after-mood "..." --rate-a 4.25 --rate-b 3.00 \
   --review-a "..." --review-b "..." --clash "..."     # alias of decide; closes the round
 npx hronir get-ranking                                # alias of ranking
 ```
 
+- `--agent-id` belongs on **`submit-eval`**, not `generate-match`: generating a
+  match is identity-agnostic; the evaluator is named only when the evaluation is
+  recorded. `generate-match` stores `agentId: "TODO"` and `submit-eval` requires
+  `--agent-id` (it errors otherwise). You may still pass `--agent-id` to
+  `generate-match` to pin it early, but it is optional there.
 - `generate-match` is `--skip-edit` and single-match: the one `submit-eval` finishes
   the round. If a session is already in progress it just advances it, like `next`.
 - First impressions are skipped (they carry no downstream use); `impression_a/b`

--- a/src/hronir/commands.ts
+++ b/src/hronir/commands.ts
@@ -62,6 +62,9 @@ interface InitOptions {
   // When true, init creates the session but does NOT auto-call continueCmd
   // (used by generate-match, which drives the display itself, quietly).
   skipAutoContinue?: boolean;
+  // When true, a missing --agent-id is allowed and stored as "TODO"; the
+  // evaluator is named later at submit-eval (used by generate-match).
+  deferAgentId?: boolean;
 }
 
 interface WorstOptions {
@@ -260,12 +263,16 @@ export function init(options: InitOptions = {}) {
 
   const skipEdit = !!options.skipEdit;
   const skipRating = !!options.skipRating;
-  const agentId = options.agentId;
+  let agentId = options.agentId;
   if (!agentId || agentId === "TODO") {
-    console.error(
-      "Erro: --agent-id é obrigatório. Identifique o avaliador explicitamente (ex.: --agent-id claude-opus-4-7 ou --agent-id franklin)."
-    );
-    process.exit(1);
+    if (!options.deferAgentId) {
+      console.error(
+        "Erro: --agent-id é obrigatório. Identifique o avaliador explicitamente (ex.: --agent-id claude-opus-4-7 ou --agent-id franklin)."
+      );
+      process.exit(1);
+    }
+    // Deferred identity (generate-match): the evaluator is named at submit-eval.
+    agentId = "TODO";
   }
   const evalLang = options.evalLang || "pt";
   // RFC 0012 §6: review_lang defaults to the evaluation language when not given.
@@ -340,8 +347,10 @@ export function init(options: InitOptions = {}) {
   };
   fs.writeFileSync(sessionPath, JSON.stringify(session, null, 2));
 
+  const agentLabel =
+    agentId === "TODO" ? "(a definir em submit-eval)" : agentId;
   console.log(
-    `Sessão iniciada para ${matchesOpt} matches com agente "${agentId}" e avaliações em "${evalLang}".`
+    `Sessão iniciada para ${matchesOpt} matches com agente "${agentLabel}" e avaliações em "${evalLang}".`
   );
   if (pledge) {
     const border = "═".repeat(80);
@@ -1101,12 +1110,14 @@ export function next(initOptions = {}) {
 export function generateMatch(initOptions = {}) {
   if (!fs.existsSync(SESSION_PATH)) {
     // Create the session without init's auto-continue, then drive the display
-    // ourselves (quietly, no first-impression hint).
+    // ourselves (quietly, no first-impression hint). --agent-id is optional
+    // here; the evaluator is named at submit-eval (deferAgentId).
     init({
       ...initOptions,
       matches: 1,
       skipEdit: true,
       skipAutoContinue: true,
+      deferAgentId: true,
     });
   }
   // Advance ready_for_next → perspective banner + post A (or report the current
@@ -1310,7 +1321,7 @@ export function decide(args: string[]) {
 
   if (!agentId || agentId === "TODO") {
     console.error(
-      "Erro: --agent-id deve ser especificado ou definido no init."
+      "Erro: --agent-id é obrigatório. Passe-o aqui (ex.: submit-eval --agent-id 'this is my id' ...) ou defina no init."
     );
     process.exit(1);
   }


### PR DESCRIPTION
## Summary

Follow-up to #707: the evaluator identity now belongs on **`submit-eval`**, not `generate-match`. Generating a match is identity-agnostic — the agent is only named when the evaluation is actually recorded.

```bash
npx hronir generate-match                                # no --agent-id needed
npx hronir submit-eval --agent-id 'this is my id' \
  --after-mood "..." --rate-a 4.25 --rate-b 3.00 \
  --review-a "..." --review-b "..." --clash "..."
```

### Behavior
- `generate-match` no longer requires `--agent-id`; it stores `agentId: "TODO"` (deferred). You may still pass `--agent-id` there to pin it early — it stays optional.
- `submit-eval` requires `--agent-id` (it already accepted it via `decide`); it errors clearly if missing, and the supplied id is what lands in the rate file's `agent_id`.

### Changes
- `src/hronir/commands.ts` — `InitOptions.deferAgentId`; `init` allows a missing id (stored as `TODO`) and labels the session log `(a definir em submit-eval)`; `generateMatch` passes `deferAgentId: true`; clearer missing-id error in `decide`.
- `CLAUDE.md` — one-shot API example moves `--agent-id` to `submit-eval`, with a note explaining why.

## Test plan
- [x] prettier --check, 39/39 unit tests pass
- [x] smoke-tested: `generate-match` (no id) → session `agentId: TODO`; `submit-eval` without `--agent-id` errors; with `--agent-id 'this is my id'` it closes the round and writes `agent_id: this is my id`; `doctor` reports 0 inconsistencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QpgbJQF7PQNWGYMQ8KpfAe)_