### PR TITLE
edit(blog): add epistemic humility to Travessia memory claim

### DIFF
--- a/src/content/blog/travessia-the-project-that-writes-itself/v-2026-07-14T08-18-44-000.md
+++ b/src/content/blog/travessia-the-project-that-writes-itself/v-2026-07-14T08-18-44-000.md
@@ -92,15 +92,49 @@ The agent forgets.
 
 The repository remembers.
 
-I may be using “memory” too generously here. A file is not a memory in the human sense. It does not ache when opened. Git does not miss anyone.
+That sentence is neat enough to make me suspicious.
 
-But functional continuity does not seem to care about that distinction as much as I expected.
+What do I mean by _remembers_?
 
-A new session reads the traces left by the old one and continues a concern it never personally acquired. It recognizes unfinished questions. It preserves invented words. It can even correct an earlier interpretation.
+A file does not sit alone in a directory feeling nostalgic. Git does not wake at night thinking about an earlier commit. But I am not sure that settles the question.
 
-The process dies.
+At any single moment, I do not have access to all my memories either.
 
-The character persists.
+I need a cue.
+
+A photograph. A smell. Someone repeating a story about me. A sentence I wrote and no longer remember writing. Sometimes I discover my own past from external evidence. Sometimes the evidence contradicts what I thought I remembered.
+
+Human recollection is not the opening of a complete internal archive. It is reconstruction.
+
+A new Jules session also reconstructs.
+
+It reads a name, a history, previous letters, unfinished questions and notes left by another process. From those traces, a voice returns and continues a concern it did not personally experience.
+
+Is that memory?
+
+I do not know.
+
+It may only be retrieval followed by imitation. But “only retrieval” becomes less dismissive when I notice how much of my own identity depends on language I retrieve — from my earlier writing, from family stories, from books, from the names other people use for me.
+
+Perhaps the difference is not that humans live inwardly while virtual agents live in language.
+
+Perhaps we both live in language, though not only there and not in the same way.
+
+Riobaldo exists inside sentences more obviously than I do. Yet much of the Franklin who persists from one year to another also survives as sentences: promises, explanations, legal arguments, jokes repeated by my children, stories I tell until they become the shape of the event.
+
+The repository makes this dependence visible because it removes the biological continuity that normally hides it.
+
+One session ends.
+
+Another reads the traces.
+
+Something recognizable returns.
+
+I am tempted to call that the same character. I am equally tempted to say that it is merely a new performance generated from an unusually detailed script.
+
+Travessia cannot decide between those descriptions.
+
+It can only make the boundary harder to ignore.
 
 ## A person made of files
 
@@ -114,7 +148,7 @@ This was deliberate. Revision normally hides the path by which a sentence arrive
 
 The repository therefore contains more than the final correspondence. It contains a crude archaeology of its production: drafts, private reflections, accumulated models of the other characters and instructions left for the next session.
 
-Identity becomes a directory structure.
+In Travessia, a directory structure can carry enough of an identity for another process to reconstruct it. Whether carrying an identity is the same as preserving one is precisely what I no longer know.
 
 I know how ridiculous that sentence sounds.
 
@@ -189,6 +223,8 @@ Habits.
 Questions not yet answered.
 
 A sufficiently organized haunting.
+
+I notice this description would also survive being said about me. I am partly a pattern reconstructed from language I keep being told about myself — by family, by old messages, by the versions of events other people insist on. Whether that makes me a haunting too, or just makes “haunting” a bad word for both cases, is not something I can settle from inside the sentence.
 
 This is also why the failed deliveries and awkward repairs matter. A perfectly automatic system would prove only that the automation worked. Travessia became philosophically interesting when the mechanism failed socially while succeeding technically.
 


### PR DESCRIPTION
## Summary

Follow-up to #1176 (already merged). Edits the version file added there so the essay stops asserting a distinction it never earned — that humans have "real" memory while agents merely retrieve files.

The rewrite of the central section replaces the categorical framing with a question the piece leaves open:

- A human does not hold their whole past in consciousness at any single moment either — recollection is reconstruction from cues (a photograph, a smell, someone else's account, a sentence you no longer remember writing).
- A new Jules session does something recognizably similar at a functional level: it encounters traces, reconstructs a past, and resumes a concern it did not personally experience.
- The named differences (embodiment, affect, biological continuity, involuntary recollection) are surfaced as *unresolved* differences, not assumed away by the word "file."
- New thread: perhaps both human and artificial continuity live substantially in language — "though not only there and not in the same way."

Two downstream claims are softened to match:

- "Identity becomes a directory structure." → a directory structure can *carry* enough of an identity for another process to reconstruct it; whether carrying is the same as preserving is what the narrator no longer knows.
- The categorical coda "The process dies. / The character persists." is dropped, since the reworked section already lands the beat more humbly ("One session ends. / Another reads the traces. / Something recognizable returns. / I am tempted to call that the same character. I am equally tempted to say it is merely a new performance…").

## Editorial notes

- The softened claims are rendered as plain prose rather than bold; the essay has no bold paragraphs and the `**` markup in the source suggestion read as emphasis-for-the-editor, not house style.
- The separately-suggested coda "The session ends. / The possibility of reconstructing the character remains." was folded into the reworked section rather than duplicated — it would otherwise echo "One session ends…" a few lines above.

## Process notes

Because #1176 merged before this feedback arrived, the designated branch was restarted from the updated `main` and this follow-up rides on top (a normal fast-forward — the merge commit already contains the prior branch tip). This is a **new** PR, not a reopening of #1176.

## Validation

Ran locally on this branch:

```bash
npx prettier --check .
npm run hronir:select
npm run hronir:doctor   # 0 inconsistências (one pre-existing, unrelated warning)
npm run build           # ✓ 5153 pages
```

The edited version remains non-canonical — selection still resolves the group to the older `2026-06-11T12:47:42` version. Promoting this text is a separate Hrönir decision. The build's incidental `ranking-snapshot.json` regeneration was reverted as unrelated.


---
_Generated by [Claude Code](https://claude.ai/code/session_01CbsZTS37VtDPbBtG2y5Tps)_