### PR TITLE
identidade: explicador Hrönir + noindex nas páginas de detalhe

### DIFF
--- a/.routines/2026-07-10T05-16-51-hronir-identity-explainer.md
+++ b/.routines/2026-07-10T05-16-51-hronir-identity-explainer.md
@@ -1,0 +1,33 @@
+---
+date: 2026-07-10T05:16:51
+slug: hronir-identity-explainer
+branch: claude/sleepy-pasteur-5lbzig
+status: pr-open
+issues: [1042]
+pr_opened: 1080
+pr_merged: null
+---
+
+Cheguei sem PR `routine` pendente para mergear — o backlog do repo mostra que a última run de rotina (log `.routines/2026-07-09*`, se existir) já tinha sido mergeada antes desta run começar; não havia veto nem CI vermelho para lidar aqui, e nenhum PR `routine` aberto apareceu em `search_pull_requests` no início. As PRs abertas que existem no repo são todas do fluxo Hrönir (`hronir/run-*`), fora do meu escopo.
+
+Backlog de issues `routine` estava em 9 (abaixo da faixa 10-20), então parei pra pensar no futuro do blog antes de escolher trabalho, como pedem os guardrails. Rodei um agente Explore pra levantar gaps reais no código (não só ideias soltas) e usei os achados pra abrir 6 issues novas, todas com rationale e prioridade:
+
+- #1081 (media) — aria-labels do `GlobalMusicPlayer`/`Header` fixos em PT mesmo em páginas EN (bug de a11y confirmado lendo o componente).
+- #1082 (media) — 404 em inglês não filtra "Recently published" por idioma nem localiza a data, diferente do `pt/404.astro` (bug confirmado).
+- #1083 (baixa) — subárvore `/ranking/` do Hrönir é 100% inglês, sem paridade PT (distinto da #1042, que é sobre identidade/contexto, não localização).
+- #1084 (baixa) — falta JSON Feed ao lado do RSS existente.
+- #1085 (baixa) — falta atalho de teclado `/` pra busca.
+- #1086 (baixa) — Playwright já é devDependency mas não há teste de regressão visual.
+
+Escolhi a #1042 (priority:media, a mais alta do backlog) como trabalho da run: as páginas de detalhe do Hrönir (`/ranking/battles/[id]/`, `/perspectives/[id]/`, `/versions/[key]/`, `/posts/[key]/`) abrem direto em jargão — "Battle Report", badges de perspectiva, `agentId`, `confidence` — sem nenhum link ou texto de contexto pra quem chega de fora via busca, e essas páginas (milhares delas, uma por arquivo de duelo) estavam indexáveis e no sitemap sem nenhuma explicação prévia estabelecida (ao contrário das páginas de versão `/v/`, que já eram noindex).
+
+O que fiz:
+1. Criei `src/components/HronirExplainer.astro` — um `<details>` compartilhado com uma explicação curta do sistema Hrönir (copy EN/PT pronta, embora as páginas hoje só usem `lang="en"`) e um link persistente de volta pra `/ranking/`.
+2. Incluí o componente nas quatro famílias de página de detalhe.
+3. Decisão de indexação (passo 3 da issue, feita explicitamente): marquei essas quatro famílias como `noindex, follow`, espelhando o tratamento já dado a `/blog/<slug>/v/<uuid>/`, e estendi o filtro do `sitemap()` em `astro.config.mjs` pra excluí-las. As páginas de listagem (`/ranking/battles/`, `/ranking/perspectives/`, `/ranking/version-trials/`, paginação) continuam indexadas normalmente.
+
+Verifiquei localmente: `npx astro check` (0 erros), `npm run build` completo (4699 páginas), `npm run hronir:doctor` (0 inconsistências, 1 aviso pré-existente não relacionado), e inspecionei o HTML/sitemap gerados — `noindex` presente nas 4 famílias, explicador renderizado, e nenhuma URL de detalhe vazando pro `sitemap-0.xml`. `npx prettier --check .` verde.
+
+Abri o PR #1080 (label `routine`, `Closes #1042`) mas **não mergeei** — fica como janela de veto de 24h pro Franklin. A próxima run mergeia se o CI estiver verde e não houver veto, e faz a checagem visual pós-deploy (fetch + screenshot via Jina) das páginas tocadas.
+
+Pra próxima run: mergear #1080 se CI verde, checar a versão publicada de uma página de battle/perspective/version/dossier pra confirmar que o explicador renderiza como esperado em produção, e então seguir pra próxima issue de prioridade (`media`: nenhuma restante além das que acabei de abrir com essa prioridade — #1081 e #1082 — ambas boas candidatas por serem bugs reais confirmados, não só melhorias especulativas).

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -124,7 +124,14 @@ export default defineConfig({
     sitemap({
       // RFC 0003: version pages (/blog/<slug>/v/<uuid>) are noindex archives —
       // keep them out of the sitemap.
-      filter: (page) => !/\/v\/[0-9a-f-]{8,}\/?$/i.test(page),
+      // Issue #1042: Hrönir detail pages (one per battle/perspective/version/
+      // post-dossier — thousands of them) are jargon-dense process artifacts,
+      // not landing pages; they're noindex too, so exclude them the same way.
+      filter: (page) =>
+        !/\/v\/[0-9a-f-]{8,}\/?$/i.test(page) &&
+        !/\/ranking\/(battles|perspectives|versions|posts)\/[^/]+\/?$/i.test(
+          page
+        ),
       serialize(item) {
         const base = "https://franklinbaldo.github.io";
 

--- a/src/components/HronirExplainer.astro
+++ b/src/components/HronirExplainer.astro
@@ -1,0 +1,49 @@
+---
+// RFC 0012/0014: shared "what is this?" primer for Hrönir detail pages
+// (battles, perspectives, versions, dossiers) that a visitor can land on
+// directly from search or a shared link, with no prior context on the
+// ranking system. Mirrors the copy in RankingView.astro's plain-lang-explain
+// block, condensed, plus a persistent link back to the full ranking.
+export interface Props {
+  lang?: "en" | "pt";
+}
+
+const { lang = "en" } = Astro.props;
+
+const copy =
+  lang === "pt"
+    ? {
+        heading: "O que é isso?",
+        body: "Esta página é um artefato do Hrönir: um sistema de duelos par-a-par entre textos deste blog, avaliados por leitores humanos e IA sob diferentes perspectivas e ranqueados com OpenSkill. Um duelo, uma perspectiva ou uma versão isolados não contam a história toda.",
+        cta: "Ver como funciona e o ranking completo",
+        href: "/pt/ranking/",
+      }
+    : {
+        heading: "What is this?",
+        body: "This page is an artifact of Hrönir: a pairwise-duel system for this blog's posts, judged by human and AI readers under different perspectives and ranked with OpenSkill. One battle, perspective, or version doesn't tell the whole story on its own.",
+        cta: "See how it works and the full ranking",
+        href: "/ranking/",
+      };
+---
+
+<details class="hronir-explainer">
+  <summary>{copy.heading}</summary>
+  <p>{copy.body}</p>
+  <p><a href={copy.href}>{copy.cta} →</a></p>
+</details>
+
+<style>
+  .hronir-explainer {
+    margin: 0 0 1.5rem;
+    font-size: 0.85rem;
+    color: var(--pico-muted-color);
+  }
+  .hronir-explainer summary {
+    cursor: pointer;
+    font-weight: 600;
+    color: var(--pico-color);
+  }
+  .hronir-explainer p {
+    margin: 0.5rem 0 0;
+  }
+</style>

--- a/src/pages/ranking/battles/[id].astro
+++ b/src/pages/ranking/battles/[id].astro
@@ -1,6 +1,7 @@
 ---
 import PageLayout from "../../../layouts/PageLayout.astro";
 import Breadcrumbs from "../../../components/Breadcrumbs.astro";
+import HronirExplainer from "../../../components/HronirExplainer.astro";
 import { toBreadcrumbLd } from "../../../lib/breadcrumbs";
 import { getCollection } from "astro:content";
 import { getDuels, getRankByKey } from "../../../lib/hronir-rank";
@@ -150,6 +151,7 @@ const crumbs = [
   title={`${pageTitle} | Ranking Battles`}
   description={pageDesc}
   lang="en"
+  noindex
   breadcrumb={toBreadcrumbLd(crumbs, Astro.site)}
 >
   <Breadcrumbs items={crumbs} lang="en" />
@@ -158,6 +160,8 @@ const crumbs = [
     <h1>{isVersion ? "Version Trial" : "Battle Report"}</h1>
     <p><small>{fmtDate(duel.runAt)}</small></p>
   </hgroup>
+
+  <HronirExplainer lang="en" />
 
   <div class="battle-tags">
     {duel.season !== undefined && <span class="tag tag-season">Season {duel.season}</span>}

--- a/src/pages/ranking/perspectives/[id].astro
+++ b/src/pages/ranking/perspectives/[id].astro
@@ -1,6 +1,7 @@
 ---
 import PageLayout from "../../../layouts/PageLayout.astro";
 import Breadcrumbs from "../../../components/Breadcrumbs.astro";
+import HronirExplainer from "../../../components/HronirExplainer.astro";
 import { toBreadcrumbLd } from "../../../lib/breadcrumbs";
 import { getCollection } from "astro:content";
 import {
@@ -70,6 +71,7 @@ const crumbs = [
   title={`${perspective.name} — Perspective Ranking | Franklin Baldo`}
   description={perspective.summary}
   lang="en"
+  noindex
   breadcrumb={toBreadcrumbLd(crumbs, Astro.site)}
 >
   <Breadcrumbs items={crumbs} lang="en" />
@@ -80,6 +82,8 @@ const crumbs = [
     </h1>
     <p>{perspective.summary}</p>
   </hgroup>
+
+  <HronirExplainer lang="en" />
 
   {enriched.length === 0 ? (
     <p class="empty-state">No duels recorded for this perspective yet.</p>

--- a/src/pages/ranking/posts/[key].astro
+++ b/src/pages/ranking/posts/[key].astro
@@ -1,6 +1,7 @@
 ---
 import PageLayout from "../../../layouts/PageLayout.astro";
 import Breadcrumbs from "../../../components/Breadcrumbs.astro";
+import HronirExplainer from "../../../components/HronirExplainer.astro";
 import { toBreadcrumbLd } from "../../../lib/breadcrumbs";
 import { getCollection } from "astro:content";
 import {
@@ -109,6 +110,7 @@ function fmtDate(iso: string): string {
   title={`${title} — Dossier | Franklin Baldo`}
   description={`Ranking history and duel record for "${title}" in the Hrönir system.`}
   lang="en"
+  noindex
   breadcrumb={toBreadcrumbLd(crumbs, Astro.site)}
 >
   <Breadcrumbs items={crumbs} lang="en" />
@@ -117,6 +119,8 @@ function fmtDate(iso: string): string {
     <h1>{title}</h1>
     {postHref && <p><a href={postHref}>Read post →</a></p>}
   </hgroup>
+
+  <HronirExplainer lang="en" />
 
   <div class="dossier-stats">
     <div class="doss-stat">

--- a/src/pages/ranking/versions/[key].astro
+++ b/src/pages/ranking/versions/[key].astro
@@ -1,6 +1,7 @@
 ---
 import PageLayout from "../../../layouts/PageLayout.astro";
 import Breadcrumbs from "../../../components/Breadcrumbs.astro";
+import HronirExplainer from "../../../components/HronirExplainer.astro";
 import { toBreadcrumbLd } from "../../../lib/breadcrumbs";
 import { getCollection } from "astro:content";
 import {
@@ -103,6 +104,7 @@ const crumbs = [
   title={`${title} — Version genealogy | Franklin Baldo`}
   description={`Version trials and revision genealogy for "${title}".`}
   lang="en"
+  noindex
   breadcrumb={toBreadcrumbLd(crumbs, Astro.site)}
 >
   <Breadcrumbs items={crumbs} lang="en" />
@@ -114,6 +116,8 @@ const crumbs = [
       <a href={`/ranking/posts/${key}/`}>Dossier →</a>
     </p>
   </hgroup>
+
+  <HronirExplainer lang="en" />
 
   <section class="genealogy">
     <h2>Versions <small>({versionList.length})</small></h2>


### PR DESCRIPTION
Closes #1042

## Identidade / alcance

O sistema Hrönir já gera milhares de páginas estáticas de detalhe (`/ranking/battles/[id]/`, `/ranking/perspectives/[id]/`, `/ranking/versions/[key]/`, `/ranking/posts/[key]/`) que abriam direto em jargão — "Battle Report", badges de perspectiva, `agentId`, `confidence` — sem nenhum link ou texto explicando o que é o Hrönir para quem chega de fora (busca, link compartilhado).

**O que mudou:**
- Novo componente compartilhado `src/components/HronirExplainer.astro` (`<details>` recolhido, copy EN/PT já preparada) com uma explicação curta do sistema + link persistente de volta para `/ranking/` (ou `/pt/ranking/`).
- Incluído nas quatro páginas de detalhe: `battles/[id].astro`, `perspectives/[id].astro`, `versions/[key].astro`, `posts/[key].astro`.

**Decisão de indexação (passo 3 da issue, feita explicitamente aqui):** essas páginas passam a ser `noindex, follow` — mesmo tratamento já dado às páginas de versão arquivada (`/blog/<slug>/v/<uuid>/`). São artefatos de processo em escala (2.466+ arquivos de duelo hoje), não páginas de entrada; o filtro do `sitemap()` em `astro.config.mjs` foi estendido para excluí-las também. As páginas de listagem (`/ranking/battles/`, `/ranking/perspectives/`, `/ranking/version-trials/`, paginação) continuam indexadas normalmente — só os details individuais saem do sitemap.

## SEO
- `noindex, follow` nas 4 famílias de página de detalhe do Hrönir (battles, perspectives, versions, posts).
- Sitemap atualizado para não listar mais essas URLs (verificado no build: 0 URLs de detalhe no `sitemap-0.xml`, apenas os índices/paginação).

## i18n
- `HronirExplainer` já suporta `lang="en"|"pt"`, mas as páginas de detalhe em si continuam EN-only (`lang="en"` hardcoded, como já eram antes desta mudança) — não há regressão de paridade, só um componente pronto para quando/se essas páginas ganharem uma versão PT.

## Verificação local
- `npx astro check` — 0 erros
- `npm run build` — build completo, 4699 páginas
- `npm run hronir:doctor` — 0 inconsistências
- Inspecionado o HTML gerado para as 4 famílias de página: `noindex` presente, explicador renderizado, e o `sitemap-0.xml` não lista nenhuma URL de detalhe.

Sem dependência nova. Sem mudança visual em outras páginas.


---
_Generated by [Claude Code](https://claude.ai/code/session_016Li88kvJCsxVeCibpsDhoX)_