### PR TITLE
fix(hronir): draft-worst pula candidatos sem arquivo em vez de abortar

### DIFF
--- a/src/hronir/commands.ts
+++ b/src/hronir/commands.ts
@@ -1905,10 +1905,15 @@ export function editWorst() {
   }
 
   // rows are sorted by ordinal DESC (best first); worst eligible is the last.
-  // We skip posts that were edited in the last two edit cycles.
+  // We skip posts that were edited in the last two edit cycles, posts with a
+  // pending draft, and posts with no surviving file (rated in the past but
+  // since deleted from src/content/blog/ — the rating history outlives the
+  // file, and computeRatings() has no way to know that).
   const recentlyEdited = getRecentlyEditedKeys(2);
   const duelRatings = computeVersionRatings();
+  const missingFileKeys: string[] = [];
   let worstRow = null;
+  let worstRowFiles: ReturnType<typeof findTranslations> = [];
   for (let i = eligible.length - 1; i >= 0; i--) {
     const row = eligible[i];
     if (recentlyEdited.includes(row.key)) continue;
@@ -1927,30 +1932,53 @@ export function editWorst() {
       );
     });
     if (hasDraft) continue;
+    const translationFiles = findTranslations(row.key).filter((t) =>
+      fs.existsSync(t.path)
+    );
+    if (translationFiles.length === 0) {
+      missingFileKeys.push(row.key);
+      continue;
+    }
     worstRow = row;
+    worstRowFiles = translationFiles;
     break;
   }
 
   if (!worstRow) {
     console.log(
-      "Aviso: Todos os posts elegíveis foram editados recentemente. Usando o pior colocado absoluto."
+      "Aviso: Todos os posts elegíveis foram editados recentemente, têm rascunho pendente, ou não têm arquivo correspondente. Usando o pior colocado absoluto com arquivo válido."
     );
-    worstRow = eligible[eligible.length - 1];
+    for (let i = eligible.length - 1; i >= 0; i--) {
+      const row = eligible[i];
+      const translationFiles = findTranslations(row.key).filter((t) =>
+        fs.existsSync(t.path)
+      );
+      if (translationFiles.length > 0) {
+        worstRow = row;
+        worstRowFiles = translationFiles;
+        break;
+      }
+    }
+  }
+
+  if (missingFileKeys.length > 0) {
+    console.log(
+      `Aviso: post(s) com histórico de avaliação mas sem arquivo (deletados sem atualizar o ranking), pulados: ${missingFileKeys.join(", ")}. Rode \`npm run hronir:doctor\` para diagnóstico.`
+    );
+  }
+
+  if (!worstRow) {
+    console.error(
+      "Erro: nenhum post elegível tem arquivo correspondente em src/content/blog/. " +
+        "Rode `npm run hronir:doctor` para diagnóstico."
+    );
+    process.exit(1);
   }
 
   const topRows = eligible.filter((r) => r.key !== worstRow.key).slice(0, 3);
   const topKeys = topRows.map((r) => r.key);
 
-  const translationFiles = findTranslations(worstRow.key).filter((t) =>
-    fs.existsSync(t.path)
-  );
-  if (translationFiles.length === 0) {
-    console.error(
-      `Erro: nenhum arquivo encontrado para o post '${worstRow.key}'. ` +
-        "O post pode ter sido deletado. Rode `npm run hronir:doctor` para diagnóstico."
-    );
-    process.exit(1);
-  }
+  const translationFiles = worstRowFiles;
 
   // RFC 0010: non-destructive drafting. Copy each selected version into a
   // sibling draft <slug>/v-<timestamp>.<ext> for the agent to edit. The


### PR DESCRIPTION
## Summary

- Bug real, reproduzido: `npm run hronir:draft-worst` aborta com "Erro: nenhum arquivo encontrado para o post" quando o candidato pior-colocado (por `computeRatings()`, baseado nos rate files) foi deletado de `src/content/blog/` mas ainda tem histórico de avaliação (rate files são imutáveis por convenção do projeto, então sobrevivem à deleção do post).
- Bateu duas vezes seguidas em produção: PRs #857 e #858, ambas com `may-in-seven-drafts-2026` — as duas sessões usaram o fallback `hronir:end --skip-edit` (documentado na PR #856) pra não travar, mas isso pula a fase de edição por inteiro.
- Causa raiz: `editWorst()` já pulava candidatos recém-editados e com rascunho pendente **dentro** do loop de seleção do pior colocado, mas só checava existência de arquivo **depois** de escolher o candidato — se esse candidato não tiver arquivo, aborta em vez de tentar o próximo.
- Fix: move a checagem de arquivo pra dentro do loop (junto com as outras condições de skip), com fallback e aviso quando candidatos são pulados por falta de arquivo.

## Test plan

- [x] Reproduzido o bug em `main` antes do fix: `npm run hronir:draft-worst` falha em `may-in-seven-drafts-2026`
- [x] Confirmado que o fix resolve: mesmo comando, mesma branch, com o patch aplicado, seleciona `o-ritual-de-abril-anos-de-saudade` (próximo pior colocado elegível) e cria os rascunhos normalmente
- [x] `npm test` — 39/39
- [x] `npx astro check` — 0 erros
- [x] `npm run hronir:doctor` — 0 inconsistências
- [x] `npx prettier --check src/hronir/commands.ts`
- [x] `npm run check:hygiene`


---
_Generated by [Claude Code](https://claude.ai/code/session_01LGcVZuAtp6v6LqK28QapAn)_