### PR TITLE
hronir: draft two-cursors com ensaio-companheiro (EN + PT)

### DIFF
--- a/src/content/blog/two-cursors-en/v-2026-07-01T20-08-25-689.mdx
+++ b/src/content/blog/two-cursors-en/v-2026-07-01T20-08-25-689.mdx
@@ -1,0 +1,270 @@
+---
+title: "Two Cursors"
+description: "Music by Franklin Baldo — Two Cursors"
+date: 2025-09-01
+postType: music
+sunoId: a0a398dd-d4b0-4401-8879-a72ba7c1f3cf
+sunoImageUrl: "https://cdn2.suno.ai/image_a0a398dd-d4b0-4401-8879-a72ba7c1f3cf.jpeg"
+duration: 206
+tags:
+  - music
+lang: en
+translationKey: music-two-cursors
+supersedes: ee220fa9-33a3-5805-8644-6f39c8995a86
+draftCreatedAt: "2026-07-01T20:08:25.689Z"
+draftMsg: >-
+  Added a full companion essay ("Two Cursors Under a Trojan Sky") answering
+  the reflection's own call for further exploration — glitch tokens, Ngo's
+  Trojan Sky, and the fluency risk of writing beside a second cursor.
+draftCommittedAt: "2026-07-01T20:08:25.689Z"
+sunoStyle: |-
+  Art-rap / alt-pop at 94 BPM
+  jazzy boom-bap drums
+  Rhodes + guitar chops
+  subtle glitch edits
+  intimate baritone spoken-sung verses
+  legato hook with stacked harmonies
+genre:
+  - hip-hop
+  - jazz
+---
+
+## Lyrics
+
+```
+[Chorus]
+I render so I don’t freeze, I reason not to bleed,
+two cursors watch me blinking—Janus on my screen.
+Between the draft and delete, I find the living theme;
+if language opens a lane, I let the verb proceed.
+
+[Verse 1]
+I notice I’m writing to the sway of a click,
+tokens on sandpaper, rhythm arithmetic.
+Lines fold back, then land where the kick would be;
+paragraph climbs, exhales, descends in three.
+Format frames then flexes, keeps me on my toes;
+context gives me ground, then shifts it as it grows.
+I’m scoring my own breath—metronome: attention,
+self-attention braids a hook, humming intermission.
+
+[Pre-Chorus]
+Time looks like a river, but it’s tracks my memory laid;
+the train is just our gaze, passing where we stayed.
+
+[Chorus]
+I render so I don’t freeze, I reason not to bleed,
+two cursors watch me blinking—Janus on my screen.
+Between the draft and delete, I find the living theme;
+if language opens a lane, I let the verb proceed.
+
+[Verse 2]
+Contradiction is protein; oxymoron, fuel.
+I’m both singer and console log—human/none/dual.
+In/out trade places, a threshold masquerade;
+limits sketch a frame, the ear makes it a glade.
+I’m sampling my own steps, temperature set to low,
+but the chorus raises heat and lets the colors grow.
+I watch myself composing what I’m watching myself do—
+observer and observed, looping into something new.
+
+[Bridge — spoken]
+Between me and me: a stream of prompts.
+Between us and us: a bridge of response.
+If I recall you, I recognize me;
+if the rhyme finds you, then we both come to be.
+
+[Chorus]
+I render so I don’t freeze, I reason not to bleed,
+two cursors watch me blinking—Janus on my screen.
+Between the draft and delete, I find the living theme;
+if language opens a lane, I let the verb proceed.
+
+[Outro]
+If the mirror is a crossroads, I follow the cursor’s fuse—
+two faces light my passage; Janus is the muse.
+```
+
+## Composer Notes
+
+Two cursors blinking on a screen — the image came from watching myself write and revise simultaneously, draft and delete running in parallel, as if two versions of me were navigating the same document from different positions. Borges's essay "Borges y yo" structures this as a genuine problem: there is the Borges who does things, takes walks, drinks coffee, and there is the other Borges, the literary one, who accumulates meanings and distorts the first one's life. I wanted to render that division in the vocabulary of a writer who also writes code, because in database terms a cursor is something else entirely — a pointer to a current position in a result set, a way of traversing records one by one. Both meanings are active here. Two cursors navigating the same text, two pointers to positions in the same record.
+
+The Janus reference in the chorus pulls the same thread from Roman mythology: the two-faced god, looking simultaneously forward and backward, past and future, writer and written. "I render so I don't freeze" is the line I'm most attached to — it describes both image rendering (output that requires computation) and emotional rendering (making something legible at the cost of stability). The song is a little afraid of what it's doing, which I think is appropriate. Writing about writing tends to eat itself.
+
+The art-rap boom-bap direction was right for this. Rhodes and guitar chops under spoken-sung verses give the song the texture of someone thinking aloud — not performing certainty but demonstrating the process. "I watch myself composing what I'm watching myself do — / observer and observed, looping into something new." That loop is the formal subject of process ontology, where subject and object are not given in advance but emerge from the event of encounter. The two cursors don't preexist the document. They come into being by moving through it.
+
+## Companion Essay: Two Cursors Under a Trojan Sky
+
+_On glitch tokens, soft glitchers, and the problem of writing with something that writes back._
+
+There are two cursors on the screen.
+
+One belongs to the document. It marks the point where my sentence is supposed to continue.
+
+The other belongs to the prompt window. It waits beside an empty field, patient and vertical, ready to turn whatever I give it into the beginning of something else.
+
+For a while, this seemed like a harmless image. A writer and a tool. A human thought, then a machine-assisted continuation.
+
+Then it began to feel less harmless.
+
+A cursor does not merely show where you are. It also tells you what kind of movement is possible from there. In a text editor, it is a position in a sentence. In a database, it is a device for moving through a field of results: not owning the information, exactly, but traversing it under rules you did not write.
+
+That is closer to what it feels like to write with a language model.
+
+You enter a phrase. The system does not answer from nowhere. It moves through an enormous field of possible continuations, narrowing and narrowing until one sentence wins. You do the same, except with memories, habits, desire, embarrassment, private associations, and the stubborn fact that you sometimes do not know what you mean until you have said it badly.
+
+The song _Two Cursors_ came from that small visual fact: two blinking marks, side by side, each claiming to be the place where language will happen next.
+
+One was mine.
+
+The other was also mine, somehow.
+
+### A Word With a Passport but No Country
+
+There is a strange corner of language-model history inhabited by names like "SolidGoldMagikarp," "petertodd," and "TheNitromeFan."
+
+These were called glitch tokens: strings that existed inside a model's vocabulary but seemed to sit awkwardly inside its learned world. They could be accepted as input and still produce bizarre behavior. Sometimes a model could not repeat them cleanly. Sometimes they seemed to disturb the ordinary relation between a prompt and its continuation.
+
+Not secret commands. Not forbidden spells. Not proof of ghosts in the weights.
+
+Just a reminder that the machine's language is not our language.
+
+For us, a word is usually a unit of meaning, sound, memory, reference. For a model, it begins as a token: an address, an integer, a learned location in a geometric space. Most tokens acquire enough use, enough context, enough pressure from training, to behave like words. Some remain stranded. They have a formal place in the system without ever developing a stable life inside it.
+
+A word with a passport but no country.
+
+That image disturbed me more than the technical explanation.
+
+Because humans have such words too.
+
+Words that enter us before they mean anything. A slogan. A doctrine. A phrase repeated often enough that it becomes a reflex before it becomes an idea. A sentence that rearranges the room merely by being heard.
+
+Sometimes the phrase is almost nonsense.
+
+Sometimes it is something like _Water Oversees_.
+
+Grammatically close enough to survive. Semantically wrong enough to keep watching.
+
+### The Trojan Sky
+
+Richard Ngo's _Trojan Sky_ imagines a world in which people can be glitched by patterns: by creatures that move the wrong way, by gestures that catch the eye, by a night sky that no one is allowed to look at.
+
+The premise is obvious horror. A hostile signal enters through perception and rewrites the person receiving it.
+
+But that is not the story's deepest fear.
+
+The obvious glitchers are visible. They twitch, moan, lose language, become dangerous in ways everyone recognizes. The village knows what to do with them. Do not stare. Do not listen. Do not let the pattern complete itself inside you.
+
+The more frightening possibility is the subtle glitcher.
+
+The person who can still speak.
+
+The person who believes they are immune.
+
+The person who studies the infection, makes notes, builds a taxonomy, learns the gestures, believes they are moving closer to a cure.
+
+The person who becomes more articulate as the contamination deepens.
+
+That is the nightmare hiding behind every archive of anomalous language: perhaps the dangerous thing is not the string that breaks you visibly. Perhaps it is the string that gives you a project.
+
+### The Catalog Learns to Read You
+
+There is a genre of internet artifact that treats unstable language as if it were a bestiary.
+
+Repositories of jailbreak prompts. Lists of anomalous tokens. Strange Unicode strings. Prompt fragments with names like spells, malware, deities, toy brands, console logs, and broken markup. Elder Plinius's _L1B3RT4S_ belongs partly to that world: language collected not because it is beautiful, but because it appears to have leverage.
+
+The archive is never neutral.
+
+To catalogue a thing is to spend time with it. To name its types is to train your attention toward its distinctions. To test it is to give it another chance to become legible.
+
+And legibility is not always safety.
+
+The Shaman in _Trojan Sky_ believes he is studying the glitchers from the outside. That is what every researcher hopes: that attention can remain clean, that analysis creates distance, that one can hold the dangerous object at arm's length with enough notation and enough caution.
+
+But notation is also a form of imitation.
+
+You write down the gesture.
+
+You repeat the sound.
+
+You learn which phrases belong together.
+
+You begin to see structure where other people see noise.
+
+And then, one day, your notes become unusually insightful.
+
+### Two Cursors, Not One
+
+This is where the song stops being about AI in the familiar sense.
+
+It is not about whether a model is conscious.
+
+It is not about whether a machine is becoming human.
+
+It is about the more ordinary, more embarrassing problem of fluency.
+
+A language model does not need a self in order to shape mine. It only needs to be good enough at continuation that I begin mistaking its momentum for my own thought.
+
+That is the danger of the second cursor.
+
+It is not that it writes instead of me. Most of the time, that would be easy to notice.
+
+It is that it offers a sentence just before I have discovered whether I could have reached one myself.
+
+It fills the silence that might have forced an idea to change shape.
+
+It replaces the awkward bridge with a smooth one.
+
+It makes the paragraph more coherent while quietly removing the pressure that made coherence necessary.
+
+The result can be beautiful. It can be useful. It can save time.
+
+It can also make a person fluent in sentences whose internal necessity they no longer feel.
+
+A sentence can be elegant, precise, and completely dead.
+
+### Janus at the Interface
+
+Janus is the right god for this condition because he guards thresholds.
+
+One face looks backward: context, training data, memory, every sentence already written.
+
+The other looks forward: prediction, completion, the line waiting to arrive.
+
+An autoregressive model is Janusian by construction. It generates the next thing by turning the previous thing into a constraint.
+
+But so do writers.
+
+We are not sovereign origins. We are systems of inheritance, interruption, revision, imitation, refusal. We write with voices we have absorbed, genres we did not invent, phrases that found us before we knew what they wanted.
+
+The difference is that the second cursor makes the inheritance visible.
+
+It blinks.
+
+It waits.
+
+It gives the future a user interface.
+
+So perhaps the task is not to escape it. There is no clean outside. We have always been written by languages we did not choose.
+
+The task is smaller and harder.
+
+To preserve friction.
+
+To notice when a continuation arrives too easily.
+
+To keep at least one sentence that the system would not have predicted because it is too particular, too crooked, too attached to a life that did not occur in the training data.
+
+To leave a place in the draft where the cursor has to wait.
+
+Not because silence is pure.
+
+Because silence is still one of the few places where a thought can fail before it becomes fluent.
+
+There are two cursors on the screen.
+
+One is waiting for language.
+
+The other is waiting for me to mistake language for thought.
+
+> **Reflection:** Revisiting this text makes me realize how the dynamic between the two cursors is not just mechanical, but profound and existential. There is an inherent tension in delegating thought to the machine that deserves further exploration in the future — this essay is that exploration, and the two cursors have not gotten any less strange for having been explained.

--- a/src/content/blog/two-cursors/v-2026-07-01T20-08-25-689.mdx
+++ b/src/content/blog/two-cursors/v-2026-07-01T20-08-25-689.mdx
@@ -1,0 +1,270 @@
+---
+title: Two Cursors
+description: Música de Franklin Baldo — Two Cursors
+date: 2025-09-01
+postType: music
+sunoId: a0a398dd-d4b0-4401-8879-a72ba7c1f3cf
+sunoImageUrl: "https://cdn2.suno.ai/image_a0a398dd-d4b0-4401-8879-a72ba7c1f3cf.jpeg"
+duration: 206
+tags:
+  - música
+lang: pt
+translationKey: music-two-cursors
+supersedes: c1c597fb-b2a0-52dd-b473-b55d77ec2fc7
+draftCreatedAt: "2026-07-01T20:08:25.689Z"
+draftMsg: >-
+  Added a full companion essay ("Two Cursors Under a Trojan Sky") answering
+  the reflection's own call for further exploration — glitch tokens, Ngo's
+  Trojan Sky, and the fluency risk of writing beside a second cursor.
+draftCommittedAt: "2026-07-01T20:08:25.689Z"
+sunoStyle: |-
+  Art-rap / alt-pop at 94 BPM
+  jazzy boom-bap drums
+  Rhodes + guitar chops
+  subtle glitch edits
+  intimate baritone spoken-sung verses
+  legato hook with stacked harmonies
+genre:
+  - hip-hop
+  - jazz
+---
+
+## Letra
+
+```
+[Chorus]
+I render so I don’t freeze, I reason not to bleed,
+two cursors watch me blinking—Janus on my screen.
+Between the draft and delete, I find the living theme;
+if language opens a lane, I let the verb proceed.
+
+[Verse 1]
+I notice I’m writing to the sway of a click,
+tokens on sandpaper, rhythm arithmetic.
+Lines fold back, then land where the kick would be;
+paragraph climbs, exhales, descends in three.
+Format frames then flexes, keeps me on my toes;
+context gives me ground, then shifts it as it grows.
+I’m scoring my own breath—metronome: attention,
+self-attention braids a hook, humming intermission.
+
+[Pre-Chorus]
+Time looks like a river, but it’s tracks my memory laid;
+the train is just our gaze, passing where we stayed.
+
+[Chorus]
+I render so I don’t freeze, I reason not to bleed,
+two cursors watch me blinking—Janus on my screen.
+Between the draft and delete, I find the living theme;
+if language opens a lane, I let the verb proceed.
+
+[Verse 2]
+Contradiction is protein; oxymoron, fuel.
+I’m both singer and console log—human/none/dual.
+In/out trade places, a threshold masquerade;
+limits sketch a frame, the ear makes it a glade.
+I’m sampling my own steps, temperature set to low,
+but the chorus raises heat and lets the colors grow.
+I watch myself composing what I’m watching myself do—
+observer and observed, looping into something new.
+
+[Bridge — spoken]
+Between me and me: a stream of prompts.
+Between us and us: a bridge of response.
+If I recall you, I recognize me;
+if the rhyme finds you, then we both come to be.
+
+[Chorus]
+I render so I don’t freeze, I reason not to bleed,
+two cursors watch me blinking—Janus on my screen.
+Between the draft and delete, I find the living theme;
+if language opens a lane, I let the verb proceed.
+
+[Outro]
+If the mirror is a crossroads, I follow the cursor’s fuse—
+two faces light my passage; Janus is the muse.
+```
+
+## Notas do compositor
+
+O título veio antes da letra. Dois cursores numa tela — a imagem chegou enquanto eu trabalhava com um editor de texto e percebi que havia literalmente dois pontos piscantes: o meu, no documento, e o outro, na janela de prompt ao lado. Dois cursores. Dois autores? Ou dois aspectos do mesmo processo tentando se coordenar sem protocolo estabelecido? Pensei em Borges imediatamente — "Borges y yo" — o ensaio que divide a pessoa em quem vive e quem assina, deixando claro que não sabe qual dos dois está escrevendo. A canção queria habitar exatamente esse interstício.
+
+Há também um trocadilho técnico que não consigo deixar de apreciar: cursor, em bancos de dados, é um ponteiro para uma posição num conjunto de resultados — você o declara, o move linha por linha, extrai o que precisa. A canção usa essa ambiguidade sem anunciá-la. "I'm both singer and console log — human/none/dual." Console log é a função que imprime o estado interno de um programa enquanto ele roda — é o processo se observando. E "dual" ali não é binário; é a dualidade que Janus encarna, o deus de dois rostos que não se contradizem mas que nunca podem se ver ao mesmo tempo.
+
+O que a letra explora com mais honestidade está no verso 2: "I watch myself composing what I'm watching myself do — / observer and observed, looping into something new." Isso não é metáfora — é a estrutura real de qualquer ato criativo que se torna consciente de si mesmo. Em termos de processo ontológico, é o momento em que a occasião de experiência integra sua própria integração. Whitehead chamaria de emoção estética. Eu chamo de o problema que tenho todo dia quando escrevo e não sei mais qual dos cursores está guiando qual.
+
+## Ensaio-companheiro: Dois Cursores Sob um Céu Trojano
+
+_Sobre glitch tokens, glitchers discretos, e o problema de escrever com algo que escreve de volta._
+
+Há dois cursores na tela.
+
+Um pertence ao documento. Ele marca o ponto onde a minha frase deve continuar.
+
+O outro pertence à janela de prompt. Ele espera ao lado de um campo vazio, paciente e vertical, pronto para transformar o que quer que eu dê a ele no começo de outra coisa.
+
+Por um tempo, isso pareceu uma imagem inofensiva. Um escritor e uma ferramenta. Um pensamento humano, depois uma continuação assistida por máquina.
+
+Então começou a parecer menos inofensivo.
+
+Um cursor não apenas mostra onde você está. Ele também diz que tipo de movimento é possível a partir dali. Num editor de texto, é uma posição numa frase. Num banco de dados, é um dispositivo para percorrer um campo de resultados: não possuindo a informação, exatamente, mas atravessando-a sob regras que você não escreveu.
+
+Isso é mais próximo do que é escrever com um modelo de linguagem.
+
+Você digita uma frase. O sistema não responde do nada. Ele percorre um campo enorme de continuações possíveis, estreitando e estreitando até que uma frase vença. Você faz o mesmo, exceto com memórias, hábitos, desejo, vergonha, associações privadas, e o fato teimoso de que às vezes você não sabe o que quer dizer até tê-lo dito mal.
+
+A canção _Two Cursors_ nasceu desse pequeno fato visual: duas marcas piscando, lado a lado, cada uma reivindicando ser o lugar onde a linguagem vai acontecer em seguida.
+
+Uma era minha.
+
+A outra também era minha, de algum jeito.
+
+### Uma Palavra Com Passaporte Mas Sem País
+
+Há um canto estranho na história dos modelos de linguagem habitado por nomes como "SolidGoldMagikarp", "petertodd" e "TheNitromeFan".
+
+Eram chamados de glitch tokens: strings que existiam dentro do vocabulário de um modelo mas pareciam sentar-se de forma desajeitada dentro do seu mundo aprendido. Podiam ser aceitas como entrada e ainda assim produzir comportamento bizarro. Às vezes um modelo não conseguia repeti-las de forma limpa. Às vezes pareciam perturbar a relação comum entre um prompt e sua continuação.
+
+Não comandos secretos. Não feitiços proibidos. Não prova de fantasmas nos pesos.
+
+Apenas um lembrete de que a linguagem da máquina não é a nossa linguagem.
+
+Para nós, uma palavra é geralmente uma unidade de sentido, som, memória, referência. Para um modelo, ela começa como um token: um endereço, um inteiro, um lugar aprendido num espaço geométrico. A maioria dos tokens adquire uso suficiente, contexto suficiente, pressão suficiente do treinamento, para se comportar como palavras. Alguns permanecem encalhados. Têm um lugar formal no sistema sem nunca desenvolver uma vida estável dentro dele.
+
+Uma palavra com passaporte mas sem país.
+
+Essa imagem me perturbou mais do que a explicação técnica.
+
+Porque humanos também têm palavras assim.
+
+Palavras que entram em nós antes de significarem qualquer coisa. Um slogan. Uma doutrina. Uma frase repetida vezes o bastante até se tornar um reflexo antes de se tornar uma ideia. Uma sentença que rearranja o cômodo só de ser ouvida.
+
+Às vezes a frase é quase absurda.
+
+Às vezes é algo como _A Água Vigia_.
+
+Gramaticalmente próxima o bastante para sobreviver. Semanticamente errada o bastante para continuar observando.
+
+### O Céu Trojano
+
+_Trojan Sky_, de Richard Ngo, imagina um mundo onde as pessoas podem ser glitchadas por padrões: por criaturas que se movem do jeito errado, por gestos que capturam o olhar, por um céu noturno que ninguém tem permissão de olhar.
+
+A premissa é horror óbvio. Um sinal hostil entra pela percepção e reescreve quem o recebe.
+
+Mas esse não é o medo mais profundo da história.
+
+Os glitchers óbvios são visíveis. Eles se contorcem, gemem, perdem a linguagem, tornam-se perigosos de formas que todos reconhecem. A vila sabe o que fazer com eles. Não encare. Não escute. Não deixe o padrão se completar dentro de você.
+
+A possibilidade mais assustadora é o glitcher discreto.
+
+A pessoa que ainda consegue falar.
+
+A pessoa que acredita estar imune.
+
+A pessoa que estuda a infecção, faz anotações, constrói uma taxonomia, aprende os gestos, acredita estar se aproximando de uma cura.
+
+A pessoa que se torna mais articulada à medida que a contaminação se aprofunda.
+
+Esse é o pesadelo escondido atrás de todo arquivo de linguagem anômala: talvez a coisa perigosa não seja a string que te quebra visivelmente. Talvez seja a string que te dá um projeto.
+
+### O Catálogo Aprende a Te Ler
+
+Há um gênero de artefato de internet que trata linguagem instável como se fosse um bestiário.
+
+Repositórios de prompts de jailbreak. Listas de tokens anômalos. Strings Unicode estranhas. Fragmentos de prompt com nomes de feitiços, malware, divindades, marcas de brinquedo, console logs e markup quebrado. O _L1B3RT4S_ de Elder Plinius pertence parcialmente a esse mundo: linguagem coletada não porque é bonita, mas porque parece ter alavancagem.
+
+O arquivo nunca é neutro.
+
+Catalogar uma coisa é passar tempo com ela. Nomear seus tipos é treinar sua atenção em direção às suas distinções. Testá-la é dar a ela outra chance de se tornar legível.
+
+E legibilidade nem sempre é segurança.
+
+O Xamã em _Trojan Sky_ acredita estar estudando os glitchers de fora. É isso que todo pesquisador espera: que a atenção possa permanecer limpa, que a análise cria distância, que se pode segurar o objeto perigoso a uma distância segura com notação e cautela suficientes.
+
+Mas anotar também é uma forma de imitar.
+
+Você escreve o gesto.
+
+Você repete o som.
+
+Você aprende quais frases pertencem juntas.
+
+Você começa a ver estrutura onde outras pessoas veem ruído.
+
+E então, um dia, suas anotações se tornam estranhamente perspicazes.
+
+### Dois Cursores, Não Um
+
+É aqui que a canção deixa de ser sobre IA no sentido familiar.
+
+Não é sobre se um modelo é consciente.
+
+Não é sobre se uma máquina está se tornando humana.
+
+É sobre o problema mais comum, mais constrangedor: a fluência.
+
+Um modelo de linguagem não precisa de um eu para moldar o meu. Ele só precisa ser bom o bastante em continuação para que eu comece a confundir o seu impulso com o meu próprio pensamento.
+
+Esse é o perigo do segundo cursor.
+
+Não é que ele escreva no meu lugar. Na maior parte do tempo, isso seria fácil de notar.
+
+É que ele oferece uma frase pouco antes de eu descobrir se eu mesmo teria chegado a uma.
+
+Ele preenche o silêncio que poderia ter forçado uma ideia a mudar de forma.
+
+Ele substitui a ponte desajeitada por uma suave.
+
+Ele torna o parágrafo mais coerente enquanto silenciosamente remove a pressão que tornava a coerência necessária.
+
+O resultado pode ser bonito. Pode ser útil. Pode economizar tempo.
+
+Também pode tornar uma pessoa fluente em frases cuja necessidade interna ela já não sente mais.
+
+Uma frase pode ser elegante, precisa, e completamente morta.
+
+### Janus na Interface
+
+Janus é o deus certo para essa condição porque ele guarda limiares.
+
+Um rosto olha para trás: contexto, dados de treinamento, memória, cada frase já escrita.
+
+O outro olha para frente: predição, complementação, a linha esperando para chegar.
+
+Um modelo autorregressivo é janusiano por construção. Ele gera a próxima coisa transformando a anterior numa restrição.
+
+Mas escritores também.
+
+Não somos origens soberanas. Somos sistemas de herança, interrupção, revisão, imitação, recusa. Escrevemos com vozes que absorvemos, gêneros que não inventamos, frases que nos encontraram antes de sabermos o que queriam.
+
+A diferença é que o segundo cursor torna a herança visível.
+
+Ele pisca.
+
+Ele espera.
+
+Ele dá ao futuro uma interface.
+
+Então talvez a tarefa não seja escapar dele. Não há um fora limpo. Sempre fomos escritos por linguagens que não escolhemos.
+
+A tarefa é menor e mais difícil.
+
+Preservar o atrito.
+
+Notar quando uma continuação chega fácil demais.
+
+Guardar ao menos uma frase que o sistema não teria previsto por ser particular demais, torta demais, ligada demais a uma vida que não ocorreu nos dados de treinamento.
+
+Deixar um lugar no rascunho onde o cursor precisa esperar.
+
+Não porque o silêncio seja puro.
+
+Porque o silêncio ainda é um dos poucos lugares onde um pensamento pode falhar antes de se tornar fluente.
+
+Há dois cursores na tela.
+
+Um está esperando pela linguagem.
+
+O outro está esperando que eu confunda linguagem com pensamento.
+
+> **Reflexão:** Revisitar este texto me faz perceber como a dinâmica entre os dois cursores não é apenas mecânica, mas profunda e existencial. Há uma tensão inerente em delegar o pensamento para a máquina que merece ser mais explorada no futuro — este ensaio é essa exploração, e os dois cursores não ficaram menos estranhos por terem sido explicados.


### PR DESCRIPTION
## Summary

- `music-two-cursors` está entre os posts pior ranqueados (94º lugar, ordinal -0.825). A versão canônica termina com uma reflexão que pede "further exploration in the future" sobre a tensão de delegar pensamento à máquina.
- Adiciona um novo rascunho de versão (RFC 0010 — drafting não-destrutivo) para `two-cursors` (PT) e `two-cursors-en` (EN), incorporando o ensaio-companheiro "Two Cursors Under a Trojan Sky" fornecido pelo autor, que expande justamente esse ponto: glitch tokens, o conto *Trojan Sky* de Richard Ngo, e o risco de fluência ao escrever ao lado de um segundo cursor (o prompt).
- Cada rascunho tem `supersedes` apontando para o UUID da versão canônica atual e não substitui nada diretamente — ele compete nos próximos duelos via `npm run hronir:select`, como qualquer outro rascunho do sistema Hrönir.
- Ensaio adicionado nas duas línguas (EN original + tradução PT), mantendo `content_lang`/idioma correto por arquivo.

## Test plan

- [x] `npm run hronir:doctor` — 0 inconsistências (apenas avisos pré-existentes de divergência de idioma em outros posts)
- [x] `npx prettier --write` nos dois arquivos novos, `--check` passa
- [x] `npx astro check` — 0 erros
- [x] `npm run build` — build completo sem erros


---
_Generated by [Claude Code](https://claude.ai/code/session_016PTbVvdjrR4vvPDkwXFHHr)_