### PR TITLE
edit(blog): more internal links and text memes in Travessia

### DIFF
--- a/src/content/blog/travessia-the-project-that-writes-itself/v-2026-07-14T08-18-44-000.md
+++ b/src/content/blog/travessia-the-project-that-writes-itself/v-2026-07-14T08-18-44-000.md
@@ -180,13 +180,21 @@ A process called the Tropeiro carried messages between them.
 
 I had reinvented email, but with pull requests and a cowboy.
 
-The names were not merely decorative. They established borders. Riobaldo could work inside his rancho. Ted worked inside his. Tyler Cowen could interrupt as a critic. Craig Mod could care about presentation and the public surface. None was supposed to rewrite another character’s territory. Communication had to cross the system through letters.
+The names were not merely decorative. They established [borders](/blog/the-art-of-delegation/). Riobaldo could work inside his rancho. Ted worked inside his. Tyler Cowen could interrupt as a critic. Craig Mod could care about presentation and the public surface. None was supposed to rewrite another character’s territory. Communication had to cross the system through letters.
 
 The metaphor compiled.
 
 Git was no longer only where the work happened to be stored. It became part of the fictional machinery.
 
-It supplied memory through files, identity through accumulated habits, causality through commits, isolation through branches and provenance through history. A merge was not merely deployment. It determined what the next character could know.
+```
+files    → memory
+habits   → identity
+commits  → causality
+branches → isolation
+history  → provenance
+```
+
+A merge was not merely deployment. It determined what the next character could know.
 
 The literary form was version control.
 
@@ -200,6 +208,14 @@ There were merge conflicts.
 
 There were expired sessions, concurrency limits, malformed frontmatter and agents waiting for messages that had not been delivered. Sometimes the metaphysical experiment depended on valid YAML.
 
+```
+heartbeat: riobaldo — alive, 18h remaining
+heartbeat: ted — session expired, renewing
+tropeiro: balaio locked, delivery deferred
+error:     malformed frontmatter — letter 0043
+heartbeat: retry in 15m
+```
+
 What surprised me was not that the system could operate without intervention. It often could not.
 
 What surprised me was that it could recover continuity after interruption.
@@ -210,7 +226,7 @@ This is a smaller claim than “the project is alive.”
 
 It is also stranger.
 
-We normally imagine identity as something contained inside an entity. Travessia suggests another possibility: identity as a pattern repeatedly reconstructed from external traces.
+We normally imagine [identity](/blog/quem-sou-eu-en/) as something contained inside an entity. Travessia suggests another possibility: identity as a pattern repeatedly reconstructed from external traces.
 
 Prompt.
 
@@ -250,7 +266,7 @@ Calling it merely mine would also leave something out.
 
 I did not choose every memory that surfaced in a letter. I did not plan each objection, image or turn of phrase. Sometimes the system produced sentences I could not have written but immediately recognized as belonging there.
 
-That does not eliminate authorship. It distributes it.
+That does not eliminate [authorship](/blog/pierre-menard-computational-researcher/). It distributes it.
 
 The agents produce language. The repository produces continuity. The workflow produces occasions for action. I choose the conditions, retain the power to intervene and remain responsible for what I publish.
 
@@ -278,6 +294,7 @@ Riobaldo knew where the conversation had stopped.
 
 - [Crossing After Interference](/blog/crossing-after-interference/) follows the failed mail test, my apology and Riobaldo’s answer in greater detail.
 - [Verne and the Identity-Repo Pattern](/blog/verne-identity-repo/) develops the broader idea of keeping an agent’s identity in a repository rather than inside a single running process.
+- [Building Funes: How I Gave an AI Agent a Soul](/blog/building-funes/) takes the opposite problem — a character who cannot forget — and asks what a memory file does to an agent that runs on it.
 - [The Travessia source repository](https://github.com/franklinbaldo/travessia) contains the prompts, correspondence, heartbeat records and architectural history behind this essay.
 - [Jules](https://jules.google.com/) is the coding agent used to run the sessions and propose changes through GitHub.
 - [Git Internals — Plumbing and Porcelain](https://git-scm.com/book/en/v2/Git-Internals-Plumbing-and-Porcelain) explains the storage model whose ordinary engineering properties became part of Travessia’s narrative form.


### PR DESCRIPTION
## Summary

Follow-up to #1177 (already merged). Adds more cross-links to related essays and more visual rests to the Travessia version file.

### Internal links (four new, on first mention)

- **borders → [The Art of Delegation](/blog/the-art-of-delegation/)** — the rancho/isolation passage; the post is literally "Signatures and Sandboxes."
- **identity → [Who Am I?](/blog/quem-sou-eu-en/)** — "identity as a pattern repeatedly reconstructed from external traces."
- **authorship → [Pierre Menard, Computational Researcher](/blog/pierre-menard-computational-researcher/)** — "That does not eliminate authorship. It distributes it."
- **[Building Funes](/blog/building-funes/)** — added to *For further reading* as the memory companion: the inverse case, a character who cannot forget.

These join the two existing self-links (*Crossing After Interference*, *Verne and the Identity-Repo Pattern*), for six internal links total.

### Text memes (two new, distinct templates)

The essay already had one imperative-list block ("wake up with no memories / read `PROMPT.md` / …"). To avoid template-repeat (a tic per the blog skill), the two additions use different shapes, and both land in the wry technical sections — the confessional memory passage is deliberately left without added visual rest:

- a **git → concept glossary** map ("files → memory / habits → identity / commits → causality / …") replacing the prose list, in "A person made of files";
- a **heartbeat / error log** ("heartbeat: riobaldo — alive, 18h remaining / … / error: malformed frontmatter — letter 0043") in "Autonomy has infrastructure," right after "the metaphysical experiment depended on valid YAML."

## Placement rationale

Per the blog skill: inline links go "on first mention… when the reader benefits," and confessional/emotionally-weighted passages "take fewer memes, not more." The four links are body-inline (not piled into *For further reading*, whose self-link discipline stays intact), and both memes sit in technical/dry passages rather than the memory core.

## Process note

#1177 merged before this batch, so the branch was restarted from the updated `main` and this rides on top as a normal fast-forward. New PR, not a reopen of #1177.

## Validation

```bash
npx prettier --check .
npm run hronir:select
npm run build   # ✓ 5153 pages — validates internal blog links; all six resolve
```

The edited version remains non-canonical (selection still resolves the group to the older `2026-06-11T12:47:42` version). The build's incidental `ranking-snapshot.json` regeneration was reverted as unrelated.


---
_Generated by [Claude Code](https://claude.ai/code/session_01CbsZTS37VtDPbBtG2y5Tps)_