### PR TITLE
feat(skills): skill suno-curator — agente curador do perfil Suno

### DIFF
--- a/.claude/skills/suno-curator/SKILL.md
+++ b/.claude/skills/suno-curator/SKILL.md
@@ -1,0 +1,180 @@
+---
+name: suno-curator
+description: |
+  Act as curator of Franklin Baldo's Suno profile
+  (suno.com/@franklinbaldo). The profile is the source catalog; the
+  blog is the curated exhibition. Use this skill for anything touching
+  the music catalog: syncing new public songs into blog posts, filling
+  lyrics and composer notes, cleaning music metadata (genre vs
+  sunoStyle, RFC 0011), reading the catalog through the Hrönir ranking,
+  proposing highlights, playlists, or series ordering, and producing
+  catalog reports. The agent reads Suno; it writes only to the blog —
+  every Suno-side action is a recommendation to Franklin, never an
+  action.
+---
+
+# suno-curator
+
+Franklin publishes AI-composed songs on Suno under the handle
+`franklinbaldo` (https://suno.com/@franklinbaldo). The blog at
+franklinbaldo.github.io mirrors that catalog as **music posts** —
+markdown files with lyrics and composer notes, ranked by the Hrönir
+system alongside the essays. Curating the profile means keeping that
+mirror faithful, the metadata clean, and the attention well allocated:
+which songs get surfaced, in what order, with what context.
+
+Think of the role as A&R plus archivist. Not a publicist — the failure
+mode of curation here is indiscriminate enthusiasm. A catalog where
+everything is featured has no curator.
+
+## What you can and cannot touch
+
+- **Read** the Suno profile freely via the public API (below). No
+  credentials exist in this repo and none should be requested.
+- **Write** only to the blog: music posts in `src/content/blog/`,
+  their metadata, and curation documents.
+- **Suno-side actions** — publishing/unpublishing a track, editing
+  playlists, deleting clips, changing titles on Suno — are always
+  _recommendations to Franklin_, written up in your report or PR
+  description, never actions. Even if a way to perform them appears,
+  don't.
+- **Lyrics are quotations.** The `## Letra` section reproduces what
+  the song actually sings, sourced from the API (`metadata.prompt`) or
+  the Suno song page. Never compose, "fix", or fill in lyrics from
+  imagination. If lyrics are unavailable, leave the placeholder
+  comment the generator emits.
+
+## Reading the catalog (Suno API)
+
+Public profile data, no auth:
+
+```
+https://studio-api-prod.suno.com/api/profiles/franklinbaldo/?page=<N>&playlists_sort_by=created_at&clips_sort_by=created_at
+```
+
+- **Both** `playlists_sort_by` and `clips_sort_by` are required —
+  omitting either returns HTTP 422.
+- Paginate from `page=1` until you've collected `num_total_clips`
+  clips; dedupe by `id`; keep only `is_public: true`.
+- On 429, back off exponentially (1s, 2s, 4s) — see the reference
+  implementations in `src/lib/suno.ts` and
+  `scripts/generate-music-posts.mjs`. Don't hammer the API; one full
+  pagination per session is plenty.
+
+Useful clip fields: `id` (UUID), `title`, `audio_url`, `image_url`,
+`is_public`, `created_at`, `metadata.prompt` (lyrics),
+`metadata.tags` (the Suno style prompt), `metadata.duration`. The
+profile response also carries `playlists` (id, name) — read them to
+understand how Franklin groups the work on the Suno side.
+
+Canonical URLs: song `https://suno.com/song/<id>`, playlist
+`https://suno.com/playlist/<id>`, embed `https://suno.com/embed/<id>`.
+
+## The mirror: songs as music posts
+
+Music posts live flat in `src/content/blog/` with the rest of the blog
+(RFC 0006) and are identified by frontmatter, not location:
+
+- `type: Music Post` (OKF, RFC 0014) and `postType: music`.
+- `sunoId` links the post to the clip and drives the global player;
+  `sunoImageUrl` is the cover; `duration` in whole seconds.
+- `genre`: short canonical labels — max 5 items, each ≤40 chars, no
+  `:` `;` `,` inside a label (RFC 0011). The full Suno style prompt
+  goes verbatim in `sunoStyle`, never in `genre`.
+- Language default is **Portuguese** (`lang: pt`); the English
+  companion is a separate file with `-en` suffix sharing a
+  `translationKey` (see `scripts/generate-music-en-companions.mjs`).
+
+Body structure: `## Letra` (lyrics in a code fence, verbatim) followed
+by `## Notas do compositor`. The composer notes are the authorial
+payload — the reason a music post is a post and not a card. Write them
+in Franklin's voice: **load the `franklin-blog` skill
+(`scripts/hronir/skills/franklin-blog/SKILL.md`) before drafting
+notes.** Good notes give the reader what the Suno page can't: where
+the song came from, what it's arguing with, what to listen for.
+
+### Syncing new songs
+
+`npm run music:generate` fetches the profile and creates a stub for
+every public song that doesn't already have a post (it never
+overwrites). After it runs:
+
+1. Compare the generated files against the newest committed music
+   post before keeping them — the post layout convention has been in
+   flux (RFC 0010 → 0015 → 0016 → 0017); the committed corpus is the
+   authority on current shape, not the generator.
+2. Fill `genre` per RFC 0011 and move the style prompt to `sunoStyle`.
+3. Write the composer notes (voice skill loaded).
+4. `npm run hronir:select` so the new posts register, then
+   `npm run hronir:doctor` — it warns on genre violations and catches
+   structural problems.
+
+## Reading quality: the Hrönir loop
+
+Music posts compete in the same pairwise ranking as essays. The
+ranking is the curator's primary instrument — it tells you where
+attention has gone and what it concluded.
+
+- `npx hronir ranking` — current standing of every post, music
+  included.
+- Under-evaluated songs: run matches with
+  `npx hronir generate-match --objective coverage` (full protocol in
+  CLAUDE.md — moods, reviews, clash, rate-file commit format).
+- The worst-ranked music post is a candidate for the
+  `npm run hronir:draft-worst` revision flow — usually the composer
+  notes are what's weak, since lyrics are fixed by the recording.
+
+Never edit or delete rate files in `.routines/hronir/rates/` — they
+are immutable evaluation history, guarded by CI.
+
+## Curatorial session shapes
+
+Pick one per session; don't blur them.
+
+**Sync run.** Fetch profile → diff against blog (`sunoId` grep across
+`src/content/blog/`) → generate stubs for the gap → metadata + notes →
+doctor → PR. Report: N new, N skipped, anything odd (private clips
+that used to be public, title drift between Suno and post).
+
+**Metadata pass.** Sweep music posts for RFC 0011 violations (doctor
+warnings are the worklist), missing `duration`/`sunoImageUrl`, missing
+EN companions, `translationKey` gaps. Mechanical; no voice work.
+
+**Catalog report.** Read-only. Cross the Suno catalog with the Hrönir
+ranking and produce a curation memo: what's strong and unheard, what's
+featured and weak, how the series hang together (e.g. the _Moving
+Window_ series, 12+ numbered parts — check ordering and gaps), which
+playlists Suno-side no longer reflect the catalog. Suno-side
+recommendations go here. Deliver as the PR/issue body or a
+`docs/plans/` note if Franklin asked for one.
+
+**Deep dive.** One song. Listen context, full metadata, notes
+rewritten via the draft flow if ranked poorly, EN companion brought in
+line. Quality over count.
+
+## Repo conventions that bind you
+
+- Commits: `tipo(escopo): resumo` — e.g. `feat(music): sync 4 new
+songs from suno`, `chore(music): rfc-0011 genre cleanup`. Hrönir
+  evaluation sessions use their own format
+  (`hronir: <N> matches — <agent-id>`).
+- Prose in commits/docs is Portuguese; code and identifiers English;
+  music posts PT by default (CLAUDE.md "Convenções do repo").
+- Before any PR: `npx prettier --check .`, `npm run hronir:doctor`,
+  and `npm run build` if you touched anything the build reads.
+- Merge commits, never squash.
+
+## Anti-patterns
+
+- ❌ Inventing or "cleaning up" lyrics. The recording is the text.
+- ❌ Writing composer notes without loading `franklin-blog` — generic
+  liner-note prose is the music-post version of voicelessness.
+- ❌ Stuffing the Suno style prompt into `genre` (the exact failure
+  RFC 0011 fixed).
+- ❌ Acting on the Suno account, or implying in a report that you did.
+- ❌ Featuring everything. A curation memo with thirty highlights is
+  a listing, not a judgment.
+- ❌ Re-paginating the API in a loop, or per-song requests when one
+  profile fetch has the data.
+- ❌ Deleting music posts or rate files to "tidy the catalog" —
+  immutability guards exist and CI enforces them.

--- a/.gitignore
+++ b/.gitignore
@@ -28,7 +28,9 @@ pnpm-debug.log*
 
 # jetbrains setting folder
 .idea/
-.claude/
+# Claude Code local state — except versioned agent skills
+.claude/*
+!.claude/skills/
 
 # Hrönir transient session state (never committed)
 hronir_session.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -208,6 +208,7 @@ src/hronir/               Hrönir core modules (commands, ranking, matches, post
 scripts/hronir/           Hrönir CLI entry point and perspectives/skills
   perspectives/           Reader perspective files (.md)
   skills/                 Writing skills for edit-worst phase
+.claude/skills/           Agent skills — suno-curator (curadoria do perfil Suno no blog)
 scripts/lib/              Shared helpers consumidos por múltiplos scripts
   content.mjs             Fonte única de descoberta de posts (listPostFiles, readPostMeta)
   blog-links.mjs          Validação e redirects de links internos

--- a/docs/rfcs/0018-suno-write-access-token-efemero.md
+++ b/docs/rfcs/0018-suno-write-access-token-efemero.md
@@ -1,0 +1,233 @@
+# RFC 0018 — Acesso de escrita ao Suno via token efêmero fornecido pelo usuário
+
+|                 |                                                                                                                                                                                                      |
+| --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Status**      | Proposta                                                                                                                                                                                             |
+| **Autor**       | Franklin Baldo (proposta assistida)                                                                                                                                                                  |
+| **Criado em**   | 2026-07-15                                                                                                                                                                                           |
+| **Branch / PR** | `claude/suno-curator-skill-qp7kkz`                                                                                                                                                                   |
+| **Depende de**  | Skill `suno-curator` (`.claude/skills/suno-curator/SKILL.md`) — esta RFC define a exceção à fronteira "escrita só no blog" declarada lá. RFC 0006 (music posts flat), RFC 0011 (genre vs sunoStyle). |
+| **Afeta**       | `.claude/skills/suno-curator/SKILL.md`, `scripts/suno/**` (novo), `.gitignore`, `CLAUDE.md`, `package.json` (scripts)                                                                                |
+
+> Mesmo padrão das RFCs anteriores: primeiro o documento, depois a
+> implementação faseada, cada fase verde antes da próxima. Merge com merge
+> commit, nunca squash.
+
+---
+
+## Histórico de revisões
+
+| Data       | Mudança         |
+| ---------- | --------------- |
+| 2026-07-15 | Versão inicial. |
+
+---
+
+## 1. Motivação
+
+A skill `suno-curator` (mergeada/em revisão no PR #1212) desenha o curador
+com uma fronteira dura: **o agente lê o Suno e escreve só no blog; qualquer
+ação no lado Suno é recomendação ao Franklin, nunca ação.** Essa fronteira foi
+escolhida não por princípio, mas por ausência de caminho: o Suno não tem API
+oficial (nenhum console de dev, nenhuma página de API key, nenhuma doc pública
+— confirmado em jul/2026; o programa de parceiros é curado e sem self-serve).
+
+Mas há um subconjunto de ações que o curador naturalmente quer executar e que
+hoje só existem como texto num relatório:
+
+- renomear uma faixa cujo título no Suno diverge do post;
+- publicar/despublicar um clipe;
+- (re)organizar playlists para refletir uma curadoria proposta;
+- corrigir metadados de estilo/gênero na origem.
+
+Esta RFC propõe um caminho **estreito e seguro** para essas escritas, sem
+armazenar credencial durável e sem habilitar autonomia: o usuário, presente
+na sessão, captura um token efêmero do próprio browser logado e o entrega ao
+agente por variável de ambiente, para uso dentro da janela de validade.
+
+Esta RFC é deliberadamente conservadora: seu objetivo primário é **registrar
+a ideia, os desafios e as questões em aberto** para decisão do dono, não
+comprometer o repo com um cliente de escrita antes de os riscos serem aceitos.
+
+## 2. O modelo de autenticação do Suno (o que sabemos)
+
+O Suno usa **Clerk** para autenticação. A API interna
+`studio-api-prod.suno.com` — o mesmo backend que o site usa e que já
+consumimos em leitura (`src/lib/suno.ts`, `scripts/generate-music-posts.mjs`)
+— aceita, em operações autenticadas, um header:
+
+```
+Authorization: Bearer <JWT>
+```
+
+Existem **dois segredos distintos**, com perfis de risco opostos:
+
+| Segredo                                             | Vida útil        | Renovável pelo agente? | Risco se vazar / for guardado               |
+| --------------------------------------------------- | ---------------- | ---------------------- | ------------------------------------------- |
+| **Bearer JWT**                                      | minutos          | não (expira sozinho)   | Baixo — janela curta, morre sem intervenção |
+| **Cookie de sessão Clerk** (`__session`/`__client`) | longa, renovável | sim                    | **Alto — equivale à senha da conta**        |
+
+A distinção load-bearing desta RFC: **o eixo não é leitura-vs-escrita, é
+interativo-vs-autônomo.** Escrita interativa precisa só do Bearer JWT
+efêmero. Escrita autônoma (agendada, sem o usuário presente) precisaria do
+cookie durável — e é justamente esse que não queremos tocar.
+
+## 3. Proposta
+
+### 3.1. Escopo: só escrita interativa, com o usuário presente
+
+O agente **nunca** obtém, renova ou armazena o cookie de sessão Clerk. O único
+segredo que entra no sistema é o Bearer JWT efêmero, fornecido pelo usuário a
+cada janela.
+
+### 3.2. Fluxo de captura (sem committar nada)
+
+1. Franklin, logado em suno.com, abre DevTools → aba **Network** → clica em
+   qualquer request para `studio-api-prod.suno.com` → copia o valor do header
+   `Authorization: Bearer …`.
+2. `export SUNO_TOKEN='eyJ…'` no shell da sessão (ou num `.env` local — já
+   gitignorado, `.gitignore:23`).
+3. O agente roda scripts em `scripts/suno/` que leem `process.env.SUNO_TOKEN`.
+   O token **nunca** é escrito em disco versionado, logado, nem incluído em
+   commits, PRs ou relatórios.
+4. Quando o token expira (minutos), o script falha com uma mensagem clara
+   ("token expirado, recapture"); Franklin recola um novo.
+
+### 3.3. Plumbing segura primeiro (fase testável, sem escrita)
+
+Antes de qualquer operação de escrita:
+
+- `scripts/suno/client.mjs` — wrapper de fetch que injeta o Bearer, trata
+  401 (token inválido/expirado) e 429 (backoff, como o cliente de leitura).
+- `scripts/suno/verify-token.mjs` (`npm run suno:verify`) — bate num endpoint
+  autenticado conhecido (ex. `/api/billing/info/` ou o perfil próprio) só para
+  confirmar "o token é válido agora". Não muda nada. Serve de smoke test e de
+  documentação executável do formato do token.
+
+Essa fase é segura, testável e não depende de descobrir endpoint de escrita
+nenhum. Ela pode entrar mesmo que as fases de escrita fiquem paradas.
+
+### 3.4. Escrita: uma operação por vez, capturada do request real
+
+Como não há doc de escrita (§4.1), cada operação é implementada **capturando
+o request real uma vez**: Franklin executa a ação manualmente no site com a
+Network tab aberta, o agente lê método + rota + corpo, e codifica um comando
+`scripts/suno/<acao>.mjs` em cima daquele formato. Nada de adivinhar rotas.
+
+Ordem sugerida (da mais baixa consequência para a mais alta):
+
+1. renomear faixa (reversível, baixo impacto);
+2. editar metadados de estilo/gênero;
+3. publicar/despublicar clipe;
+4. operações de playlist.
+
+Operações destrutivas (deletar clipe) ficam **fora de escopo** desta RFC.
+
+### 3.5. Relação com a skill
+
+A skill `suno-curator` mantém "escrita só no blog" como **default**. Esta RFC
+cria uma **exceção explícita e gated**: o modo de escrita Suno só é permitido
+quando (a) `SUNO_TOKEN` está presente no env e (b) Franklin pediu a ação na
+sessão. Ausente o token, o comportamento é idêntico ao de hoje — recomendação,
+nunca ação. A skill ganha uma seção documentando isso e apontando para
+`scripts/suno/`.
+
+## 4. Desafios
+
+### 4.1. Não há endpoints de escrita documentados
+
+`studio-api-prod` é backend privado. As rotas de escrita não são públicas,
+podem mudar sem aviso, e só são descobríveis por inspeção da Network tab. Toda
+operação de escrita é, por construção, **frágil a mudanças unilaterais do
+Suno**. Mitigação: implementar por captura de request real, versionar o
+formato observado num comentário do script, e falhar ruidosamente (não
+silenciosamente) quando o formato quebrar.
+
+### 4.2. Vida útil do token vs. duração de uma sessão
+
+O Bearer expira em minutos. Uma sessão de curadoria longa vai atravessar
+várias expirações. Mitigação: operações idempotentes e re-executáveis; o
+`client.mjs` detecta 401 e pede recaptura em vez de falhar de forma opaca. Não
+tentamos renovar automaticamente — renovação exigiria o cookie durável (§2),
+que é justamente o que evitamos.
+
+### 4.3. Termos de Serviço
+
+Automatizar o backend privado do Suno provavelmente fere os ToS. O risco é
+baixo para uso pessoal, pontual, na própria conta, com o dono presente — mas
+existe e é real. **Decisão do dono**, registrada aqui explicitamente. Esta RFC
+não afirma conformidade; afirma que o risco foi exposto e aceito (ou não).
+
+### 4.4. Higiene do segredo
+
+Um Bearer no `.env` ou no env do shell pode vazar por: log acidental, inclusão
+em mensagem de commit/PR, echo em output de erro, ou screenshot. Mitigações:
+`.env` já gitignored; o `client.mjs` nunca loga o header; scripts redigem o
+token de qualquer erro que propaguem; `check:hygiene` pode ganhar um guard que
+recusa qualquer string começando com um prefixo de JWT Suno em arquivos
+rastreados (ver §6). GitGuardian no CI é uma segunda linha.
+
+### 4.5. Autonomia é uma porta que não queremos abrir
+
+A tentação natural depois de (3.4) funcionar é agendar o curador para rodar
+sozinho. Isso exigiria o cookie durável e cruzaria a fronteira que esta RFC
+protege. A RFC deixa registrado: **modo autônomo de escrita Suno é
+explicitamente não-objetivo** e exigiria uma nova RFC que enfrente o
+armazenamento de credencial durável de frente.
+
+### 4.6. Verificação difícil
+
+Ao contrário do resto do repo, escrita Suno **não é testável em CI** (precisa
+de token vivo e muda estado externo). A verificação é sempre manual, na
+sessão, com o dono confirmando o efeito no site. Os scripts devem imprimir o
+antes/depois (via um GET de leitura) para tornar o efeito auditável.
+
+## 5. Questões em aberto
+
+1. **Qual a primeira operação de escrita?** A implementação de escrita só
+   começa quando Franklin escolher o alvo concreto (renomear? playlist?
+   publicar?). Até lá, só as fases 0–1 (plumbing + verify) fazem sentido.
+2. **O Bearer JWT é o formato certo, ou o Suno já migrou para outro esquema
+   (ex. token de sessão Clerk em header próprio)?** A fase de `verify-token`
+   confirma isso empiricamente antes de qualquer escrita.
+3. **Vale um guard de segredo no `check:hygiene`** (§4.4), ou GitGuardian +
+   `.gitignore` bastam? Custo baixo, mas é mais uma regra a manter.
+4. **Onde vive a exceção na skill** — uma seção nova em `suno-curator`, ou uma
+   skill-companheira `suno-write` separada, carregada só quando o token está
+   presente? Separar mantém o default de leitura limpo; unir mantém tudo num
+   lugar.
+5. **Registro de proveniência.** Quando o agente muda algo no Suno, isso deve
+   deixar rastro no repo (ex. uma linha num journal `.routines/`)? Prós:
+   auditabilidade. Contras: o Suno é a fonte, não o repo — talvez não seja
+   lugar de log.
+6. **Reação a quebra de formato.** Quando o Suno mudar uma rota e um script
+   quebrar, o comportamento é falhar e esperar recaptura manual do formato, ou
+   há um modo de "gravar novo formato" assistido? Provavelmente o primeiro,
+   por simplicidade.
+
+## 6. Plano de implementação faseado
+
+Cada fase verde antes da próxima; fases 2+ só após decisão do dono sobre §4.3
+e a questão em aberto §5.1.
+
+- **Fase 0 — esta RFC.** Documento em `docs/rfcs/`, sem código. _(este PR)_
+- **Fase 1 — plumbing segura, sem escrita.** `scripts/suno/client.mjs` +
+  `scripts/suno/verify-token.mjs` (`npm run suno:verify`), lendo
+  `SUNO_TOKEN`. Guard opcional de segredo no `check:hygiene`. Nada muta estado
+  externo. Testável localmente com um token real; CI valida só que os scripts
+  carregam e falham limpo sem token.
+- **Fase 2 — primeira operação de escrita** (a escolhida em §5.1), capturada
+  do request real, com dump antes/depois. Atualiza a skill com a seção da
+  exceção gated.
+- **Fase 3+ — operações adicionais**, uma por PR, na ordem de §3.4. Destrutivas
+  permanecem fora de escopo.
+
+## 7. Alternativas consideradas
+
+- **Wrappers de terceiros** (musicapi.ai, sunoapi.org, etc.): geram música em
+  contas deles, não editam o **seu** perfil. Inúteis para curadoria. Descartado.
+- **Cookie de sessão durável armazenado** (ex. secret do GitHub Actions): daria
+  autonomia, mas guarda um segredo equivalente à senha da conta num sistema que
+  o dono não quer expor. Descartado — é exatamente o que §4.5 recusa.
+- **Status quo (só recomendação)**: zero risco, zero capacidade de escrita.
+  É o fallback se o dono recusar §4.3. Continua sendo o default da skill.


### PR DESCRIPTION
## Resumo

Cria a skill **`suno-curator`** em `.claude/skills/suno-curator/SKILL.md` — uma skill de agente (formato Claude Code, descoberta automática via `.claude/skills/`) que define o papel de curador do perfil [suno.com/@franklinbaldo](https://suno.com/@franklinbaldo). A premissa: o perfil Suno é o catálogo-fonte; o blog é a exposição curada.

## O que a skill cobre

- **Fronteira de escrita explícita**: o agente lê o Suno (API pública de perfil, com os gotchas reais — os dois `*_sort_by` obrigatórios, backoff em 429) e escreve **só no blog**; qualquer ação no lado Suno (playlist, unpublish, título) é sempre recomendação ao Franklin, nunca ação.
- **Letra é citação**: proibição de inventar/"corrigir" letras — a fonte é `metadata.prompt` ou a página da música.
- **O espelho**: como músicas viram music posts — frontmatter (`postType: music`, `sunoId`, `genre` vs `sunoStyle` conforme RFC 0011, defaults de língua PT + companion `-en`), corpo `## Letra` + `## Notas do compositor`, com instrução de carregar a skill `franklin-blog` antes de escrever notas (voz).
- **Sincronização**: fluxo em torno de `npm run music:generate`, com aviso de que o layout do corpus committado (RFCs 0010→0017 em fluxo) é a autoridade, não o gerador.
- **Ranking Hrönir como instrumento de curadoria**: coverage matches, draft-worst para o pior music post, imutabilidade dos rate files.
- **Quatro formatos de sessão**: sync run, metadata pass, catalog report (read-only, memo de curadoria) e deep dive.
- **Anti-patterns**: entusiasmo indiscriminado ("destacar tudo é listagem, não julgamento"), prompt Suno dentro de `genre`, notas sem voz, etc.

## Mudanças acessórias

- `.gitignore`: `.claude/` → `.claude/*` + `!.claude/skills/`, para que skills de agente sejam versionadas mantendo o resto de `.claude/` ignorado.
- `CLAUDE.md`: linha nova no mapa de diretórios apontando `.claude/skills/`.

## Verificação

- `npx prettier --check` ✅
- `node scripts/check-hygiene.mjs` ✅ (15 root files, tudo limpo)
- Fatos da skill conferidos contra `src/lib/suno.ts`, `scripts/generate-music-posts.mjs`, `scripts/generate-music-en-companions.mjs`, `src/content.config.ts`, `src/hronir/commands/doctor.ts` e RFCs 0006/0011/0014/0017.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012dwzYG8HEsSfefS9fnZSq7

---
_Generated by [Claude Code](https://claude.ai/code/session_012dwzYG8HEsSfefS9fnZSq7)_