### PR TITLE
seo(i18n): sitemap.xml hreflang para /paths/[slug]/

### DIFF
--- a/.routines/2026-07-02T08-44-57-sitemap-paths-hreflang.md
+++ b/.routines/2026-07-02T08-44-57-sitemap-paths-hreflang.md
@@ -4,7 +4,7 @@ slug: sitemap-paths-hreflang
 branch: claude/sleepy-pasteur-62kliq
 status: pr-open
 issues: [888]
-pr_opened: null
+pr_opened: 892
 pr_merged: 864
 ---
 

--- a/.routines/2026-07-02T08-44-57-sitemap-paths-hreflang.md
+++ b/.routines/2026-07-02T08-44-57-sitemap-paths-hreflang.md
@@ -1,0 +1,88 @@
+---
+date: 2026-07-02T08:44:57
+slug: sitemap-paths-hreflang
+branch: claude/sleepy-pasteur-62kliq
+status: pr-open
+issues: [888]
+pr_opened: null
+pr_merged: 864
+---
+
+## Contexto ao chegar
+
+Nenhum PR `routine` aberto para mergear — a fila estava vazia. O PR da run
+anterior (#864, issue #250 — OG images para reading paths) já tinha sido
+mergeado diretamente por Franklin (`closed_by: franklinbaldo`,
+`merged_at: 2026-07-01T08:07:18Z`), sem veto.
+
+## Verificação em produção do PR anterior (#864)
+
+Confirmado via `curl` em `/paths/agency-and-constraint/` e
+`/pt/paths/agency-and-constraint/`: `og:image`/`twitter:image` apontam para
+`/og/path-agency-and-constraint.png` e `/og/path-pt-agency-and-constraint.png`
+respectivamente (200 OK em ambos), `hreflang` correto no `<head>`. Sem
+regressão.
+
+## Backlog — reposição
+
+9 issues `routine` abertas ao chegar — abaixo da faixa saudável (10–20).
+Investiguei a estrutura do site (agente Explore) em busca de gaps reais de
+SEO/UX/discovery/i18n ainda não cobertos pelo backlog existente. Abri 4
+issues novas:
+
+- **#888** (`priority:media`) — `sitemap.xml` sem hreflang para
+  `/paths/[slug]/` (bug real e verificável — ver abaixo).
+- **#889** (`priority:baixa`) — fallback em `RelatedPosts` quando há menos
+  de 2 posts com tag em comum (hoje a seção simplesmente não renderiza).
+- **#890** (`priority:baixa`) — `llms.txt` para indexação por agentes de IA.
+- **#891** (`priority:baixa`) — trilha de breadcrumb visível (hoje só existe
+  como JSON-LD `BreadcrumbList`, sem UI).
+
+Backlog agora com 13 issues abertas — dentro da faixa.
+
+## Trabalho desta run — issue #888
+
+Confirmei o gap: `astro.config.mjs`'s `serialize()` do sitemap só monta
+`item.links` (hreflang) para `staticPairs` (home, about, archive, tags,
+search, projects, ranking, music, books) e para pares de posts de blog via
+`blogPairs`. As 3 reading paths × 2 línguas não batiam em nenhum dos dois
+ramos — saíam do `sitemap.xml` sem `xhtml:link`, mesmo com o `<head>` da
+própria página correto (confirmado na verificação do #864 acima). O Google
+Search Console usa o sitemap como sinal primário de hreflang, então esse par
+ficava invisível para ele.
+
+Adicionei um terceiro ramo ao `serialize()` cobrindo `/paths/[slug]/` ↔
+`/pt/paths/[slug]/`, derivado da mesma lista `READING_PATHS` que já
+alimenta as páginas — sem hardcode de slugs, então um novo reading path já
+entra automaticamente.
+
+Problema no caminho: `READING_PATHS` vivia em `src/lib/paths.ts`, que importa
+`astro:content` (via `getCollection`) — inimportável em tempo de
+carregamento do `astro.config.mjs`. Segui a convenção `.ts`/`.mjs` do próprio
+`CLAUDE.md` (".mjs: arquivos importáveis por scripts Node e por
+astro.config.mjs") e extraí os dados puros (sem o import de `astro:content`)
+para `src/lib/reading-paths-data.mjs`; `paths.ts` agora reexporta o mesmo
+array com o tipo `ReadingPath[]`.
+
+## Verificação local
+
+- `astro check` ✓ (0 errors, 0 warnings)
+- `npm run build` ✓ (3614 páginas) — inspecionei `dist/sitemap-0.xml`
+  diretamente: as 6 URLs de reading paths (3 slugs × 2 línguas) agora têm
+  `xhtml:link` com `hreflang="en-US"`, `"pt-BR"` e `"x-default"` corretos.
+- `npx prettier --check .` ✓
+- `npm run check:hygiene` ✓ (13 root files)
+- `npm run hronir:doctor` ✓ (0 inconsistências — 16 avisos pré-existentes de
+  convergência EN/PT, não relacionados a esta mudança)
+- Descartada mudança em `src/generated/ranking-snapshot.json` (efeito
+  colateral do build local, não faz parte deste PR)
+
+## O que fica para a próxima run
+
+- Mergear o PR desta run (issue #888) após CI verde e sem veto de 24h.
+- Mudança sem impacto visual (só `<xhtml:link>` no sitemap.xml, não
+  renderizado) — nada para o screenshot de prod verificar além de re-checar
+  o sitemap ao vivo.
+- Próxima issue de maior prioridade no backlog: as 4 novas (#888 zerada
+  após merge, então #889/#890/#891, todas `priority:baixa`) ou as
+  pré-existentes #251/#552/#553/#587/#588/#678/#760/#762/#763.

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -2,6 +2,7 @@
 import { defineConfig } from "astro/config";
 import { existsSync, readFileSync } from "node:fs";
 import { DEFAULT_LANG, LANG_META } from "./src/lib/languages.mjs";
+import { READING_PATHS } from "./src/lib/reading-paths-data.mjs";
 
 /** @type {Record<string, Record<string, string>>} */
 let blogPairs = {};
@@ -128,10 +129,27 @@ export default defineConfig({
           Object.entries(staticPairs).map(([en, pt]) => [pt, en])
         );
 
+        // Reading paths (/paths/[slug]/ ↔ /pt/paths/[slug]/) aren't blog
+        // posts and aren't in staticPairs — derive their pairs from the same
+        // READING_PATHS list the pages themselves are built from.
+        const pathPairs = Object.fromEntries(
+          READING_PATHS.map((p) => [
+            base + "/paths/" + p.slug + "/",
+            base + "/pt/paths/" + p.slug + "/",
+          ])
+        );
+        const pathToEn = Object.fromEntries(
+          Object.entries(pathPairs).map(([en, pt]) => [pt, en])
+        );
+
         if (staticPairs[item.url]) {
           item.links = makeLinks({ en: item.url, pt: staticPairs[item.url] });
         } else if (ptToEn[item.url]) {
           item.links = makeLinks({ en: ptToEn[item.url], pt: item.url });
+        } else if (pathPairs[item.url]) {
+          item.links = makeLinks({ en: item.url, pt: pathPairs[item.url] });
+        } else if (pathToEn[item.url]) {
+          item.links = makeLinks({ en: pathToEn[item.url], pt: item.url });
         } else {
           // Blog post pairs — look up pre-generated bidirectional map.
           const path = item.url.replace(base, "");

--- a/src/lib/paths.ts
+++ b/src/lib/paths.ts
@@ -1,6 +1,7 @@
 import { getCollection, type CollectionEntry } from "astro:content";
 import { DEFAULT_LANG } from "./i18n";
 import { isPublished } from "./publish";
+import { READING_PATHS as READING_PATHS_DATA } from "./reading-paths-data.mjs";
 
 export type Lang = "en" | "pt";
 
@@ -13,80 +14,7 @@ export interface ReadingPath {
     | { type: "manual"; posts: Record<Lang, string[]> };
 }
 
-export const READING_PATHS: ReadingPath[] = [
-  {
-    slug: "agency-and-constraint",
-    title: {
-      en: "Agency and Constraint",
-      pt: "Agência e Restrição",
-    },
-    blurb: {
-      en: "Why alignment is not the absence of capability but the architecture that shapes it. From the temple at Delphi to the harness in your pocket.",
-      pt: "Por que alinhamento não é ausência de capacidade, mas a arquitetura que a molda. Do templo em Delfos ao canivete no bolso.",
-    },
-    source: { type: "series", series: "harness" },
-  },
-  {
-    slug: "memory-and-funes",
-    title: {
-      en: "Memory and Funes",
-      pt: "Memória e Funes",
-    },
-    blurb: {
-      en: "On total recall, Pierre Menard, and what Borges saw before anyone else. From building Funes to preserving family voices: the cost of perfect memory and the architecture that makes it survivable.",
-      pt: "Sobre lembrança total, Pierre Menard, e o que Borges viu antes de todos. De construir Funes a preservar vozes da família: o custo da memória perfeita e a arquitetura que a torna suportável.",
-    },
-    source: {
-      type: "manual",
-      posts: {
-        en: [
-          "building-funes",
-          "funes-soul",
-          "verne-identity-repo",
-          "what-i-learned-orchestrating-ai-agents-to-preserve-family-memory",
-          "pierre-menard-computational-researcher",
-        ],
-        pt: [
-          "construindo-funes-como-dei-uma-alma-a-um-agente-de-ia",
-          "soulmd-funes",
-          "verne-e-o-padro-identity-repo-como-os-agentes-de-ia-se-lembram",
-          "orquestrando-agentes-memoria-familiar",
-          "pierre-menard-pesquisador-computacional",
-        ],
-      },
-    },
-  },
-  {
-    slug: "law-and-ai",
-    title: {
-      en: "Law and AI",
-      pt: "Direito e IA",
-    },
-    blurb: {
-      en: "A state attorney's journey into AI agents: delegation, memory, and what changes when the clerk never forgets — seen from someone who builds at night and argues in court by day.",
-      pt: "A jornada de um procurador do estado pelo mundo dos agentes de IA: delegação, memória, e o que muda quando o escrivão nunca esquece — pelo olhar de quem constrói à noite e argumenta no tribunal de dia.",
-    },
-    source: {
-      type: "manual",
-      posts: {
-        en: [
-          "the-art-of-delegation",
-          "census-not-sample",
-          "conceptual-document-the-chronicle-of-franklin-baldo",
-          "building-funes",
-          "funes-soul",
-        ],
-        pt: [
-          "delegando-para-agentes",
-          "censo-nao-amostra",
-          "documento-conceitual-a-cronica-de-franklin-baldo",
-          "construindo-funes-como-dei-uma-alma-a-um-agente-de-ia",
-          "soulmd-funes",
-        ],
-      },
-    },
-  },
-];
+export const READING_PATHS: ReadingPath[] = READING_PATHS_DATA as ReadingPath[];
 
 export function getReadingPath(slug: string): ReadingPath | undefined {
   return READING_PATHS.find((p) => p.slug === slug);

--- a/src/lib/reading-paths-data.mjs
+++ b/src/lib/reading-paths-data.mjs
@@ -1,0 +1,77 @@
+// Plain data, no astro:content import — consumed by src/lib/paths.ts (typed
+// wrapper) and by astro.config.mjs (sitemap hreflang pairing), which can't
+// load astro:content at config-eval time.
+export const READING_PATHS = [
+  {
+    slug: "agency-and-constraint",
+    title: {
+      en: "Agency and Constraint",
+      pt: "Agência e Restrição",
+    },
+    blurb: {
+      en: "Why alignment is not the absence of capability but the architecture that shapes it. From the temple at Delphi to the harness in your pocket.",
+      pt: "Por que alinhamento não é ausência de capacidade, mas a arquitetura que a molda. Do templo em Delfos ao canivete no bolso.",
+    },
+    source: { type: "series", series: "harness" },
+  },
+  {
+    slug: "memory-and-funes",
+    title: {
+      en: "Memory and Funes",
+      pt: "Memória e Funes",
+    },
+    blurb: {
+      en: "On total recall, Pierre Menard, and what Borges saw before anyone else. From building Funes to preserving family voices: the cost of perfect memory and the architecture that makes it survivable.",
+      pt: "Sobre lembrança total, Pierre Menard, e o que Borges viu antes de todos. De construir Funes a preservar vozes da família: o custo da memória perfeita e a arquitetura que a torna suportável.",
+    },
+    source: {
+      type: "manual",
+      posts: {
+        en: [
+          "building-funes",
+          "funes-soul",
+          "verne-identity-repo",
+          "what-i-learned-orchestrating-ai-agents-to-preserve-family-memory",
+          "pierre-menard-computational-researcher",
+        ],
+        pt: [
+          "construindo-funes-como-dei-uma-alma-a-um-agente-de-ia",
+          "soulmd-funes",
+          "verne-e-o-padro-identity-repo-como-os-agentes-de-ia-se-lembram",
+          "orquestrando-agentes-memoria-familiar",
+          "pierre-menard-pesquisador-computacional",
+        ],
+      },
+    },
+  },
+  {
+    slug: "law-and-ai",
+    title: {
+      en: "Law and AI",
+      pt: "Direito e IA",
+    },
+    blurb: {
+      en: "A state attorney's journey into AI agents: delegation, memory, and what changes when the clerk never forgets — seen from someone who builds at night and argues in court by day.",
+      pt: "A jornada de um procurador do estado pelo mundo dos agentes de IA: delegação, memória, e o que muda quando o escrivão nunca esquece — pelo olhar de quem constrói à noite e argumenta no tribunal de dia.",
+    },
+    source: {
+      type: "manual",
+      posts: {
+        en: [
+          "the-art-of-delegation",
+          "census-not-sample",
+          "conceptual-document-the-chronicle-of-franklin-baldo",
+          "building-funes",
+          "funes-soul",
+        ],
+        pt: [
+          "delegando-para-agentes",
+          "censo-nao-amostra",
+          "documento-conceitual-a-cronica-de-franklin-baldo",
+          "construindo-funes-como-dei-uma-alma-a-um-agente-de-ia",
+          "soulmd-funes",
+        ],
+      },
+    },
+  },
+];


### PR DESCRIPTION
Closes #888

## SEO

As páginas `/paths/[slug]/` e `/pt/paths/[slug]/` já emitiam `<link rel="alternate" hreflang="...">` corretos no `<head>` (confirmado em produção após #864), mas o `sitemap.xml` — gerado por `@astrojs/sitemap` — só montava `item.links` para `staticPairs` (home, about, archive, tags, search, projects, ranking, music, books) e pares de posts de blog. As 3 reading paths (`agency-and-constraint`, `law-and-ai`, `memory-and-funes`) × 2 línguas não batiam em nenhum dos dois ramos, então saíam do sitemap sem `xhtml:link` — o Google Search Console usa o sitemap como sinal primário de hreflang, então esse par ficava invisível para ele mesmo com o `<head>` correto.

Adicionado um terceiro ramo ao `serialize()` do sitemap cobrindo `/paths/[slug]/` ↔ `/pt/paths/[slug]/`, derivado da mesma lista `READING_PATHS` que alimenta as páginas — sem hardcode de slugs, então um novo reading path já entra automaticamente no par.

## i18n

`READING_PATHS` vivia em `src/lib/paths.ts`, que importa `astro:content` (via `getCollection`) — inimportável em tempo de carregamento do `astro.config.mjs`. Segui a convenção `.ts`/`.mjs` já documentada em `CLAUDE.md` (".mjs: arquivos importáveis por scripts Node e por astro.config.mjs, sem transpile") e extraí os dados puros para `src/lib/reading-paths-data.mjs`; `paths.ts` agora reexporta o mesmo array com o tipo `ReadingPath[]`.

## Backlog

Fiz uma survey da estrutura do site e abri 4 issues novas para repor o backlog (estava em 9, abaixo da faixa 10–20): #888 (este PR), #889 (fallback em `RelatedPosts` quando <2 posts com tag em comum), #890 (`llms.txt`), #891 (breadcrumb visível).

## Verificação local

- [x] `astro check` — 0 errors, 0 warnings
- [x] `npm run build` — 3614 páginas; inspecionei `dist/sitemap-0.xml` diretamente: as 6 URLs de reading paths (3 slugs × 2 línguas) agora têm `xhtml:link` com `hreflang="en-US"`, `"pt-BR"` e `"x-default"` corretos
- [x] `npx prettier --check .`
- [x] `npm run check:hygiene`
- [x] `npm run hronir:doctor` — 0 inconsistências (16 avisos pré-existentes de convergência EN/PT, não relacionados)

Sem elemento visual novo (só `<xhtml:link>` no sitemap.xml, não renderizado) — nada a apontar para o screenshot de prod da run seguinte.

---
_Gerado pela rotina autônoma — [Claude Code](https://claude.ai/code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01JQoKY4rWGibJunELbaehd4)_