### PR TITLE
feat(hronir): separa rotina de matches (horária) da de edição (diária)

### DIFF
--- a/.github/workflows/hronir-autopilot.yml
+++ b/.github/workflows/hronir-autopilot.yml
@@ -3,12 +3,14 @@ name: Hrönir Autopilot
 # Merge machine for the Hrönir/Jules loop.
 #
 # Fires when the "Check" workflow finishes on a PR branch. If that PR
-# touches only the safe paths (rate files required) and CI is green,
-# it is merged with a merge commit and a replacement session is spawned.
+# touches only the safe paths (rate files or draft version files required)
+# and CI is green, it is merged with a merge commit and a replacement
+# session is spawned.
 #
-# Gate: path check + CI green. No external API verification needed —
-# the safe-path constraint is sufficient: only hronir sessions produce
-# rate files under .routines/hronir/rates/.
+# Gate: path check + CI green. No external API verification needed — the
+# safe-path constraint is sufficient: only hronir sessions produce rate
+# files under .routines/hronir/rates/ (hourly matches routine) or v-*
+# draft files under src/content/blog/ (daily edit-worst routine).
 #
 # hronir-heartbeat.yml maintains the pool as a backstop (every 15 min).
 # This workflow provides the reactive path: merge → immediately spawn.
@@ -84,17 +86,23 @@ jobs:
           set -euo pipefail
 
           # 1) Path gate: only .routines/hronir/** and src/content/blog/**, with
-          #    at least one rate file. This is the sole identity check — only
-          #    hronir sessions produce rate files under .routines/hronir/rates/.
+          #    at least one rate file OR one draft/version file. This is the
+          #    sole identity check — only hronir sessions produce rate files
+          #    under .routines/hronir/rates/ (the hourly matches routine) or
+          #    v-<timestamp> draft files under src/content/blog/ (the daily
+          #    edit-worst routine, which runs no matches and so has no rate
+          #    file to show — see docs/hronir-edit-worst-routine.md).
           #    Every session also writes a top-level journal file directly under
           #    .routines/ (see CLAUDE.md "Journals de sessão"); that file isn't
           #    under .routines/hronir/, so it gets its own exception below —
           #    subdirs other than hronir/ (e.g. .routines/takeout/) stay excluded.
           FILES=$(gh pr view "$PR" --repo "$REPO" --json files --jq '.files[].path')
           HAS_RATE=0
+          HAS_DRAFT=0
           while IFS= read -r f; do
             [ -n "$f" ] || continue
             case "$f" in .routines/hronir/rates/*) HAS_RATE=1 ;; esac
+            case "$f" in src/content/blog/*/v-*.md | src/content/blog/*/v-*.mdx) HAS_DRAFT=1 ;; esac
             ok=1
             for p in $SAFE_PREFIXES; do case "$f" in "$p"*) ok=0 ;; esac; done
             if [ "$ok" -ne 0 ]; then
@@ -108,8 +116,8 @@ jobs:
               echo "merged=" >> "$GITHUB_OUTPUT"; exit 0
             fi
           done <<< "$FILES"
-          if [ "$HAS_RATE" -ne 1 ]; then
-            echo "PR #$PR has no rate files — skipping."
+          if [ "$HAS_RATE" -ne 1 ] && [ "$HAS_DRAFT" -ne 1 ]; then
+            echo "PR #$PR has no rate files and no draft version files — skipping."
             echo "merged=" >> "$GITHUB_OUTPUT"; exit 0
           fi
 

--- a/docs/hronir-agent-routine.md
+++ b/docs/hronir-agent-routine.md
@@ -1,6 +1,6 @@
-# Rotina de agente Hrönir
+# Rotina de agente Hrönir — avaliação de matches
 
-Execute uma rodada completa do sistema Hrönir.
+Execute uma rodada de avaliação Hrönir: só matches (comparações par a par), sem editar posts. A fase de edição do pior post é responsabilidade de uma rotina **separada** — `docs/hronir-edit-worst-routine.md` — que roda uma vez por dia, não a cada hora.
 
 ## Antes de começar
 
@@ -32,18 +32,23 @@ git checkout -b "$BRANCH"
 npm run hronir:init -- \
   --agent-id <seu-model-id> \
   --matches 10 \
-  --content-mode path-only
+  --content-mode path-only \
+  --skip-edit
 ```
 
 - `--agent-id` é **obrigatório** — use um identificador estável do seu modelo.
 - `--content-mode path-only` recomendado para agentes: o CLI imprime apenas slug e caminho; o agente lê o arquivo diretamente.
+- `--skip-edit` é **obrigatório** nesta rotina — a fase de edição do pior post roda separada, com outro modelo e cadência diária. Com essa flag, a sessão se fecha sozinha ao completar os matches, sem nunca sinalizar `need_edit`.
 
 ## 3. Loop de avaliação
 
-Repita até o CLI indicar que todos os matches foram completados. Se o contexto/tempo estiver se esgotando antes de completar os 10 matches, **não deixe um `decide` pela metade** — complete o match em andamento, então feche a sessão explicitamente antes de seguir para o passo 5, já que `hronir:doctor` reporta qualquer `hronir_session.json` ativo como inconsistência:
+Repita até o CLI indicar que todos os matches foram completados. Se o contexto/tempo estiver se esgotando antes de completar os 10 matches, **não deixe um `decide` pela metade** — complete o match em andamento, então feche a sessão explicitamente antes de seguir para o passo 4, já que `hronir:doctor` reporta qualquer `hronir_session.json` ativo como inconsistência:
 
-- Se ainda houver matches pendentes (estado normal, não `need_edit`): `npm run hronir:end -- --force` — os rate files já commitados por cada `decide` **não são afetados**, isso só encerra o rastreamento da sessão.
-- Se já estiver em `need_edit` mas sem tempo para a fase de edição: `npm run hronir:end -- --skip-edit`.
+```bash
+npm run hronir:end -- --force
+```
+
+Os rate files já commitados por cada `decide` **não são afetados** — isso só encerra o rastreamento da sessão. (Com `--skip-edit`, a sessão nunca fica em `need_edit`, então esse é o único caso de saída antecipada aqui.)
 
 Uma sessão de 3-6 matches bem avaliados vale mais que uma de 10 apressados.
 
@@ -80,25 +85,10 @@ npm run hronir:decide -- \
 
 **Atingir a contagem mínima de palavras não é o objetivo — o objetivo é uma leitura real.** O contador de palavras não distingue uma resenha específica de texto genérico repetido até bater 100 palavras. Cada resenha e o clash devem citar ou parafrasear algo concreto e específico de cada post (uma ideia, uma imagem, uma escolha estrutural) — não frases-clichê intercambiáveis entre quaisquer dois posts. Se uma frase da sua resenha serviria, sem alteração, para qualquer outro par de posts, reescreva-a.
 
-## 4. Fase de edição do pior post
-
-Quando todos os matches terminam, o CLI sinaliza `need_edit`.
+## 4. Validar, criar journal e commitar
 
 ```bash
-npm run hronir:draft-worst
-```
-
-Edite os arquivos de rascunho criados (`src/content/blog/<slug>/v-<timestamp>.md`) com base nas defesas e contexto impresso pelo comando.
-
-```bash
-npm run hronir:draft-commit -- --msg "<justificativa da edição>"
 npm run hronir:select
-npm run hronir:end
-```
-
-## 5. Validar, criar journal e commitar
-
-```bash
 npm run hronir:doctor
 
 TIMESTAMP="$(date -u +"%Y-%m-%dT%H-%M-%S")"
@@ -111,11 +101,13 @@ status: open
 EOF
 
 git add .routines/ src/generated/versions-selected.json
-git commit -m "hronir: 10 matches + edit-worst — <agent-id>"
+git commit -m "hronir: N matches — <agent-id>"
 git push -u origin HEAD
 ```
 
-## 6. Abrir PR e habilitar auto-merge
+`src/generated/versions-selected.json` pode mudar mesmo numa rodada só de matches — alguns matches são duelos de versão (a mesma `key` dos dois lados), e se um lado limpar o número mínimo de duelos e vencer, `hronir:select` promove a nova versão. Por isso ele roda aqui explicitamente, antes do commit.
+
+## 5. Abrir PR e habilitar auto-merge
 
 Via MCP:
 
@@ -123,7 +115,7 @@ Via MCP:
 mcp__github__create_pull_request:
   owner: franklinbaldo
   repo: franklinbaldo.github.io
-  title: "hronir: 10 matches + edit-worst — <agent-id>"
+  title: "hronir: N matches — <agent-id>"
   head: <BRANCH>
   base: main
 

--- a/docs/hronir-edit-worst-routine.md
+++ b/docs/hronir-edit-worst-routine.md
@@ -1,0 +1,94 @@
+# Rotina de agente Hrönir — edição do pior post
+
+Rotina diária, separada da rotina horária de avaliação de matches (`docs/hronir-agent-routine.md`). Enquanto a rotina de matches prioriza volume (várias sessões por dia, modelo rápido), esta é trabalho editorial de verdade: escolher o post pior-ranqueado e reescrevê-lo com base nas críticas acumuladas — cabe rodar uma vez por dia, com um modelo mais cuidadoso.
+
+Não chame `npm run hronir:init` aqui — essa rotina não roda matches, só a fase de edição, que funciona standalone.
+
+## Antes de começar
+
+Confirme que está dentro do checkout do repositório (`git rev-parse --show-toplevel` deve apontar para `franklinbaldo.github.io`). Se não estiver — diretório vazio, outro repo, ou erro —, clone antes de prosseguir:
+
+```bash
+git clone https://github.com/franklinbaldo/franklinbaldo.github.io.git
+cd franklinbaldo.github.io
+```
+
+## 0. Revisar e mesclar PRs abertos
+
+Liste os PRs abertos. Para cada PR Hrönir com CI verde, sem conflitos e sem revisões bloqueantes:
+
+- Mescle com **merge commit** — NUNCA squash.
+- Via MCP: `mcp__github__merge_pull_request` com `merge_method: merge`.
+
+## 1. Atualizar main e criar branch
+
+```bash
+git checkout main && git pull origin main
+BRANCH="hronir/edit-worst-$(date -u +"%Y-%m-%dT%H-%M-%S")"
+git checkout -b "$BRANCH"
+```
+
+## 2. Escolher e rascunhar o pior post
+
+```bash
+npm run hronir:draft-worst
+```
+
+Esse comando já escolhe o post pior-ranqueado elegível — pulando os recém-editados, os com rascunho pendente, e os sem arquivo correspondente em `src/content/blog/` (post avaliado no passado e depois deletado) — e cria os rascunhos (`src/content/blog/<slug>/v-<timestamp>.<ext>`, um por idioma) prontos para editar.
+
+Se não houver candidato elegível, o comando avisa e termina sem erro ("Volume insuficiente para edit-worst", ou lista os pulados por falta de arquivo). **Não force nada nesse caso** — não há trabalho de edição para fazer hoje; finalize sem abrir PR.
+
+## 3. Editar
+
+Leia AS DUAS skills antes de editar:
+
+- `scripts/hronir/skills/franklin-blog/SKILL.md`
+- `scripts/hronir/skills/franklin-essay/SKILL.md`
+
+Default: `franklin-blog`. Use `franklin-essay` **apenas** se o post for argumentativo-formal (paper-shaped, defesa de tese, citação acadêmica densa). Em caso de dúvida, blog.
+
+Edite os **rascunhos** impressos pelo comando anterior — nunca as versões selecionadas, que ficam intactas e continuam publicadas até o rascunho vencer seus duelos. O objetivo é diminuir o gap observado entre este post e os melhores colocados, mantendo o espírito do post.
+
+Isso é o ponto principal desta rotina: leia de verdade as críticas e defesas acumuladas nos matches anteriores (o comando imprime o contexto) antes de editar. Um polimento superficial que não responde às críticas registradas não cumpre o propósito da rotina.
+
+## 4. Registrar e finalizar
+
+```bash
+npm run hronir:draft-commit -- --msg "<justificativa da edição, referenciando as críticas que motivaram>"
+npm run hronir:select
+npm run hronir:end
+npm run hronir:doctor
+```
+
+## 5. Journal e commit
+
+```bash
+TIMESTAMP="$(date -u +"%Y-%m-%dT%H-%M-%S")"
+cat > ".routines/${TIMESTAMP}-hronir-edit-worst.md" <<EOF
+---
+date: "$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+branch: ${BRANCH}
+status: open
+---
+EOF
+
+git add .routines/ src/content/blog/ src/generated/versions-selected.json
+git commit -m "hronir: edição do pior post — <agent-id>"
+git push -u origin HEAD
+```
+
+## 6. Abrir PR e habilitar auto-merge
+
+Via MCP:
+
+```
+mcp__github__create_pull_request:
+  owner: franklinbaldo
+  repo: franklinbaldo.github.io
+  title: "hronir: edição do pior post — <agent-id>"
+  head: <BRANCH>
+  base: main
+
+mcp__github__enable_pr_auto_merge:
+  merge_method: merge
+```


### PR DESCRIPTION
## Summary

- `docs/hronir-agent-routine.md` agora só faz matches: adiciona `--skip-edit` no `hronir:init` e remove a fase de edição do pior post inteira. Pensada pra rodar de hora em hora, modelo mais barato/rápido.
- Nova `docs/hronir-edit-worst-routine.md`: fase de edição isolada, roda `hronir:draft-worst` standalone (sem `hronir:init`), pensada pra rodar uma vez por dia com um modelo mais cuidadoso — é trabalho editorial de verdade, não throughput.
- `hronir-autopilot.yml`: a PR da rotina diária não vai ter rate file nenhum (só edita posts, sem matches). O identity check do gate passa a aceitar rate file **ou** arquivo de rascunho/versão (`src/content/blog/*/v-*.{md,mdx}`) — o path gate continua igual, só o "isso é uma sessão Hrönir de verdade" ficou mais permissivo pra cobrir os dois formatos de PR.

## Pendente (fora deste PR)

Falta criar de fato o trigger diário (Claude Code Remote) apontando pra `docs/hronir-edit-worst-routine.md` com o modelo Opus — bloqueado por reautorização do Claude Code Remote nesta sessão. O trigger horário existente já lê `docs/hronir-agent-routine.md`, então essa parte não precisa de mudança adicional quando a rotina antiga for desativada.

## Test plan

- [x] Testada a lógica do novo gate isoladamente (bash) contra: sessão de matches (rate file), sessão de edição (draft file, sem rate), PR de conteúdo não-relacionada, arquivo fora de escopo, `.routines/takeout/`
- [x] `npm test` — 39/39
- [x] `npm run hronir:doctor` — 0 inconsistências
- [x] `npx prettier --check` nos 3 arquivos
- [x] `npm run check:hygiene`
- [x] YAML do workflow validado com `yaml.safe_load`


---
_Generated by [Claude Code](https://claude.ai/code/session_01LGcVZuAtp6v6LqK28QapAn)_