### PR TITLE
a11y(motion): respect prefers-reduced-motion across the site

### DIFF
--- a/.routines/2026-07-05T05-06-00-reduced-motion.md
+++ b/.routines/2026-07-05T05-06-00-reduced-motion.md
@@ -1,0 +1,54 @@
+---
+date: 2026-07-05T05:06:00
+slug: reduced-motion
+branch: claude/sleepy-pasteur-i6kxpp
+status: pr-open
+issues: [931]
+pr_opened: null
+pr_merged: null
+---
+
+Cheguei sem PR `routine` pendente — a última run de blog (breadcrumbs, #891) já tinha
+sido mergeada (PR #935) por Franklin antes desta run, então o passo 2 foi verificar a
+produção em vez de mergear. Chequei via `fetch` as três páginas tocadas
+(`/tags/law/`, `/pt/tags/AI agents/`, `/ranking/posts/music-borges-e-eu/`): breadcrumb
+visível presente e correto nas três, EN e PT, sem regressão.
+
+Backlog em 12 issues abertas — dentro da faixa 10-20, sem necessidade de repor.
+
+Escolhi a issue de maior prioridade disponível: **#931** (a11y — suporte a
+`prefers-reduced-motion` no site inteiro), única com `priority:media`; o resto do
+backlog é `priority:baixa`.
+
+Auditei todo `@keyframes`/`scroll-behavior` do repo (`grep -r "@keyframes\|scroll-behavior" src/`)
+e encontrei exatamente 4 pontos de movimento automático, sem gatilho do usuário:
+
+1. `src/styles/global.css` — `scroll-behavior: smooth` no `html`, sem guarda.
+2. `src/components/BackToTop.astro` — animação `fade-in` ligada a
+   `animation-timeline: scroll(root)`.
+3. `src/components/LanguageSwitcher.astro` — keyframe `lgIn` do toast de troca de
+   idioma (slide+fade).
+4. `src/components/RankingView.astro` — keyframe `fadeInUp` de entrada dos cards do
+   pódio em `/ranking/`.
+
+Também investiguei os dois exemplos citados na issue (`.music-play-btn`, drop cap) —
+nenhum dos dois tem `animation`/`transition` de fato (só cor/fundo estático), então
+não precisavam de tratamento.
+
+Fix: envolvi os quatro pontos em `@media (prefers-reduced-motion: no-preference)`
+(em vez de override em `reduce`, que evita duplicar regras). No `BackToTop.astro`,
+ajustei também o fallback JS — antes só entrava em ação em browsers sem suporte a
+`animation-timeline`; agora entra também quando o usuário prefere movimento reduzido,
+preservando a funcionalidade (o link aparece após rolar, só sem a animação). No
+`LanguageSwitcher.astro`, adicionei `@media (prefers-reduced-motion: reduce){#lg-toast{animation:none}}`
+ao CSS injetado via JS.
+
+Confirmei no `dist/` gerado que as quatro regras saem compiladas corretamente
+(ex. `RankingView.CVsOLfHD.css` tem
+`@media (prefers-reduced-motion:no-preference){.podium-card{animation:...}}`, e o HTML
+de post de blog tem o mesmo guard em `.back-to-top`). `npx astro check` (0 erros, 0
+warnings) e `npm run build` passam limpos. `npx prettier --check .` limpo.
+
+Fica pra próxima run: mergear este PR (depois da janela de veto) — mudança é só CSS,
+sem novo texto visível, então o screenshot de produção da run seguinte pode ser rápido
+(confirmar que nada quebrou visualmente em `/`, um post de blog e `/ranking/`).

--- a/src/components/BackToTop.astro
+++ b/src/components/BackToTop.astro
@@ -21,10 +21,12 @@
   }
 
   /* Show only after the user has scrolled past the first viewport. */
-  .back-to-top {
-    animation: fade-in linear both;
-    animation-timeline: scroll(root);
-    animation-range: 100vh 110vh;
+  @media (prefers-reduced-motion: no-preference) {
+    .back-to-top {
+      animation: fade-in linear both;
+      animation-timeline: scroll(root);
+      animation-range: 100vh 110vh;
+    }
   }
 
   @keyframes fade-in {
@@ -38,11 +40,13 @@
 <script>
   // JS fallback for browsers that don't support scroll-driven animations
   // (mainly Safari < 17 and any narrow-viewport context where the CSS
-  // animation-timeline rule may not fire).
+  // animation-timeline rule may not fire) — also used when the user prefers
+  // reduced motion, since the scroll-driven animation is skipped above.
   function initBackToTop() {
     const el = document.querySelector<HTMLAnchorElement>('.back-to-top');
     if (!el) return;
-    if (CSS.supports('animation-timeline', 'scroll(root)')) return;
+    const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    if (!reduceMotion && CSS.supports('animation-timeline', 'scroll(root)')) return;
     const update = () => {
       const show = window.scrollY > window.innerHeight;
       el.style.opacity = show ? '0.85' : '0';

--- a/src/components/LanguageSwitcher.astro
+++ b/src/components/LanguageSwitcher.astro
@@ -78,6 +78,7 @@ const ariaTable = Object.fromEntries(
             'box-shadow:0 4px 20px rgba(0,0,0,.12);' +
             'animation:lgIn .25s ease;max-width:calc(100vw - 2rem);}' +
             '@keyframes lgIn{from{transform:translateY(.5rem);opacity:0}to{transform:translateY(0);opacity:1}}' +
+            '@media (prefers-reduced-motion: reduce){#lg-toast{animation:none}}' +
             '#lg-toast a{white-space:nowrap;font-weight:500;}' +
             '#lg-toast button{background:none;border:none;cursor:pointer;padding:0 .2rem;' +
             'color:var(--pico-muted-color);font-size:1.1em;line-height:1;}';

--- a/src/components/RankingView.astro
+++ b/src/components/RankingView.astro
@@ -528,7 +528,11 @@ function snapshotElo(key: string): { elo: number; peak: number } | null {
     gap: 0.6rem;
     flex: 1 1 14rem;
     transition: transform 0.3s ease, box-shadow 0.3s ease;
-    animation: fadeInUp 0.5s ease-out both;
+  }
+  @media (prefers-reduced-motion: no-preference) {
+    .podium-card {
+      animation: fadeInUp 0.5s ease-out both;
+    }
   }
   @keyframes fadeInUp {
     from { opacity: 0; transform: translateY(15px); }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -131,8 +131,12 @@
 
 /* Smooth scroll with offset for the sticky header so anchors land visible. */
 html {
-  scroll-behavior: smooth;
   scroll-padding-top: 4.5rem;
+}
+@media (prefers-reduced-motion: no-preference) {
+  html {
+    scroll-behavior: smooth;
+  }
 }
 
 /*


### PR DESCRIPTION
Closes #931

## a11y

Nenhum lugar do site respeitava `prefers-reduced-motion: reduce`. Auditei todo `@keyframes`/`scroll-behavior` do repo e encontrei 4 pontos de movimento automático (não iniciado pelo usuário):

1. `src/styles/global.css` — `scroll-behavior: smooth` no `html`, incondicional.
2. `src/components/BackToTop.astro` — animação `fade-in` ligada a `animation-timeline: scroll(root)`.
3. `src/components/LanguageSwitcher.astro` — keyframe `lgIn` do toast de troca de idioma (slide+fade).
4. `src/components/RankingView.astro` — keyframe `fadeInUp` de entrada dos cards do pódio em `/ranking/`.

Todos os quatro agora ficam dentro de `@media (prefers-reduced-motion: no-preference)`. Em `BackToTop.astro`, o fallback JS (que já existia para browsers sem suporte a `animation-timeline`) agora também cobre o caso de movimento reduzido, então a funcionalidade (o link aparece depois de rolar a página) é preservada — só a animação é removida. Nenhum elemento fica "preso" a meio-caminho de uma transição.

Também investiguei os dois exemplos citados na issue (`.music-play-btn`, drop cap) — nenhum dos dois tem `animation`/`transition` de fato, então não precisavam de tratamento.

## Test plan

- [x] `npx astro check` — 0 erros, 0 warnings (só hints pré-existentes)
- [x] `npm run build` — build limpo
- [x] `npx prettier --check .` — limpo
- [x] Confirmado no `dist/` gerado que as 4 regras saem compiladas dentro do media query (ex. `.podium-card{animation:...}` só sob `prefers-reduced-motion:no-preference`, mesmo para `.back-to-top` no HTML de post de blog)
- [ ] Screenshot de produção pós-deploy (mudança é só CSS/comportamento condicional, sem novo texto visível — a próxima run confirma que nada quebrou em `/`, um post de blog e `/ranking/`)

https://claude.ai/code/session_011t6esTZJVC5eRtXZVPTkiZ


---
_Generated by [Claude Code](https://claude.ai/code/session_011t6esTZJVC5eRtXZVPTkiZ)_