### PR TITLE
seo: add llms.txt for AI agent discovery + explicit AI bot allow in robots.txt

### DIFF
--- a/.routines/2026-07-03T05-09-54-llms-txt.md
+++ b/.routines/2026-07-03T05-09-54-llms-txt.md
@@ -4,7 +4,7 @@ slug: llms-txt
 branch: claude/sleepy-pasteur-mt22vi
 status: pr-open
 issues: [890]
-pr_opened: null
+pr_opened: 907
 pr_merged: null
 ---
 

--- a/.routines/2026-07-03T05-09-54-llms-txt.md
+++ b/.routines/2026-07-03T05-09-54-llms-txt.md
@@ -1,0 +1,61 @@
+---
+date: 2026-07-03T05:09:54
+slug: llms-txt
+branch: claude/sleepy-pasteur-mt22vi
+status: pr-open
+issues: [890]
+pr_opened: null
+pr_merged: null
+---
+
+Cheguei sem PR `routine` pendente para mergear — a run anterior (#906, campo
+`type` do OKF) já tinha sido mergeada antes desta run começar. Passo 2 foi
+no-op.
+
+Backlog `routine` tinha 12 issues abertas ao chegar, dentro da faixa 10–20,
+então não abri issues novas.
+
+Peguei a issue mais antiga (#251, "verificar skip-to-content em páginas PT")
+já que todas as 12 abertas compartilham `priority:baixa`. Investigação via
+subagent: existe um único layout no repo (`PageLayout.astro`), usado por
+100% das páginas EN e PT, e o alvo do skip-link é `#main` (não
+`#main-content`, como o título da issue supunha) — presente e consistente em
+toda a árvore de páginas, PT incluído. Sem gap. Fechei a issue como
+`not_planned` com o achado documentado no comentário.
+
+Segui para a próxima da fila, #552 (auditoria de `:focus-visible`). Grep por
+`outline:\s*(0|none)` no `src/` não achou nenhum override. Para ir além do
+grep, fiz build local do site, servi `dist/` estaticamente, e rodei um
+audit automatizado com Playwright: Tab através de até 80 elementos focáveis
+em `/`, `/pt/`, `/blog/`, `/pt/blog/`, `/paths/`, `/tags/`, `/ranking/` e em
+duas páginas de post reais (TOC, tags, related posts, share button
+incluídos), lendo `outline`/`box-shadow` computados de cada elemento
+focado. Nenhum elemento sem indicador — o `box-shadow` de foco padrão do
+Pico.css está presente em todos os links/botões/inputs testados, e os
+elementos que dependem do outline nativo (`<summary>`, `<th sortable>`)
+também o preservam. Fechei como `not_planned` também.
+
+Como as duas primeiras da fila eram moot, fui para #890 (`llms.txt`) —
+trabalho de verdade, escopo bem definido. Adicionei `public/llms.txt`
+seguindo a convenção (título, resumo, links curados: about, blog archive,
+ranking, e as três reading paths existentes em
+`src/lib/reading-paths-data.mjs` — fonte objetiva, não escolha arbitrária).
+Também tornei explícita no `public/robots.txt` a política de bots de IA
+(`GPTBot`, `ClaudeBot`, `CCBot`, `Google-Extended` — todos `Allow: /`,
+espelhando o wildcard já existente), conforme sugerido como opcional na
+issue.
+
+Verifiquei: `npx astro check` (0 erros), `npx prettier --check .` (limpo —
+`.txt` fica fora do escopo do prettier), `npm run build` (passou), `npm run
+hronir:doctor` (passou). Revertido o diff de
+`src/generated/ranking-snapshot.json` que o build local gerou — artefato
+regenerado, não fazia parte da mudança.
+
+PR aberto, `Closes #890`, com o changelog em `## SEO`. Fica para a janela
+de veto de 24h — próxima run mergeia se CI verde e sem veto. Sem elemento
+visual novo, então não há necessidade de screenshot de prod desta vez além
+da checagem padrão de conteúdo/meta do `llms.txt` e `robots.txt` publicados.
+
+Para a próxima run: backlog ficou em 10 issues abertas (12 − 2 fechadas
+como moot) — ainda dentro da faixa 10–20, mas no limite inferior; vale
+reabastecer se cair abaixo de 10 antes da próxima run.

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,0 +1,23 @@
+# Franklin Baldo
+
+> Essays on AI agents, memory, law, and the architecture of constraint — written by a Brazilian state attorney who builds agent harnesses at night. Posts are ranked by Hrönir, an open pairwise-comparison system judged by AI reader personas rather than a simple popularity count.
+
+## Start here
+
+- [About](https://franklinbaldo.github.io/about/): Who I am and what this site is.
+- [Blog archive](https://franklinbaldo.github.io/blog/): All essays and posts, most recent first.
+- [Ranking](https://franklinbaldo.github.io/ranking/): Live Hrönir ranking of posts, judged pairwise by AI reader perspectives.
+
+## Reading paths
+
+Curated sequences through the archive, each with its own thread:
+
+- [Agency and Constraint](https://franklinbaldo.github.io/paths/agency-and-constraint/): Why alignment is not the absence of capability but the architecture that shapes it — from the temple at Delphi to the harness in your pocket.
+- [Memory and Funes](https://franklinbaldo.github.io/paths/memory-and-funes/): On total recall, Pierre Menard, and what Borges saw before anyone else — from building Funes to preserving family voices.
+- [Law and AI](https://franklinbaldo.github.io/paths/law-and-ai/): A state attorney's journey into AI agents — delegation, memory, and what changes when the clerk never forgets.
+
+## Optional
+
+- [Português (site em PT-BR)](https://franklinbaldo.github.io/pt/): Portuguese version of the site, translation-paired with every English page.
+- [RSS feed](https://franklinbaldo.github.io/rss.xml): Subscribe to new posts.
+- [Sitemap](https://franklinbaldo.github.io/sitemap-index.xml): Full, exhaustive list of every page — use this instead of the above for complete crawling.

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -2,4 +2,18 @@ User-agent: *
 Allow: /
 Disallow: /og/
 
+# Content is public and the author wants reach — AI crawlers and agents are
+# explicitly welcome, same terms as everyone else.
+User-agent: GPTBot
+Allow: /
+
+User-agent: ClaudeBot
+Allow: /
+
+User-agent: CCBot
+Allow: /
+
+User-agent: Google-Extended
+Allow: /
+
 Sitemap: https://franklinbaldo.github.io/sitemap-index.xml


### PR DESCRIPTION
Closes #890

## SEO

- Added `public/llms.txt` — a curated Markdown index of the site's main entry points for LLM agents/crawlers that want context without crawling the full HTML tree. Sections: **Start here** (about, blog archive, ranking), **Reading paths** (the three curated paths already defined in `src/lib/reading-paths-data.mjs` — an existing objective source, not an arbitrary pick), and **Optional** (PT site, RSS, sitemap for exhaustive crawling).
- `public/robots.txt`: made the AI-bot policy explicit by listing `GPTBot`, `ClaudeBot`, `CCBot`, and `Google-Extended` with `Allow: /`, mirroring the wildcard `Allow: /` already in place — documents the intent rather than changing behavior.

## Notes

While triaging the `routine` backlog this run, I also investigated and closed two older issues as already resolved (not part of this diff, no code changes needed):
- **#251** (skip-to-content on PT pages) — the site has a single shared `PageLayout.astro` used by every EN/PT page; the skip-link target (`#main`) is present and consistent everywhere.
- **#552** (focus-visible audit) — ran an automated Playwright Tab-through audit (80 focusable elements × 9 pages, including real post pages with TOC/tags/related-posts/share-button) checking computed `outline`/`box-shadow`; found no element missing a focus indicator, and no `outline: 0/none` overrides exist in the codebase.

## Verification

- `npx astro check` — 0 errors (pre-existing warnings unrelated to this diff)
- `npx prettier --check .` — clean (`.txt` files are outside prettier's scope)
- `npm run build` — passes
- `npm run hronir:doctor` — passes
- Manually verified all linked URLs exist in the built `dist/` output

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CCEaKKGsv94YgKx4rYewd8)_