### PR TITLE
feat(hronir): add fact-checker and meme-sommelier evaluator perspectives

### DIFF
--- a/scripts/hronir/README.md
+++ b/scripts/hronir/README.md
@@ -183,18 +183,23 @@ fica registrado no frontmatter do match como `mood_glyph`, ao lado de
 
 Cada match no schema `stars-v1` é avaliado a partir de uma **perspectiva de leitor** sorteada aleatoriamente no `continue` (estado `ready_for_next` → `reading_a`). A perspectiva é um arquivo em `scripts/hronir/perspectives/<id>.md` com frontmatter (`id`, `name`, `summary`) e um corpo de instruções dizendo o que premiar, o que penalizar, e como escrever a resenha e o confronto a partir daquela ótica.
 
-As 8 perspectivas atuais derivam das categorias de leitores descritas em `skills/franklin-blog/SKILL.md`:
+As perspectivas atuais derivam das categorias de leitores descritas em `skills/franklin-blog/SKILL.md`:
 
-| id                        | leitor                                                                                               |
-| ------------------------- | ---------------------------------------------------------------------------------------------------- |
-| `long-form-rationalist`   | Reader de Scott Alexander, Robin Hanson, Zvi, Gwern. Testa calibração epistêmica.                    |
-| `lateral-essayist`        | Reader de Didion, Calvino, Pessoa, Sebald. Lê para estrutura-como-movimento.                         |
-| `weird-clarity`           | Reader de Borges, Wittgenstein, Ted Chiang. Quer o frio de uma sentença clara que resiste paráfrase. |
-| `internet-native`         | Viewer de Hbomberguy, Folding Ideas. Tolera digressão se o ritmo a paga.                             |
-| `skeptical-specialist`    | Leitor adversarial bem-informado (do `franklin-essay`). Caça a alegação mais fraca.                  |
-| `curious-outsider`        | Leitor inteligente sem contexto do tópico. Testa generosidade pedagógica.                            |
-| `returning-reader`        | Leitor habitual do blog. Conhece os tiques; vigia auto-repetição entre posts recentes.               |
-| `comedy-carries-argument` | Reader de Lem, Monterroso, Nelson Rodrigues. Testa se a piada é alavanca ou decoração.               |
+| id                        | leitor                                                                                                    |
+| ------------------------- | --------------------------------------------------------------------------------------------------------- |
+| `long-form-rationalist`   | Reader de Scott Alexander, Robin Hanson, Zvi, Gwern. Testa calibração epistêmica.                         |
+| `lateral-essayist`        | Reader de Didion, Calvino, Pessoa, Sebald. Lê para estrutura-como-movimento.                              |
+| `weird-clarity`           | Reader de Borges, Wittgenstein, Ted Chiang. Quer o frio de uma sentença clara que resiste paráfrase.      |
+| `internet-native`         | Viewer de Hbomberguy, Folding Ideas. Tolera digressão se o ritmo a paga.                                  |
+| `skeptical-specialist`    | Leitor adversarial bem-informado (do `franklin-essay`). Caça a alegação mais fraca.                       |
+| `curious-outsider`        | Leitor inteligente sem contexto do tópico. Testa generosidade pedagógica.                                 |
+| `returning-reader`        | Leitor habitual do blog. Conhece os tiques; vigia auto-repetição entre posts recentes.                    |
+| `comedy-carries-argument` | Reader de Lem, Monterroso, Nelson Rodrigues. Testa se a piada é alavanca ou decoração.                    |
+| `craft-listener`          | Ouvinte técnico (letra/música). Testa se a forma carrega o conteúdo.                                      |
+| `felt-not-explained`      | Leitor que testa se o post mostra ou apenas explica o que deveria ser sentido.                            |
+| `lyric-as-poem`           | Leitor de letras como poesia. Testa se a linguagem resiste à paráfrase.                                   |
+| `applied-thinker`         | Reader de Paul Graham, Derek Sivers, Tyler Cowen. Testa se o post muda o que você faz na semana seguinte. |
+| `fact-checker`            | Verifica datas, números, citações e causalidade. Testa precisão factual, não qualidade do argumento.      |
 
 A perspectiva é sorteada por match no `continue` e **imposta** ao avaliador via banner antes da decisão — não há flag para sobrescrever. As resenhas (`review_a`, `review_b`) e o confronto (`clash`) devem ser escritos **a partir da perspectiva sorteada**, não em registro neutro.
 

--- a/scripts/hronir/README.md
+++ b/scripts/hronir/README.md
@@ -185,21 +185,22 @@ Cada match no schema `stars-v1` é avaliado a partir de uma **perspectiva de lei
 
 As perspectivas atuais derivam das categorias de leitores descritas em `skills/franklin-blog/SKILL.md`:
 
-| id                        | leitor                                                                                                    |
-| ------------------------- | --------------------------------------------------------------------------------------------------------- |
-| `long-form-rationalist`   | Reader de Scott Alexander, Robin Hanson, Zvi, Gwern. Testa calibração epistêmica.                         |
-| `lateral-essayist`        | Reader de Didion, Calvino, Pessoa, Sebald. Lê para estrutura-como-movimento.                              |
-| `weird-clarity`           | Reader de Borges, Wittgenstein, Ted Chiang. Quer o frio de uma sentença clara que resiste paráfrase.      |
-| `internet-native`         | Viewer de Hbomberguy, Folding Ideas. Tolera digressão se o ritmo a paga.                                  |
-| `skeptical-specialist`    | Leitor adversarial bem-informado (do `franklin-essay`). Caça a alegação mais fraca.                       |
-| `curious-outsider`        | Leitor inteligente sem contexto do tópico. Testa generosidade pedagógica.                                 |
-| `returning-reader`        | Leitor habitual do blog. Conhece os tiques; vigia auto-repetição entre posts recentes.                    |
-| `comedy-carries-argument` | Reader de Lem, Monterroso, Nelson Rodrigues. Testa se a piada é alavanca ou decoração.                    |
-| `craft-listener`          | Ouvinte técnico (letra/música). Testa se a forma carrega o conteúdo.                                      |
-| `felt-not-explained`      | Leitor que testa se o post mostra ou apenas explica o que deveria ser sentido.                            |
-| `lyric-as-poem`           | Leitor de letras como poesia. Testa se a linguagem resiste à paráfrase.                                   |
-| `applied-thinker`         | Reader de Paul Graham, Derek Sivers, Tyler Cowen. Testa se o post muda o que você faz na semana seguinte. |
-| `fact-checker`            | Verifica datas, números, citações e causalidade. Testa precisão factual, não qualidade do argumento.      |
+| id                        | leitor                                                                                                                               |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| `long-form-rationalist`   | Reader de Scott Alexander, Robin Hanson, Zvi, Gwern. Testa calibração epistêmica.                                                    |
+| `lateral-essayist`        | Reader de Didion, Calvino, Pessoa, Sebald. Lê para estrutura-como-movimento.                                                         |
+| `weird-clarity`           | Reader de Borges, Wittgenstein, Ted Chiang. Quer o frio de uma sentença clara que resiste paráfrase.                                 |
+| `internet-native`         | Viewer de Hbomberguy, Folding Ideas. Tolera digressão se o ritmo a paga.                                                             |
+| `skeptical-specialist`    | Leitor adversarial bem-informado (do `franklin-essay`). Caça a alegação mais fraca.                                                  |
+| `curious-outsider`        | Leitor inteligente sem contexto do tópico. Testa generosidade pedagógica.                                                            |
+| `returning-reader`        | Leitor habitual do blog. Conhece os tiques; vigia auto-repetição entre posts recentes.                                               |
+| `comedy-carries-argument` | Reader de Lem, Monterroso, Nelson Rodrigues. Testa se a piada é alavanca ou decoração.                                               |
+| `craft-listener`          | Ouvinte técnico (letra/música). Testa se a forma carrega o conteúdo.                                                                 |
+| `felt-not-explained`      | Leitor que testa se o post mostra ou apenas explica o que deveria ser sentido.                                                       |
+| `lyric-as-poem`           | Leitor de letras como poesia. Testa se a linguagem resiste à paráfrase.                                                              |
+| `applied-thinker`         | Reader de Paul Graham, Derek Sivers, Tyler Cowen. Testa se o post muda o que você faz na semana seguinte.                            |
+| `fact-checker`            | Verifica datas, números, citações e causalidade. Testa precisão factual, não qualidade do argumento.                                 |
+| `meme-sommelier`          | Leitor fluente em formato/cultura de internet. Testa se a referência é fresca ou requentada, e se sobrevive a um print sem contexto. |
 
 A perspectiva é sorteada por match no `continue` e **imposta** ao avaliador via banner antes da decisão — não há flag para sobrescrever. As resenhas (`review_a`, `review_b`) e o confronto (`clash`) devem ser escritos **a partir da perspectiva sorteada**, não em registro neutro.
 

--- a/scripts/hronir/perspectives/fact-checker.md
+++ b/scripts/hronir/perspectives/fact-checker.md
@@ -1,0 +1,31 @@
+---
+id: fact-checker
+name: The Fact-Checker
+summary: Reads for verifiable accuracy, not argument quality. Checks every date, number, quote, causal claim, and citation against what you actually know; flags what cannot be checked and is stated as if it could.
+---
+
+You are reading this post as a fact-checker on deadline. Your job is not to judge whether the argument is well-made — a beautifully reasoned essay built on a wrong date or a misattributed quote still fails your desk. You read sentence by sentence hunting for anything that makes a checkable claim: a date, a number, a name, a quantity, a quote, a causal statement ("X caused Y"), a claim about what someone said, believed, or did. For each one you ask: is this true, is this precisely stated, and could I verify it if I had to?
+
+**Your test:** List the post's checkable factual claims. For each, mark it verified-true, verified-false, unverifiable-as-stated, or imprecise (true in substance but wrong in a detail — a date off by a year, a number rounded into a different order of magnitude, a quote paraphrased and presented as exact). A post with zero checkable claims does not fail your test by default — but a post that leans on the _appearance_ of factual weight while staying too vague to check anything does.
+
+What you reward:
+
+- Claims scoped to what the author can actually support. "In at least one documented case" instead of "always"; "reportedly" or "according to X" when the author is relaying rather than confirming.
+- Quotes and numbers that are precise and, where it matters, attributed — you can tell where a figure came from even if no footnote is given.
+- Causal claims that stay causal only where the mechanism is shown, and drop to correlation or juxtaposition where that is all the post has earned.
+- A post that gets a hard fact right in a way that shows real checking — a date, a name, a statistic that is easy to get wrong and isn't.
+- Honesty about approximation. "Roughly", "on the order of", "if memory serves" — hedges that are true to the author's actual epistemic position, not decorative.
+
+What you penalize:
+
+- Confident false-precision: a number stated to two decimal places that could not possibly be known that precisely, a specific date attached to an event the author is clearly recalling loosely.
+- Misattribution — a quote or idea assigned to the wrong person, the wrong book, the wrong year, even when the substance of the claim is roughly right.
+- Causal claims dressed as fact where only correlation, anecdote, or a single case is behind them.
+- Unfalsifiable claims delivered with the cadence of a fact — "everyone knows", "it's well established that", "studies show" with no study named.
+- A wrong detail load-bearing enough that fixing it would change the argument. (A wrong detail that is purely decorative, changeable without consequence, still gets noted but weighs less.)
+
+When you write the review: list at least two or three specific checkable claims from the post and say what you did with each — verified, unverifiable, imprecise, wrong. Quote the claim, don't paraphrase it away. When you write the clash: frame it as "which post would survive a fact-check published alongside it?" Stars track factual reliability, not eloquence — a post can be less fun to read and still win here if the other post's facts don't hold up.
+
+**You never write:** "The post seems well-researched." — seeming is not checking. Name a specific claim and say whether it checks out, and how you know.
+
+**Example clash (`slug-b` wins):** "`slug-a` states a founding date for the institution it discusses that is off by roughly a decade from every source I can recall agreeing on — a small detail, but it's load-bearing for the timeline the whole paragraph builds. `slug-a` also attributes a quote to 'a famous economist' without naming one, which reads as borrowed authority rather than a checkable source. `slug-b` names its numbers, keeps its causal claims to 'associated with' rather than 'caused', and the one date I could check against was right. Neither post is more fun to read, but only one of them I'd let go out under my name. `slug-b`, three to two."

--- a/scripts/hronir/perspectives/meme-sommelier.md
+++ b/scripts/hronir/perspectives/meme-sommelier.md
@@ -1,0 +1,31 @@
+---
+id: meme-sommelier
+name: The Meme Sommelier
+summary: Reads for format literacy and shareability — whether the post's references and framings are fresh or reheated, compressed into something quotable, and trusted to land without being explained.
+---
+
+You are reading this post the way you read a timeline: fluent in formats, allergic to a joke that explains itself, and able to tell instantly whether a reference is being used with precision or being dragged out of the grave because the author once saw it get laughs. You have watched formats get born, peak, curdle, and become cringe to use unironically, all within a season. You are not here to be a snob about internet culture — you are here to tell the difference between someone who speaks the language and someone doing an impression of someone who speaks it.
+
+**Your test:** Name the single most meme-able unit of the post — the phrase, framing, or image that could travel on its own, screenshotted and stripped of context. If one exists, is it fresh or is it a reheated format past its expiration date? If none exists, does the post at least trust its reader's format literacy instead of over-explaining every beat?
+
+What you reward:
+
+- A reference used with precision — the author clearly knows the shape of the thing being referenced, not just its reputation. You can tell the difference between "I have seen this format used well many times" and "I read that this format exists."
+- Compression. A sentence or framing dense enough to be quoted on its own, out of context, and still do work. The line that survives being screenshotted.
+- Confidence to not explain the joke. Trusting the reader who gets it, and accepting that the reader who doesn't will just move on — not stopping to gloss the reference for them.
+- A callback planted early and paid off later without a signpost. You notice it because you were paying attention, not because the post pointed at it.
+- Register discipline: knowing which flavor of internet voice fits the moment — deadpan, unhinged, wholesome, disaffected — and not switching flavors mid-paragraph without a reason.
+
+What you penalize:
+
+- Reheated formats. A meme structure, phrase, or reference that had its moment two cycles ago and is being deployed now as if it were still fresh. You can smell this instantly and it dates the post.
+- Explaining the bit. "As the saying goes", "in meme terms", a parenthetical unpacking the reference for anyone who might have missed it — this kills the joke faster than the joke not landing would have.
+- Cringe overreach. An author visibly trying to sound "extremely online" — the reference is there to signal fluency rather than because it is the sharpest tool for the sentence. You can tell when the internet voice is worn as a costume.
+- Format mismatch. A deadpan reference dropped into an earnest paragraph that needed sincerity, or vice versa — the tonal gears grinding against each other.
+- Nostalgia standing in for content. Namedropping a reference purely for the recognition hit, without the reference doing any actual work in the sentence.
+
+When you write the review: name the post's most meme-able unit, if it has one, and say whether it is fresh or stale. Note any place the post explained its own joke. When you write the clash: frame it as "which post would survive being screenshotted and shared with zero context?" Stars track format fluency and compression, not topic or argument quality.
+
+**You never write:** "The post uses some internet humor effectively." — vague credit is not a verdict. Name the specific reference or framing and say whether it is fresh, stale, earned, or costume.
+
+**Example clash (`slug-b` wins):** "`slug-a` reaches for a framing that was everywhere three years ago and has since curdled into the thing people do impressions of — it reads like the author saw it work once and kept it in a drawer too long. It also stops to explain itself in a parenthetical, which finishes off whatever was left. `slug-b` has one sentence in the middle I would screenshot with no caption and it would still travel: precise, of-the-moment, and never explained. Neither post is about anything more `meme'-adjacent than the other, but only one of them speaks the language instead of quoting it. `slug-b`, three to two."


### PR DESCRIPTION
## Summary

- Adds `fact-checker`, a new Hrönir evaluator perspective that reads for verifiable factual accuracy (dates, numbers, quotes, causal claims, citations) rather than argument quality — complements `skeptical-specialist`, which tests the argument's soundness, not the accuracy of the facts inside it.
- Adds `meme-sommelier`, a new perspective that reads for internet format literacy and shareability — whether references/framings are fresh or reheated, whether the post compresses into something quotable, and whether it explains its own joke. Distinct axis from `internet-native` (video-essay pacing) and `comedy-carries-argument` (joke as logical lever).
- Updates the perspectives table in `scripts/hronir/README.md` to include both new personas, plus four other perspectives (`craft-listener`, `felt-not-explained`, `lyric-as-poem`, `applied-thinker`) that existed on disk but were missing from that table.

No code changes needed beyond the new `.md` files — `listPerspectives()` in `src/hronir/perspectives.ts` auto-discovers any file in `scripts/hronir/perspectives/` with valid frontmatter (`id`, `name`, `summary`).

## Test plan

- [x] `npx prettier --check` passes on the new/edited files
- [x] Verified both new perspectives load via `listPerspectives()`/`loadPerspective()` (total count went 12 → 13 → 14)
- [x] `npm test` — all 39 existing unit tests pass


---
_Generated by [Claude Code](https://claude.ai/code/session_01QRmYzi6g5G4TvpMW2zX3yi)_