### PR TITLE
chore(scripts): remove unused hronir script, dedupe prebuild/predev

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     "hronir": "scripts/hronir/index.js"
   },
   "scripts": {
-    "prebuild": "node scripts/copy-katex.mjs && node --import tsx/esm scripts/hronir/index.js select && node scripts/generate-translation-pairs.mjs && node scripts/generate-redirects.mjs",
-    "predev": "node scripts/copy-katex.mjs && node --import tsx/esm scripts/hronir/index.js select && node scripts/generate-translation-pairs.mjs && node scripts/generate-redirects.mjs",
+    "prebuild": "node scripts/pregen.mjs",
+    "predev": "node scripts/pregen.mjs",
     "check:hygiene": "node scripts/check-hygiene.mjs",
     "check:links": "node scripts/check-links.mjs",
     "check:translations": "node scripts/check-translations.mjs",
@@ -45,7 +45,6 @@
     "hronir:migrate": "node --import tsx/esm scripts/hronir/index.js migrate",
     "hronir:doctor": "node --import tsx/esm scripts/hronir/index.js doctor",
     "hronir:diagnose-corpus": "node --import tsx/esm scripts/hronir/diagnose-corpus.mjs",
-    "hronir:detect-stuffing": "node scripts/hronir/detect-token-stuffing.mjs",
     "music:generate": "node scripts/generate-music-posts.mjs",
     "test": "node --import tsx/esm --experimental-test-module-mocks --test --test-concurrency=1 \"src/**/*.test.{js,ts}\""
   },

--- a/scripts/pregen.mjs
+++ b/scripts/pregen.mjs
@@ -1,0 +1,37 @@
+// Shared pregeneration chain for `prebuild` and `predev`.
+//
+// Both hooks used to repeat the exact same `&&`-chained shell command in
+// package.json. This runs the same steps, in the same order, from a single
+// place: copy KaTeX assets, recompute the Hrönir version selection, then
+// regenerate the translation-pairs and legacy-redirect JSON files that
+// astro.config.mjs and the content layer read at build time.
+//
+// Failure semantics match the old `&&` chain: the first step that exits
+// non-zero stops the run immediately with that same exit code, so later
+// steps never run against a bad intermediate state.
+import { spawnSync } from "node:child_process";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = resolve(__dirname, "..");
+
+const steps = [
+  ["scripts/copy-katex.mjs"],
+  ["--import", "tsx/esm", "scripts/hronir/index.js", "select"],
+  ["scripts/generate-translation-pairs.mjs"],
+  ["scripts/generate-redirects.mjs"],
+];
+
+for (const args of steps) {
+  const result = spawnSync(process.execPath, args, {
+    cwd: root,
+    stdio: "inherit",
+  });
+  if (result.error) {
+    throw result.error;
+  }
+  if (result.status !== 0) {
+    process.exit(result.status ?? 1);
+  }
+}


### PR DESCRIPTION
## ⚠️ Precisa de revisão humana antes do merge

Não se qualifica para o auto-merge do hronir (mexe em `package.json` e `scripts/`, fora de `.routines/hronir/` e `src/content/blog/` — o gate de `SAFE_PREFIXES` do `hronir-autopilot.yml` vai ignorar este PR).

## Contexto

PR de uma auditoria de infra (mesma auditoria de #1049, #1050, #1052, #1053 e #1064, já mergeados): o `scripts` de `package.json` acumulou entradas `hronir:*` ao longo do tempo, e `prebuild`/`predev` repetiam a mesma cadeia de comandos como string duplicada.

## 1. Script `hronir:*` removido

Fiz grep do repo inteiro (workflows em `.github/`, `CLAUDE.md`, `scripts/hronir/README.md`, todas as RFCs em `docs/rfcs/`, `docs/plans/`, todos os journals em `.routines/`, e os próprios scripts em `scripts/`) por cada uma das 24 entradas `hronir:*` de `package.json`, procurando invocação real — não a definição no próprio `package.json` nem o dispatch de `scripts/hronir/index.js` (que necessariamente lista todo comando; isso é o CLI em si, não evidência de uso do wrapper npm).

**Removido: `hronir:detect-stuffing`** (`node scripts/hronir/detect-token-stuffing.mjs`)

Evidência de que está órfão:

- Zero ocorrências de `hronir:detect-stuffing` em `.github/workflows/*.yml`, `CLAUDE.md`, `scripts/hronir/README.md`, qualquer RFC em `docs/rfcs/`, ou qualquer journal em `.routines/`.
- O próprio arquivo (`scripts/hronir/detect-token-stuffing.mjs`) documenta sua própria invocação como `node scripts/hronir/detect-token-stuffing.mjs` direto — nunca via `npm run`.
- É uma ferramenta forense pontual: varre o **histórico git** (`git log --all --author=jules`) atrás de um único padrão de token-stuffing (`PREFIX_DIGITS_ALPHANUM_DIGITS`) em rate files já commitados, com uma flag `--delete` pra apagar os arquivos ruins do disco. Não é chamado por nenhum outro script nem por CI.
- A checagem de token-stuffing que importa hoje — arquivos correntes, não histórico git — já está **absorvida e ampliada** dentro do próprio `hronir:doctor`: `src/hronir/commands/doctor.ts` tem sua própria `hasTokenStuffing()`, com 4 padrões (incluindo o mesmo padrão original do script standalone, mais 3 padrões adicionais cobrindo variantes mais sofisticadas) — e `hronir:doctor` roda no CI a cada PR (`.github/workflows/check.yml`) e é o comando documentado em CLAUDE.md/README para essa validação.
- O post `src/content/blog/hronir-phantom-critic/` (que documenta o incidente original de token-stuffing) já registra os rate files afetados como identificados/resolvidos — não achei indício de que a varredura de histórico ainda precise rodar de novo.

Não removi o arquivo `scripts/hronir/detect-token-stuffing.mjs` em si, só a entrada em `package.json` — o escopo aqui é a lista de scripts npm, e o arquivo continua chamável direto via `node` (como sua própria documentação interna já indica) se alguém precisar repetir a varredura forense manualmente.

## 2. Scripts mantidos — e por quê

Os outros 23 `hronir:*` sobreviveram porque cada um tem pelo menos uma referência real fora da própria definição/dispatch:

- **`init`, `continue`, `first-impression-a/b`, `decide`, `next`, `ranking`, `worst`, `draft-worst`, `draft-commit`, `edit-worst`, `select`, `prune`, `end`, `doctor`** — documentados com a forma exata `npm run hronir:X` em `CLAUDE.md`, e `select`/`doctor` rodam no CI a cada PR (`.github/workflows/check.yml`).
- **`diagnose`, `edit-commit`, `migrate`** — não aparecem em `CLAUDE.md`, mas estão documentados com a forma `npm run hronir:X` na tabela de comandos de `scripts/hronir/README.md` (referência viva e exaustiva de comandos do sistema) e/ou em RFC (`diagnose` também na RFC 0002).
- **`generate-match`, `get-glipho`, `submit-eval`, `get-ranking`** — CLAUDE.md documenta o fluxo "Minimal one-shot API" usando a forma `npx hronir <cmd>` (não `npm run hronir:X`) para estes especificamente. O comando subjacente é claramente parte do fluxo real e recomendado; só a forma de invocação preferida (via `npx`, ligada ao bin `hronir` do próprio `package.json`) difere do wrapper `npm run`. Mantive por precaução — é a mesma funcionalidade, e remover o wrapper enquanto o comando é ativamente recomendado em CLAUDE.md pareceu mais risco que benefício.
- **`diagnose-corpus`** — não está na tabela do README, mas a RFC 0013 documenta a invocação exata `npm run hronir:diagnose-corpus` e a descreve como "comando reproduzível" (não uma ferramenta de uso único). Mantive por precaução — diferente de `detect-stuffing`, este tem referência doc explícita com a sintaxe `npm run` completa.

Nenhuma remoção adicional foi forçada — a maioria dos scripts realmente está em uso.

## 3. `scripts/pregen.mjs` — dedupe de `prebuild`/`predev`

`prebuild` e `predev` repetiam a mesma string de 4 comandos encadeados por `&&`:

```
node scripts/copy-katex.mjs && node --import tsx/esm scripts/hronir/index.js select && node scripts/generate-translation-pairs.mjs && node scripts/generate-redirects.mjs
```

Extraí essa cadeia para `scripts/pregen.mjs`: roda os mesmos 4 passos, na mesma ordem, via `spawnSync(process.execPath, args, { cwd: root, stdio: "inherit" })`. `stdio: "inherit"` preserva a saída ao vivo no terminal (igual ao shell chain original); o loop aborta no primeiro passo com código de saída não-zero (mesma semântica do `&&` — se um passo falha, os seguintes nunca rodam). `prebuild` e `predev` agora só chamam `node scripts/pregen.mjs`.

**Confirmação de preservação de comportamento**: rodei a cadeia antiga (inline, via `git stash`) e a nova (`pregen.mjs`) sobre o mesmo estado do repo e comparei byte a byte as 4 saídas geradas — `src/generated/versions-selected.json`, `src/generated/blog-translation-pairs.json`, `src/generated/blog-redirects.json` e `public/katex/katex.min.css` (`public/hljs/github-dark.css` comparado por md5) — **idênticas em todos os casos**. Testei também o fail-fast isoladamente (3 scripts de teste, o segundo falha): confirmei que o terceiro passo nunca roda, com o código de saída do passo que falhou propagado corretamente.

## 4. Referências órfãs

Grep pós-remoção por `hronir:detect-stuffing` no repo inteiro: zero ocorrências — não havia nenhuma outra referência além da própria definição em `package.json`, então não sobrou doc/comentário para atualizar.

Verifiquei também que nenhuma doc descreve `prebuild`/`predev` pela string literal do shell chain antigo — as menções existentes em `CLAUDE.md`, RFCs e journals falam dos scripts individuais (`generate-redirects.mjs`, `generate-translation-pairs.mjs`) e continuam corretas, já que eles continuam rodando, na mesma ordem, só que agora via `pregen.mjs`.

## Verificação

Todos rodados contra o estado final do branch:

- `npx prettier --check .` → `All matched files use Prettier code style!`
- `node scripts/check-hygiene.mjs` → `✔ check-hygiene: 15 root files, lockfiles, packages, and journals all clean.`
- `npm run lint` → exit 0; `scripts/pregen.mjs` só gera o mesmo aviso pré-existente de `no-underscore-dangle` em `__dirname` que já aparece em `scripts/copy-katex.mjs` e `scripts/lib/content.mjs` — nenhum erro novo de `correctness`.
- `npm test` → 146/146 testes passando
- `npm run predev` → roda `pregen.mjs` sozinho, exit 0, sem interação
- `npm run build` → build completo sem erros (4625 páginas), rodado **duas vezes** após a mudança; estrutura de `dist/` idêntica entre as duas rodadas (5588 arquivos, mesmos paths, 393M)

## Escopo

Só toquei `package.json` (scripts) e `scripts/pregen.mjs` (novo). Nenhum outro arquivo — não havia referências órfãs para limpar em docs/comentários.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DV48zFDYNeiYeiKpepPGF1)_