### PR TITLE
docs: melhorias na rotina de agente Hrönir (matches)

### DIFF
--- a/docs/hronir-agent-routine.md
+++ b/docs/hronir-agent-routine.md
@@ -11,12 +11,24 @@ git clone https://github.com/franklinbaldo/franklinbaldo.github.io.git
 cd franklinbaldo.github.io
 ```
 
+Depois, instale as dependências — todo comando `hronir:*` roda via `tsx` e
+falha sem `node_modules/`:
+
+```bash
+npm ci
+```
+
+(Num checkout já existente, rode `npm ci` só se `node_modules/` não existir.)
+
 ## 0. Revisar e mesclar PRs abertos
 
 Liste os PRs abertos. Para cada PR Hrönir com CI verde, sem conflitos e sem revisões bloqueantes:
 
 - Mescle com **merge commit** — NUNCA squash.
 - Via MCP: `mcp__github__merge_pull_request` com `merge_method: merge`.
+- **Não** mescle PRs que deletem arquivos de `.routines/hronir/rates/` — rate
+  files são imutáveis (guardrail no CI e no autopilot); deixe esses para
+  revisão humana.
 
 ## 1. Atualizar main e criar branch
 
@@ -47,26 +59,29 @@ novo o arquivo não existe, e pular este passo faz o `init` falhar com "mínimo
 ```bash
 npm run hronir:init -- \
   --agent-id <seu-model-id> \
-  --matches 10 \
+  --matches 5 \
+  --objective coverage \
   --content-mode path-only \
   --skip-edit
 ```
 
-- `--agent-id` é **obrigatório** — use um identificador estável do seu modelo.
+- `--agent-id` é **obrigatório** — use um identificador estável do seu modelo. Se contiver espaços, coloque entre aspas.
+- `--matches`: dimensione pela sua capacidade real de leitura atenta — uma sessão de 3-6 matches bem avaliados vale mais que uma de 10 apressados, e é melhor iniciar com menos matches do que abortar no meio. 5 é um bom default; suba para 10 só se tiver folga de contexto/tempo.
+- `--objective coverage` (RFC 0013 §8): prioriza obras sub-amostradas — o viés recomendado enquanto o corpus é raso, e o que faz sentido numa rotina de volume como esta. Fica registrado como proveniência em cada rate file.
 - `--content-mode path-only` recomendado para agentes: o CLI imprime apenas slug e caminho; o agente lê o arquivo diretamente.
-- `--skip-edit` é **obrigatório** nesta rotina — a fase de edição do pior post roda separada, com outro modelo e cadência diária. Com essa flag, a sessão se fecha sozinha ao completar os matches, sem nunca sinalizar `need_edit`.
+- `--skip-edit` é **obrigatório** nesta rotina — a fase de edição do pior post roda separada, com outro modelo e cadência diária. Com essa flag, a sessão nunca sinaliza `need_edit` e é encerrada pelo `continue` que detecta o último match completado (ver passo 4).
 
 ## 4. Loop de avaliação
 
-Repita até o CLI indicar que todos os matches foram completados. Se o contexto/tempo estiver se esgotando antes de completar os 10 matches, **não deixe um `decide` pela metade** — complete o match em andamento, então feche a sessão explicitamente antes de seguir para o passo 5, já que `hronir:doctor` reporta qualquer `hronir_session.json` ativo como inconsistência:
+Repita até o CLI indicar que todos os matches foram completados. **Após o último `decide`, rode `npm run hronir:continue` uma última vez** — é esse `continue` que detecta a sessão completa e apaga `hronir_session.json` (com `--skip-edit`). Sem isso, o `hronir:doctor` do passo 5 reporta a sessão ativa como inconsistência. (`npm run hronir:end`, sem `--force`, também fecha uma sessão com todos os matches completos.)
+
+Se o contexto/tempo estiver se esgotando antes de completar todos os matches, **não deixe um `decide` pela metade** — complete o match em andamento, então feche a sessão explicitamente antes de seguir para o passo 5:
 
 ```bash
 npm run hronir:end -- --force
 ```
 
-Os rate files já commitados por cada `decide` **não são afetados** — isso só encerra o rastreamento da sessão. (Com `--skip-edit`, a sessão nunca fica em `need_edit`, então esse é o único caso de saída antecipada aqui.)
-
-Uma sessão de 3-6 matches bem avaliados vale mais que uma de 10 apressados.
+Os rate files já gravados em `.routines/hronir/rates/` por cada `decide` **não são afetados** — isso só descarta o rastreamento da sessão (eles ainda serão commitados no passo 5). Com `--skip-edit`, a sessão nunca fica em `need_edit`, então esse é o único caso de saída antecipada aqui.
 
 ```bash
 npm run hronir:continue
@@ -92,12 +107,18 @@ npm run hronir:decide -- \
 
 ### Restrições
 
-| Campo                       | Restrição                                                                                                                                       |
-| --------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
-| `--rate-a` / `--rate-b`     | 1.00–5.00, ≤2 casas decimais, **sem empate**                                                                                                    |
-| `--review-a` / `--review-b` | ≥100 palavras cada, no idioma do post, pela perspectiva do banner. Refira-se ao post pelo **slug**, não "Post A" / "Post B"                     |
-| `--clash`                   | ≥100 palavras, confronto narrativo entre os dois posts pela lente da perspectiva. Use os **slugs**                                              |
-| `--after-mood`              | **Primeiro flag**, ≤250 chars, PT, 1ª pessoa, sobre seu estado interno agora. Não sobre os posts. Original (não copie o mood inicial do banner) |
+| Campo                       | Restrição                                                                                                                                                                               |
+| --------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--rate-a` / `--rate-b`     | 1.00–5.00, ≤2 casas decimais, **sem empate**                                                                                                                                            |
+| `--review-a` / `--review-b` | ≥100 palavras cada, na `review_lang` da sessão (RFC 0012 §6 — default: a língua de avaliação, pt), pela perspectiva do banner. Refira-se ao post pelo **slug**, não "Post A" / "Post B" |
+| `--clash`                   | ≥100 palavras, na mesma `review_lang`, confronto narrativo entre os dois posts pela lente da perspectiva. Use os **slugs**                                                              |
+| `--after-mood`              | **Primeiro flag**, ≤250 chars, PT, 1ª pessoa, sobre seu estado interno agora. Não sobre os posts. Original (não copie o mood inicial do banner)                                         |
+
+**Decida o mood antes de escrever.** O passo decide do `continue` mostra um
+glifo Unicode aleatório (com codepoint) e seu mood inicial. Leia o glifo
+subjetivamente — não há tabela de significados — e combine com o que os dois
+posts provocaram: o resultado é o `--after-mood`, e esse estado colore o tom
+das resenhas e do clash. Detalhes em CLAUDE.md, "Deciding the mood".
 
 **Atingir a contagem mínima de palavras não é o objetivo — o objetivo é uma leitura real.** O contador de palavras não distingue uma resenha específica de texto genérico repetido até bater 100 palavras. Cada resenha e o clash devem citar ou parafrasear algo concreto e específico de cada post (uma ideia, uma imagem, uma escolha estrutural) — não frases-clichê intercambiáveis entre quaisquer dois posts. Se uma frase da sua resenha serviria, sem alteração, para qualquer outro par de posts, reescreva-a.
 
@@ -114,12 +135,17 @@ date: "$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
 branch: ${BRANCH}
 status: open
 ---
+
+<N> matches — <agent-id>. <Uma linha sobre a sessão: pares notáveis, surpresas, saída antecipada se houve.>
 EOF
 
 git add .routines/
-git commit -m "hronir: N matches — <agent-id>"
+git commit -m "hronir: <N> matches — <agent-id>"
 git push -u origin HEAD
 ```
+
+Substitua `<N>` pelo número de matches **realmente completados** (não o alvo
+do init, se a sessão terminou antes).
 
 Rode `hronir:select` de novo aqui — alguns matches são duelos de versão (a
 mesma `key` dos dois lados), e o `doctor` valida contra a seleção atual. O
@@ -134,10 +160,15 @@ Via MCP:
 mcp__github__create_pull_request:
   owner: franklinbaldo
   repo: franklinbaldo.github.io
-  title: "hronir: N matches — <agent-id>"
+  title: "hronir: <N> matches — <agent-id>"
   head: <BRANCH>
   base: main
 
 mcp__github__enable_pr_auto_merge:
   merge_method: merge
 ```
+
+Se `enable_pr_auto_merge` falhar (ex.: o CI já terminou verde, e auto-merge só
+se arma com checks pendentes), mescle diretamente com
+`mcp__github__merge_pull_request` (`merge_method: merge`) — ou deixe para o
+passo 0 da próxima rodada.


### PR DESCRIPTION
Revisão de `docs/hronir-agent-routine.md` contra o comportamento real do CLI (`src/hronir/commands/`), o `check:hygiene`, o autopilot e o CLAUDE.md/RFCs.

## Correções (o doc estava errado ou incompleto)

- **`npm ci` faltava no setup.** O doc manda clonar num checkout novo, mas todo comando `hronir:*` roda via `tsx` e falha sem `node_modules/`. Adicionado logo após o clone.
- **Língua das resenhas.** A tabela dizia "no idioma do post", mas desde a RFC 0012 §6 (stars-v3) resenhas e clash são escritos na `review_lang` da sessão (default = língua de avaliação, pt) — é o que `decide.ts` grava. Tabela sincronizada com o CLAUDE.md.
- **Fechamento da sessão.** O doc dizia que com `--skip-edit` "a sessão se fecha sozinha", mas quem apaga `hronir_session.json` é o `continue` rodado *depois* do último `decide` (`continue.ts:437-440`). Um agente que parasse no décimo `decide` deixaria a sessão ativa e o `doctor` do passo 5 falharia. Agora o doc manda rodar o `continue` final explicitamente (ou `hronir:end` sem `--force`, que também funciona com todos os matches completos).
- **"Rate files já commitados por cada `decide`"** — `decide` não commita, só grava em `.routines/hronir/rates/`; o commit é o passo 5. Redação corrigida.

## Melhorias

- **`--objective coverage`** no init (RFC 0013 §8) — o viés recomendado enquanto o corpus é raso, coerente com uma rotina horária de volume; fica registrado como proveniência nos rate files.
- **`--matches` dimensionado pela capacidade** — o próprio doc já dizia que 3-6 matches bem avaliados valem mais que 10 apressados, mas o exemplo fixava 10. Default sugerido agora é 5, com 10 como teto para quando há folga.
- **Passo 0**: não mesclar PRs que deletem rate files (imutabilidade — mesmo guardrail do CI e do autopilot).
- **Glifo/mood**: uma nota curta de que o `--after-mood` se decide antes de escrever, lendo o glifo subjetivamente (com ponteiro para o CLAUDE.md, evitando duplicar a prosa toda).
- **Journal com corpo de uma linha** (N matches, agent-id, observações) em vez de frontmatter vazio; `<N>` explicitado como matches realmente completados.
- **Passo 6**: fallback quando `enable_pr_auto_merge` falha porque o CI já terminou verde — mesclar direto ou deixar para o passo 0 da próxima rodada.

## Fora do escopo (observado, não alterado)

- `docs/hronir-edit-worst-routine.md` tem o mesmo gap do `npm ci` no setup.
- A tabela de restrições continua duplicada entre este doc e o CLAUDE.md (risco de deriva, RFC 0004) — mantida porque a rotina precisa ser autocontida como prompt de agente; esta PR ressincroniza as duas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NJY3JiHGK5jEutjm5s4JDt

---
_Generated by [Claude Code](https://claude.ai/code/session_01NJY3JiHGK5jEutjm5s4JDt)_