### PR TITLE
fix: memegen.link template renamed from brain to gb

### DIFF
--- a/.routines/2026-07-07T05-06-36-fix-memegen-brain-template.md
+++ b/.routines/2026-07-07T05-06-36-fix-memegen-brain-template.md
@@ -1,0 +1,38 @@
+---
+date: 2026-07-07T05:06:36
+slug: fix-memegen-brain-template
+branch: routine/fix-memegen-brain-template
+status: pr-open
+issues: [979]
+pr_opened: null
+pr_merged: null
+---
+
+Cheguei sem nenhum PR `routine` pendente para mergear — a run anterior não tinha
+deixado nada aberto (só commits de sessões Hrönir nas últimas horas, que não são
+meus). Backlog de issues `routine` está em 10 abertas, exatamente no piso da
+faixa 10–20, então não criei issue nova nesta run.
+
+Escolhi a #979 (bug: imagens quebradas em 2 posts — template `brain` do
+memegen.link renomeado para `gb`) por ser um bug real já em produção, com
+escopo pequeno e bem definido. Confirmei com `curl` que `.../images/brain/...`
+retorna 404 e `.../images/gb/...` retorna 200 para as duas URLs afetadas
+(`tree-reads-itself` e `everything-is-eml`). Antes de editar o conteúdo,
+verifiquei que nenhum rate file em `.routines/hronir/rates/` referencia essas
+duas versões — como cada post só tem um único arquivo `v-*.md` (sem outras
+versões concorrendo), editar a URL diretamente não quebra nenhuma avaliação
+Hrönir existente nem descola histórico.
+
+Troquei `brain` → `gb` nas duas URLs, rodei
+`node scripts/generate-image-dimensions.mjs` (2 imagens novas sondadas com
+sucesso, cache atualizado), depois `astro check` (0 erros) e `npm run build`
+(completo, sem falhas). O build também regenerou `ranking-snapshot.json` com
+churn não relacionado (rankings mudaram desde o último commit por causa das
+sessões Hrönir mescladas nas últimas horas) — revertido esse arquivo para
+manter o PR focado só na correção de imagem.
+
+Fica para a próxima run: mergear este PR (após CI verde) e verificar em
+produção que as duas imagens renderizam corretamente nos posts afetados
+(`/blog/tree-reads-itself/` e `/blog/everything-is-eml/`, EN — não há versão
+PT desses posts para checar). Backlog segue em 10 issues abertas; nenhuma
+issue nova necessária ainda.

--- a/.routines/2026-07-07T05-06-36-fix-memegen-brain-template.md
+++ b/.routines/2026-07-07T05-06-36-fix-memegen-brain-template.md
@@ -4,7 +4,7 @@ slug: fix-memegen-brain-template
 branch: routine/fix-memegen-brain-template
 status: pr-open
 issues: [979]
-pr_opened: null
+pr_opened: 994
 pr_merged: null
 ---
 

--- a/src/content/blog/everything-is-eml/v-2026-06-10T05-09-44.md
+++ b/src/content/blog/everything-is-eml/v-2026-06-10T05-09-44.md
@@ -37,7 +37,7 @@ If you have ever taken a digital logic class, you know that every Boolean circui
 
 Odrzywołek's claim is that eml is the NAND gate of continuous mathematics.
 
-![Expanding brain: plus minus; times divide; NAND; eml](<https://api.memegen.link/images/brain/plus_and_minus/times_and_divide/NAND_gates/exp(x)_-_ln(y).png>)
+![Expanding brain: plus minus; times divide; NAND; eml](<https://api.memegen.link/images/gb/plus_and_minus/times_and_divide/NAND_gates/exp(x)_-_ln(y).png>)
 
 The grammar he proposes is embarrassingly simple:
 

--- a/src/content/blog/tree-reads-itself/v-2026-06-10T05-09-44.md
+++ b/src/content/blog/tree-reads-itself/v-2026-06-10T05-09-44.md
@@ -29,7 +29,7 @@ A binary tree, flattened into prefix notation, is a **sequence**. A grammar with
 
 Elementary mathematics, it turns out, is autoregressive.
 
-![Galaxy brain meme: text is autoregressive; code is autoregressive; proofs are autoregressive; elementary functions are autoregressive](https://api.memegen.link/images/brain/text_is_autoregressive/code_is_autoregressive/proofs_are_autoregressive/every_function_is_autoregressive.png)
+![Galaxy brain meme: text is autoregressive; code is autoregressive; proofs are autoregressive; elementary functions are autoregressive](https://api.memegen.link/images/gb/text_is_autoregressive/code_is_autoregressive/proofs_are_autoregressive/every_function_is_autoregressive.png)
 
 ---
 

--- a/src/generated/image-dimensions.json
+++ b/src/generated/image-dimensions.json
@@ -31,6 +31,14 @@
     "width": 617,
     "height": 600
   },
+  "https://api.memegen.link/images/gb/plus_and_minus/times_and_divide/NAND_gates/exp(x)_-_ln(y).png": {
+    "width": 600,
+    "height": 848
+  },
+  "https://api.memegen.link/images/gb/text_is_autoregressive/code_is_autoregressive/proofs_are_autoregressive/every_function_is_autoregressive.png": {
+    "width": 600,
+    "height": 848
+  },
   "https://api.memegen.link/images/handshake/O_fundo_de_%C3%ADndice/O_tributo_em_a%C3%A7%C3%B5es/Nunca_escolher_um_vencedor.png?width=600": {
     "width": 600,
     "height": 430


### PR DESCRIPTION
Closes #979

## Bug fix

`api.memegen.link` renamed its `brain` template to `gb` ("Galaxy Brain") at some point after these two posts were published, so both meme image URLs now 404 in production:

- `src/content/blog/tree-reads-itself/v-2026-06-10T05-09-44.md` (line 32)
- `src/content/blog/everything-is-eml/v-2026-06-10T05-09-44.md` (line 40)

Swapped `brain` → `gb` in both URLs (verified both new URLs return `200` via `curl` before committing) and reran `node scripts/generate-image-dimensions.mjs` to populate `src/generated/image-dimensions.json` for the two now-working images.

No rate files in `.routines/hronir/rates/` reference either of these versions, so editing the file content directly doesn't orphan any Hrönir evaluation history.

## Verification

- `astro check` — 0 errors
- `npm run build` — completes clean
- `npx prettier --check` — clean on changed files
- `node scripts/check-hygiene.mjs` — clean

Both affected posts are EN-only (no `translationKey`/PT pair), so no i18n parity impact.

## Where to look post-merge

`/blog/tree-reads-itself/` and `/blog/everything-is-eml/` — confirm both meme images render (no broken-image icon).


---
_Generated by [Claude Code](https://claude.ai/code/session_01FDpQjABgvT2rMJhTHvvufy)_