### PR TITLE
fix(autopilot): allow session journal files through the merge gate

### DIFF
--- a/.github/workflows/hronir-autopilot.yml
+++ b/.github/workflows/hronir-autopilot.yml
@@ -86,6 +86,10 @@ jobs:
           # 1) Path gate: only .routines/hronir/** and src/content/blog/**, with
           #    at least one rate file. This is the sole identity check — only
           #    hronir sessions produce rate files under .routines/hronir/rates/.
+          #    Every session also writes a top-level journal file directly under
+          #    .routines/ (see CLAUDE.md "Journals de sessão"); that file isn't
+          #    under .routines/hronir/, so it gets its own exception below —
+          #    subdirs other than hronir/ (e.g. .routines/takeout/) stay excluded.
           FILES=$(gh pr view "$PR" --repo "$REPO" --json files --jq '.files[].path')
           HAS_RATE=0
           while IFS= read -r f; do
@@ -93,6 +97,12 @@ jobs:
             case "$f" in .routines/hronir/rates/*) HAS_RATE=1 ;; esac
             ok=1
             for p in $SAFE_PREFIXES; do case "$f" in "$p"*) ok=0 ;; esac; done
+            if [ "$ok" -ne 0 ]; then
+              case "$f" in
+                .routines/*/*) ;;
+                .routines/*.md) ok=0 ;;
+              esac
+            fi
             if [ "$ok" -ne 0 ]; then
               echo "PR #$PR touches out-of-scope file: $f — skipping."
               echo "merged=" >> "$GITHUB_OUTPUT"; exit 0


### PR DESCRIPTION
## Summary

- Diagnosed why none of the 19 open Hrönir session PRs (#803–#849) were being auto-merged: every "Hrönir Autopilot" run logs `PR #NNN touches out-of-scope file: .routines/<timestamp>-hronir-run.md — skipping.`
- Root cause: the autopilot's `SAFE_PREFIXES` path gate only allowlists `.routines/hronir/` and `src/content/blog/`, but the session-journal convention documented in `CLAUDE.md` ("Journals de sessão") writes a `.md` file directly at the top level of `.routines/` for every session — a path the gate has never recognized. That convention was added after the autopilot workflow was written, so every Hrönir PR has failed the gate since.
- Fix: `.github/workflows/hronir-autopilot.yml` now also allows `.md` files that are direct children of `.routines/` (matching the journal naming convention), while still excluding other `.routines/` subdirectories such as `.routines/takeout/`.
- The two non-Hrönir open PRs (#834, #712/dependabot) were never in scope for this autopilot by design — they still need manual review/merge, that's expected behavior, not a bug.

## Test plan

- [x] Validated the updated gate logic in an isolated bash harness against representative paths (journal file → allow, rate file → allow, blog post → allow, `.routines/takeout/**` → reject, unrelated file → reject)
- [x] `npx prettier --check .github/workflows/hronir-autopilot.yml`
- [ ] Confirm in production that the next "Check" → "Hrönir Autopilot" run actually merges one of the backlogged hronir PRs


---
_Generated by [Claude Code](https://claude.ai/code/session_01LGcVZuAtp6v6LqK28QapAn)_