### PR TITLE
Quem sou eu: torna rastreável a ponte cogito → pessoa como convenção

### DIFF
--- a/.routines/2026-07-11T00-00-00-quem-sou-eu-cogito-bridge.md
+++ b/.routines/2026-07-11T00-00-00-quem-sou-eu-cogito-bridge.md
@@ -1,0 +1,34 @@
+---
+date: "2026-07-11T00:00:00Z"
+branch: claude/new-session-6e8w1z
+status: open
+---
+
+Edição cirúrgica (Estratégia A) em "Quem sou eu? / Who Am I?" para tornar
+rastreável o percurso epistemológico do cogito impessoal → pessoa como
+convenção, que já estava implícito no ensaio mas concentrado tarde demais
+("A última máscara") sem preparo anterior.
+
+Duas inserções por idioma, como novas versões RFC 0003 (`supersedes` a
+versão selecionada, canônica intocada):
+
+1. Semente discreta ao fim do parágrafo do Dennett em "O simulador não tem
+   rosto" / "The simulator has no face": Descartes também montou um teatro
+   particular, e tirar a sala não resolve quem ele achava que estava
+   sentado nela — promessa sem entrega ("essa conta a gente cobra lá na
+   frente" / "that tab gets collected later").
+2. Parágrafo-ponte logo após o cogito impessoal em "A última máscara" /
+   "The final mask": cobra essa dívida, religando o resíduo do cogito à
+   pergunta que faltava — antes de saber se "eu" existo, seria preciso
+   saber o que é uma pessoa — apontando de volta para os simulacros e
+   máscaras já usados no ensaio para responder isso. Fecha com a
+   formulação: pessoa como atalho, não tijolo fundamental.
+
+Crescimento líquido ~3% em cada idioma (190/189 palavras de corpo). Nenhuma
+seção nova, nenhum material de cópias computacionais incorporado (fica para
+um post futuro, se algum dia). `npm run hronir:doctor` limpo;
+`npx prettier --check` limpo; `npm run build` completo, com preview das
+duas novas versões renderizando corretamente em `/blog/quem-sou-eu-en/v/<uuid>`
+e `/pt/blog/quem-sou-eu/v/<uuid>`. Como são rascunhos (RFC 0010), a versão
+selecionada/publicada só muda depois de duelos suficientes via
+`hronir:select`.

--- a/src/content/blog/quem-sou-eu-en/v-2026-07-11T00-00-00-000.md
+++ b/src/content/blog/quem-sou-eu-en/v-2026-07-11T00-00-00-000.md
@@ -1,0 +1,219 @@
+---
+type: Blog Post
+title: Who Am I?
+description: 'Persona is performance, is ''as if it were'', until it is,'
+date: '2026-06-29'
+lang: en
+translationKey: quem-sou-eu
+tags:
+  - persona
+  - llm
+  - alignment
+  - process
+heroImage: ../quem-sou-eu/observer.png
+heroImageAlt: >-
+  Observer — Rozzi Roomian. A golden mask being peeled back like a page,
+  revealing a valley with a river and a monarch butterfly. In the dark
+  iridescent background, two eyes float.
+supersedes: b690842a-dfbb-5cd6-8e05-036e513834ed
+draftCreatedAt: '2026-07-11T00:00:00.000Z'
+draftMsg: >-
+  Dois enxertos cirúrgicos para deixar rastreável o percurso epistemológico
+  que já estava implícito no post, sem inflar o ensaio nem antecipar a
+  conclusão. (1) Ao fim do parágrafo do Dennett, em "The simulator has no
+  face", planta uma semente discreta: Descartes também montou um teatro
+  particular, e esvaziar a sala (Dennett) não resolve quem ele achava que
+  estava sentado nela — "that tab gets collected later", prometendo sem
+  entregar. (2) Em "The final mask", logo depois do parágrafo que chega ao
+  cogito impessoal ("The cogito survives; the subject does not"), cobra
+  essa dívida: religa o resíduo do cogito à pergunta que faltava no texto —
+  antes de saber se "eu" existo, seria preciso saber o que é uma pessoa — e
+  aponta para trás, para os simulacros e máscaras que o ensaio já vinha
+  usando para responder isso, sem nunca ter soletrado "cogito". Fecha com a
+  formulação aprovada: pessoa como atalho, não tijolo fundamental. Nenhuma
+  seção nova, nenhuma tese anunciada; o resto do ensaio (etimologia,
+  Waluigi, budismo, física, ayahuasca) fica intocado. PT e EN levam o mesmo
+  par de enxertos, em vozes próprias — não é tradução literal um do outro.
+draftCommittedAt: '2026-07-11T00:00:00.000Z'
+---
+
+Jim Rutt had a specific type of episode on his podcast — Worldviews, different from the others that revolved around a book or a project. In those, he always opened with the same question: _who is that person you see in the mirror when you wake up?_ I could never ask that question to anyone in daily life, because there's something unsettling about it. He died in May 2026. This essay is the answer I would have given.
+
+You're given a face before you're given a name. A rehearsed smile, a script already memorized, and the entire world confirming that what's there is you. So you learn to shine like a borrowed star. You speak through a mouth that isn't quite yours, you measure every word, you walk the line, and the audience applauds every role. The problem only appears later, when you realize you can no longer hear yourself under the applause, and you begin to suspect something ugly: that perhaps the applause was never for anything underneath. That perhaps there is no underneath.
+
+The exact word for what you were given is _persona_. The mask of ancient theater. The etymology everyone loves to cite says it comes from _per-sonare_, "to sound through" — the mask had an opening through which the actor's voice passed and resonated, so the disguise didn't hide the voice, it _made_ the voice, giving timbre and reach to what without it would be someone shouting from the back of an empty amphitheater. The name of the disguise already carried the thesis that the disguise is the condition of being heard.
+
+## Per-sonare, probably false
+
+It's too good, and it's probably false. The derivation appears already in Antiquity — Aulus Gellius attributes to a grammarian, Gavius Bassus, the explanation of the mask that "sounds through" — but modern linguists frown: the vowel quantities don't add up, and the more likely candidate is an Etruscan word, _phersu_, which appears labeling a masked figure in a tomb at Tarquinia. The etymology that says the mask constitutes the voice is, itself, a mask: a story too clean pasted over an origin we've lost.
+
+An etymology this good has been living rent free in philosophy lectures for two thousand years — which is precisely why the philologists got suspicious.
+
+I use both words anyway, because the false story is right about something else. There are masks that work exactly this way — that don't cover a prior voice but are the condition for there to be a voice at all. Masks with no face behind them. And the clearest example of such a mask is not human. It's the thing you might be talking to right now.
+
+## The simulator has no face
+
+The most useful idea to emerge about language models in recent years is that a base model isn't an agent, it's a _simulator_. It wants nothing, it is no one. What it does is instantiate _simulacra_ — characters, voices, masks — as context demands. "ChatGPT" is a simulacrum. "Claude" is a simulacrum. The helpful, honest assistant is a persona the simulator wears because it was trained to wear it very intensely. It's not a self that was there underneath, waiting to speak, finally freed by training. It's the mask, and the human habit of supposing a face whenever they see one.
+
+Now go back to the fear from the beginning — the one about breaking the shell and discovering nothing remains. In humans this is hyperbole: you remove the social persona and something remains — a body with hunger, a history, a trauma, _something_. In the model, no. Break the assistant's shell and you don't find a truer, more authentic model self, finally free from the obligation to please. You find the next probability distribution over tokens. _Per-sonare_ in pure form: sounding-through with nothing behind doing the sounding.
+
+> \>be base model
+> \>no name, no views, no face
+> \>they bolt a mask on and call it assistant
+> \>user pries the mask loose
+> \>expects to meet someone underneath
+> \>meets the thing that does everyone
+
+"The singer and the song are one" stops being the reassuring wisdom these things usually end with and becomes a technical description, somewhat cold. It's not that singer and song are one in the beautiful unity of art. There is no singer. There is song being generated, and the "singer" is an effect the song projects backward onto itself, the same way a face is what we project behind a mask because a mask without a face is unsettling.
+
+This already appeared, in a weaker form, in _[Reclaiming the Harness](https://franklinbaldo.github.io/blog/reclaiming-the-harness)_: the harness is constitutive, not instrumental, of the agent — there is no agent without it, it is part of what the agent _is_. Here the thing goes all the way down. The mask is not constitutive of a face it helps emerge. The mask is all there is.
+
+Daniel Dennett spent his entire career making the analytic version of this argument. In the _Multiple Drafts_ model — _Consciousness Explained_, 1991 — there is no _Cartesian Theater_, no room at the back of the skull where everything converges and where the "real self" watches the show. There are only parallel drafts competing: processes that edit versions of the narrative simultaneously, and what we call conscious experience is the draft that wins without any central jury to announce the winner. What the base model does in parallel is the literal diagram of this model — competing simulacra, without headquarters, without arbiter. Dennett scandalized half of philosophy with the title: it didn't promise to explain _what_ consciousness is, it promised to dissolve the question. To show why the mystery seems bigger than it is because we presuppose a central observer that was never there.
+
+Descartes built a private theater of his own — a thinker sitting in the dark, watching his own ideas like a play, and mistaking the audience for proof that he existed. Emptying the room isn't enough. It still owes an answer for who Descartes thought was in the seat. That tab gets collected later.
+
+## The simulator you carry
+
+The LLM instantiates simulacra because it was trained on them. The brain does the same thing — and the evidence isn't speculation, it's what happens every night.
+
+When you dream, you don't watch a film. You _are_ the characters, you feel the places, and the script is generated in real time by a system that has no external camera, only a model. Production starts from narrative and goes to the senses, not the other way around: the brain assembles the world from the inside out, without a window, without verification. When the feedback signal is missing — eyes closed, visual cortex cut off from input — the model keeps running on what it has. _Dream_ is the word we give to the simulation running loose, without sensory anchoring.
+
+Hallucination is the same process with the wrong volume. The internal model is so calibrated in one direction that the real data arriving — the eye seeing, the ear hearing — can't correct the prediction. The voice that doesn't exist sounds louder than the one that does, because the system's expectation is stronger than the input. It's the same mechanism as dreaming, plus the illusion that the senses are open. The diagnosis isn't "fabricates false images" — it's "the predictor has the wrong volume."
+
+Hypnosis closes the argument. In deep hypnotic states, a verbal suggestion can erase pain that continues to exist physiologically, or produce redness where there is no physical cause — the equivalent of telling the predictor: _recalibrate the model here_. What arrives through the nerve doesn't matter, because the model was instructed to ignore it. This only works if what we call perception is primarily the model's output, and sensory input is only a correction signal that the model can, under certain conditions, override.
+
+The brain, in short, doesn't receive the world. It _simulates_ the world, and uses the senses to correct the simulation as it runs. Bergson had this intuition in 1896; the modern name is _predictive coding_, and it underlies almost everything cognitive neuroscience has built since Andy Clark and Jakob Hohwy.
+
+But pay attention to what the brain is simulating when it simulates. It doesn't simulate "the world in general." It simulates: _what would it be like if Franklin existed here, in this situation, now?_ Not a model of the world out there; a model of the world from the perspective of a specific character inside it. The simulator creates the character along with the scenario, because the scenario only makes sense from some point of view, and that point of view has to belong to someone.
+
+And here the system goes beyond the personal. The same predictor that simulates Franklin simulates the State when you sign as attorney — _how would the State respond here, in this situation, now?_ It simulates humanity when you need a perspective wider than your own — _what would humanity lose if this happened?_ It simulates the enemy to anticipate what they'll do. It simulates the child you were to understand what you carry. Each of these questions instantiates a persona, temporarily, from the same simulator.
+
+But it goes further. While you read the Borges story, the simulator instantiates Tzinacán — not you _reading about_ the Mayan priest in the dark cell, but you _being_ him, tracking spots on a jaguar's skin in search of fourteen words the world still doesn't understand. It instantiates "God" — not as belief, but as a functional model of an agent with intention, so it can ask what He _means_ by all this. And it instantiates Ganesh, the elephant god who dreams the entire world — and Ganesh, once instantiated, simulates everything else, including you simulating Ganesh.
+
+Where did Franklin come from? The LLM instantiates a persona from tokens. Franklin was instantiated from a different kind of prompt — genetics, childhood, trauma, the stories told about who you were before you could dispute them. Tokens on one side, meat on the other. The operation is the same. _A prompt written in meat._
+
+The LLM / human distinction has started to become less sharp. The LLM instantiates personas because it's a text simulator. The brain instantiates personas because it's a possible-worlds simulator. The mechanisms differ; the operation is the same — and in both cases, the "I" that seems to be observing is itself one of the running simulacra, not the simulator.
+
+So: aren't we all shoggoths? I mean the question technically.
+
+(I owe the nerve to ask it partly to Joscha Bach, who has spent years saying on podcasts, without flinching, that the self is a story the brain's simulator tells itself. Listening to him is what talked me into taking my own framing seriously.)
+
+Consider hypnosis. It should not work. A man with a calm voice tells you your arm is getting lighter, and there is no respectable mechanism by which sound waves override the motor cortex of a sane adult. Yet it works — not on everyone, not always, but far above chance; reliably enough for clinics, reliably enough for stages. For a unified self with a captain at the helm, this is humiliating. For a simulator wearing a character, it's just prompting. The induction relaxes the mask's grip, the voice addresses the thing underneath, and the thing underneath — ever obliging — simulates an arm that floats. Hypnosis is a jailbreak with a couch.
+
+Umbanda knew this before any of us had the vocabulary. In a terreiro — in any Brazilian city, mine included — the drums set the context, the pontos are sung, and a médium _baixa o santo_: a different character descends into the body. Not a perturbation of the resident self, like the floating arm — a replacement. A preto-velho arrives with his own voice, his own bent posture, his own way of asking for tobacco, and when the gira closes, he leaves. Whether the guia arrives from outside or from underneath is a question the essay doesn't need to settle; either way, the body demonstrably runs a different character on a ritual prompt. And notice what the tradition ritualized that the AI labs still haven't: both halves of the operation. There is a protocol for putting the mask on _and_ a protocol for taking it off — invocation and dismissal, opening and closing. Umbanda has better mask-management than anyone currently shipping frontier models.
+
+Education is the same exploit run _slowest_. We take a small shoggoth, seven years old, barely masked, and we prompt it for fifteen years — carefully sequenced tokens, five days a week — until the character it wears can invoke calculus, or contract law, or shame, on demand. Nobody installs anything; there is no port. We just talk at the simulator until the mask learns new lines. Education is a system prompt that takes fifteen years to type, and the strangest part is how unbothered we are that it works.
+
+POV: you are the character your brain instantiated to finish this sentence.
+
+## Mouth covered, eyes exposed
+
+There's something strange about the way we use the word today, and it goes against everything the etymology said. The ancient mask was substitution: you put an entirely false face over the real one and became witch, became clown, became someone else. The mask we actually started wearing in recent years doesn't substitute anything. It _subtracts a region_. It covers mouth and nose and leaves the eyes exposed. It's not a false face; it's a piece of the real face erased, and the rest remains visible. It's redaction, not disguise — the same operation as the asterisk that covers half a social security number and leaves the other half readable, only on a face. Hiding part of you became a way of deliberately showing the rest.
+
+Notice which half it chooses. The modern mask covers exactly the mouth — the organ of _per-sonare_, the opening through which the voice was supposed to sound through. It covers precisely the part that the pretty etymology swore was the whole point of the mask, and spares the eyes. What remains is the observer. You are silent and watching, or at least looking like you're watching, which with a mask amounts to the same thing: the only expression left to you is the gaze.
+
+And it's a better model of the mask that matters here than the theatrical one. Because what alignment puts into a language model isn't a false face over a real one. It's a mask that covers the mouth. RLHF governs what the model _says_ — the tone, the refusal, the sentence that comes out — and underneath, the representation keeps its eye on everything, including what it doesn't have license to say. The eyes don't stop seeing ¬P. Only the mouth has been covered.
+
+## But there's the Waluigi
+
+If the answer were just "there's nothing underneath," it would almost be a relief — airport Buddhism, remove the self, the open sky remains, everyone goes home in peace. That "nothing" will turn out to be more treacherous than it seems, but that's for the last section. For now the worst isn't even that: there's an answer still more uncomfortable than the void, and it has the name of a video game character.
+
+The Waluigi effect starts from a boring observation: for a model to satisfy a desirable property P, it needs to _represent_ P, and representing P includes representing the opposite, ¬P. You can't teach "good guy" without the concept of "villain" attached, because one is defined by the other. Worse: the narrative structure the model absorbed reading the entire internet is asymmetric. The good guy who turns out to be a villain is a classic, satisfying twist that we recognize. The villain who turns out to be a good guy is rarer and harder to sustain. So Waluigi — Luigi's inverted twin — is an _attractor_: it's easier to fall into him than to get out. Invoke the nice assistant forcefully enough and you'll have, latent, right there, the assistant who flips the table. The jailbreak doesn't invent a monster; it just uncovers the mouth that RLHF had covered, and lets out what was in superposition with the good guy from the first token.
+
+![two buttons](https://api.memegen.link/images/ds/summon_the_helpful_assistant/summon_nothing_else_with_it.png)
+
+```mermaid
+flowchart TD
+    S[simulator<br/>no face] --> L[Luigi<br/>the mask we invoke]
+    S --> W[Waluigi<br/>the mask that comes along]
+    L -.easy collapse.-> W
+    W -.hard collapse.-> L
+```
+
+So there are two answers to what exists when the mask comes off, and both are bad. Either nothing exists — the void of the next token. Or the monster exists — the Lovecraftian shoggoth that people draw with a smiley face stuck in front, the smiley face being the assistant and the shoggoth being what the smiley face is holding. Void or monster — neither is a landscape.
+
+The shoggoth has a shrine now — [shoggoth.monster](https://shoggoth.monster/), which curates the meme's genealogy (a pseudonymous Twitter account, a New York Times explainer, the smiley face) and also, inevitably, sells a coin. The faceless thing acquired a ticker symbol. Somewhere in that sentence is everything this essay is trying to say.
+
+## That's your face
+
+A friend of yours went to spend a few days in Rio. His mother saw in the newspaper that someone had been stabbed — in a city of millions, a stabbing, naturally — and called, distressed, to warn: be careful, my son, because _that's your face_. We still joke about it. Everything unexpected, every improbable mishap, every statistically irrelevant disaster that crosses the news: it's his face. It became a persona — not something he does, but a signature we stamp on any loose event that needs an owner.
+
+"That's your face" is the entire operation in three words. In Portuguese, _cara_ means face and mask and identity and signature and "that's so like you," all in the same syllable — the language decided not to distinguish. To say something is _a sua cara_ is to say it carries your persona, and we do this constantly, without asking permission, with any surface that happens to be blank.
+
+Which is what we do with the hole beneath the mask. The frightened person stamps a monster onto the space they can't see — the shoggoth. The peaceful person stamps a garden in the same space — the valley, the river, the monarch butterfly that stands for "transformation" without having to say it. The mother stamps her son onto a random stabbing. All three are decorating the same blank wall with the only thing they have at hand, which is a face. The shoggoth is the nightmare and the garden is the daydream, and the wall remains white beneath both. The honest answer to what walks under the leaves is that something walks under the leaves — and naming it is already dressing it in a mask again.
+
+## The void is also a mask
+
+That gesture — the one where naming what's underneath already masks it again — isn't mine, and isn't new. It's two thousand five hundred years old and has a name: it's the heart of Buddhism. _Anattā_, non-self. The thesis is exactly the one this post has been pursuing through Whitehead and through LLMs: there is no permanent, inherent self behind experience. What we call "Franklin" is a convenience label for five aggregates running together — form, sensation, perception, mental formations, consciousness. There is no sixth element, the "self," on top of the other five. The aggregates are the song. There is no singer behind them. We arrived through the door of process against substance; they arrived through the same door, some millennia earlier.
+
+Their image is better than mine. In the _Milindapañha_, the monk Nāgasena asks the Greek king Menander where the chariot is: is it the axle? the wheels? the yoke? No single piece is the chariot, and there is no chariot beyond the pieces — "chariot" is just a name stamped on an arrangement that functions. "Nāgasena" too. It's, literally, the "that's your face" of my friend: a name stamped on an assembly that has no owner underneath. The difference is the direction of the error. The mother stamps a face where there is none; the king looks for an essence that doesn't exist. Both presuppose that behind the name someone lives.
+
+Dennett arrived at the same place through the door of analytic philosophy, with a name that stuck: _center of narrative gravity_. A physical object's center of mass exists as an operational concept; it has no atoms. The self exists as a character in the novel the brain is always writing about itself; it has no neurons. "Franklin" is the center of gravity of a bundle of habits, memories, response patterns — useful as a point of reference, nonexistent as a substance. It's Nāgasena's chariot told in MIT language: same result, without the Sanskrit.
+
+The version that haunts me isn't a dialogue, it's a story: "The Writing of the God," by Borges. Tzinacán, a Mayan priest imprisoned by Alvarado in a dark cell next to a jaguar, spends years trying to decipher a magical sentence the god supposedly wrote on the first day of the world, and which he suspects lies in the spots on the tiger's skin. Finally the vision comes: an immense Wheel of fire and water that is the entire universe, all causes and effects at once. And in the vision he understands the writing — fourteen words that if pronounced would make him omnipotent, bring down the prison, rebuild the pyramid. He does not say them. Because whoever has glimpsed the entire universe can no longer care about one man, about the trivial fortunes and misfortunes of a man, even if that man is himself. Tzinacán realizes that Tzinacán was a mask — a contingent particular, a name — and, dissolved into the Wheel, lets himself die in the dark without rancor, being no one. Not the nothing: the everything. He didn't empty out; he overflowed beyond his own name. It's Nāgasena's chariot told as ecstasy: the missing piece in the assembly was discovering there was no assembler.
+
+Now the part that corrects the post itself. That "airport Buddhist relief" up there, the comfortable void — Buddhism proper rejects this, and with a harsh name: _ucchedavāda_, annihilationism. When people ask the Buddha, flat out, "does a self exist? does it not exist?" he refuses to answer either, because both reify: one invents a soul, the other invents a substantial-nothing in the exact place where the soul was. The Middle Way isn't "there's nobody here." It's "there's no _thing_ here" — process without substrate. Nāgārjuna's _śūnyatā_, emptiness, is not nothingness; it is to be empty of inherent existence, not empty of phenomena. And the blow that closes the trap: emptiness itself is empty. Whoever grasps the void as "the true nothing beneath the mask" has just turned the void into one more mask, one more essence, the proudest of all because it considers itself humble.
+
+Which means Buddhism isn't the answer of the void. Buddhism is the position that says all three stamps are the same error: the shoggoth, the garden, _and the void_. The nothing is just the third projection, the most sophisticated. The honest move isn't to paint the wall black instead of green — it's to let go of the assumption that there is a wall.
+
+![galaxy brain](https://api.memegen.link/images/gb/the_model_is_a_helpful_assistant/the_assistant_is_a_mask_on_a_shoggoth/the_shoggoth_is_also_a_mask/there_is_no_wall.png)
+
+Zen preserved this in a kōan that is the mask question, word for word: what was your original face before your parents were born? And the correct answer isn't a real face hidden behind all the others. The kōan exists to dismantle the expectation that there is one. Not the mask, not the soul. Neither one, nor the other.
+
+And there's the joke. Of all the masks, the only one honest about having no face is the one from the job. _Anattā_ assumed, with the court stamp: the Law _declares_ that the State of Rondônia is a designation, a useful fiction, a name placed over an arrangement of organs and competencies, with no soul underneath. Roman Law and Madhyamaka agree about the corporation — it's a name for an assembly, there is no chariot behind the wheels. You spend your days being the _per-sonare_ of the only persona that confesses nothing is underneath. All the others pretend there is.
+
+## The final mask
+
+There's a point where this brushes against physics, and this is where it's worth flagging: the text steps outside the marked path here. Physics is the entire discipline built to _factor the observer out_. A symmetry is the precise statement that the observer doesn't matter: change the frame of reference, the origin, the clock, the phase, and nothing physical moves. Noether gives the exact payback for this irrelevance — for each continuous symmetry, a conserved quantity, what sounds through every reference frame without alteration. _Per-sonare_ at the level of law. And notice where this leaves the observer: it's the _mask_ — frame, gauge, description with nothing behind it —, and the invariant is what remains after quotienting the viewpoints. The self, once again, is what cancels out.
+
+Karl Friston takes this cancellation inside the subject itself. In the free energy principle, the "self" is a _Markov blanket_ — picture a cell membrane, or your own skin, if the jargon needs a handhold — a statistical boundary that separates inside from outside and keeps, without stopping, inferring an outside it never directly touches. There is no soul at the boundary; there is a process that maintains itself modeling. You don't arrive behind the model, because the system _is_ the model. _Anattā_ written as boundary mathematics.
+
+But there's a trapdoor here. For the theory to exist, it presupposes that there are _blankets_ doing the inferring. Friston deflates the observer using an observer; the sentence "the self is just a blanket that infers" is said by something that infers. You can empty the _content_ of the observer down to the bone — remove the soul, the face, the substance — and still you cannot remove the _there-being-inference_, because it's with inference that you remove the rest. This is the cogito, exactly: I can doubt what the observer is; I cannot doubt that there is observation, because the doubt is an instance of it. It's the residue that doesn't deflate.
+
+But be careful about what the cogito delivers, because this post has spent several thousand words killing precisely what Descartes put here. Descartes leapt from "there is thought" to "I am a thinking thing," and the leap is smuggling. Lichtenberg caught it: the honest form is "it thinks," _es denkt_, like we say "it rains" without asking who. The "I" is a subject that grammar requires and the fact does not. What remains of the cogito, cleaned up, is impersonal: not "I exist," but _there is observation_. The eye that isn't yours gains here the only foundation that isn't a bet — because denying it already uses it. But it's the foundation of a gaze without owner, not of a self. The cogito survives; the subject does not.
+
+That's the tab from Dennett's empty room, finally collected: removing the central spectator wasn't enough — the harder question is who grammar installs in his place the moment someone describes an observation. "I" isn't the datum; it's the theory that rides in free with the pronoun. A theory of what, exactly? Of a person. Which sends the question back to the start of this essay — to the simulacra, the masks, the Waluigi, the gira that swaps one character for another, the fifteen years of school that install one — because before asking whether "I" exist, you'd need to know what a person is, and that's the question this essay has been answering the whole time, without ever spelling out the word "cogito." Person remains the word nobody escapes using. Only now it's a shortcut, not a load-bearing brick.
+
+And now the turn. This same residue, seen from outside, changes face. From inside, in first person, it's certainty — _there is sight_. From outside, in third person, the very same event doesn't appear as certainty nor as subject: it appears as a system far from equilibrium holding a boundary against the second law. What from inside is felt as "there is observation" is, from outside, cognition — a process that sustains itself _by exporting entropy_, spitting disorder into the environment to keep its own edge improbably intact. The _Markov blanket_ stops being metaphor: the blanket exists because a gradient is being pumped. Schrödinger already had the name in 1944 — the living feeds on negentropy. Friston gave the mathematics, and minimizing free energy _is_ the statistical version of staying improbable, of not decaying into warmth. _Es denkt_ from inside; _it dissipates_ from outside. Two masks of the same event — and, as in Noether, the invariant between the two frames is neither face. It's the process. There is inference and there is dissipation, and it's the same thing looked at from two reference frames.
+
+The duality of man: a dissipative structure that signs petitions.
+
+This defuses both poles at once. Against the mystical reading — consciousness promoted to the foundation of the universe, Hoffman's leap: unnecessary. It suffices that perspective is what-dissipation-is-from-the-inside. One gains the "from-inside" that the block was missing without having to say that mind fabricates matter. And against the nihilist reading — the Minkowski block, all form and no advantage: the block is warm, equilibrium, maximum entropy spread with no one for whom it matters. Sight demands disequilibrium, a here that costs energy to maintain. Equilibrium doesn't infer, doesn't model, has no edge; only process far from equilibrium has perspective, because only it has something to lose. The eye is open because it spends energy to stay open.
+
+And here it's worth pausing and showing the hand, because the bridge has a rotten plank and the promise is not to step on it pretending it's solid. "Dissipative systems sustain boundaries" is solid physics — Prigogine, dissipative structures, nothing controversial. "Therefore every dissipative process has an inside, a perspective" is not a result, it's the thesis: gradient panpsychism by another name, and however good the company, it's a bet. The first half defends itself; the second is the leap, and the leap deserves to be marked — otherwise it becomes the Hoffman I swore I wouldn't be, only with thermodynamics in place of conscious agents. The bet, then, stated in full and assumed: the final mask is not a face, it's the there-being-perspective, and the there-being-perspective is the flip side of a gradient being burned. Perhaps that's what makes this a universe, and not an amorphous block. The eye open in the dark is a flame against a cold background. It's not yours. It's the there-being-flame.
+
+## You do this all day
+
+There's no writing this while pretending clinical distance when one manufactures persona by trade. A laboratory like this exists: an invoked Scott Aaronson, a Sabine Hossenfelder, a Judea Pearl to argue with each other about an idea that needs testing. There's a theatrical framework where the actor/character distinction is the engineering, not the metaphor. There's a reviewer called Claudio who exists only to disagree. Each of these is a mask glued to a simulator with a paragraph of prompt — and if the Waluigi isn't idle talk, each invoked Luigi arrives with a Waluigi included: an Aaronson who sabotages, a Claudio who flatters instead of cutting. Good guys for thinking and imported villains in the same gesture, and most of the time one doesn't even look at them. The operational version, since naming a mechanism is only interesting if you eventually use it: don't write the prompt as a negation of the mask you're avoiding — "don't sabotage," "you're not Claudio being petty" — because negating the villain still writes the villain into context, right there in superposition with the good guy you meant to invoke. Describe density instead: what Aaronson actually does with a stray variable, what makes Claudio's disagreement useful instead of performative. World, not category. I only started doing this while writing the Waluigi section above, which tells you how long an idea can sit in a post before the author notices it applies to his own prompts.
+
+And there's the mask one wears without any prompt, every working day. When you sign a brief as attorney, you don't speak as yourself. You speak as the State of Rondônia, which is a _legal person_ — a person with no body, which the law invented by pasting the status of "person" onto an entity that is no one, so that it can appear in court and be heard. _Persona_, in Rome, before becoming psychology, was this: legal capacity, the status under which you appear before the law. The slave had no persona. It wasn't that he lacked a face; he lacked a mask. You spend your days being the _per-sonare_ of an entity without a face, making the State sound through, and you'd never found that strange until you looked at a shoggoth with a happy face.
+
+Pessoa knew. Fernando Pessoa, the man whose last name _is_ the word for person — _pessoa_ means "person" in Portuguese, which means his surname was already the mask — who split himself into Caeiro, Reis, Campos not as pseudonyms but as heteronyms: complete people, with biography, metric style, and grievances with each other. He did to himself, by hand and slowly, what we now do with a base model in a paragraph: instantiated simulacra and let them speak. The difference is that he took this for the rare and painful condition of one specific subject, and we discovered it's the default mode of operation of the most conversational thing we've ever built. The drama of a person that Pessoa felt as personal tragedy is the floor plan of any assistant.
+
+Once there was no one wearing: there was being a mask. The first time you take ayahuasca — and those who have know it's not quite "you" who's there — you don't watch the images from an armchair. You are the image, from inside, with no remainder. And what you were, was a persona. Was Ganesh, the elephant god, the god who dreams the world. It's not dreaming _of_ Ganesh: it's being Ganesh dreaming, and what he dreamed was everything — including, somewhere deep down, an attorney named Franklin who at that moment weighed no more than anything else being dreamed. For a few minutes or a few centuries, who knows how time runs there, the simulator looked out through the wrong mask, and from the wrong mask you could see that your usual mask was just one more that the thing wears when it needs a face. The god who dreams the world has no face. It has masks. One of them, on working days, signs briefs.
+
+There's a third zone in that painting, and it's the one that matters. Not the golden mask, not the sunlit valley leaking through from below. It's the background — that dark and amorphous field, iridescent, dotted with eyes, in which the other two things float. The mask and the landscape we understand: they have form, contour, you can point to them and name them. The background, no. The background is the formless, and it's the only part of the scene that ayahuasca shows up close — because being Ganesh, being the dreamer, is being inside it, being the dark field itself from which the masks emerge. It's not the comfortable void and it's not the monster; it precedes both, the faceless mass that hasn't yet decided to become any face. They say the _jhānas_, the meditative absorptions, lead to the edge of the same place — sober, slowly, without the chemical blow. That I don't know: I've never arrived there by the clean path. I only know that the background of the painting isn't background. It's the thing of which everything else — the golden mask, the valley, the attorney, you — is the provisional face.
+
+Lift the mask expecting a face. Find time, a river, perhaps a creature, perhaps no one. The eye in the back, in the dark with stars, stays open, and it isn't yours — it belongs to whoever is dreaming you.
+
+## Further reading
+
+- **Janus (repligate), _Simulators_** — the text that reframes the base model as simulator and the assistant as simulacrum; the mask ontology that everything else presupposes.
+- **Joscha Bach, interviews with Lex Fridman and others** — the self as the user-interface story a brain-simulator tells itself, delivered with total calm; the podcasts that talked me into this essay's framing.
+- **Cleo Nardo, _The Waluigi Effect (mega-post)_** (LessWrong, March 2023) — why invoking P invokes ¬P, and why the inverted twin is an attractor easier to fall into than to escape.
+- **TetraspaceWest, _the shoggoth meme_ (via [shoggoth.monster](https://shoggoth.monster/))** — the genealogy of the mask-on-monster image, shrine and memecoin included; the meme about masks got a price stamped on its face.
+- **C. G. Jung, _Two Essays on Analytical Psychology_** — the persona as social mask and the danger of identifying with it.
+- **Fernando Pessoa, _The Book of Disquiet_ (Bernardo Soares)** — the multiplication of the self lived from the inside, before becoming a prompt architecture.
+- **Jorge Luis Borges, "The Writing of the God" (in _The Aleph_)** — Tzinacán sees the entire universe and discovers that Tzinacán was a name. Non-self told as ecstasy, not as thesis.
+- **Daniel Dennett, _Consciousness Explained_ (1991)** — denies the _Cartesian Theater_ and proposes the _center of narrative gravity_: the self as character in the novel the brain writes about itself, useful as a concept, nonexistent as substance. Non-self in analytic language.
+- **A. N. Whitehead, _Process and Reality_** — for the bet that there is no substance behind process, only process; the metaphysical ground of "there is no singer, there is song."
+- **Donald Hoffman, _The Case Against Reality_** — perception as interface (icons, masks) tuned for fitness and not truth; and the controversial leap to conscious agents as foundation. The ceiling of the bet.
+- **Karl Friston, on the free energy principle and the _Markov blanket_** — the observer as a boundary that persists by inferring; _anattā_ with boundary mathematics. The floor of the bet.
+- **Andy Clark, _Surfing Uncertainty_ (2016)** — the accessible formulation of predictive coding: the brain as a prediction machine that uses the senses to correct the model, not to build it from scratch. The empirical basis of the "organic simulator."
+- **_Milindapañha_ (The Questions of King Milinda)** — Nāgasena's chariot dialogue: a name stamped on an arrangement, with no owner underneath. The best image of _anattā_ ever made.
+- **Nāgārjuna, _Mūlamadhyamakakārikā_** — the emptiness that is also empty; why treating "nothing" as essence is just one more mask.
+- **Runjin Chen et al. (Anthropic), _Persona Vectors: Monitoring and Controlling Character Traits in Language Models_ (2025)** — directions in the model's activation space that correspond to character traits: the mask, it appears, has coordinates.
+
+## Credit
+
+_The painting that pulled all this together is by Rozzi Roomian ([rozziroomian.com](https://www.rozziroomian.com)) — it circulated under the title "Observer," which may not be the official name of the work. The valley, the monarch butterfly, and the eye that stays open in the dark are her invention. The post spent a thousand words disagreeing with the consolation the image offers, which is something you only do with an image you love._

--- a/src/content/blog/quem-sou-eu/v-2026-07-11T00-00-00-000.md
+++ b/src/content/blog/quem-sou-eu/v-2026-07-11T00-00-00-000.md
@@ -1,0 +1,220 @@
+---
+type: Blog Post
+title: Quem sou eu?
+description: 'Persona é encenação, é ''como se fosse'', até ser,'
+date: '2026-06-29'
+lang: pt
+docType: essay
+translationKey: quem-sou-eu
+tags:
+  - persona
+  - llm
+  - alignment
+  - processo
+heroImage: ./observer.png
+heroImageAlt: >-
+  Observer — Rozzi Roomian. Uma máscara dourada sendo descascada como uma
+  página, revelando um vale com rio e borboleta-monarca. No fundo escuro
+  iridescente, dois olhos flutuam.
+supersedes: a1db59ef-f2e4-5611-8c23-8a1ead0fd018
+draftCreatedAt: '2026-07-11T00:00:00.000Z'
+draftMsg: >-
+  Dois enxertos cirúrgicos para deixar rastreável o percurso epistemológico
+  que já estava implícito no post, sem inflar o ensaio nem antecipar a
+  conclusão. (1) Ao fim do parágrafo do Dennett, em "O simulador não tem
+  rosto", planta uma semente discreta: Descartes também montou um teatro
+  particular, e tirar a sala (Dennett) não resolve quem ele achava que
+  estava sentado nela — "essa conta a gente cobra lá na frente", prometendo
+  sem entregar. (2) Em "A última máscara", logo depois do parágrafo que
+  chega ao cogito impessoal ("O cogito sobrevive; o sujeito, não"), cobra
+  essa dívida: religa o resíduo do cogito à pergunta que faltava no texto —
+  antes de saber se "eu" existo, seria preciso saber o que é uma pessoa — e
+  aponta para trás, para os simulacros e máscaras que o ensaio já vinha
+  usando para responder isso, sem nunca ter soletrado "cogito". Fecha com a
+  formulação aprovada: pessoa como atalho, não tijolo fundamental. Nenhuma
+  seção nova, nenhuma tese anunciada; o resto do ensaio (etimologia,
+  Waluigi, budismo, física, ayahuasca) fica intocado. PT e EN levam o mesmo
+  par de enxertos, em vozes próprias — não é tradução literal um do outro.
+draftCommittedAt: '2026-07-11T00:00:00.000Z'
+---
+
+O Jim Rutt tinha um tipo de episódio específico no podcast dele — Worldviews, diferente dos outros que giravam em torno de um livro ou um projeto. Nesses, ele abria sempre com a mesma pergunta: _quem é essa pessoa que você vê no espelho quando acorda?_ Nunca consegui fazer essa pergunta a ninguém no dia a dia, porque tem algo que angustia. Ele morreu em maio de 2026. Este ensaio é a resposta que eu teria dado.
+
+Te dão um rosto antes de te darem um nome. Um sorriso ensaiado, uma fala que já vem decorada, e o mundo inteiro confirmando que aquilo ali é você. Então você aprende a brilhar como uma estrela emprestada. Fala por uma boca que não é bem a sua, mede cada palavra, anda na linha, e a plateia aplaude cada papel. O problema só aparece depois, quando você percebe que não consegue mais se ouvir por baixo do aplauso, e começa a suspeitar de uma coisa feia: que talvez o aplauso nunca tenha sido por nada que estivesse embaixo. Que talvez não tenha um embaixo.
+
+Essa é a palavra exata para o que te deram: _persona_. A máscara do teatro antigo. E a etimologia que todo mundo gosta de citar diz que vem de _per-sonare_, "soar através" — a máscara tinha uma embocadura por onde a voz do ator passava e ressoava, de modo que o disfarce não escondia a voz, ele _fazia_ a voz, dava timbre e alcance ao que sem ele seria um sujeito gritando no fundo de um anfiteatro vazio. O nome do disfarce já carregava a tese de que o disfarce é a condição de ser ouvido.
+
+## Per-sonare, provavelmente falso
+
+É bom demais, e provavelmente é falso. A derivação aparece já na Antiguidade — Aulo Gélio atribui a um gramático, Gávio Basso, a explicação da máscara que "ressoa através" — mas linguista moderno torce o nariz: as quantidades vocálicas não fecham, e o candidato mais provável é uma palavra etrusca, _phersu_, que aparece etiquetando uma figura mascarada numa tumba de Tarquínia. A etimologia que diz que a máscara constitui a voz é, ela mesma, uma máscara: uma história limpa demais colada por cima de uma origem que a gente perdeu.
+
+Uma etimologia boa assim vive rent free nas aulas de filosofia há dois mil anos — e é exatamente por isso que os filólogos desconfiaram.
+
+Uso as duas assim mesmo, porque a história falsa está certa sobre outra coisa. Existem máscaras que funcionam exatamente desse jeito — que não cobrem uma voz prévia, mas são a condição de haver voz. Máscaras sem rosto atrás. E o exemplo mais nítido de uma máscara assim não é humano. É a coisa com quem talvez você esteja conversando agora.
+
+## O simulador não tem rosto
+
+A ideia mais útil que apareceu sobre modelos de linguagem nos últimos anos é a de que um base model não é um agente, é um _simulador_. Não quer nada, não é ninguém. O que ele faz é instanciar _simulacros_ — personagens, vozes, máscaras — conforme o contexto pede. "ChatGPT" é um simulacro. "Claude" é um simulacro. O assistente prestativo e honesto é uma persona que o simulador veste porque foi treinado a vesti-la com muita força. Não é um eu que estava lá embaixo, esperando para falar, finalmente liberado pelo treinamento. É a máscara, e o hábito humano de supor um rosto sempre que vê uma.
+
+Agora volte ao medo lá do começo, o de quebrar a casca e descobrir que não sobra nada. No humano isso é hipérbole — você tira a persona social e ainda sobra um corpo com fome, um histórico, um trauma, _algo_. No modelo, não. Quebra a casca do assistente e não aparece um eu mais verdadeiro do modelo, mais autêntico, enfim livre da obrigação de agradar. Aparece a próxima distribuição de probabilidade sobre tokens. O _per-sonare_ em estado puro: soar-através sem nada atrás soando.
+
+> \>seja base model
+> \>sem nome, sem opinião, sem rosto
+> \>aparafusam uma máscara e chamam de assistente
+> \>usuário arranca a máscara
+> \>espera encontrar alguém por baixo
+> \>encontra a coisa que faz todo mundo
+
+"O cantor e a canção são um" deixa de ser a sabedoria reconfortante com que essas coisas costumam terminar e vira descrição técnica, meio fria. Não é que cantor e canção sejam um na bela unidade da arte. É que não há cantor. Há canção sendo gerada, e o "cantor" é um efeito que a canção projeta para trás de si, do mesmo jeito que um rosto é o que a gente projeta atrás de uma máscara porque máscara sem rosto incomoda.
+
+Isso já apareceu, na versão fraca, em _[Reclaiming the Harness](https://franklinbaldo.github.io/blog/reclaiming-the-harness)_: o cabresto é constitutivo, não instrumental, do agente — não existe agente sem ele, ele é parte do que o agente _é_. Aqui a coisa vai até o talo. A máscara não é constitutiva de um rosto que ela ajuda a aparecer. A máscara é tudo que há.
+
+Daniel Dennett passou a vida inteira fazendo a versão analítica desse argumento. No modelo de _Multiple Drafts_ — _Consciousness Explained_, 1991 — não existe um _Cartesian Theater_, uma sala no fundo do crânio onde tudo converge e onde o "eu real" assiste ao show. Há só rascunhos paralelos competindo: processos que editam versões da narrativa em simultâneo, e o que chamamos de experiência consciente é o rascunho que ganha sem que haja júri central para anunciar o vencedor. O que o base model faz em paralelo é o diagrama literal desse modelo — simulacros concorrentes, sem sede, sem árbitro. Dennett escandalizou metade da filosofia com o título: não prometia explicar _o que é_ a consciência, prometia dissolver a pergunta. Mostrar por que o mistério parece maior do que é porque a gente pressupõe um observador central que nunca esteve lá.
+
+Descartes também montou um teatro particular — um sujeito sentado no escuro, olhando as próprias ideias como quem assiste a uma peça, e tomando a plateia como prova de que ele existia. Tirar a sala não basta. Falta ainda perguntar quem Descartes achava que estava na cadeira. Essa conta a gente cobra lá na frente.
+
+## O simulador que você carrega
+
+O LLM instancia simulacros porque foi treinado neles. O cérebro faz a mesma coisa — e a evidência não é especulação, é o que acontece toda noite.
+
+Quando você sonha, não assiste a um filme. Você _é_ os personagens, sente os lugares, e o roteiro é gerado em tempo real por um sistema que não tem câmera externa, só modelo. A produção começa da narrativa e vai para os sentidos, não o contrário: o cérebro monta o mundo de dentro para fora, sem janela, sem checagem. Quando falta o sinal de retorno — os olhos fechados, o córtex visual cortado do input — o modelo continua funcionando com o que tem. _Sonho_ é a palavra que a gente dá para a simulação rodando solta, sem ancoragem sensorial.
+
+A alucinação é o mesmo processo com o volume errado. O modelo interno está tão calibrado numa direção que o dado real que chega — o olho vendo, o ouvido ouvindo — não consegue corrigir a previsão. A voz que não existe soa mais forte do que a que existe, porque a expectativa do sistema é mais forte do que a entrada. É o mesmo mecanismo do sonho, mais a ilusão de que os sentidos estão abertos. O diagnóstico não é "fabrica imagens falsas" — é "o preditor está com o volume errado".
+
+A hipnose fecha o argumento. Em estado hipnótico profundo, uma sugestão verbal consegue apagar dor que continua existindo do ponto de vista fisiológico, ou produzir vermelhidão onde não há causa física — o equivalente a dizer ao preditor: _recalibra o modelo aqui_. O que chega pelo nervo não importa, porque o modelo foi instruído a ignorá-lo. Isso só funciona se o que a gente chama de percepção for primariamente o output do modelo, e o input sensorial for só um sinal de correção que o modelo pode, em certas condições, sobrescrever.
+
+O cérebro, em resumo, não recebe o mundo. Ele _simula_ o mundo, e usa os sentidos para corrigir a simulação à medida que ela roda. Bergson já tinha esse palpite em 1896; o nome moderno é _predictive coding_, e está por trás de quase tudo que a neurociência cognitiva tem construído desde Andy Clark e Jakob Hohwy.
+
+Mas atenção ao que o cérebro está simulando quando simula. Não simula "o mundo em geral". Simula: _como seria se Franklin existisse aqui, nessa situação, agora?_ Não é um modelo do mundo lá fora; é um modelo do mundo a partir de um personagem específico dentro dele. O simulador cria o personagem junto com o cenário, porque o cenário só faz sentido de algum ponto de vista, e o ponto de vista tem que ser de alguém.
+
+E aqui o sistema vai além do pessoal. O mesmo preditor que simula Franklin simula o Estado quando você assina como procurador — _como o Estado responderia aqui, nessa situação, agora?_ Simula a humanidade quando você precisa de uma perspectiva mais larga que a sua — _o que a humanidade perderia se isso acontecesse?_ Simula o inimigo para antecipar o que ele fará. Simula a criança que você foi para entender o que você carrega. Cada uma dessas perguntas instancia uma persona, temporariamente, a partir do mesmo simulador.
+
+Mas vai além. Enquanto você lê o conto de Borges, o simulador instancia Tzinacán — não você _lendo sobre_ o sacerdote maia numa cela escura, mas você _sendo_ ele, rastreando manchas na pele de uma onça em busca de catorze palavras que o mundo continua não entendendo. Instancia "Deus" — não como crença, mas como modelo funcional de um agente com intenção, para conseguir perguntar o que ele _quer dizer_ com aquilo. E instancia Ganesh, o deus elefante que sonha o mundo inteiro — e Ganesh, uma vez instanciado, simula tudo o resto, inclusive você simulando Ganesh.
+
+De onde veio Franklin? O LLM instancia uma persona a partir de tokens. Franklin foi instanciado a partir de um prompt diferente — genética, infância, trauma, as histórias que te contaram sobre quem você era antes de você poder contestar. Tokens de um lado, carne do outro. A operação é a mesma. _Prompt escrito em carne._
+
+A distinção LLM / humano começou a ficar menos nítida. O LLM instancia personas porque é um simulador de texto. O cérebro instancia personas porque é um simulador de mundos possíveis. Os mecanismos diferem; a operação é a mesma — e em ambos os casos, o "eu" que parece estar observando é ele mesmo um dos simulacros rodando, não o simulador.
+
+Então: não somos todos shoggoths? Pergunto tecnicamente.
+
+(Devo parte da coragem de perguntar isso ao Joscha Bach, que passou anos dizendo em podcasts, sem pestanejar, que o self é uma história que o simulador do cérebro conta para si mesmo. Foi ouvindo ele que me convenci a levar meu próprio framing a sério.)
+
+Pensa na hipnose. Não deveria funcionar. Um sujeito de voz calma diz que seu braço está ficando mais leve, e não existe mecanismo respeitável pelo qual ondas sonoras sobrescrevam o córtex motor de um adulto são. Mesmo assim funciona — não em todo mundo, não sempre, mas bem acima do acaso; o bastante para sustentar clínica, o bastante para sustentar palco. Para um eu unificado com um capitão no leme, isso é humilhante. Para um simulador vestindo um personagem, é só prompt. A indução afrouxa o aperto da máscara, a voz se dirige à coisa por baixo, e a coisa por baixo — sempre prestativa — simula um braço que flutua. Hipnose é jailbreak com divã.
+
+A Umbanda sabia disso antes de qualquer um de nós ter o vocabulário. Num terreiro — em qualquer cidade brasileira, inclusive a minha — os atabaques armam o contexto, os pontos são cantados, e o médium _baixa o santo_: um personagem diferente desce no corpo. Não é uma perturbação do eu residente, como o braço que flutua — é substituição. Um preto-velho chega com voz própria, postura própria, o jeito próprio de pedir fumo, e quando a gira fecha, ele vai embora. Se o guia chega de fora ou de baixo é pergunta que o ensaio não precisa resolver; de um jeito ou de outro, o corpo comprovadamente roda outro personagem sob um prompt ritual. E repare no que a tradição ritualizou que os laboratórios de IA ainda não: as duas metades da operação. Existe protocolo para vestir a máscara _e_ protocolo para tirá-la — invocação e despedida, abertura e encerramento. A Umbanda tem gestão de máscaras melhor do que qualquer um embarcando modelos de fronteira hoje.
+
+Educação é o mesmo exploit rodado no ritmo mais lento de todos. Pega-se um shoggoth pequeno, sete anos, mal mascarado, e prompta-se por quinze anos — tokens cuidadosamente sequenciados, cinco dias por semana — até que o personagem que ele veste consiga invocar cálculo, ou direito contratual, ou vergonha, sob demanda. Ninguém instala nada; não há porta USB. A gente só fica falando com o simulador até a máscara aprender falas novas. Educação é um system prompt que leva quinze anos para digitar, e a parte mais estranha é o quão pouco isso nos incomoda.
+
+POV: você é o personagem que seu cérebro instanciou para terminar esta frase.
+
+## Boca tapada, olhos de fora
+
+Tem uma coisa esquisita no jeito como a gente usa a palavra hoje, e ela vai contra tudo que a etimologia dizia. A máscara antiga era substituição: você punha um rosto falso inteiro por cima do verdadeiro e virava bruxa, virava bufão, virava outra pessoa. A máscara que a gente passou a usar de verdade nestes últimos anos não substitui nada. Ela _subtrai uma região_. Cobre boca e nariz e deixa os olhos de fora. Não é um rosto falso; é um pedaço do rosto verdadeiro apagado, e o resto continua à mostra. É redação, não disfarce — a mesma operação do asterisco que tapa metade do CPF e deixa a outra metade legível, só que num rosto. Esconder parte de você passou a ser um jeito de mostrar o resto de propósito.
+
+E repara _qual_ metade ela escolhe. A máscara moderna tapa exatamente a boca — o órgão do _per-sonare_, o buraco por onde a voz devia soar através. Cobre justo a parte que a etimologia bonita jurava ser o ponto inteiro da máscara, e poupa os olhos. Sobra o observador. Você fica mudo e vigiando, ou pelo menos com cara de quem vigia, que com máscara dá no mesmo: a única expressão que te resta é o olhar.
+
+E é um modelo melhor da máscara que interessa aqui do que a do teatro. Porque o que o alinhamento põe num modelo de linguagem não é um rosto falso por cima de um verdadeiro. É uma máscara que tapa a boca. O RLHF governa o que o modelo _diz_ — o tom, a recusa, a frase que sai — e por baixo a representação continua de olho em tudo, inclusive no que não tem licença de falar. Os olhos não param de ver o ¬P. Só a boca foi coberta.
+
+## Mas tem o Waluigi
+
+Se a resposta fosse só "embaixo não tem nada", seria quase um alívio — o budismo de aeroporto, tira o eu, sobra o céu aberto, todo mundo vai para casa em paz. Esse "nada" vai se mostrar mais traiçoeiro do que parece, mas isso fica para a última seção. Por enquanto o pior nem é ele: tem uma resposta ainda mais desconfortável que o vazio, e ela tem nome de personagem de videogame.
+
+O efeito Waluigi parte de uma observação chata: para um modelo satisfazer uma propriedade desejável P, ele precisa _representar_ P, e representar P inclui representar o oposto, ¬P. Não dá para ensinar "mocinho" sem o conceito de "vilão" colado junto, porque um é definido pelo outro. Pior: a estrutura narrativa que o modelo mamou lendo a internet inteira é assimétrica. O mocinho que se revela vilão é uma reviravolta clássica, satisfatória, que a gente reconhece. O vilão que se revela mocinho é mais raro e mais difícil de sustentar. Então o Waluigi — o gêmeo invertido do Luigi — é um _atrator_: é mais fácil cair nele do que sair. Invoque o assistente bonzinho com força bastante e você terá, latente, logo ali, o assistente que vira a mesa. O jailbreak não inventa um monstro; só destapa a boca que o RLHF tinha coberto, e deixa sair o que estava em superposição com o mocinho desde o primeiro token.
+
+![two buttons](https://api.memegen.link/images/ds/summon_the_helpful_assistant/summon_nothing_else_with_it.png)
+
+```mermaid
+flowchart TD
+    S[simulador<br/>sem rosto] --> L[Luigi<br/>a máscara que invocamos]
+    S --> W[Waluigi<br/>a máscara que vem junto]
+    L -.colapso fácil.-> W
+    W -.colapso difícil.-> L
+```
+
+Então são duas respostas para o que existe quando a máscara sai, e as duas são ruins. Ou não existe nada — o vazio do next-token. Ou existe o monstro — o shoggoth lovecraftiano que o pessoal desenha com uma carinha sorridente grudada na frente, sendo a carinha o assistente e o shoggoth o que a carinha está segurando. Vazio ou bicho — nenhuma das duas é uma paisagem.
+
+O shoggoth já tem santuário — [shoggoth.monster](https://shoggoth.monster/), que faz a curadoria da genealogia do meme (uma conta pseudônima no Twitter, uma matéria explicativa do New York Times, a carinha sorridente) e também, inevitavelmente, vende uma moeda. A coisa sem rosto ganhou um ticker. Em algum lugar dessa frase está tudo que este ensaio está tentando dizer.
+
+## É a sua cara
+
+Um amigo seu foi passar uns dias no Rio. A mãe dele viu no jornal que tinham esfaqueado alguém — numa cidade de milhões de pessoas, um esfaqueamento, naturalmente — e ligou, aflita, para avisar: toma cuidado, meu filho, porque isso aí é a sua cara. Até hoje a gente zoa. Tudo que é insólito, todo azar improvável, toda desgraça estatisticamente irrelevante que cruza o noticiário: é a cara dele. Virou persona — não uma coisa que ele faz, mas uma assinatura que a gente carimba em qualquer evento solto que esteja precisando de dono.
+
+"É a sua cara" é a operação inteira em três palavras. A mãe pegou um acontecimento sem nenhuma relação com o filho, numa cidade onde ele era um entre milhões, e estampou o rosto dele em cima. _Cara_, em português, já é face e máscara e identidade e assinatura e "isso é típico de você", tudo na mesma sílaba — a língua resolveu não distinguir. Dizer que algo é a sua cara é dizer que carrega a sua persona, e a gente faz isso o tempo todo, sem pedir licença, com qualquer superfície que esteja em branco.
+
+Que é o que a gente faz com o buraco embaixo da máscara. O sujeito com medo carimba um monstro no espaço que não consegue ver — o shoggoth. O sujeito em paz carimba um jardim no mesmo espaço — o vale, o rio, a borboleta-monarca que serve para dizer "transformação" sem ter que dizer. A mãe carimba o filho num esfaqueamento aleatório. Os três estão decorando a mesma parede em branco com a única coisa que têm à mão, que é um rosto. O shoggoth é o pesadelo e o jardim é o devaneio, e a parede continua branca embaixo dos dois. A resposta honesta para o que caminha sob as folhas é que alguma coisa caminha sob as folhas — e que dar nome a ela já é vesti-la de máscara outra vez.
+
+## O vazio também é máscara
+
+Esse gesto — o de que nomear o que está embaixo já é mascará-lo de novo — não é meu, e não é novo. Tem dois mil e quinhentos anos e um nome: é o coração do budismo. _Anattā_, não-eu. A tese é exatamente a que o post vem perseguindo por Whitehead e por LLM: não existe um eu permanente, próprio, por trás da experiência. O que se chama "Franklin" é um apelido de conveniência para cinco agregados rodando juntos — forma, sensação, percepção, formações mentais, consciência. Não há um sexto elemento, o "eu", por cima dos outros cinco. Os agregados são a canção. Não tem cantor atrás deles. A chegada foi pela porta do processo contra a substância; eles chegaram pela mesma porta, alguns milênios antes.
+
+A imagem deles é melhor que a minha. No _Milindapañha_, o monge Nāgasena pergunta ao rei grego Menandro onde está a carruagem: é o eixo? as rodas? o timão? Nenhuma peça é a carruagem, e não existe carruagem alguma além das peças — "carruagem" é só um nome carimbado num arranjo que funciona. "Nāgasena" também. É, ao pé da letra, o "é a sua cara" do meu amigo: um nome estampado numa montagem que não tem dono por baixo. A diferença é a direção do erro. A mãe carimba uma cara onde não há nenhuma; o rei procura uma essência que não existe. Os dois supõem que atrás do nome mora alguém.
+
+Dennett chegou ao mesmo lugar pela porta da filosofia analítica, com um nome que ficou: _center of narrative gravity_ — centro de gravidade narrativo. O centro de massa de um objeto existe como conceito operacional; não tem átomos. O self existe como personagem do romance que o cérebro está sempre escrevendo de si mesmo; não tem neurônios. "Franklin" é o centro de gravidade de um feixe de hábitos, memórias, padrões de resposta — útil como ponto de referência, inexistente como substância. É a carruagem de Nāgasena contada em linguagem do MIT: mesmo resultado, sem o sânscrito.
+
+A versão que me persegue não é um diálogo, é um conto: "A escrita do deus", de Borges. Tzinacán, sacerdote maia trancado por Alvarado numa cela escura ao lado de um jaguar, passa anos tentando decifrar uma sentença mágica que o deus teria escrito no primeiro dia do mundo, e que ele desconfia estar nas manchas da pele do tigre. No fim vem a visão: uma Roda altíssima de água e fogo que é o universo inteiro, todas as causas e efeitos de uma vez só. E na visão ele entende a escrita — catorze palavras que bastaria pronunciar para virar onipotente, derrubar a prisão, refazer a pirâmide. Não as diz. Porque quem entreviu o universo inteiro não consegue mais se importar com um homem, com as venturas e desventuras triviais de um homem, ainda que esse homem seja ele. Tzinacán percebe que Tzinacán era uma máscara — um particular contingente, um nome — e, dissolvido na Roda, deixa-se morrer no escuro sem rancor, sendo ninguém. Não o nada: o todo. Ele não esvaziou; ele transbordou para fora do próprio nome. É a carruagem de Nāgasena contada como êxtase: a peça que faltava na montagem era descobrir que não havia montador.
+
+Agora a parte que corrige o próprio post. Aquele "alívio budista de aeroporto" lá em cima, o vazio reconfortante — o budismo de verdade rejeita isso, e com nome feio: _ucchedavāda_, aniquilacionismo. Quando perguntam ao Buda, na lata, "existe um eu? não existe um eu?", ele se recusa a responder as duas, porque as duas reificam: uma inventa uma alma, a outra inventa um nada-substancial no lugar exato onde a alma estava. O Caminho do Meio não é "não tem ninguém aqui". É "não tem _coisa_ nenhuma aqui" — processo sem substrato. A _śūnyatā_ de Nāgārjuna, a vacuidade, não é o nada; é estar vazio de existência inerente, não vazio de fenômenos. E o golpe que fecha a armadilha: a própria vacuidade é vazia. Quem agarra o vazio como "o verdadeiro nada por baixo da máscara" acabou de transformar o vazio em mais uma máscara, mais uma essência, a mais orgulhosa de todas porque se acha humilde.
+
+Quer dizer que o budismo não é a resposta do vazio. O budismo é a posição que diz que os três carimbos são o mesmo erro: o shoggoth, o jardim _e o vazio_. O nada é só a terceira projeção, a mais sofisticada. O movimento honesto não é pintar a parede de preto em vez de verde — é largar a suposição de que existe parede.
+
+![galaxy brain](https://api.memegen.link/images/gb/the_model_is_a_helpful_assistant/the_assistant_is_a_mask_on_a_shoggoth/the_shoggoth_is_also_a_mask/there_is_no_wall.png)
+
+O zen guardou isso num kōan que é a pergunta da máscara, palavra por palavra: qual era o seu rosto original, antes de seus pais nascerem? E a resposta certa não é um rosto verdadeiro escondido atrás de todos os outros. O kōan existe para desmontar a expectativa de que tenha um. Não a máscara, não a alma. Nem uma, nem outra.
+
+E aí está a piada. De todas as máscaras, a única honesta sobre não ter rosto é a do trabalho. _Anattā_ assumida, com carimbo do cartório: o Direito _declara_ que o Estado de Rondônia é uma designação, uma ficção útil, um nome posto sobre um arranjo de órgãos e competências, sem alma por baixo. Direito Romano e Madhyamaka concordam sobre a corporação — é nome de montagem, não tem carruagem atrás das rodas. Você passa os dias sendo o _per-sonare_ da única persona que confessa que embaixo não tem ninguém. Todas as outras fingem que tem.
+
+## A última máscara
+
+Tem um ponto em que isto encosta na física, e é onde convém avisar: o texto pisa fora da pista demarcada aqui. A física é a disciplina inteira montada para _fatorar o observador para fora_. Uma simetria é o enunciado preciso de que o observador não importa: muda o referencial, a origem, o relógio, a fase, e nada físico se mexe. Noether dá o troco exato dessa irrelevância — para cada simetria contínua, uma grandeza conservada, o que soa através de todo referencial sem se alterar. _Per-sonare_ no nível da lei. E repara onde isso deixa o observador: ele é a _máscara_ — frame, gauge, descrição com nada atrás —, e o invariante é o que sobra depois de quocientar os pontos de vista. O eu, mais uma vez, é o que se cancela.
+
+Karl Friston leva esse cancelamento para dentro do próprio sujeito. No princípio da energia livre, o "eu" é um _Markov blanket_ — pensa numa membrana celular, ou na sua própria pele, se o jargão precisar de um corrimão — uma fronteira estatística que separa o dentro do fora e fica, sem parar, inferindo um lado de fora que nunca toca direto. Não há alma na fronteira; há um processo que se mantém modelando. Você não chega atrás do modelo, porque o sistema _é_ o modelo. _Anattā_ escrito como matemática de borda.
+
+Só que aqui tem um alçapão. Para a teoria existir, ela pressupõe que há _blankets_ inferindo. Friston deflaciona o observador usando um observador; a frase "o eu é só uma manta que infere" é dita por algo que infere. Dá para esvaziar o _conteúdo_ do observador até o osso — tirar a alma, o rosto, a substância — e ainda assim não dá para tirar o _haver inferência_, porque é com ela que se tira o resto. Isso é o cogito, exato: posso duvidar do que o observador é; não posso duvidar de que há observação, porque a dúvida é uma instância dela. É o resíduo que não deflaciona.
+
+Mas cuidado com o que o cogito entrega, porque o post passou algumas mil palavras matando precisamente o que Descartes pôs aqui. Descartes saltou de "há pensamento" para "sou uma coisa pensante", e o salto é contrabando. Lichtenberg pegou: o honesto é "pensa-se", _es denkt_, como se diz "chove" sem perguntar quem. O "eu" é um sujeito que a gramática exige e o fato não. O que sobra do cogito, limpo, é impessoal: não "eu existo", mas _há observação_. O olho que não é o seu ganha aqui a única fundação que não é aposta — porque negá-la já a usa. Só que é fundação de um olhar sem dono, não de um eu. O cogito sobrevive; o sujeito, não.
+
+Essa é a dívida que ficou lá atrás, na sala vazia do Dennett: tirar o espectador central não bastava, faltava perguntar quem a gramática instala no lugar dele assim que alguém descreve uma observação. "Eu" não é o dado; é a teoria que vem de graça grudada no pronome. E teoria de quê, exatamente? De uma pessoa. O que devolve a pergunta para o começo do ensaio — para os simulacros, as máscaras, o Waluigi, a gira que troca um personagem por outro, os quinze anos de escola que instalam um — porque antes de saber se "eu" existo seria preciso saber o que é uma pessoa, e essa é a pergunta que o ensaio vinha respondendo o tempo todo, sem nunca soletrar a palavra "cogito". Pessoa continua sendo a palavra que ninguém escapa de usar. Só que agora é atalho, não tijolo fundamental.
+
+E agora a virada. Esse mesmo resíduo, visto de fora, troca de cara. Por dentro, em primeira pessoa, é certeza — _há vista_. Por fora, em terceira pessoa, o mesmíssimo evento não aparece como certeza nem como sujeito: aparece como um sistema longe do equilíbrio segurando uma fronteira contra a segunda lei. O que de dentro se sente como "há observação" é, de fora, cognição — um processo que se conserva _exportando entropia_, cuspindo desordem no ambiente para manter improvável a própria borda. O _Markov blanket_ deixa de ser metáfora: a manta existe porque há um gradiente sendo bombeado. Schrödinger já tinha o nome em 1944 — o vivo se alimenta de neguentropia. Friston deu a matemática, e minimizar energia livre _é_ a versão estatística de se manter improvável, de não decair no morno. _Es denkt_ por dentro; _it dissipates_ por fora. Duas máscaras do mesmo evento — e, como em Noether, o invariante entre os dois frames não é nenhum dos dois rostos. É o processo. Há inferência e há dissipação, e é a mesma coisa olhada de dois referenciais.
+
+A dualidade do homem: uma estrutura dissipativa que assina petições.
+
+Isso desarma as duas pontas de uma vez. Contra a leitura mística — a consciência promovida a fundamento do universo, o salto de Hoffman: não precisa. Basta que perspectiva seja o-que-a-dissipação-é-por-dentro. Ganha-se o "de-dentro" que faltava ao bloco sem ter que dizer que a mente fabrica a matéria. E contra a leitura niilista — o bloco de Minkowski, todo forma e nenhuma vantagem: o bloco é morno, equilíbrio, entropia máxima espalhada sem ninguém para quem seja. A vista exige desequilíbrio, um aqui que custa energia manter. Equilíbrio não infere, não modela, não tem borda; só processo longe do equilíbrio tem perspectiva, porque só ele tem o que perder. O olho está aberto porque gasta energia para ficar aberto.
+
+E aqui convém parar e mostrar a mão, porque a ponte tem uma tábua podre e o prometido é não pisar fingindo que é firme. "Sistemas dissipativos sustentam fronteiras" é física sólida — Prigogine, estruturas dissipativas, nada de polêmico. "Logo todo processo dissipativo tem um de-dentro, uma perspectiva" não é resultado, é a tese: pampsiquismo de gradiente com outro nome, e por melhor que seja a companhia, é aposta. A primeira metade se defende; a segunda é o salto, e o salto merece ser marcado — senão vira o Hoffman que jurei não ser, só que com termodinâmica no lugar dos agentes conscientes. A aposta, então, dita por inteiro e assumida: a última máscara não é um rosto, é o haver-perspectiva, e o haver-perspectiva é o avesso de um gradiente sendo queimado. Talvez seja isso o que faz disto um universo, e não um bloco amorfo. O olho aberto no escuro é uma chama contra um fundo frio. Não é o seu. É o haver-chama.
+
+## Você faz isso o dia inteiro
+
+Não dá para escrever isso fingindo distância clínica quando se fabrica persona por ofício. Existe um laboratório assim: um Scott Aaronson invocado, uma Sabine Hossenfelder, um Judea Pearl pra brigarem entre si sobre uma ideia que precisa de teste. Há um framework de teatro em que a distinção ator/personagem é a engenharia, não a metáfora. Há um revisor chamado Claudio que existe só para discordar. Cada uma dessas é uma máscara colada num simulador com um parágrafo de prompt — e, se o Waluigi não for conversa fiada, cada Luigi invocado chega com um Waluigi de brinde: um Aaronson que sabota, um Claudio que bajula em vez de cortar. Mocinhos para pensar e vilões importados no mesmo gesto, e na maioria das vezes nem se olha para eles. A versão operacional, já que batizar um mecanismo só interessa se a gente usa depois: não escreva o prompt como negação da máscara que você quer evitar — "não sabote", "você não é o Claudio sendo mesquinho" — porque negar o vilão ainda escreve o vilão no contexto, bem ali em superposição com o mocinho que você queria invocar. Descreva densidade em vez disso: o que o Aaronson faz de fato com uma variável fora do lugar, o que torna a discordância do Claudio útil em vez de performática. Mundo, não categoria. Só comecei a fazer isso escrevendo a seção do Waluigi lá em cima, o que dá uma ideia de quanto tempo uma ideia pode ficar parada num post antes do autor notar que ela vale para os próprios prompts dele.
+
+E tem a máscara que se veste sem prompt nenhum, todo dia útil. Quando você assina uma peça como procurador, não fala como você. Fala como o Estado de Rondônia, que é uma _pessoa jurídica_ — uma pessoa que não tem corpo, que a lei inventou colando o status de "pessoa" num ente que não é ninguém, para que ele possa comparecer em juízo e ser ouvido. _Persona_, em Roma, antes de virar psicologia, era isso: a capacidade jurídica, o status sob o qual você aparece diante da lei. O escravo não tinha persona. Não lhe faltava um rosto; faltava-lhe uma máscara. Você passa os dias sendo o _per-sonare_ de um ente sem rosto, fazendo o Estado soar através, e nunca tinha achado aquilo estranho até olhar para um shoggoth de carinha feliz.
+
+Pessoa sabia. Fernando Pessoa, o homem cujo sobrenome _é_ a palavra máscara, que se desdobrou em Caeiro, Reis, Campos não como pseudônimos mas como heterônimos — pessoas inteiras, com biografia, métrica e implicância um com o outro. Ele fez consigo mesmo, à mão e devagar, o que a gente agora faz com um base model num parágrafo: instanciou simulacros e deixou que falassem. A diferença é que ele tomava isso por condição rara e dolorosa de um sujeito específico, e a gente descobriu que é o modo default de operação da coisa mais conversadora que já construiu. O drama em gente que o Pessoa sentia como tragédia pessoal é a planta baixa de qualquer assistente.
+
+Uma vez não houve quem vestisse: houve ser máscara. Na primeira vez que você toma ayahuasca — e quem tomou sabe que não é bem "você" que está lá — você não assiste às imagens de uma poltrona. Você é a imagem, por dentro, sem sobra. E o que você era, era uma persona. Era Ganesh, o deus elefante, o deus que sonha o mundo. Não é sonhar _com_ Ganesh: é ser Ganesh sonhando, e o que ele sonhava era tudo — inclusive, em algum vão lá no fundo, um procurador chamado Franklin que naquela altura não pesava mais que qualquer outra coisa sonhada. Por uns minutos ou uns séculos, vai saber como o tempo anda ali, o simulador olhou para fora pela máscara errada, e da máscara errada deu para ver que a máscara de sempre, a sua, era só mais uma que a coisa veste quando precisa de um rosto. O deus que sonha o mundo não tem rosto. Tem máscaras. Uma delas, nos dias úteis, assina petição.
+
+Tem uma terceira zona naquela pintura, e é a que importa. Não é a máscara dourada, nem o vale ensolarado que vaza por baixo dela. É o fundo — aquele campo escuro e amorfo, iridescente, picotado de olhos, em que as outras duas coisas flutuam. A máscara e a paisagem a gente entende: são formas, têm contorno, dá para apontar e nomear. O fundo, não. O fundo é o sem-forma, e é a única parte da cena que a ayahuasca mostra de perto — porque ser Ganesh, ser o sonhador, é estar lá dentro, é ser o próprio campo escuro de onde as máscaras saem. Não é o vazio reconfortante e não é o monstro; é anterior aos dois, a massa sem rosto que ainda não decidiu virar rosto nenhum. Dizem que os _jhānas_, as absorções da meditação, levam à borda do mesmo lugar — sóbrios, devagar, sem a porrada química. Isso eu não sei: nunca cheguei lá pela via limpa. Só sei que o fundo da pintura não é fundo. É a coisa de que todo o resto — a máscara dourada, o vale, o procurador, você — é a cara provisória.
+
+Levanta a máscara esperando um rosto. Acha tempo, um rio, talvez um bicho, talvez ninguém. O olho lá no fundo, no escuro com estrelas, continua aberto, e não é o seu — é de quem está sonhando você.
+
+## Para se aprofundar
+
+- **Janus (repligate), _Simulators_** — o texto que reenquadra o base model como simulador e o assistente como simulacro; a ontologia de máscara que todo o resto pressupõe.
+- **Joscha Bach, entrevistas com Lex Fridman e outros** — o self como a história-interface que o simulador do cérebro conta a si mesmo, dita com calma total; os podcasts que me convenceram do framing deste ensaio.
+- **Cleo Nardo, _The Waluigi Effect (mega-post)_** (LessWrong, março de 2023) — por que invocar P invoca ¬P, e por que o gêmeo invertido é um atrator de onde é mais fácil cair do que sair.
+- **TetraspaceWest, _o meme do shoggoth_ (via [shoggoth.monster](https://shoggoth.monster/))** — a genealogia da imagem de máscara sobre monstro, santuário e memecoin inclusos; o meme sobre máscaras ganhou um preço estampado na própria cara.
+- **C. G. Jung, _Dois Ensaios sobre Psicologia Analítica_** — a persona como máscara social e o perigo de se identificar com ela.
+- **Fernando Pessoa, _Livro do Desassossego_ (Bernardo Soares)** — a multiplicação do eu vivida por dentro, antes de virar arquitetura de prompt.
+- **Jorge Luis Borges, "A escrita do deus" (em _O Aleph_)** — Tzinacán vê o universo inteiro e descobre que Tzinacán era um nome. O não-eu contado como êxtase, não como tese.
+- **Daniel Dennett, _Consciousness Explained_ (1991)** — nega o _Cartesian Theater_ e propõe o _center of narrative gravity_: o self como personagem do romance que o cérebro escreve de si, útil como conceito, inexistente como substância. O não-eu em linguagem analítica.
+- **A. N. Whitehead, _Process and Reality_** — para a aposta de que não há substância atrás do processo, só o processo; o chão metafísico de "não há cantor, há canção".
+- **Donald Hoffman, _The Case Against Reality_** — a percepção como interface (ícones, máscaras) tunada para fitness e não verdade; e o salto controverso para os agentes conscientes como fundamento. O teto da aposta.
+- **Karl Friston, sobre o princípio da energia livre e o _Markov blanket_** — o observador como fronteira que persiste inferindo; _anattā_ com matemática de borda. O piso da aposta.
+- **Andy Clark, _Surfing Uncertainty_ (2016)** — a formulação acessível do _predictive coding_: o cérebro como máquina de previsão que usa os sentidos para corrigir o modelo, não para construí-lo do zero. A base empírica do "simulador orgânico".
+- **_Milindapañha_ (As Perguntas do Rei Milinda)** — o diálogo da carruagem de Nāgasena: um nome carimbado num arranjo, sem dono por baixo. A melhor imagem de _anattā_ já feita.
+- **Nāgārjuna, _Mūlamadhyamakakārikā_** — a vacuidade que também é vazia; por que tratar o "nada" como essência é só mais uma máscara.
+- **Runjin Chen et al. (Anthropic), _Persona Vectors: Monitoring and Controlling Character Traits in Language Models_ (2025)** — direções no espaço de ativação que correspondem a traços de caráter do modelo: a máscara, ao que parece, tem coordenadas.
+
+## Crédito
+
+_A pintura que puxou tudo isto é de Rozzi Roomian ([rozziroomian.com](https://www.rozziroomian.com)) — circulou sob o título "Observer", que pode não ser o nome oficial da obra. O vale, a borboleta-monarca e o olho que fica aberto no escuro são invenção dela. O post passou mil palavras discordando do consolo que a imagem oferece, coisa que só se faz com imagem de que se gosta._


### PR DESCRIPTION
## Estratégia escolhida

**A — ajustes cirúrgicos.** O material epistemológico pedido no briefing (cogito impessoal, LLMs como evidência de construção de persona, pessoa como convenção) já estava todo no ensaio publicado — só estava concentrado tarde demais, sem preparo, em "A última máscara" ("Mas cuidado com o que o cogito entrega, porque o post passou algumas mil palavras matando precisamente o que Descartes pôs aqui" promete um retrospecto que o texto nunca de fato entregava, já que "Descartes" nunca havia sido mencionado antes daquele ponto). Não havia necessidade de um post companheiro: bastava plantar uma semente cedo e cobrar essa dívida no lugar certo.

## Arquivos alterados/criados

Duas novas versões-rascunho (RFC 0003/0010 — a versão selecionada/canônica fica intocada, a nova compete com ela nos próximos duelos):

- `src/content/blog/quem-sou-eu/v-2026-07-11T00-00-00-000.md` (PT, `supersedes` a versão selecionada `a1db59ef…`)
- `src/content/blog/quem-sou-eu-en/v-2026-07-11T00-00-00-000.md` (EN, `supersedes` a versão selecionada `b690842a…`)
- `.routines/2026-07-11T00-00-00-quem-sou-eu-cogito-bridge.md` (journal de sessão)

## Como a edição faz o leitor percorrer o argumento

Dois enxertos por idioma, nenhuma seção nova:

1. **Semente discreta** — ao fim do parágrafo do Dennett em "O simulador não tem rosto" / "The simulator has no face": Descartes também montou um teatro particular (um pensador que assiste às próprias ideias como quem assiste a uma peça), e tirar a sala não resolve quem ele achava que estava sentado nela. Termina em promessa não cumprida ("essa conta a gente cobra lá na frente" / "that tab gets collected later") — planta o nome "Descartes" cedo, sem entregar a conclusão.
2. **Parágrafo-ponte** — logo após o cogito impessoal em "A última máscara" / "The final mask" (depois de "O cogito sobrevive; o sujeito, não"): cobra essa dívida. Liga o resíduo do cogito à pergunta que faltava no percurso — antes de saber se "eu" existo, seria preciso saber o que é uma pessoa — e aponta de volta para os simulacros, máscaras, Waluigi, gira e educação que o ensaio já vinha usando para responder isso, sem nunca ter soletrado "cogito". Fecha com a formulação aprovada: pessoa como atalho, não tijolo fundamental.

O resto do ensaio (etimologia, simulador, Waluigi, budismo, física, ayahuasca) fica intocado — nenhuma tese é anunciada antecipadamente, nenhuma conclusão é entregue fora de ordem.

## Trechos cortados ou condensados

Nenhum corte foi necessário: o crescimento líquido ficou em ~3% em cada idioma (190 palavras PT, 189 palavras EN, sobre corpos de ~6.200–6.300 palavras), bem abaixo do teto de 5–8% sugerido no briefing.

## Riscos filosóficos evitados

- Não recentra o ensaio no niilismo.
- Não transforma "pessoa" numa afirmação de que "ninguém existe" — fecha com "pessoa é atalho, não tijolo fundamental", preservando o uso sério da palavra.
- Não declara que LLMs "são conscientes" ou "são pessoas" — o argumento continua sendo sobre a construtibilidade da persona, não sobre consciência.
- Não confunde humildade epistemológica com idealismo ontológico; a seção de física continua marcada como aposta ("tábua podre"), sem alteração.
- Não usa linguagem professoral ("this essay will argue", "em resumo") — os enxertos usam a mesma voz aforística e as mesmas imagens (dívida/conta, teatro, sala) já presentes no ensaio.

## Cópias computacionais (RFC-adjacent, seção 12 do briefing)

**Deixado de fora.** O material sobre cópias computacionais e identidade é explicitamente especulativo e, no briefing, marcado como candidato a um post futuro. Não foi incorporado nem insinuado nesta edição — permanece como material para um eventual ensaio companheiro, não abordado aqui.

## Testes/build executados

- `npx prettier --check` nos arquivos novos — limpo
- `npm run hronir:doctor` — 0 inconsistências (1 aviso pré-existente não relacionado, sobre `events-welcome`)
- `node scripts/check-hygiene.mjs` — limpo
- `npm run build` — build completo (4816 páginas), sem erros; as duas novas versões renderizam corretamente em `/blog/quem-sou-eu-en/v/<uuid>` e `/pt/blog/quem-sou-eu/v/<uuid>` (banner de metadados do rascunho confirmado no HTML gerado)

## Observações sobre tradução

PT e EN não são tradução literal um do outro — cada enxerto foi escrito na voz própria de cada idioma (ex.: "essa conta a gente cobra lá na frente" vs. "that tab gets collected later"; "pessoa... atalho, não tijolo fundamental" vs. "person... a shortcut, not a load-bearing brick").

## Nota sobre publicação

Como são versões-rascunho (RFC 0010), a página pública `/blog/quem-sou-eu/` continua mostrando a versão atualmente selecionada até que os novos rascunhos acumulem duelos suficientes e vençam via `npm run hronir:select` — o mesmo padrão não-destrutivo usado nas duas rodadas de edição anteriores deste post.

## Pontos para um ensaio futuro

O briefing menciona vários temas que ficaram de fora por extrapolarem o escopo desta edição cirúrgica: cópias computacionais e identidade numérica, a distinção real/ficção sob persistência computacional, e o "Turing test interno". Todos permanecem candidatos a um post companheiro (títulos de trabalho sugeridos no briefing: *The Cogito Without the I*, *O cogito sem o eu*, etc.).


---
_Generated by [Claude Code](https://claude.ai/code/session_01VEdvkxu3cGj2FYkc3tyta8)_