### PR TITLE
seo(paths): OG images dedicadas para reading paths

### DIFF
--- a/.routines/2026-07-01T05-09-18-og-image-paths.md
+++ b/.routines/2026-07-01T05-09-18-og-image-paths.md
@@ -1,0 +1,70 @@
+---
+date: 2026-07-01T05:09:18
+slug: og-image-paths
+branch: claude/sleepy-pasteur-w7o12s
+status: pr-open
+issues: [250]
+pr_opened: null
+pr_merged: 834
+---
+
+## Contexto ao chegar
+
+Único PR aberto era o #862 (`hronir: edição do pior post`), fora do escopo desta
+rotina (label não é `routine` — é do fluxo hronir edit-worst). Nada meu pendente
+para mergear: o PR anterior desta rotina, #834 (a11y `lang="pt"` → `pt-BR`), já
+tinha sido mergeado por Franklin diretamente (`merged_at: 2026-06-30T21:05:13Z`),
+sem veto.
+
+Backlog com exatamente 10 issues `routine` abertas — dentro da faixa saudável
+(10–20), sem necessidade de repor.
+
+## Verificação em produção do PR anterior (#834)
+
+Confirmado via `curl` direto (sem precisar de screenshot — mudança é só um
+atributo HTML, sem impacto visual):
+
+- `/ranking/battles/<id>/` — `<blockquote lang="pt-BR">` presente em 10 battles
+  amostrados com mood em PT.
+- `/pt/blog/a-api-do-jules-como-backend-do-harness/v/<uuid>/` (versão
+  arquivada) — `<article lang="pt-BR">` confirmado.
+
+Sem regressão, nada a reportar.
+
+## Trabalho desta run — issue #250 (OG image audit para paths pages)
+
+Auditoria: `/paths/[slug]/` e `/pt/paths/[slug]/` não passavam `image` ao
+`PageLayout`, então caíam no fallback `home.png`/`home-pt.png` (confirmado em
+`PageLayout.astro:64`). `translations`/hreflang já estavam corretos (verificado
+no HTML de build local: `hreflang="en"`/`"pt-BR"`/`"x-default"` presentes e
+apontando certo) — nenhum fix necessário nessa parte.
+
+Adicionados dois endpoints Satori seguindo o padrão existente de
+`og/[...slug].png.ts` (posts):
+
+- `src/pages/og/path-[slug].png.ts` — EN, título/descrição do reading path.
+- `src/pages/og/path-pt-[slug].png.ts` — PT.
+
+`src/pages/paths/[slug].astro` e `src/pages/pt/paths/[slug].astro` agora
+passam `image={/og/path-...(-pt-)${path.slug}.png}` ao `PageLayout`.
+
+Build local gerou as 6 imagens esperadas (3 reading paths × 2 línguas,
+~190–200KB cada) e o HTML de `/paths/agency-and-constraint/` já referencia a
+OG image correta em `og:image`.
+
+## Verificação local
+
+- `astro check` ✓ (0 errors, 0 warnings — hints preexistentes não relacionados)
+- `npm run build` ✓ (3508 páginas, sem erros)
+- `npx prettier --check .` ✓
+- `npm run check:hygiene` ✓ (13 root files)
+- `npm run hronir:doctor` ✓ (0 inconsistências)
+- Descartadas mudanças não relacionadas em `src/generated/ranking-snapshot.json`
+  e `blog-translation-pairs.json` (regeneradas como efeito colateral do build
+  local, refletindo sessões hronir mais recentes — não fazem parte deste PR)
+
+## O que fica para a próxima run
+
+- Mergear o PR desta run (issue #250) após CI verde e sem veto de 24h.
+- Próxima issue de maior prioridade no backlog: #251 (skip-to-content em PT) ou
+  #552 (focus-visible audit).

--- a/src/pages/og/path-[slug].png.ts
+++ b/src/pages/og/path-[slug].png.ts
@@ -1,0 +1,31 @@
+import type { APIRoute } from "astro";
+import { READING_PATHS } from "../../lib/paths";
+import { renderOgCard } from "../../lib/og-card";
+import { getQrPng } from "../../lib/og-qr";
+
+export async function getStaticPaths() {
+  return READING_PATHS.map((path) => ({
+    params: { slug: path.slug },
+    props: { path },
+  }));
+}
+
+export const GET: APIRoute = async ({ props }) => {
+  const path = props.path as (typeof READING_PATHS)[number];
+  const qrSlug = `path-${path.slug}`;
+  const qrPng = getQrPng({ slug: qrSlug, fallbackSlug: "home" });
+  const png = await renderOgCard({
+    title: path.title.en,
+    description: path.blurb.en,
+    lang: "en",
+    kind: "post",
+    path: `/paths/${path.slug}/`,
+    qrPng: qrPng ?? undefined,
+  });
+  return new Response(new Uint8Array(png), {
+    headers: {
+      "Content-Type": "image/png",
+      "Cache-Control": "public, max-age=31536000, immutable",
+    },
+  });
+};

--- a/src/pages/og/path-pt-[slug].png.ts
+++ b/src/pages/og/path-pt-[slug].png.ts
@@ -1,0 +1,31 @@
+import type { APIRoute } from "astro";
+import { READING_PATHS } from "../../lib/paths";
+import { renderOgCard } from "../../lib/og-card";
+import { getQrPng } from "../../lib/og-qr";
+
+export async function getStaticPaths() {
+  return READING_PATHS.map((path) => ({
+    params: { slug: path.slug },
+    props: { path },
+  }));
+}
+
+export const GET: APIRoute = async ({ props }) => {
+  const path = props.path as (typeof READING_PATHS)[number];
+  const qrSlug = `path-pt-${path.slug}`;
+  const qrPng = getQrPng({ slug: qrSlug, fallbackSlug: "home-pt" });
+  const png = await renderOgCard({
+    title: path.title.pt,
+    description: path.blurb.pt,
+    lang: "pt",
+    kind: "post",
+    path: `/pt/paths/${path.slug}/`,
+    qrPng: qrPng ?? undefined,
+  });
+  return new Response(new Uint8Array(png), {
+    headers: {
+      "Content-Type": "image/png",
+      "Cache-Control": "public, max-age=31536000, immutable",
+    },
+  });
+};

--- a/src/pages/paths/[slug].astro
+++ b/src/pages/paths/[slug].astro
@@ -19,6 +19,7 @@ const translations: Record<string, string> = ptHasPosts ? { pt: `/pt/paths/${pat
 <PageLayout
   title={`${path.title.en} | Reading path`}
   description={path.blurb.en}
+  image={`/og/path-${path.slug}.png`}
   lang="en"
   translations={translations}
   breadcrumb={[

--- a/src/pages/pt/paths/[slug].astro
+++ b/src/pages/pt/paths/[slug].astro
@@ -19,6 +19,7 @@ const translations: Record<string, string> = enHasPosts ? { en: `/paths/${path.s
 <PageLayout
   title={`${path.title.pt} | Caminho de leitura`}
   description={path.blurb.pt}
+  image={`/og/path-pt-${path.slug}.png`}
   lang="pt"
   translations={translations}
   breadcrumb={[


### PR DESCRIPTION
Closes #250

## SEO

`/paths/[slug]/` e `/pt/paths/[slug]/` (3 reading paths × 2 línguas) caíam no
fallback genérico `home.png`/`home-pt.png` para `og:image`/`twitter:image`
(`PageLayout.astro:64`), sem identidade visual própria para compartilhamento
social.

Adiciona dois endpoints Satori seguindo o mesmo padrão já usado para posts
(`og/[...slug].png.ts`):

- `src/pages/og/path-[slug].png.ts` — título/descrição EN do reading path.
- `src/pages/og/path-pt-[slug].png.ts` — PT.

Geradas em build time (estático, sem custo em runtime), como as demais OG
images do site. `src/pages/paths/[slug].astro` e
`src/pages/pt/paths/[slug].astro` agora passam
`image={/og/path-...(-pt-)${path.slug}.png}` ao `PageLayout`.

Também auditei `translations`/hreflang nas paths pages (segunda parte do
issue) — já funcionavam corretamente (`hreflang="en"`/`"pt-BR"`/`"x-default"`
presentes e corretos no HTML de build), sem necessidade de fix.

## Verificação local

- [x] `astro check` — 0 errors, 0 warnings
- [x] `npm run build` — 3508 páginas, gerou as 6 imagens esperadas
  (`dist/og/path-{agency-and-constraint,law-and-ai,memory-and-funes}.png` e as
  3 variantes `-pt-`)
- [x] `npx prettier --check .`
- [x] `npm run check:hygiene`
- [x] `npm run hronir:doctor` — 0 inconsistências

Sem elementos visuais novos na própria página (só a meta tag `og:image`
muda) — nada a apontar para o screenshot de prod da run seguinte.

---
_Gerado pela rotina autônoma — [Claude Code](https://claude.ai/code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01CAWRnTFLihbnkBfxjJbbfd)_