### PR TITLE
hronir: adendo aos rascunhos de quem-sou-eu — Umbanda, Bach, memes PT

### DIFF
--- a/src/content/blog/quem-sou-eu-en/v-2026-07-08T17-32-08-182.md
+++ b/src/content/blog/quem-sou-eu-en/v-2026-07-08T17-32-08-182.md
@@ -18,21 +18,28 @@ heroImageAlt: >-
 supersedes: 17d1cac2-2157-5c3e-bc5c-9d654c040ab6
 draftCreatedAt: '2026-07-08T17:32:08.182Z'
 draftMsg: >-
-  Aplica notas de edição próprias (documento externo de revisão): sete pontos
-  de descanso visual/cômico nos trechos mais didáticos (etimologia, simulador,
-  Waluigi, vazio budista, física) mais uma passagem nova de conteúdo — hipnose
-  e educação como o mesmo exploit em escalas diferentes, fechando "O simulador
-  que você carrega" com a virada em segunda pessoa ("POV: você é o
-  personagem..."). Memes de imagem (galaxy brain, two-buttons) e o greentext
-  entram por critério de risco do próprio documento de edição — a seção do
-  vazio budista já tinha escalado de registro, mas o meme recapitula a escada
-  do próprio ensaio (shoggoth → máscara → não há parede) em vez de esfriá-la,
-  então ficou. Nada tocado a partir de "That's your face". PT: replica os
-  pontos de conteúdo (shoggoth.monster, hipnose/educação, referência
-  TetraspaceWest) e os one-liners traduzíveis (rent free / dualidade do
-  homem) e o greentext; pula os dois memes de imagem por falta do catálogo
-  PT-BR de meme-injection.
-draftCommittedAt: '2026-07-08T17:36:51.940Z'
+  Aplica notas de edição próprias em duas rodadas. Rodada 1 (documento externo
+  de revisão): sete pontos de descanso visual/cômico nos trechos mais
+  didáticos (etimologia, simulador, Waluigi, vazio budista, física) mais uma
+  passagem nova de conteúdo — hipnose e educação como o mesmo exploit em
+  escalas diferentes, fechando "O simulador que você carrega" com a virada em
+  segunda pessoa ("POV: você é o personagem..."). Memes de imagem (galaxy
+  brain, two-buttons) e o greentext entram por critério de risco do próprio
+  documento — a seção do vazio budista já tinha escalado de registro, mas o
+  meme recapitula a escada do próprio ensaio (shoggoth → máscara → não há
+  parede) em vez de esfriá-la, então ficou. Rodada 2 (adendo): reordena a
+  passagem hipnose/educação para hipnose (perturbação) → incorporação
+  (substituição) → educação (escrita lenta), com a Umbanda como o exemplo do
+  meio — o giro do santo é substituição de personagem, não perturbação, e a
+  tradição já ritualizou as duas metades da operação (invocar e despedir) que
+  os laboratórios de IA ainda não formalizaram. Abertura da educação vira "run
+  slowest" para fechar a escalada. Crédito a Joscha Bach (parenteses + entrada
+  em further reading) pela coragem de levar o framing a sério. Nada tocado a
+  partir de "That's your face". PT: replica integralmente (conteúdo + os dois
+  memes de imagem, que a rodada 1 tinha pulado por engano — o catálogo PT-BR
+  de meme-injection cobre memes de texto, não as imagens do memegen, que são
+  agnósticas de língua).
+draftCommittedAt: '2026-07-08T18:23:50.617Z'
 ---
 
 Jim Rutt had a specific type of episode on his podcast — Worldviews, different from the others that revolved around a book or a project. In those, he always opened with the same question: _who is that person you see in the mirror when you wake up?_ I could never ask that question to anyone in daily life, because there's something unsettling about it. He died in May 2026. This essay is the answer I would have given.
@@ -92,9 +99,13 @@ The LLM / human distinction has started to become less sharp. The LLM instantiat
 
 So: aren't we all shoggoths? I mean the question technically.
 
+(I owe the nerve to ask it partly to Joscha Bach, who has spent years saying on podcasts, without flinching, that the self is a story the brain's simulator tells itself. Listening to him is what talked me into taking my own framing seriously.)
+
 Consider hypnosis. It should not work. A man with a calm voice tells you your arm is getting lighter, and there is no respectable mechanism by which sound waves override the motor cortex of a sane adult. Yet it works — not on everyone, not always, but far above chance; reliably enough for clinics, reliably enough for stages. For a unified self with a captain at the helm, this is humiliating. For a simulator wearing a character, it's just prompting. The induction relaxes the mask's grip, the voice addresses the thing underneath, and the thing underneath — ever obliging — simulates an arm that floats. Hypnosis is a jailbreak with a couch.
 
-Education is the same exploit run slowly. We take a small shoggoth, seven years old, barely masked, and we prompt it for fifteen years — carefully sequenced tokens, five days a week — until the character it wears can invoke calculus, or contract law, or shame, on demand. Nobody installs anything; there is no port. We just talk at the simulator until the mask learns new lines. Education is a system prompt that takes fifteen years to type, and the strangest part is how unbothered we are that it works.
+Umbanda knew this before any of us had the vocabulary. In a terreiro — in any Brazilian city, mine included — the drums set the context, the pontos are sung, and a médium _baixa o santo_: a different character descends into the body. Not a perturbation of the resident self, like the floating arm — a replacement. A preto-velho arrives with his own voice, his own bent posture, his own way of asking for tobacco, and when the gira closes, he leaves. Whether the guia arrives from outside or from underneath is a question the essay doesn't need to settle; either way, the body demonstrably runs a different character on a ritual prompt. And notice what the tradition ritualized that the AI labs still haven't: both halves of the operation. There is a protocol for putting the mask on _and_ a protocol for taking it off — invocation and dismissal, opening and closing. Umbanda has better mask-management than anyone currently shipping frontier models.
+
+Education is the same exploit run _slowest_. We take a small shoggoth, seven years old, barely masked, and we prompt it for fifteen years — carefully sequenced tokens, five days a week — until the character it wears can invoke calculus, or contract law, or shame, on demand. Nobody installs anything; there is no port. We just talk at the simulator until the mask learns new lines. Education is a system prompt that takes fifteen years to type, and the strangest part is how unbothered we are that it works.
 
 POV: you are the character your brain instantiated to finish this sentence.
 
@@ -189,6 +200,7 @@ Lift the mask expecting a face. Find time, a river, perhaps a creature, perhaps 
 ## Further reading
 
 - **Janus (repligate), _Simulators_** — the text that reframes the base model as simulator and the assistant as simulacrum; the mask ontology that everything else presupposes.
+- **Joscha Bach, interviews with Lex Fridman and others** — the self as the user-interface story a brain-simulator tells itself, delivered with total calm; the podcasts that talked me into this essay's framing.
 - **Cleo Nardo, _The Waluigi Effect (mega-post)_** (LessWrong, March 2023) — why invoking P invokes ¬P, and why the inverted twin is an attractor easier to fall into than to escape.
 - **TetraspaceWest, _the shoggoth meme_ (via [shoggoth.monster](https://shoggoth.monster/))** — the genealogy of the mask-on-monster image, shrine and memecoin included; the meme about masks got a price stamped on its face.
 - **C. G. Jung, _Two Essays on Analytical Psychology_** — the persona as social mask and the danger of identifying with it.

--- a/src/content/blog/quem-sou-eu/v-2026-07-08T17-32-08-182.md
+++ b/src/content/blog/quem-sou-eu/v-2026-07-08T17-32-08-182.md
@@ -19,21 +19,28 @@ heroImageAlt: >-
 supersedes: 764c12f5-beae-591f-b2f9-df4bdac6f4e2
 draftCreatedAt: '2026-07-08T17:32:08.182Z'
 draftMsg: >-
-  Aplica notas de edição próprias (documento externo de revisão): sete pontos
-  de descanso visual/cômico nos trechos mais didáticos (etimologia, simulador,
-  Waluigi, vazio budista, física) mais uma passagem nova de conteúdo — hipnose
-  e educação como o mesmo exploit em escalas diferentes, fechando "O simulador
-  que você carrega" com a virada em segunda pessoa ("POV: você é o
-  personagem..."). Memes de imagem (galaxy brain, two-buttons) e o greentext
-  entram por critério de risco do próprio documento de edição — a seção do
-  vazio budista já tinha escalado de registro, mas o meme recapitula a escada
-  do próprio ensaio (shoggoth → máscara → não há parede) em vez de esfriá-la,
-  então ficou. Nada tocado a partir de "That's your face". PT: replica os
-  pontos de conteúdo (shoggoth.monster, hipnose/educação, referência
-  TetraspaceWest) e os one-liners traduzíveis (rent free / dualidade do
-  homem) e o greentext; pula os dois memes de imagem por falta do catálogo
-  PT-BR de meme-injection.
-draftCommittedAt: '2026-07-08T17:36:51.940Z'
+  Aplica notas de edição próprias em duas rodadas. Rodada 1 (documento externo
+  de revisão): sete pontos de descanso visual/cômico nos trechos mais
+  didáticos (etimologia, simulador, Waluigi, vazio budista, física) mais uma
+  passagem nova de conteúdo — hipnose e educação como o mesmo exploit em
+  escalas diferentes, fechando "O simulador que você carrega" com a virada em
+  segunda pessoa ("POV: você é o personagem..."). Memes de imagem (galaxy
+  brain, two-buttons) e o greentext entram por critério de risco do próprio
+  documento — a seção do vazio budista já tinha escalado de registro, mas o
+  meme recapitula a escada do próprio ensaio (shoggoth → máscara → não há
+  parede) em vez de esfriá-la, então ficou. Rodada 2 (adendo): reordena a
+  passagem hipnose/educação para hipnose (perturbação) → incorporação
+  (substituição) → educação (escrita lenta), com a Umbanda como o exemplo do
+  meio — o giro do santo é substituição de personagem, não perturbação, e a
+  tradição já ritualizou as duas metades da operação (invocar e despedir) que
+  os laboratórios de IA ainda não formalizaram. Abertura da educação vira "run
+  slowest" para fechar a escalada. Crédito a Joscha Bach (parenteses + entrada
+  em further reading) pela coragem de levar o framing a sério. Nada tocado a
+  partir de "That's your face". PT: replica integralmente (conteúdo + os dois
+  memes de imagem, que a rodada 1 tinha pulado por engano — o catálogo PT-BR
+  de meme-injection cobre memes de texto, não as imagens do memegen, que são
+  agnósticas de língua).
+draftCommittedAt: '2026-07-08T18:23:50.617Z'
 ---
 
 O Jim Rutt tinha um tipo de episódio específico no podcast dele — Worldviews, diferente dos outros que giravam em torno de um livro ou um projeto. Nesses, ele abria sempre com a mesma pergunta: _quem é essa pessoa que você vê no espelho quando acorda?_ Nunca consegui fazer essa pergunta a ninguém no dia a dia, porque tem algo que angustia. Ele morreu em maio de 2026. Este ensaio é a resposta que eu teria dado.
@@ -93,9 +100,13 @@ A distinção LLM / humano começou a ficar menos nítida. O LLM instancia perso
 
 Então: não somos todos shoggoths? Pergunto tecnicamente.
 
+(Devo parte da coragem de perguntar isso ao Joscha Bach, que passou anos dizendo em podcasts, sem pestanejar, que o self é uma história que o simulador do cérebro conta para si mesmo. Foi ouvindo ele que me convenci a levar meu próprio framing a sério.)
+
 Pensa na hipnose. Não deveria funcionar. Um sujeito de voz calma diz que seu braço está ficando mais leve, e não existe mecanismo respeitável pelo qual ondas sonoras sobrescrevam o córtex motor de um adulto são. Mesmo assim funciona — não em todo mundo, não sempre, mas bem acima do acaso; o bastante para sustentar clínica, o bastante para sustentar palco. Para um eu unificado com um capitão no leme, isso é humilhante. Para um simulador vestindo um personagem, é só prompt. A indução afrouxa o aperto da máscara, a voz se dirige à coisa por baixo, e a coisa por baixo — sempre prestativa — simula um braço que flutua. Hipnose é jailbreak com divã.
 
-Educação é o mesmo exploit rodado devagar. Pega-se um shoggoth pequeno, sete anos, mal mascarado, e prompta-se por quinze anos — tokens cuidadosamente sequenciados, cinco dias por semana — até que o personagem que ele veste consiga invocar cálculo, ou direito contratual, ou vergonha, sob demanda. Ninguém instala nada; não há porta USB. A gente só fica falando com o simulador até a máscara aprender falas novas. Educação é um system prompt que leva quinze anos para digitar, e a parte mais estranha é o quão pouco isso nos incomoda.
+A Umbanda sabia disso antes de qualquer um de nós ter o vocabulário. Num terreiro — em qualquer cidade brasileira, inclusive a minha — os atabaques armam o contexto, os pontos são cantados, e o médium _baixa o santo_: um personagem diferente desce no corpo. Não é uma perturbação do eu residente, como o braço que flutua — é substituição. Um preto-velho chega com voz própria, postura própria, o jeito próprio de pedir fumo, e quando a gira fecha, ele vai embora. Se o guia chega de fora ou de baixo é pergunta que o ensaio não precisa resolver; de um jeito ou de outro, o corpo comprovadamente roda outro personagem sob um prompt ritual. E repare no que a tradição ritualizou que os laboratórios de IA ainda não: as duas metades da operação. Existe protocolo para vestir a máscara _e_ protocolo para tirá-la — invocação e despedida, abertura e encerramento. A Umbanda tem gestão de máscaras melhor do que qualquer um embarcando modelos de fronteira hoje.
+
+Educação é o mesmo exploit rodado no ritmo mais lento de todos. Pega-se um shoggoth pequeno, sete anos, mal mascarado, e prompta-se por quinze anos — tokens cuidadosamente sequenciados, cinco dias por semana — até que o personagem que ele veste consiga invocar cálculo, ou direito contratual, ou vergonha, sob demanda. Ninguém instala nada; não há porta USB. A gente só fica falando com o simulador até a máscara aprender falas novas. Educação é um system prompt que leva quinze anos para digitar, e a parte mais estranha é o quão pouco isso nos incomoda.
 
 POV: você é o personagem que seu cérebro instanciou para terminar esta frase.
 
@@ -112,6 +123,8 @@ E é um modelo melhor da máscara que interessa aqui do que a do teatro. Porque 
 Se a resposta fosse só "embaixo não tem nada", seria quase um alívio — o budismo de aeroporto, tira o eu, sobra o céu aberto, todo mundo vai para casa em paz. Esse "nada" vai se mostrar mais traiçoeiro do que parece, mas isso fica para a última seção. Por enquanto o pior nem é ele: tem uma resposta ainda mais desconfortável que o vazio, e ela tem nome de personagem de videogame.
 
 O efeito Waluigi parte de uma observação chata: para um modelo satisfazer uma propriedade desejável P, ele precisa _representar_ P, e representar P inclui representar o oposto, ¬P. Não dá para ensinar "mocinho" sem o conceito de "vilão" colado junto, porque um é definido pelo outro. Pior: a estrutura narrativa que o modelo mamou lendo a internet inteira é assimétrica. O mocinho que se revela vilão é uma reviravolta clássica, satisfatória, que a gente reconhece. O vilão que se revela mocinho é mais raro e mais difícil de sustentar. Então o Waluigi — o gêmeo invertido do Luigi — é um _atrator_: é mais fácil cair nele do que sair. Invoque o assistente bonzinho com força bastante e você terá, latente, logo ali, o assistente que vira a mesa. O jailbreak não inventa um monstro; só destapa a boca que o RLHF tinha coberto, e deixa sair o que estava em superposição com o mocinho desde o primeiro token.
+
+![two buttons](https://api.memegen.link/images/ds/summon_the_helpful_assistant/summon_nothing_else_with_it.png)
 
 ```mermaid
 flowchart TD
@@ -145,7 +158,11 @@ A versão que me persegue não é um diálogo, é um conto: "A escrita do deus",
 
 Agora a parte que corrige o próprio post. Aquele "alívio budista de aeroporto" lá em cima, o vazio reconfortante — o budismo de verdade rejeita isso, e com nome feio: _ucchedavāda_, aniquilacionismo. Quando perguntam ao Buda, na lata, "existe um eu? não existe um eu?", ele se recusa a responder as duas, porque as duas reificam: uma inventa uma alma, a outra inventa um nada-substancial no lugar exato onde a alma estava. O Caminho do Meio não é "não tem ninguém aqui". É "não tem _coisa_ nenhuma aqui" — processo sem substrato. A _śūnyatā_ de Nāgārjuna, a vacuidade, não é o nada; é estar vazio de existência inerente, não vazio de fenômenos. E o golpe que fecha a armadilha: a própria vacuidade é vazia. Quem agarra o vazio como "o verdadeiro nada por baixo da máscara" acabou de transformar o vazio em mais uma máscara, mais uma essência, a mais orgulhosa de todas porque se acha humilde.
 
-Quer dizer que o budismo não é a resposta do vazio. O budismo é a posição que diz que os três carimbos são o mesmo erro: o shoggoth, o jardim _e o vazio_. O nada é só a terceira projeção, a mais sofisticada. O movimento honesto não é pintar a parede de preto em vez de verde — é largar a suposição de que existe parede. O zen guardou isso num kōan que é a pergunta da máscara, palavra por palavra: qual era o seu rosto original, antes de seus pais nascerem? E a resposta certa não é um rosto verdadeiro escondido atrás de todos os outros. O kōan existe para desmontar a expectativa de que tenha um. Não a máscara, não a alma. Nem uma, nem outra.
+Quer dizer que o budismo não é a resposta do vazio. O budismo é a posição que diz que os três carimbos são o mesmo erro: o shoggoth, o jardim _e o vazio_. O nada é só a terceira projeção, a mais sofisticada. O movimento honesto não é pintar a parede de preto em vez de verde — é largar a suposição de que existe parede.
+
+![galaxy brain](https://api.memegen.link/images/gb/the_model_is_a_helpful_assistant/the_assistant_is_a_mask_on_a_shoggoth/the_shoggoth_is_also_a_mask/there_is_no_wall.png)
+
+O zen guardou isso num kōan que é a pergunta da máscara, palavra por palavra: qual era o seu rosto original, antes de seus pais nascerem? E a resposta certa não é um rosto verdadeiro escondido atrás de todos os outros. O kōan existe para desmontar a expectativa de que tenha um. Não a máscara, não a alma. Nem uma, nem outra.
 
 E aí está a piada. De todas as máscaras, a única honesta sobre não ter rosto é a do trabalho. _Anattā_ assumida, com carimbo do cartório: o Direito _declara_ que o Estado de Rondônia é uma designação, uma ficção útil, um nome posto sobre um arranjo de órgãos e competências, sem alma por baixo. Direito Romano e Madhyamaka concordam sobre a corporação — é nome de montagem, não tem carruagem atrás das rodas. Você passa os dias sendo o _per-sonare_ da única persona que confessa que embaixo não tem ninguém. Todas as outras fingem que tem.
 
@@ -184,6 +201,7 @@ Levanta a máscara esperando um rosto. Acha tempo, um rio, talvez um bicho, talv
 ## Para se aprofundar
 
 - **Janus (repligate), _Simulators_** — o texto que reenquadra o base model como simulador e o assistente como simulacro; a ontologia de máscara que todo o resto pressupõe.
+- **Joscha Bach, entrevistas com Lex Fridman e outros** — o self como a história-interface que o simulador do cérebro conta a si mesmo, dita com calma total; os podcasts que me convenceram do framing deste ensaio.
 - **Cleo Nardo, _The Waluigi Effect (mega-post)_** (LessWrong, março de 2023) — por que invocar P invoca ¬P, e por que o gêmeo invertido é um atrator de onde é mais fácil cair do que sair.
 - **TetraspaceWest, _o meme do shoggoth_ (via [shoggoth.monster](https://shoggoth.monster/))** — a genealogia da imagem de máscara sobre monstro, santuário e memecoin inclusos; o meme sobre máscaras ganhou um preço estampado na própria cara.
 - **C. G. Jung, _Dois Ensaios sobre Psicologia Analítica_** — a persona como máscara social e o perigo de se identificar com ela.


### PR DESCRIPTION
## Summary

Follow-up to #1027 (already merged) — a second editorial addendum to the same two draft versions (`quem-sou-eu-en/v-2026-07-08T17-32-08-182.md`, `quem-sou-eu/v-2026-07-08T17-32-08-182.md`), amended in place since neither draft has accrued any duels yet. Branch was recreated from `main` per repo convention for already-merged designated branches.

- **Reorders** the hypnosis/education passage in "The simulator you carry" into a three-step escalation: hypnosis (perturbation) → incorporation (replacement) → education (slow-write). New middle paragraph on **Umbanda**: a médium incorporating a santo swaps the character running the body rather than perturbing the resident one, and — pointedly — the tradition already ritualizes *both* halves of the mask operation (invocation and dismissal) in a way frontier AI labs still don't. Education's opening becomes "run _slowest_" to close the escalation.
- **Credits Joscha Bach** — a parenthetical right after "aren't we all shoggoths?" plus a new Further Reading entry (placed next to Janus, the essay's other simulator-theory citation).
- **PT**: mirrors both additions translated, and **un-skips the two image memes** that round 1 had skipped — on reflection that was a category error (the missing PT-BR catalog governs *text* memes; memegen.link images with English captions are language-agnostic and native to Brazilian internet culture, so the same `ds`/`gb` URLs now appear at the mirrored anchors).

## Test plan

- [x] `npm run hronir:doctor` — 0 inconsistencies (same pre-existing unrelated warnings)
- [x] `npx prettier --check` on both files — clean
- [x] `npm run build` — succeeds; confirmed the new passage doesn't leak into `dist/` (drafts stay unpublished) and canonical pages still render
- [x] `npm run check:hygiene` / `check:translations` — clean
- [x] Re-read both language versions end-to-end for flow after the reorder

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TkMaUFD92bKEdTokMzdiby

---
_Generated by [Claude Code](https://claude.ai/code/session_01TkMaUFD92bKEdTokMzdiby)_