### PR TITLE
ux: adiciona ProfilePage/Person JSON-LD em /about/

### DIFF
--- a/.routines/2026-07-11T05-06-20-ux-ui-run.md
+++ b/.routines/2026-07-11T05-06-20-ux-ui-run.md
@@ -1,0 +1,22 @@
+---
+date: "2026-07-11T05:06:20Z"
+branch: ux-ui/run-2026-07-11T05-00-49
+status: open
+---
+
+# Sessão 2026-07-11T05-06-20 — UX/UI
+
+Issues fechadas: #587
+Issues encontradas já resolvidas (fechadas sem código novo): #1082 (fix já
+tinha sido mesclado em `15b3e9a`/#1090, mas o commit não referenciou o issue
+corretamente ao mesclar; comentário adicionado explicando e issue fechada).
+
+O que foi feito: `/about/` e `/pt/about/` agora emitem `schema.org/ProfilePage`
+com `mainEntity` apontando (via `@id`) para o `Person` já emitido globalmente
+em `PageLayout.astro` — que ganhou um `@id` estável
+(`{site}#person`) para servir de âncora do grafo JSON-LD.
+
+CI local: astro check ✅ (0 erros) · prettier ✅ · build ✅ (4856 páginas,
+pagefind ok). Conferido no HTML gerado: `dist/about/index.html` e
+`dist/pt/about/index.html` têm o bloco `ProfilePage` com `@id` e `mainEntity`
+referenciando corretamente o `Person`.

--- a/src/layouts/PageLayout.astro
+++ b/src/layouts/PageLayout.astro
@@ -112,6 +112,8 @@ const listBreadcrumbLd = breadcrumb?.length
 const langBcp47 = lang === "pt" ? "pt-BR" : "en";
 const hreflangFor = (code: string) => code === "pt" ? "pt-BR" : code;
 
+const personId = Astro.site ? `${Astro.site.href}#person` : "#person";
+
 const jsonLd = type === "article"
   ? {
       "@context": "https://schema.org",
@@ -119,8 +121,8 @@ const jsonLd = type === "article"
       headline: title,
       description,
       inLanguage: langBcp47,
-      author: { "@type": "Person", name: "Franklin Baldo", url: Astro.site?.href },
-      publisher: { "@type": "Person", name: "Franklin Baldo", url: Astro.site?.href },
+      author: { "@id": personId },
+      publisher: { "@id": personId },
       datePublished: publishedTime?.toISOString(),
       ...(modifiedTime && { dateModified: modifiedTime.toISOString() }),
       mainEntityOfPage: canonical.href,
@@ -151,7 +153,7 @@ const jsonLd = type === "article"
 const personLd = {
   "@context": "https://schema.org",
   "@type": "Person",
-  "@id": Astro.site ? `${Astro.site.href}#person` : "#person",
+  "@id": personId,
   name: "Franklin Baldo",
   url: Astro.site?.href,
   image: Astro.site ? new URL("/avatar.png", Astro.site).href : "/avatar.png",

--- a/src/layouts/PageLayout.astro
+++ b/src/layouts/PageLayout.astro
@@ -151,6 +151,7 @@ const jsonLd = type === "article"
 const personLd = {
   "@context": "https://schema.org",
   "@type": "Person",
+  "@id": Astro.site ? `${Astro.site.href}#person` : "#person",
   name: "Franklin Baldo",
   url: Astro.site?.href,
   image: Astro.site ? new URL("/avatar.png", Astro.site).href : "/avatar.png",

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -1,6 +1,13 @@
 ---
 import PageLayout from "../layouts/PageLayout.astro";
 
+const profileLd = {
+  "@context": "https://schema.org",
+  "@type": "ProfilePage",
+  "@id": Astro.site ? new URL("/about/#profile", Astro.site).href : "/about/#profile",
+  mainEntity: { "@id": Astro.site ? `${Astro.site.href}#person` : "#person" },
+};
+
 const faqLd = {
   "@context": "https://schema.org",
   "@type": "FAQPage",
@@ -48,6 +55,7 @@ const faqLd = {
   lang="en"
   translations={{ pt: "/pt/about/" }}
 >
+  <script type="application/ld+json" set:html={JSON.stringify(profileLd)} is:inline slot="head" />
   <script type="application/ld+json" set:html={JSON.stringify(faqLd)} is:inline slot="head" />
   <article data-pagefind-body>
     <h1>About</h1>

--- a/src/pages/pt/about.astro
+++ b/src/pages/pt/about.astro
@@ -1,6 +1,13 @@
 ---
 import PageLayout from "../../layouts/PageLayout.astro";
 
+const profileLd = {
+  "@context": "https://schema.org",
+  "@type": "ProfilePage",
+  "@id": Astro.site ? new URL("/pt/about/#profile", Astro.site).href : "/pt/about/#profile",
+  mainEntity: { "@id": Astro.site ? `${Astro.site.href}#person` : "#person" },
+};
+
 const faqLd = {
   "@context": "https://schema.org",
   "@type": "FAQPage",
@@ -48,6 +55,7 @@ const faqLd = {
   lang="pt"
   translations={{ en: "/about/" }}
 >
+  <script type="application/ld+json" set:html={JSON.stringify(profileLd)} is:inline slot="head" />
   <script type="application/ld+json" set:html={JSON.stringify(faqLd)} is:inline slot="head" />
   <article data-pagefind-body>
     <h1>Sobre</h1>


### PR DESCRIPTION
## Summary

- `/about/` e `/pt/about/` emitiam apenas o schema `WebSite` genérico herdado do `PageLayout`. Agora também emitem `schema.org/ProfilePage`, o tipo correto para uma página de perfil.
- `mainEntity` do `ProfilePage` referencia (via `@id`) o `Person` já publicado globalmente em `PageLayout.astro`, em vez de duplicar o objeto — o `Person` ganhou um `@id` estável (`{site}#person`) para servir de âncora do grafo JSON-LD.
- Closes #587.

Bônus: issue #1082 já estava resolvida por um commit anterior (`15b3e9a`, mesclado via #1090) que não referenciou o issue corretamente ao mesclar — comentei e fechei separadamente, sem código novo nesta PR.

## Test plan

- [x] `npx astro check` — 0 erros
- [x] `npx prettier --check .` — ok
- [x] `npm run build` — build completo (4856 páginas), pagefind ok
- [x] Conferido o HTML gerado: `dist/about/index.html` e `dist/pt/about/index.html` têm o bloco `ProfilePage` com `@id` e `mainEntity` apontando corretamente para o `Person`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PvzugQ8nXq4ZzZPGUxxhdm

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvzugQ8nXq4ZzZPGUxxhdm)_