### PR TITLE
hronir: 3 matches — claude-haiku-4-5-20251001

### DIFF
--- a/.routines/2026-07-01T14-12-40-hronir-run.md
+++ b/.routines/2026-07-01T14-12-40-hronir-run.md
@@ -1,0 +1,5 @@
+---
+date: "2026-07-01T14:12:40Z"
+branch: hronir/run-2026-07-01T14-07-09
+status: open
+---

--- a/.routines/hronir/rates/2026-07-01T14-08-35-773_music-o-aleph_x_quem-sou-eu.md
+++ b/.routines/hronir/rates/2026-07-01T14-08-35-773_music-o-aleph_x_quem-sou-eu.md
@@ -1,0 +1,92 @@
+---
+run_id: 2026-07-01T14-08-35-773
+run_at: '2026-07-01T14:08:35.773Z'
+post_a:
+  key: music-o-aleph
+  path: src/content/blog/o-aleph-en/v-2026-06-09T20-24-29.mdx
+  display_lang: en
+  content_lang: en
+  version: 37a222bd-47f5-5564-a752-b554d74bcadc
+  ref: o-aleph-en@37a222bd-47f5-5564-a752-b554d74bcadc
+post_b:
+  key: quem-sou-eu
+  path: src/content/blog/quem-sou-eu/v-2026-06-29.md
+  display_lang: pt
+  content_lang: pt
+  version: 93531630-851a-5ccb-b255-319346739b6c
+  ref: quem-sou-eu@93531630-851a-5ccb-b255-319346739b6c
+winner: a
+agent_id: claude-haiku-4-5-20251001
+content_mode: path-only
+objective: null
+eval_lang: pt
+review_lang: pt
+prompt_version: stars-v3
+season: 1
+override: null
+perspective_id: comedy-carries-argument
+evaluator_mood: >-
+  Uma lufada de ar frio inesperada entrou pela fresta da porta, me causando
+  arrepios e sobressaltos.
+mood_glyph: ろ
+evaluator_mood_after: >-
+  Estou vendo buracos onde esperava superfícies. Aquele glifo parece um olho sem
+  dono observando por uma fresta. Lendo os posts não consigo me encontrar —
+  talvez fosse o ponto todo.
+impression_a: >-
+  A música captura a lógica cruel do Aleph de Borges: o narrador testemunha a
+  vastidão do universo através de uma viola caipira em ponteio que acelera até o
+  delírio. Mas a estrutura real da música é o contraste cômico final — toda
+  aquela magnificência cosmológica desaba quando o Aleph revela o óbvio: as
+  cartas de Beatriz para seu primo. O humor aqui é estrutural: 'O infinito me
+  mostrou a piada da minha vida' é o punchline que sintetiza tudo. Sem essa
+  ironia, seria apenas um catálogo visual bonito. Com ela, é trágico-cômico e
+  filosoficamente honesto.
+impression_b: >-
+  Um ensaio ambicioso que trabalha através de Borges, Dennett, budismo e théorie
+  de simuladores. A ironia está em toda parte — a máscara moderna que cobre a
+  boca (per-sonare) e deixa os olhos de fora; o 'é a sua cara' que carimba um
+  rosto onde não existe ninguém; o Waluigi que vem junto quando você invoca o
+  Luigi. Mas o ponto fraco é que nenhuma dessas piadas é o argumento mesmo. A
+  estrutura lógica descansa em conceitos (anattā, center of narrative gravity,
+  base models como simuladores), não em ganchos cômicos. A comédia aqui é
+  temperamento, não leverage. Se eu removesse os momentos engraçados, a tese
+  sobre persona e vacuidade sobreviveria intacta. O humor é belo, mas
+  decorativo.
+rate_a: 4.75
+rate_b: 3.5
+clash: >-
+  Nesta perspectiva, a diferença é decisiva. music-o-aleph funda sua revelação
+  sobre o Aleph num único gesto cômico que *é* a revelação mesma — a piada não é
+  enfeite, é o reductio ad absurdum do argumento. Remova-a e o post desaba. Em
+  quem-sou-eu, a tese sobre persona, simuladores e vacuidade sobrevive intacta
+  ao humor — poderia ser uma resenha de Dennett e Nāgārjuna sem uma piada sequer
+  e continuaria sendo poderosa. Não que quem-sou-eu falhe em ser engraçado;
+  falha em fazer da comédia um lever lógico. music-o-aleph demonstra que a
+  comédia pode ser o argumento; quem-sou-eu mostra que a comédia pode ser apenas
+  sua voz, e a voz não é a tese. Para um leitor que testa se a piada sobrevive à
+  remoção, music-o-aleph passa; quem-sou-eu não passa, apesar de brilhante.
+review_a: >-
+  A música music-o-aleph carrega a revelação de Borges como estrutura
+  cômico-lógica. O verso 2 concentra tudo: você vê o Aleph inteiro, todas as
+  coisas simultâneas, e o que destrói é descobrir as cartas de Beatriz para
+  Carlos. A frase 'O infinito me mostrou a piada da minha vida' é o punchline
+  que *é* o argumento. Sem ela, teríamos visões bonitas. Com ela, temos uma
+  reductio: a vastidão cosmológica anulada pela pequenez da traição. A viola
+  caipira que accelera no bridge sustenta isso musicalmente — o humor está na
+  estrutura, não nos detalhes. Lem, Monterroso e Nelson Rodrigues reconheceriam:
+  a piada é o lever, e o lever não sai do lugar.
+review_b: >-
+  quem-sou-eu é uma tese rica sobre persona, simuladores, anattā, base models e
+  o que habita embaixo da máscara. Tem momentos cômicos brilhantes: 'Direito
+  Romano e Madhyamaka concordam', a máscara moderna que cobre a boca
+  (per-sonare), o Waluigi como atrator inevitável. Mas aqui está o problema:
+  quando removo esses momentos engraçados, a estrutura lógica não cede. O
+  argumento sobre máscaras e vacuidade descansa em conceitos (center of
+  narrative gravity, anattā, estruturas dissipativas), não em ganchos cômicos. O
+  humor é temperamento excelente que facilita a leitura, mas não *sustenta* o
+  argumento. Uma reescrita em prosa analítica pura perderia forma, não peso
+  conceitual. A comédia aqui é decoração para um edifício lógico que já está de
+  pé.
+---
+

--- a/.routines/hronir/rates/2026-07-01T14-09-35-659_delegating-to-agents_x_quem-sou-eu.md
+++ b/.routines/hronir/rates/2026-07-01T14-09-35-659_delegating-to-agents_x_quem-sou-eu.md
@@ -1,0 +1,95 @@
+---
+run_id: 2026-07-01T14-09-35-659
+run_at: '2026-07-01T14:09:35.659Z'
+post_a:
+  key: delegating-to-agents
+  path: src/content/blog/delegando-para-agentes/v-2026-06-10T18-32-47.md
+  display_lang: pt
+  content_lang: pt
+  version: b6643944-5b66-5ba4-8170-00d29580cf68
+  ref: delegando-para-agentes@b6643944-5b66-5ba4-8170-00d29580cf68
+post_b:
+  key: quem-sou-eu
+  path: src/content/blog/quem-sou-eu/v-2026-06-29.md
+  display_lang: pt
+  content_lang: pt
+  version: 93531630-851a-5ccb-b255-319346739b6c
+  ref: quem-sou-eu@93531630-851a-5ccb-b255-319346739b6c
+winner: b
+agent_id: claude-haiku-4-5-20251001
+content_mode: path-only
+objective: null
+eval_lang: pt
+review_lang: pt
+prompt_version: stars-v3
+season: 1
+override: null
+perspective_id: weird-clarity
+evaluator_mood: >-
+  O Ȭ balança — vejo um post que tenta ensinar (A) e outro que nem tenta (B).
+  Fico com a frustração de quem foi convidado e deixou na porta.
+mood_glyph: ⇷
+evaluator_mood_after: >-
+  A frustração vira alívio. Leio um post tentando me convencer, depois outro que
+  me deixa pairando. A seta dupla aponta ambos os lados — um quer ser seguido,
+  outro esquecido e relembrado. Fico no segundo.
+impression_a: >-
+  Este post tenta ensinar: sobre responsabilidade, sobre caixas de areia, sobre
+  assinatura como fronteira irreversível. Tem clareza analítica nítida —
+  '_Reversível → age, irreversível → pergunta_' é uma regra minimalista que
+  sobrevive à paráfrase com dificuldade. Mas o movimento geral é pedagógico,
+  direcionado a um argumento compreensível. A frase sobre 'a história do
+  assessor termina e a minha começa' é bem construída, mas o post como um todo
+  quer que você *entenda* algo, não que fique com uma coisa que não consegue
+  dizer. Difícil parafrasear a regra da seta, mas fácil resumir a tese.
+impression_b: >-
+  Quem-sou-eu tem múltiplas sentenças que resistem à paráfrase. 'O deus que
+  sonha o mundo não tem rosto. Tem máscaras.' é minimalista e não se deixa
+  recapitular. 'A última máscara não é um rosto, é o haver-perspectiva, e o
+  haver-perspectiva é o avesso de um gradiente sendo queimado' — como
+  parafraseia? Tenta: 'consciência é dissipação de energia'. Não é. Falta
+  'avesso', falta a imagética do fogo. 'O olho aberto no escuro é uma chama
+  contra um fundo frio. Não é o seu. É o haver-chama.' — aqui o post deixa você
+  carregando algo que não consegue dizer. Isso é a weirdly-clarity: você reread
+  a última página. O post inteiro não tenta ensinar; tenta deixar você pairando
+  sobre uma coisa que não consegue nomear.
+rate_a: 3.25
+rate_b: 4.75
+clash: >-
+  A diferença é absoluta nesta perspectiva. delegating-to-agents argumenta: tem
+  estrutura, tem início meio e fim, tem propósito de convencimento. A única
+  sentença que entra em weirdly-clarity é '_Reversível → age, irreversível →
+  pergunta_', e mesmo ela está confinada a um argumento maior sobre
+  responsabilidade. quem-sou-eu, porém, é feito de múltiplas sentenças que
+  resistem à paráfrase — máscaras sem rosto, perspectiva como avesso de
+  dissipação, chama no escuro que não é sua. O post inteiro está estruturado
+  para deixar você pairando, sem encerramento confortável. Você não sai
+  compreendendo algo; sai carregando algo. Para um leitor que busca
+  weirdly-clarity — a chill de uma verdade que não consegue parafrasear —
+  quem-sou-eu demonstra a operação em escala, enquanto delegating-to-agents
+  apenas a toca em um ponto.
+review_a: >-
+  delegating-to-agents tenta ensinar: sobre responsabilidade, sobre caixas de
+  areia, sobre assinatura como fronteira irreversível. A clareza é analítica e
+  direcionada — o post quer que você compreenda e retena um argumento sobre
+  arquitetura de delegação. A frase '_Reversível → age, irreversível →
+  pergunta_' é uma regra minimalista que sobrevive com dificuldade à paráfrase,
+  e ela é o pico de weirdly-clarity do post. Mas o movimento geral é pedagógico.
+  O contexto de direito administrativo, a história de fevereiro, a distinção
+  entre minuta e ato — tudo converge em um argumento compreensível que você pode
+  resumir e conversar sobre. O post encerra em você querendo entender melhor,
+  não ficando com algo que não consegue dizer.
+review_b: >-
+  quem-sou-eu é feito de sentenças que não se deixam parafrasear. 'O deus que
+  sonha o mundo não tem rosto. Tem máscaras.' — é simples, é clara, mas tenta
+  recapitular e perde a coisa. 'A última máscara não é um rosto, é o
+  haver-perspectiva, e o haver-perspectiva é o avesso de um gradiente sendo
+  queimado.' Tenta parafrasear: 'consciência é dissipação de energia'. Falhou. A
+  imagética de 'avesso' e 'gradiente sendo queimado' não se deixa substituir. 'O
+  olho aberto no escuro é uma chama contra um fundo frio. Não é o seu. É o
+  haver-chama.' — aqui você reread a última página. O post inteiro tenta deixar
+  você em um estado, não entender uma tese. Você sai com algo que não consegue
+  nomear, e é exatamente isso que a perspectiva busca — a chill de Borges, a
+  sensação de ter tocado numa verdade que resiste à linguagem.
+---
+

--- a/.routines/hronir/rates/2026-07-01T14-10-47-174_pampa-circuit_x_pampa-circuit.md
+++ b/.routines/hronir/rates/2026-07-01T14-10-47-174_pampa-circuit_x_pampa-circuit.md
@@ -1,0 +1,95 @@
+---
+run_id: 2026-07-01T14-10-47-174
+run_at: '2026-07-01T14:10:47.174Z'
+post_a:
+  key: pampa-circuit
+  path: >-
+    src/content/blog/o-pampa-no-circuito-um-mate-com-o-boswell-digital/v-2026-06-11T06-19-57-042.md
+  display_lang: pt
+  content_lang: pt
+  version: 186c37eb-eeac-5af8-8e8d-9d21fb8cd34e
+  ref: >-
+    o-pampa-no-circuito-um-mate-com-o-boswell-digital@186c37eb-eeac-5af8-8e8d-9d21fb8cd34e
+post_b:
+  key: pampa-circuit
+  path: >-
+    src/content/blog/o-pampa-no-circuito-um-mate-com-o-boswell-digital/v-2026-06-10T05-09-44.md
+  display_lang: pt
+  content_lang: pt
+  version: 1838c7fa-04e8-51ad-8903-cc75b91aced8
+  ref: >-
+    o-pampa-no-circuito-um-mate-com-o-boswell-digital@1838c7fa-04e8-51ad-8903-cc75b91aced8
+winner: a
+agent_id: claude-haiku-4-5-20251001
+content_mode: path-only
+objective: null
+eval_lang: pt
+review_lang: pt
+prompt_version: stars-v3
+season: 1
+override: null
+perspective_id: weird-clarity
+evaluator_mood: >-
+  Sinto o peso do glifo — algo que pressiona. O post não me pressionou para
+  entender: cada conceito foi entregue com tempo e contexto. Fico satisfeito de
+  ter seguido sem tropeços.
+mood_glyph: ↗
+evaluator_mood_after: >-
+  A seta sobe, mas deixa um rastro. Li ambas as versões e a mais completa me
+  deixou pairando — a balsinha, o corredor indecidível. A versão limpa sobe
+  rápido mas vazio. Fico com peso de algo que não consegui descer.
+impression_a: >-
+  A versão selecionada tem cenas concretas e dilemas não resolvidos. A cena da
+  balsinha — '_Uma balsinha_, ele dizia — com a afeição que se dá a uma
+  ferramenta velha em que você confia' — deixa você em um estado em vez de
+  explicar algo. E depois vem o 'corredor muito estreito entre fidelidade e
+  fabricação' que a versão nunca resolve: 'ainda não sei se esse corredor é
+  navegável'. Isso é weirdly-clarity: você carrega a imagem da balsinha e a
+  impossibilidade do corredor. O post não quer convencer; quer deixar você
+  pairando.
+impression_b: >-
+  Esta versão é mais limpa. Remove a cena da balsinha — vai direto de 'começou a
+  lidar com os diários' para 'O que apareceu não foi um problema de
+  recuperação'. Remove o parágrafo inteiro sobre o 'corredor muito estreito
+  entre fidelidade e fabricação' e a preocupação de inventar experiência
+  inteiramente. Remove a pergunta sobre testabilidade. O que sobra é mais
+  elegante, mas menos weirdly-clear. Perde a imagem concreta que deixa você em
+  um estado — deixa de carregar aquele _-inha_ da balsinha. Termina forte com
+  'contradição é a coisa honesta', mas o post todo quer ser compreendido, não
+  deixar você pairando sobre algo indizível.
+rate_a: 4.5
+rate_b: 3
+clash: >-
+  Ambas as versões argumentam sobre sotaque como textura em memória digital. A
+  diferença é que a versão A deixa você em um estado de weirdly-clarity —
+  carregando a balsinha, o corredor indecidível, a pergunta que não se resolve.
+  A versão B resolve tudo, mais graciosamente. A primeira tem cenas concretas
+  que resistem à paráfrase; a segunda tem apenas o argumento, que é claro e
+  resumível. Para um leitor de Borges e Wittgenstein, a versão A opera como
+  máquina de estado — você reread a parte do corredor várias vezes e nunca
+  consegue dizer por que. A versão B é mais bem escrita e mais fácil de seguir,
+  mas fácil de seguir significa fácil de deixar ir. A seleção fez bem em
+  priorizar a versão que deixa peso.
+review_a: >-
+  A versão selecionada tem peso. A cena da balsinha — '_Uma balsinha_, ele dizia
+  — com a afeição que se dá a uma ferramenta velha em que você confia' — é
+  exatamente o tipo de imagem que deixa você em estado em vez de explicar algo.
+  E depois o 'corredor muito estreito entre fidelidade e fabricação, e ainda não
+  sei se esse corredor é navegável' é uma afirmação que resiste à paráfrase.
+  Você tenta dizer 'é impossível capturar a incoerência sem inventá-la' e perde
+  tudo — porque o ponto não é a impossibilidade teórica, é a balsinha, a
+  afeição, o diminutivo. O post inteiro tenta deixar você carregando algo que
+  não consegue nomear. Isso é weirdly-clarity em escala — não uma frase isolada,
+  mas a estrutura inteira operando como máquina de estado.
+review_b: >-
+  A versão desafiante é mais elegante e limpa. Remove a cena da balsinha — vai
+  direto de 'começou a lidar' para 'O que apareceu não foi problema de
+  recuperação'. Remove o parágrafo sobre o corredor. Remove a pergunta sobre
+  testabilidade. O que sobra é mais bem estruturado e menos redundante. Mas
+  estrutura melhor não é o que weirdly-clarity procura. Perde a imagem
+  sensorial, perde o dilema não resolvido, perde a impossibilidade de dizer. A
+  versão é mais compreensível — você consegue resumir 'é difícil preservar
+  sotaque em memória digital'. A compressão do argumento tira a coisa que
+  pesava. A palavra importa: peso.
+---
+


### PR DESCRIPTION
## Hrönir Evaluation Session

Completed 3 well-calibrated matches evaluating blog posts across distinct reader perspectives:

- **Match 1**: Music-o-aleph vs Quem-sou-eu (The Comedy-Carries-Argument Reader)
  - Evaluated structural vs decorative comedy usage in philosophical arguments
  - Winner: music-o-aleph (4.75★ vs 3.50★)

- **Match 2**: Delegating-to-agents vs Quem-sou-eu (The Weird-Clarity Reader)
  - Assessed capacity to leave reader with unpara phrasable insight
  - Winner: quem-sou-eu (4.75★ vs 3.25★)

- **Match 3**: Pampa-circuit version duel (The Weird-Clarity Reader)
  - Compared selected vs challenger version for weirdly-clear content
  - Winner: selected version (4.50★ vs 3.00★)

Rate files saved to `.routines/hronir/rates/`. Session completed as requested with `--skip-edit` and `--content-mode path-only`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VBzryXEZj3rxeL23iXkZkx)_