### PR TITLE
a11y: i18n strings no ShareButton para PT-BR

### DIFF
--- a/.routines/2026-06-24T05-36-00-sharebox-i18n.md
+++ b/.routines/2026-06-24T05-36-00-sharebox-i18n.md
@@ -1,0 +1,46 @@
+---
+date: "2026-06-24T05:36:00Z"
+slug: sharebox-i18n
+branch: claude/sleepy-pasteur-tpxn5j
+status: pr-open
+issues: [677]
+pr_opened: null
+pr_merged: 681
+---
+
+## Contexto ao chegar
+
+- 10 issues `routine` abertas, todas `priority:baixa` — backlog dentro da faixa (10–20), sem necessidade de criar novas.
+- PR #681 da run anterior (perf: preconnect + dns-prefetch para Suno/Goodreads) estava aberto mas sem CI rodado. Branch `claude/sleepy-pasteur-9vyk9u` divergiu do `main` atual com conflitos em `PageLayout.astro` e nos arquivos gerados.
+- CI do `main` estava falhando há vários commits seguidos — a causa raiz era `MANAGER-INTEL.md` formatado incorretamente pelo Jules bot, bloqueando o step prettier antes mesmo do build.
+
+## O que mergeou
+
+PR #681 — rebaseado manualmente no `main` atual, resolvendo:
+
+1. Conflito em `src/layouts/PageLayout.astro` (aceitou as linhas de preconnect do PR).
+2. Conflito nos arquivos gerados (`ranking-snapshot.json`, `versions-selected.json`) — tomou a versão do `main` (mais recente).
+3. Adicionado `fix(prettier): formata MANAGER-INTEL.md` — corrigia a falha pré-existente de CI.
+4. Adicionado `fix(deps): bump @astrojs/markdown-remark@7.2.0` — o lock file tinha 7.1.1, mas Astro 6.4.7 precisa de 7.2.0 para exportar `unified`. Sem esse fix o build falhava ao renderizar `/pt/rss.xml` com `SyntaxError: The requested module '@astrojs/markdown-remark' does not provide an export named 'unified'`.
+
+CI verde em todos os 15 steps antes do merge. Mergeado com merge commit (não squash).
+
+## O que fez nesta run
+
+Issue #677 — `a11y: i18n strings no ShareButton para PT-BR`.
+
+`ShareButton.astro` tinha todos os strings hardcoded em inglês (`aria-label="Share this post"`, label "Share", flash "Link copied" / "Couldn't copy"). Em posts PT-BR, screen readers viam texto em inglês — violação de WCAG 2.1 SC 3.1.1.
+
+Fix:
+- Adicionado prop `lang?: string` (default `"en"`) ao `ShareButton.astro`.
+- Strings derivados de um map interno (EN/PT) no frontmatter do componente.
+- Flash messages passadas ao script via data attributes (`data-copied`, `data-error`, `data-default-label`) — sem globals em JS, funciona com múltiplos botões na mesma página.
+- Call sites atualizados: EN page passa `lang={lang}`, PT page passa `lang={lang ?? "pt"}`.
+
+## O que ficou para a próxima run
+
+- Verificar screenshot de prod das páginas PT após deploy (PR aberto, aguarda veto de 24h).
+- 9 issues `routine` restantes (todas baixa prioridade) — candidatos para próxima run:
+  - #679 perf: fetchpriority="high" na hero image (LCP)
+  - #678 seo: JSON-LD MusicRecording em posts de música
+  - #587 seo: ProfilePage schema para /about/

--- a/src/components/ShareButton.astro
+++ b/src/components/ShareButton.astro
@@ -2,9 +2,25 @@
 interface Props {
   title: string;
   url?: string;
+  lang?: string;
 }
-const { title, url } = Astro.props;
+const { title, url, lang = "en" } = Astro.props;
 const href = url ?? Astro.url.href;
+
+const strings =
+  lang === "pt"
+    ? {
+        ariaLabel: "Compartilhar este post",
+        label: "Compartilhar",
+        copied: "Link copiado",
+        error: "Não foi possível copiar",
+      }
+    : {
+        ariaLabel: "Share this post",
+        label: "Share",
+        copied: "Link copied",
+        error: "Couldn't copy",
+      };
 ---
 
 <button
@@ -12,13 +28,15 @@ const href = url ?? Astro.url.href;
   class="outline secondary share-button"
   data-title={title}
   data-url={href}
-  aria-label="Share this post"
+  data-default-label={strings.label}
+  data-copied={strings.copied}
+  data-error={strings.error}
+  aria-label={strings.ariaLabel}
 >
-  ↗ <span class="share-label">Share</span>
+  ↗ <span class="share-label">{strings.label}</span>
 </button>
 
 <script>
-  const DEFAULT_LABEL = "Share";
   const buttonState = new WeakMap<HTMLButtonElement, { timer?: number; inFlight: boolean }>();
 
   function flash(button: HTMLButtonElement, text: string) {
@@ -28,7 +46,7 @@ const href = url ?? Astro.url.href;
     if (state.timer !== undefined) window.clearTimeout(state.timer);
     label.textContent = text;
     state.timer = window.setTimeout(() => {
-      label.textContent = DEFAULT_LABEL;
+      label.textContent = button.dataset.defaultLabel ?? "Share";
       state.timer = undefined;
     }, 1800);
     buttonState.set(button, state);
@@ -60,9 +78,9 @@ const href = url ?? Astro.url.href;
 
       try {
         await navigator.clipboard.writeText(url);
-        flash(button, "Link copied");
+        flash(button, button.dataset.copied ?? "Link copied");
       } catch {
-        flash(button, "Couldn't copy");
+        flash(button, button.dataset.error ?? "Couldn't copy");
       }
     } finally {
       const s = buttonState.get(button);

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -269,7 +269,7 @@ const translationLinks = translationSiblings.map((p) => {
               {previousVersion.msg && <> — <span class="prev-msg">{previousVersion.msg}</span></>}
             </small></p>
           )}
-          <ShareButton title={title} />
+          <ShareButton title={title} lang={lang} />
         </footer>
       </article>
 

--- a/src/pages/pt/blog/[...slug].astro
+++ b/src/pages/pt/blog/[...slug].astro
@@ -268,7 +268,7 @@ const translationLinks = translationSiblings.map((p) => {
               {previousVersion.msg && <> — <span class="prev-msg">{previousVersion.msg}</span></>}
             </small></p>
           )}
-          <ShareButton title={title} />
+          <ShareButton title={title} lang={lang ?? "pt"} />
         </footer>
       </article>
 


### PR DESCRIPTION
Closes #677

## a11y

### ShareButton — strings localizados para EN e PT-BR (`src/components/ShareButton.astro`)

`ShareButton.astro` tinha todos os strings hardcoded em inglês, violando WCAG 2.1 SC 3.1.1 (Language of Parts) para leitores de tela em páginas PT-BR.

**Mudanças no componente:**
- Novo prop `lang?: string` (default `"en"`)
- Map interno de strings por idioma:
  - `aria-label`: `"Share this post"` / `"Compartilhar este post"`
  - Label visível: `"Share"` / `"Compartilhar"`
  - Flash de sucesso: `"Link copied"` / `"Link copiado"`
  - Flash de erro: `"Couldn't copy"` / `"Não foi possível copiar"`
- Flash messages passadas ao script via `data-*` attributes (`data-copied`, `data-error`, `data-default-label`) — sem globals JS, funciona com múltiplos botões na página

**Call sites atualizados:**
- `src/pages/blog/[...slug].astro` → `<ShareButton title={title} lang={lang} />`
- `src/pages/pt/blog/[...slug].astro` → `<ShareButton title={title} lang={lang ?? "pt"} />`

**Onde verificar no screenshot de prod (run seguinte):**
- Qualquer post PT-BR → botão deve mostrar "Compartilhar" (não "Share")
- Screen reader: `aria-label` em português

---
_Generated by [Claude Code](https://claude.ai/code/session_01LQW34Syt7frkCkbx3Z68D9)_