### PR TITLE
ci(autopilot): restringir trigger a branches hronir/*

### DIFF
--- a/.github/workflows/hronir-autopilot.yml
+++ b/.github/workflows/hronir-autopilot.yml
@@ -13,6 +13,17 @@ name: Hrönir Autopilot
 # sessions produce rate files under .routines/hronir/rates/ (hourly matches
 # routine) or v-* draft files under src/content/blog/ (daily edit-worst
 # routine).
+#
+# `workflow_run: workflows: ["Check"]` fires on EVERY PR's Check completion
+# repo-wide — Dependabot bumps, manual infra PRs, anything — not just
+# Hrönir session PRs. The path gate below already rejects those correctly,
+# but only after a full checkout + several `gh` API calls per irrelevant PR
+# (confirmed in practice: e.g. run 29319125165 spent a full job on PR #1055,
+# a Dependabot workflow-file bump, before hitting "touches out-of-scope
+# file"). The job-level `if` below adds a branch-prefix check so those never
+# get past "Set up job" — every legitimate Hrönir branch (routine sessions,
+# edit-worst, flatten pilots/batches) uses the `hronir/` prefix by
+# convention (see docs/hronir-agent-routine.md, docs/hronir-edit-worst-routine.md).
 
 on:
   workflow_run:
@@ -45,12 +56,15 @@ env:
 jobs:
   merge:
     runs-on: ubuntu-latest
-    # Manual dispatch, or a successful Check run on a real PR branch (not main).
+    # Manual dispatch, or a successful Check run on a hronir/* PR branch.
+    # The branch-prefix check is what keeps every non-Hrönir PR (Dependabot
+    # bumps, manual infra/content PRs) from even reaching "Set up job" — see
+    # the comment above SAFE_PREFIXES.
     if: >
       github.event_name == 'workflow_dispatch' ||
       (github.event.workflow_run.conclusion == 'success' &&
       github.event.workflow_run.event == 'pull_request' &&
-      github.event.workflow_run.head_branch != 'main')
+      startsWith(github.event.workflow_run.head_branch, 'hronir/'))
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 


### PR DESCRIPTION
## O que motivou

Revisando o estado atual dos workflows (Check, Deploy, Hrönir Autopilot),
percebi que o `hronir-autopilot.yml` está funcionando corretamente — faz merge
das sessões Hrönir de verdade (ex. PRs #1182, #1183, `merged_by:
"github-actions[bot]"`) e corretamente recusa PRs manuais (ex. #1181,
`merged_by: "franklinbaldo"`, sem rate file/draft).

Mas o `on: workflow_run: workflows: ["Check"]` dispara para **toda** conclusão
do workflow "Check" no repositório — não só PRs de sessão Hrönir. Como o
`check.yml` roda em todo `pull_request`, isso inclui bumps do Dependabot,
PRs de infra, qualquer coisa.

Confirmei isso na prática: a run 29319125165 do autopilot rodou um job
completo (checkout + múltiplas chamadas `gh pr view`) até logar
`"PR #1055 touches out-of-scope file: .github/workflows/check.yml —
skipping."` — o PR #1055 é um bump de workflow do Dependabot, nada a ver com
Hrönir. O path gate (`SAFE_PREFIXES`) já rejeita esses PRs corretamente, mas só
depois de gastar um job inteiro de CI e várias chamadas de API por PR
irrelevante.

## O que muda

Adiciona um filtro de prefixo de branch na condição `if` do job `merge`: em
vez de só excluir `head_branch != 'main'`, agora exige
`startsWith(github.event.workflow_run.head_branch, 'hronir/')`. Isso é um
estreitamento estrito — toda branch `hronir/*` já satisfazia `!= 'main'`
trivialmente — então nenhum PR de sessão legítima deixa de ser mergeado.

Verifiquei que toda branch de sessão Hrönir usa esse prefixo por convenção:

- `docs/hronir-agent-routine.md`: `BRANCH="hronir/run-..."`
- `docs/hronir-edit-worst-routine.md`: `BRANCH="hronir/edit-worst-..."`
- Minhas próprias branches de flatten (RFC 0015 Fase D):
  `hronir/flatten-pilot-...`, `hronir/flatten-batch-...`

Com o filtro, PRs de Dependabot/infra/conteúdo manual nunca chegam a "Set up
job" no autopilot — economia de checkout + chamadas de API por PR irrelevante,
sem mudar nenhum resultado de merge real.

Também adicionei um bloco de comentário no topo do arquivo documentando esse
achado (com a evidência da run 29319125165 / PR #1055) para o próximo agente
que revisar o workflow não precisar redescobrir isso.

## Validação

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/hronir-autopilot.yml'))"` — YAML válido
- `npx prettier --check .github/workflows/hronir-autopilot.yml` — formatação ok
- Nenhuma mudança de comportamento para PRs de sessão Hrönir reais (todas usam o prefixo `hronir/`)


---
_Generated by [Claude Code](https://claude.ai/code/session_01NJY3JiHGK5jEutjm5s4JDt)_