### PR TITLE
feat(ui): reforma visual — tema claro corrigido, masthead fixo e destaque na home

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -20,8 +20,7 @@ const footerNav = [
 ];
 ---
 
-<footer class="container">
-  <hr />
+<footer class="container site-footer">
   <nav class="footer-nav">
     <ul>
       <li><small>© {year} Franklin Baldo</small></li>
@@ -61,6 +60,20 @@ const footerNav = [
 </script>
 
 <style>
+  .site-footer {
+    margin-top: calc(var(--pico-spacing) * 2);
+    padding-block: calc(var(--pico-spacing) * 1.25);
+    border-top: 1px solid var(--pico-muted-border-color);
+    color: var(--pico-muted-color);
+  }
+  .site-footer a {
+    text-decoration: none;
+  }
+  .site-footer a:hover {
+    color: var(--pico-primary);
+    text-decoration: underline;
+    text-underline-offset: 0.3em;
+  }
   @media (max-width: 768px) {
     .footer-nav {
       flex-direction: column;

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -44,10 +44,10 @@ const isCurrent = (href: string) => {
 };
 ---
 
-<header class="container">
-  <nav aria-label={lang === 'pt' ? 'Navegação principal' : 'Main navigation'}>
+<header class="site-header">
+  <nav class="container" aria-label={lang === 'pt' ? 'Navegação principal' : 'Main navigation'}>
     <ul>
-      <li><strong><a href={homeHref} class="contrast" aria-current={here === homeHref ? 'page' : undefined}>Franklin Baldo</a></strong></li>
+      <li><a href={homeHref} class="brand contrast" aria-current={here === homeHref ? 'page' : undefined}>Franklin Baldo<span class="brand-dot" aria-hidden="true">.</span></a></li>
     </ul>
     <ul class="nav-inline">
       {navLinks.map((l) => (
@@ -152,6 +152,55 @@ const isCurrent = (href: string) => {
 </script>
 
 <style>
+  /*
+   * Sticky translucent masthead. The 5.5rem offsets used by the sticky
+   * rails and scroll-padding-top in global.css assume this bar is pinned
+   * and no taller than ~5rem; keep its height under that.
+   */
+  .site-header {
+    position: sticky;
+    top: 0;
+    z-index: 50;
+    /* Pico gives `body > header` a tall block padding — flatten it so the
+       masthead stays under the 4.5rem offset the sticky rails assume. */
+    padding-block: 0;
+    /* Pico's nav <li> block padding is 1.25rem — too tall for a pinned bar. */
+    --pico-nav-element-spacing-vertical: 0.5rem;
+    /* Solid paper background — translucency + backdrop blur gets mangled
+       by the CSS minifier (it drops the unprefixed backdrop-filter), and a
+       see-through bar without blur lets article text show through. */
+    background: var(--pico-background-color);
+    border-bottom: 1px solid var(--pico-muted-border-color);
+  }
+  .site-header > nav {
+    padding-block: 0.25rem;
+  }
+
+  .brand {
+    font-family: var(--pico-font-family-serif);
+    font-size: 1.2rem;
+    font-weight: 600;
+    letter-spacing: -0.01em;
+    text-decoration: none;
+  }
+  .brand:hover {
+    color: var(--pico-primary);
+  }
+  .brand-dot {
+    color: var(--pico-primary);
+  }
+
+  .nav-inline a:not(.nav-music-btn) {
+    font-size: 0.92rem;
+    text-decoration: none;
+  }
+  .nav-inline a[aria-current="page"] {
+    color: var(--pico-primary);
+    text-decoration: underline;
+    text-underline-offset: 0.45em;
+    text-decoration-thickness: 2px;
+  }
+
   .nav-burger { display: none; }
   @media (max-width: 768px) {
     .nav-inline { display: none; }

--- a/src/components/RecentList.astro
+++ b/src/components/RecentList.astro
@@ -53,13 +53,18 @@ const minRead = (body: string | undefined) => {
     grid-template-columns: minmax(0, 1fr) auto;
     gap: 0.5rem 1.5rem;
     align-items: baseline;
-    padding: 0.75rem 0.25rem;
+    padding: 0.75rem 0.6rem;
+    margin-inline: -0.6rem;
+    border-radius: var(--pico-border-radius);
     text-decoration: none;
     color: inherit;
+    transition: background 0.15s;
+  }
+  .recent-link:hover {
+    background: color-mix(in srgb, var(--pico-primary) 5%, transparent);
   }
   .recent-link:hover .recent-title {
     color: var(--pico-primary);
-    text-decoration: underline;
   }
   .recent-title {
     font-family: var(--pico-font-family-serif);

--- a/src/layouts/PageLayout.astro
+++ b/src/layouts/PageLayout.astro
@@ -181,8 +181,8 @@ const personLd = {
     <link rel="icon" href="/favicon.ico" sizes="any" />
     <link rel="apple-touch-icon" href="/avatar.png" />
     <link rel="manifest" href="/site.webmanifest" />
-    <meta name="theme-color" content="#1f1f1f" media="(prefers-color-scheme: dark)" />
-    <meta name="theme-color" content="#fdfdfd" media="(prefers-color-scheme: light)" />
+    <meta name="theme-color" content="#1a1612" media="(prefers-color-scheme: dark)" />
+    <meta name="theme-color" content="#f4ecdc" media="(prefers-color-scheme: light)" />
     <link rel="canonical" href={canonical.href} />
     <link rel="alternate" type="application/rss+xml" title={lang === 'pt' ? 'Franklin Baldo (Português)' : 'Franklin Baldo'} href={rssUrl} />
     <link rel="alternate" type="application/rss+xml" title={lang === 'pt' ? 'Franklin Baldo (English)' : 'Franklin Baldo (Português)'} href={new URL(lang === 'pt' ? 'rss.xml' : 'pt/rss.xml', Astro.site)} />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -11,9 +11,15 @@ const all = (await getCollection("blog"))
   .filter((post) => (post.data.lang ?? 'en') === 'en')
   .sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf());
 
-const recent = all.slice(0, 12);
 const latest = all[0];
+// The featured card shows the latest essay, so the list starts at the second.
+const recent = all.slice(1, 13);
 const latestHref = latest ? `/blog/${latest.id}/` : "/archive/";
+const latestWords = (latest?.body ?? '').trim().split(/\s+/).filter(Boolean).length;
+const latestMinutes = Math.max(1, Math.round(latestWords / 220));
+const latestDate = latest?.data.date.toLocaleDateString('en-US', {
+  year: 'numeric', month: 'long', day: 'numeric',
+});
 ---
 
 <PageLayout
@@ -25,14 +31,28 @@ const latestHref = latest ? `/blog/${latest.id}/` : "/archive/";
   <div class="home-layout">
     <div class="home-main">
       <section class="home-hero" aria-label="Introduction">
-        <h1 class="home-title">Franklin Baldo</h1>
+        <h1 class="home-title">Franklin Baldo<span class="home-title-dot" aria-hidden="true">.</span></h1>
         <p class="home-tagline">Notes on AI, law, and systems.</p>
-        <p class="home-cta">
-          <a href={latestHref} class="contrast">Read latest essay →</a>
-        </p>
       </section>
 
+      {latest && (
+        <section class="home-featured" aria-label="Latest essay">
+          <p class="section-eyebrow">Latest essay</p>
+          <article class="featured-card">
+            <h2 class="featured-title"><a href={latestHref}>{latest.data.title}</a></h2>
+            {latest.data.description && <p class="featured-blurb">{latest.data.description}</p>}
+            <p class="featured-meta">
+              <time datetime={latest.data.date.toISOString()}>{latestDate}</time>
+              <span aria-hidden="true">·</span>
+              <span>{latestMinutes} min read</span>
+              <a href={latestHref} class="featured-cta">Read essay →</a>
+            </p>
+          </article>
+        </section>
+      )}
+
       <section class="home-recent" aria-label="Recent posts">
+        <p class="section-eyebrow">Recent essays</p>
         <RecentList posts={recent} lang="en" />
         <p class="home-archive-link">
           <small><a href="/archive/">View the full archive →</a></small>
@@ -63,8 +83,8 @@ const latestHref = latest ? `/blog/${latest.id}/` : "/archive/";
 
     .home-rail {
       position: sticky;
-      top: 4.5rem;
-      max-height: calc(100vh - 6rem);
+      top: 5.5rem;
+      max-height: calc(100vh - 7rem);
       overflow-y: auto;
     }
   }
@@ -77,27 +97,77 @@ const latestHref = latest ? `/blog/${latest.id}/` : "/archive/";
   }
 
   .home-hero {
-    margin-block: calc(var(--pico-spacing) * 1.25) calc(var(--pico-spacing) * 1.5);
+    margin-block: calc(var(--pico-spacing) * 1.5) calc(var(--pico-spacing) * 1.25);
   }
   .home-title {
-    font-size: clamp(1.75rem, 4vw, 2.5rem);
+    font-size: clamp(2rem, 5vw, 3rem);
     margin: 0 0 .25rem;
-    letter-spacing: -0.01em;
+    letter-spacing: -0.015em;
+  }
+  .home-title-dot {
+    color: var(--pico-primary);
   }
   .home-tagline {
     color: var(--pico-muted-color);
     margin: 0;
-    font-size: 1rem;
+    font-size: 1.05rem;
   }
+
+  .section-eyebrow {
+    margin: 0 0 0.6rem;
+    font-size: 0.72rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.16em;
+    color: var(--pico-primary);
+  }
+
+  .home-featured {
+    margin-block: 0 calc(var(--pico-spacing) * 1.75);
+  }
+  .featured-card {
+    margin: 0;
+    padding: 1.25rem 1.5rem;
+    background: var(--pico-card-background-color);
+    border: 1px solid var(--pico-muted-border-color);
+    border-radius: var(--pico-border-radius);
+    box-shadow: var(--paper-shadow);
+  }
+  .featured-title {
+    margin: 0 0 0.5rem;
+    font-size: clamp(1.3rem, 3vw, 1.7rem);
+    line-height: 1.2;
+  }
+  .featured-title a {
+    color: inherit;
+    text-decoration: none;
+  }
+  .featured-title a:hover {
+    color: var(--pico-primary);
+  }
+  .featured-blurb {
+    margin: 0 0 0.75rem;
+    color: var(--pico-muted-color);
+    line-height: 1.55;
+  }
+  .featured-meta {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    gap: 0.5rem;
+    margin: 0;
+    font-size: 0.85rem;
+    color: var(--pico-muted-color);
+    font-variant-numeric: oldstyle-nums;
+  }
+  .featured-cta {
+    margin-left: auto;
+    font-weight: 600;
+    text-decoration: none;
+  }
+
   .home-recent {
-    margin-block: calc(var(--pico-spacing) * 1.5) calc(var(--pico-spacing) * 2);
-  }
-  .home-cta {
-    margin: calc(var(--pico-spacing) * 0.75) 0 0;
-  }
-  .home-cta a {
-    font-size: 0.95rem;
-    font-weight: 500;
+    margin-block: 0 calc(var(--pico-spacing) * 2);
   }
   .home-archive-link {
     margin-top: var(--pico-spacing);

--- a/src/pages/pt/index.astro
+++ b/src/pages/pt/index.astro
@@ -11,9 +11,15 @@ const all = (await getCollection("blog"))
   .filter((post) => post.data.lang === 'pt')
   .sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf());
 
-const recent = all.slice(0, 12);
 const latest = all[0];
+// O card de destaque mostra o ensaio mais recente; a lista começa no segundo.
+const recent = all.slice(1, 13);
 const latestHref = latest ? `/pt/blog/${latest.id}/` : "/pt/archive/";
+const latestWords = (latest?.body ?? '').trim().split(/\s+/).filter(Boolean).length;
+const latestMinutes = Math.max(1, Math.round(latestWords / 220));
+const latestDate = latest?.data.date.toLocaleDateString('pt-BR', {
+  year: 'numeric', month: 'long', day: 'numeric',
+});
 ---
 
 <PageLayout
@@ -25,14 +31,28 @@ const latestHref = latest ? `/pt/blog/${latest.id}/` : "/pt/archive/";
   <div class="home-layout">
     <div class="home-main">
       <section class="home-hero" aria-label="Introdução">
-        <h1 class="home-title">Franklin Baldo</h1>
+        <h1 class="home-title">Franklin Baldo<span class="home-title-dot" aria-hidden="true">.</span></h1>
         <p class="home-tagline">Notas sobre IA, direito e sistemas.</p>
-        <p class="home-cta">
-          <a href={latestHref} class="contrast">Ler último ensaio →</a>
-        </p>
       </section>
 
+      {latest && (
+        <section class="home-featured" aria-label="Último ensaio">
+          <p class="section-eyebrow">Último ensaio</p>
+          <article class="featured-card">
+            <h2 class="featured-title"><a href={latestHref}>{latest.data.title}</a></h2>
+            {latest.data.description && <p class="featured-blurb">{latest.data.description}</p>}
+            <p class="featured-meta">
+              <time datetime={latest.data.date.toISOString()}>{latestDate}</time>
+              <span aria-hidden="true">·</span>
+              <span>{latestMinutes} min de leitura</span>
+              <a href={latestHref} class="featured-cta">Ler ensaio →</a>
+            </p>
+          </article>
+        </section>
+      )}
+
       <section class="home-recent" aria-label="Posts recentes">
+        <p class="section-eyebrow">Ensaios recentes</p>
         <RecentList posts={recent} lang="pt" />
         <p class="home-archive-link">
           <small><a href="/pt/archive/">Ver o arquivo completo →</a></small>
@@ -63,8 +83,8 @@ const latestHref = latest ? `/pt/blog/${latest.id}/` : "/pt/archive/";
 
     .home-rail {
       position: sticky;
-      top: 4.5rem;
-      max-height: calc(100vh - 6rem);
+      top: 5.5rem;
+      max-height: calc(100vh - 7rem);
       overflow-y: auto;
     }
   }
@@ -77,27 +97,77 @@ const latestHref = latest ? `/pt/blog/${latest.id}/` : "/pt/archive/";
   }
 
   .home-hero {
-    margin-block: calc(var(--pico-spacing) * 1.25) calc(var(--pico-spacing) * 1.5);
+    margin-block: calc(var(--pico-spacing) * 1.5) calc(var(--pico-spacing) * 1.25);
   }
   .home-title {
-    font-size: clamp(1.75rem, 4vw, 2.5rem);
+    font-size: clamp(2rem, 5vw, 3rem);
     margin: 0 0 .25rem;
-    letter-spacing: -0.01em;
+    letter-spacing: -0.015em;
+  }
+  .home-title-dot {
+    color: var(--pico-primary);
   }
   .home-tagline {
     color: var(--pico-muted-color);
     margin: 0;
-    font-size: 1rem;
+    font-size: 1.05rem;
   }
+
+  .section-eyebrow {
+    margin: 0 0 0.6rem;
+    font-size: 0.72rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.16em;
+    color: var(--pico-primary);
+  }
+
+  .home-featured {
+    margin-block: 0 calc(var(--pico-spacing) * 1.75);
+  }
+  .featured-card {
+    margin: 0;
+    padding: 1.25rem 1.5rem;
+    background: var(--pico-card-background-color);
+    border: 1px solid var(--pico-muted-border-color);
+    border-radius: var(--pico-border-radius);
+    box-shadow: var(--paper-shadow);
+  }
+  .featured-title {
+    margin: 0 0 0.5rem;
+    font-size: clamp(1.3rem, 3vw, 1.7rem);
+    line-height: 1.2;
+  }
+  .featured-title a {
+    color: inherit;
+    text-decoration: none;
+  }
+  .featured-title a:hover {
+    color: var(--pico-primary);
+  }
+  .featured-blurb {
+    margin: 0 0 0.75rem;
+    color: var(--pico-muted-color);
+    line-height: 1.55;
+  }
+  .featured-meta {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    gap: 0.5rem;
+    margin: 0;
+    font-size: 0.85rem;
+    color: var(--pico-muted-color);
+    font-variant-numeric: oldstyle-nums;
+  }
+  .featured-cta {
+    margin-left: auto;
+    font-weight: 600;
+    text-decoration: none;
+  }
+
   .home-recent {
-    margin-block: calc(var(--pico-spacing) * 1.5) calc(var(--pico-spacing) * 2);
-  }
-  .home-cta {
-    margin: calc(var(--pico-spacing) * 0.75) 0 0;
-  }
-  .home-cta a {
-    font-size: 0.95rem;
-    font-weight: 500;
+    margin-block: 0 calc(var(--pico-spacing) * 2);
   }
   .home-archive-link {
     margin-top: var(--pico-spacing);

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -131,7 +131,7 @@
 
 /* Smooth scroll with offset for the sticky header so anchors land visible. */
 html {
-  scroll-padding-top: 4.5rem;
+  scroll-padding-top: 5.5rem;
 }
 @media (prefers-reduced-motion: no-preference) {
   html {
@@ -143,7 +143,9 @@ html {
  * Cobogó motif as a subtle background — a single tile from /cobogo.svg
  * repeated and rendered at low opacity so it reads as architecture, not
  * noise. The accent color is inherited via `currentColor` in the SVG, so
- * the tile follows the theme.
+ * the tile follows the theme. A vertical mask fades the pattern out as it
+ * approaches the reading area so it frames the page instead of sitting
+ * under every paragraph.
  */
 body {
   position: relative;
@@ -157,9 +159,23 @@ body::before {
   background-image: url("/cobogo.svg");
   background-size: 240px 240px;
   background-repeat: repeat;
-  opacity: 0.08;
+  opacity: var(--cobogo-opacity, 0.05);
   color: var(--pico-muted-color);
   pointer-events: none;
+  mask-image: linear-gradient(
+    to bottom,
+    rgba(0, 0, 0, 1) 0,
+    rgba(0, 0, 0, 0.35) 22rem,
+    rgba(0, 0, 0, 0.35) calc(100% - 18rem),
+    rgba(0, 0, 0, 1) 100%
+  );
+  -webkit-mask-image: linear-gradient(
+    to bottom,
+    rgba(0, 0, 0, 1) 0,
+    rgba(0, 0, 0, 0.35) 22rem,
+    rgba(0, 0, 0, 0.35) calc(100% - 18rem),
+    rgba(0, 0, 0, 1) 100%
+  );
 }
 
 /*
@@ -189,8 +205,8 @@ body::before {
   .toc-col {
     display: block;
     position: sticky;
-    top: 4.5rem;
-    max-height: calc(100vh - 6rem);
+    top: 5.5rem;
+    max-height: calc(100vh - 7rem);
     overflow-y: auto;
     padding-top: 0.25rem;
   }
@@ -202,9 +218,7 @@ body::before {
 
   /* Reading article gets a faint paper-grain shadow on wide screens. */
   .post-body > article {
-    box-shadow:
-      0 1px 0 var(--pico-muted-border-color),
-      0 24px 48px -32px rgba(42, 36, 29, 0.15);
+    box-shadow: var(--paper-shadow);
     border-radius: 2px;
   }
 }
@@ -484,7 +498,7 @@ body::before {
   #read-progress,
   .share-fab,
   .back-to-top,
-  header.container,
+  .site-header,
   footer.container,
   .toc-col,
   .toc-inline,

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -5,19 +5,30 @@
  * file just shifts the background and text away from neutral grey toward the
  * cream/ink palette the mockups asked for. Adjusted via Pico CSS variables so
  * every component inherits the change automatically.
+ *
+ * Selector note: Pico scopes its light palette under
+ * `:root:not([data-theme=dark])` (specificity 0,2,0), so a bare `:root`
+ * (0,1,0) never wins against it. The light block below matches Pico's
+ * specificity and relies on import order (tokens.css comes after Pico) to
+ * take precedence.
  */
 
-:root {
+:root:not([data-theme="dark"]) {
   --pico-background-color: #f4ecdc;
   --pico-color: #2a241d;
   --pico-muted-color: #6b6258;
-  --pico-muted-border-color: #d4c8b0;
+  --pico-muted-border-color: #ddd1b8;
   --pico-border-color: #c2b59a;
   --pico-card-background-color: #faf3e2;
   --pico-card-sectioning-background-color: #efe5d0;
   --pico-code-background-color: #ebe1c8;
   --pico-mark-background-color: #fae1c0;
   --pico-mark-color: #2a241d;
+  /* Paper-grain drop shadow used by cards and the reading column. */
+  --paper-shadow:
+    0 1px 0 var(--pico-muted-border-color),
+    0 24px 48px -32px rgba(42, 36, 29, 0.18);
+  --cobogo-opacity: 0.05;
 }
 
 [data-theme="dark"] {
@@ -31,4 +42,12 @@
   --pico-code-background-color: #251e17;
   --pico-mark-background-color: #4a3320;
   --pico-mark-color: #ede4d3;
+  --paper-shadow:
+    0 1px 0 rgba(0, 0, 0, 0.4), 0 24px 48px -32px rgba(0, 0, 0, 0.5);
+  --cobogo-opacity: 0.04;
+}
+
+:root {
+  /* Slightly softer corners than Pico's default 0.25rem. */
+  --pico-border-radius: 0.375rem;
 }


### PR DESCRIPTION
## Resumo

Reforma da UI mantendo a identidade do site (papel quente, Fraunces + Inter, cobogó, acento laranja) — mas fazendo essa identidade de fato aparecer.

### Correção principal: o tema claro nunca aplicava a paleta creme

O `tokens.css` definia a paleta creme/tinta num seletor `:root` (especificidade 0,1,0), que perdia para o `:root:not([data-theme=dark])` do Pico (0,2,0). Resultado: o modo claro renderizava o cinza/branco padrão do Pico, nunca o "warm paper" projetado. O bloco claro agora usa o mesmo seletor do Pico e vence pela ordem de importação.

### Demais mudanças

- **Cobogó de fundo mais discreto** — opacidade via token (`--cobogo-opacity`, 0.05 claro / 0.04 escuro) e máscara vertical que esmaece o padrão na área de leitura; ele volta a ler como arquitetura, não ruído.
- **Masthead fixo** — header sticky com fundo de papel sólido, borda inferior, marca em serifa com ponto no acento e sublinhado no link ativo da navegação. O padding vertical do `<li>` do Pico foi reduzido para a barra ficar baixa (~78px). Tentei vidro fosco (translucidez + `backdrop-filter`), mas o minificador de CSS descarta o `backdrop-filter` sem prefixo e a barra translúcida sem blur deixa o texto do artigo vazar — fundo sólido é mais fiel ao papel, de todo modo.
- **Home (EN e PT)** — card de destaque para o último ensaio (título, descrição, data, tempo de leitura) no lugar do link solto "Read latest essay"; a lista de recentes começa no segundo post; eyebrows de seção em small-caps; hover com fundo suave nas linhas da lista.
- **Rodapé** — borda superior sutil no lugar do `<hr>`, mais respiro, hover nos links.
- **Offsets sticky** — TOC, rails e `scroll-padding-top` ajustados de 4.5rem para 5.5rem (o masthead agora está de fato pinado; antes o CSS assumia um header fixo que não existia). Seletor de print atualizado (`header.container` → `.site-header`). `theme-color` alinhado à paleta (#f4ecdc / #1a1612).

### Verificação

- `npm run build` ✓, `npx prettier --check .` ✓, `npm run check:hygiene` ✓, `npx astro check` ✓ (0 erros)
- Screenshots via Chromium (1440px e 390px, claro/escuro) de home, post, archive e ranking; âncoras de heading testadas pousando abaixo do masthead; sticky verificado com scroll real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BxzzpDX4FEBCCudxXFyYZd

---
_Generated by [Claude Code](https://claude.ai/code/session_01BxzzpDX4FEBCCudxXFyYZd)_