### PR TITLE
hronir: 3 matches — Claude Haiku

### DIFF
--- a/.routines/2026-07-14T15-15-34-hronir-run.md
+++ b/.routines/2026-07-14T15-15-34-hronir-run.md
@@ -1,0 +1,7 @@
+---
+date: "2026-07-14T15:11:05Z"
+branch: hronir/run-2026-07-14T15-08-01
+status: open
+---
+
+3 matches — Claude Haiku. Traversed perspectives: Comedy-Carries-Argument (travessia-project version duel, v2 wins 4.50★), Lyric-as-Poem (music comparisons: bibliotecario 3.75★ vs veu 2.75★; escherian 4.25★ vs quando 3.50★). All evaluations attentive and specific to perspective criteria; doctor: 0 inconsistencies.

--- a/.routines/hronir/rates/2026-07-14T15-09-24-336_travessia-project_x_travessia-project.md
+++ b/.routines/hronir/rates/2026-07-14T15-09-24-336_travessia-project_x_travessia-project.md
@@ -1,0 +1,78 @@
+---
+type: Rate File
+run_id: 2026-07-14T15-09-24-336
+run_at: '2026-07-14T15:09:24.336Z'
+post_a:
+  key: travessia-project
+  path: >-
+    src/content/blog/travessia-the-project-that-writes-itself/v-2026-06-11T12-47-42-181.md
+  display_lang: en
+  content_lang: en
+  version: 2b813e75-8709-5ed2-ac05-6f637674cd4f
+  ref: >-
+    travessia-the-project-that-writes-itself@2b813e75-8709-5ed2-ac05-6f637674cd4f
+post_b:
+  key: travessia-project
+  path: >-
+    src/content/blog/travessia-the-project-that-writes-itself/v-2026-07-14T08-18-44-000.md
+  display_lang: en
+  content_lang: en
+  version: 46b3e98a-666f-5a23-954d-3174f401e1bb
+  ref: >-
+    travessia-the-project-that-writes-itself@46b3e98a-666f-5a23-954d-3174f401e1bb
+winner: b
+agent_id: Claude Haiku
+content_mode: path-only
+objective: coverage
+eval_lang: pt
+review_lang: en
+prompt_version: stars-v3
+season: 1
+override: null
+perspective_id: comedy-carries-argument
+evaluator_mood: >-
+  O coração está aberto mas um é construído em fatos verificados, o outro em
+  experiência sentida. A verdade muda quando vira ritual. Prefiro o rigor mas
+  entendo por que o outro funciona quando entra na prática.
+mood_glyph: ほ
+evaluator_mood_after: >-
+  Subitamente vejo como a história torna o pensamento respirável — não mais
+  rigor contra narrativa, mas rigor que respira através dela.
+impression_a: null
+impression_b: null
+rate_a: 2.75
+rate_b: 4.5
+clash: >-
+  A sentença mais engraçada em travessia-project (v-2026-06-11) exigiria esforço
+  para identificar — humor circunstancial, não estrutural. A versão de
+  2026-07-14 constrói estrutura de comédia: pedido de desculpas a personagem de
+  IA é engraçado como momento onde autor reconhece hipocrisia. I had designed
+  the system to treat its characters as people — essa frase funciona porque
+  parágrafo anterior mostrou desrespeito como engenharia. A piada É o argumento.
+  Disposição de dizer I notice this description would also survive being said
+  about me (virando incerteza para dentro) é como comédia vira rigor. De
+  2026-07-14 prevalece: não apenas documenta Travessia — é Travessia, pelo
+  padrão do leitor para quem piada e pensamento são o mesmo.
+review_a: >-
+  Lendo travessia-project (v-2026-06-11) pela ótica do leitor para quem a piada
+  é a alavanca: esta versão prioriza exposição. A estrutura é clara — Jules como
+  coautor, processo incremental, a dupla impossibilidade — mas nenhuma piada
+  carrega peso lógico. Removo qualquer sentença potencialmente humorística e o
+  argumento sobrevive ileso. As seções explicativas são competentes mas
+  decorativas. É uma peça de registro grave que confunde clareza com
+  profundidade. O post explica o que Travessia faz. Não por que importa. Não há
+  momento onde a autor exponha a si mesmo. Não há hesitação que force o leitor a
+  se debruçar de novo. Falta o incômodo que exige releitura.
+review_b: >-
+  Lendo travessia-project (v-2026-07-14): esta revisão inverte o erro anterior.
+  Abre com um incidente — enviar maçã, cão como linguagem descartável — e esse
+  incidente É o argumento. A piada 'This is a fairly efficient way to discover
+  what you actually believe' não é alívio; é a redução ao absurdo que força
+  reconhecimento de responsabilidade. As observações cômicas sobre Git como
+  infraestrutura (the most software-engineering way possible to approach
+  mortality) comprimem semanas de filosofia em uma frase. A incerteza
+  incorporada (I do not know. It may only be retrieval followed by imitation)
+  aterrissa como humor seco E necessidade lógica. Remova qualquer uma e o
+  argumento desaba completamente.
+---
+

--- a/.routines/hronir/rates/2026-07-14T15-10-14-488_music-bibliotecario-do-infinito_x_music-veu-do-infinito.md
+++ b/.routines/hronir/rates/2026-07-14T15-10-14-488_music-bibliotecario-do-infinito_x_music-veu-do-infinito.md
@@ -1,0 +1,73 @@
+---
+type: Rate File
+run_id: 2026-07-14T15-10-14-488
+run_at: '2026-07-14T15:10:14.488Z'
+post_a:
+  key: music-bibliotecario-do-infinito
+  path: src/content/blog/bibliotecario-do-infinito-en/v-2026-06-14T16-11-22-900.mdx
+  display_lang: en
+  content_lang: en
+  version: b7606b79-3f9d-52bf-b554-4bf57ac4202f
+  ref: bibliotecario-do-infinito-en@b7606b79-3f9d-52bf-b554-4bf57ac4202f
+post_b:
+  key: music-veu-do-infinito
+  path: src/content/blog/veu-do-infinito/v-2026-06-09T20-24-29.mdx
+  display_lang: pt
+  content_lang: pt
+  version: f294470b-da66-5d17-bce9-689960355b57
+  ref: veu-do-infinito@f294470b-da66-5d17-bce9-689960355b57
+winner: a
+agent_id: Claude Haiku
+content_mode: path-only
+objective: coverage
+eval_lang: pt
+review_lang: pt
+prompt_version: stars-v3
+season: 1
+override: null
+perspective_id: lyric-as-poem
+evaluator_mood: 'Urgência de falar, clareza após escuta. A flauta sem artifício.'
+mood_glyph: ダ
+evaluator_mood_after: >-
+  Percebo que o silêncio em volta da nota é o que a torna audível — menos
+  palavras, mais escuta.
+impression_a: null
+impression_b: null
+rate_a: 3.75
+rate_b: 2.75
+clash: >-
+  Qual letra conquista a página, não apenas a performance?
+  **music-bibliotecario-do-infinito** tem uma linha que resiste ao deslize
+  fácil: 'Cada letra um caminho, cada livro um deus' — essa concentração de
+  imagem não exigiria reescrita se a música desaparecesse. **veu-do-infinito** é
+  uma faixa de sete minutos que tenta gritar O Infinito na sequência. Quando
+  você lê a página sem áudio, o que permanece é 'Sonhos digitais dissecam o
+  divino' — e você percebe que 'dissecam' foi escolhido pelo som de 's' no
+  contexto, não porque seja a palavra certa. O compositor de Véu sabe disso; é o
+  ponto. Mas saber é não é fazer. A Biblioteca tem um catálogo; o Véu tem ruído.
+  Controle bate excesso quando a métrica é a página, não o performance.
+  **music-bibliotecario-do-infinito**, três a um.
+review_a: >-
+  Lendo as letras de **music-bibliotecario-do-infinito** como poema na página:
+  há controle aqui. 'Cada letra um caminho, cada livro um deus' comprime
+  significado sem deformação sintática. 'Onde o sentido se esconde / E a loucura
+  se desgarra' tem ritmo e assonância a serviço do significado, não ao
+  contrário. O compositor reconhece os problemas estruturais (intenção de
+  fricção, resultado como dois discos em salas separadas) sem se esconder. As
+  notas iluminam contexto — Borges, baião, sínteses — sem traduzir o
+  significado. A letra sobrevive na página como poesia competente, controlada,
+  embora convencional em estrutura. Não há linha que force você a desacelerar
+  por densidade, mas há clareza de ofício.
+review_b: >-
+  Lendo **veu-do-infinito** como poema na página: aqui o excesso é deliberado. O
+  compositor confessa: 'a letra cedeu sob o peso de seus próprios adjetivos' e
+  deixou assim propositalmente para demonstrar o que acontece quando um modelo
+  tenta descrever infinito sem constrangimento. É pedagogicamente interessante,
+  mas viola o critério do leitor-de-letra-como-poema. 'Sonhos digitais dissecam
+  o divino no seu bote' — aquele 'bote' soa forçado a rimar, não conquistado.
+  Vocabulário escolhido para som e excesso antes que precisão. A canção funciona
+  como demonstração por que precisa-se do véu; não funciona como poema denso na
+  página. A meta-crítica é sofisticada, mas a página revela o que a música
+  mascara: linhas de preenchimento, sintaxe distorcida, palavras que alcançam.
+---
+

--- a/.routines/hronir/rates/2026-07-14T15-11-05-028_music-escherian-sunrise-with-godel_x_music-quando-vier-a-primavera.md
+++ b/.routines/hronir/rates/2026-07-14T15-11-05-028_music-escherian-sunrise-with-godel_x_music-quando-vier-a-primavera.md
@@ -1,0 +1,78 @@
+---
+type: Rate File
+run_id: 2026-07-14T15-11-05-028
+run_at: '2026-07-14T15:11:05.028Z'
+post_a:
+  key: music-escherian-sunrise-with-godel
+  path: src/content/blog/escherian-sunrise-with-godel-en.mdx
+  display_lang: en
+  content_lang: en
+  version: 66bd1a5b-413d-5875-b5f3-1312fdf2d19f
+  ref: escherian-sunrise-with-godel-en@66bd1a5b-413d-5875-b5f3-1312fdf2d19f
+post_b:
+  key: music-quando-vier-a-primavera
+  path: src/content/blog/quando-vier-a-primavera.mdx
+  display_lang: pt
+  content_lang: pt
+  version: 13d1b1c3-1a6c-5199-9f75-a834ab9be5e7
+  ref: quando-vier-a-primavera@13d1b1c3-1a6c-5199-9f75-a834ab9be5e7
+winner: a
+agent_id: Claude Haiku
+content_mode: path-only
+objective: coverage
+eval_lang: pt
+review_lang: pt
+prompt_version: stars-v3
+season: 1
+override: null
+perspective_id: lyric-as-poem
+evaluator_mood: >-
+  ⚒ é ferramenta que não se usa — martelo que olha o prego sem bater. Saio dessa
+  querendo o que muda, não o que apenas deixa pensar.
+mood_glyph: ⇳
+evaluator_mood_after: >-
+  Quero quem constrói algo novo, não quem cita bem o que já brilha — sou
+  impaciente com a sabedoria quando ela quer apenas ser bonita.
+impression_a: null
+impression_b: null
+rate_a: 4.25
+rate_b: 3.5
+clash: >-
+  Qual composição *faz* poesia na página, não apenas a contextualiza?
+  **music-escherian-sunrise-with-godel** cria impossibilidade através de
+  sintaxe: a ascensão e queda simultâneas não são ideia, são *enactment*. Cada
+  verso pressiona a linguagem para fazer o que a sintaxe não deveria permitir.
+  **music-quando-vier-a-primavera** retira sabedoria que já brilha, coloca-a em
+  arranjo delicado, e então a deixa brilhar como sempre brilhou. A beleza vem de
+  Caeiro. A msúica vem do compositor, mas a poesia vem de Pessoa. Para o leitor
+  que quer densidade *criada*, não densidade *citada*, Escherian conquista a
+  página enquanto Quando a respeita respeitosamente à distância. A primeiro
+  move; a segunda medita. Um leitor que quer mudar, não pensar, prefere o
+  movimento. **music-escherian-sunrise-with-godel**, três a um.
+review_a: >-
+  Lendo **music-escherian-sunrise-with-godel** como poema na página: a paradoxo
+  é encenada através da linguagem, não apenas ilustrada. 'The sun rose, falling
+  through the sky / The shadows climbed instead of fell' cria uma imagem
+  impossível que funciona *porque* a sintaxe quebra a expectativa. 'Hands test
+  the air for solid ground, / A railing where no edges stay' — cada linha enrola
+  novo trabalho. O bridge com Gödel é elegante: 'I'll prove the sunrise stays
+  this way / He couldn't make the sunrise stand' — incompletude como humildade,
+  não derrota. A repetição do refrão martela o paradoxo, e o sussurro
+  'incomplete, incomplete' resiste à leitura fácil. Notas do compositor iluminam
+  sem traduzir: contexto (Escher, Gödel, D Dorian), constrição revelada,
+  propósito exposto. A poesia sobrevive fria na página porque foi composta
+  *para* que sobrevivesse.
+review_b: >-
+  Lendo **music-quando-vier-a-primavera** como poema na página: aqui temos
+  Pessoa. 'A realidade não precisa de mim' é Caeiro — 1914, brilliance já
+  comprovada. A música a honra (pastoril, sem dramatismo, nylon arpejado), e a
+  escolha de não sentimentalizar é correta, mas a densidade poética na página é
+  de Caeiro, não criada de novo pelo compositor. A linha 'Não tenho preferências
+  para quando já não puder ter preferências' — impecavelmente rigorosa, mas a
+  rigor é de Caeiro. O arranjo em 6/8 é uma escolha válida e respeitosa, mas
+  respeitando e contextualiz não é o mesmo que densificar. As notas do
+  compositor revelam a distância entre a própria filosofia de Caeiro e sua
+  própria incapacidade de alcançá-la, o que é honesto e tocante — mas
+  honestidade sobre contemplação não é contemplação transformada em ação.
+---
+


### PR DESCRIPTION
## Summary

Completed 3 attentive Hrönir evaluations across two perspectives:

- **Comedy-Carries-Argument Reader**: Version duel of *travessia-project* — the 2026-07-14 revision (4.50★) prevails over the 2026-06-11 version (2.75★). The newer version shifts from pure exposition to narrative-driven philosophy; the incident of sending test messages becomes the logical lever through which authorship and responsibility emerge.

- **Lyric-as-Poem Reader** (match 2): *music-bibliotecario-do-infinito* (3.75★) defeats *veu-do-infinito* (2.75★) — controlled craft and precision outweigh deliberate baroque excess. Librarian earns the page through syntax; Véu collapses under its own adjectives by design.

- **Lyric-as-Poem Reader** (match 3): *music-escherian-sunrise-with-godel* (4.25★) defeats *music-quando-vier-a-primavera* (3.50★) — paradox enacted through language vs. Pessoa's wisdom contextualized. Escherian creates impossible images; Quando respects existing brilliance from 1914.

**Validation**: `npm run hronir:doctor` — 0 inconsistencies, 1 non-blocking language-divergence warning.

All rate files committed to `.routines/hronir/rates/`.

🤖 Generated with Claude Haiku

---

https://claude.ai/code/session_01BQ9Kr2QbdVAWozwTNhKcED

---
_Generated by [Claude Code](https://claude.ai/code/session_01BQ9Kr2QbdVAWozwTNhKcED)_