### PR TITLE
ci: check changelog/version-bump pairing; run build+lighthouse in parallel

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -21,46 +21,11 @@ jobs:
 
       - run: npm ci
 
-      # PRs da rotina horária tocam só .routines/** (rate files + journal):
-      # mudam dados de ranking, não a performance das páginas — nem o build
-      # nem o Lighthouse têm o que pegar nelas (ver os gates abaixo). Usa
-      # `...` (merge-base diff, isolando só os commits desta PR) de propósito
-      # — não `..`, usado pelo passo "Rate file deletion guard" mais abaixo
-      # para um propósito diferente (deleção contra o main atual). Nota:
-      # esta checagem é deliberadamente mais estreita que o SAFE_PREFIXES do
-      # hronir-autopilot.yml — PRs de draft de edição (src/content/blog/**)
-      # continuam de propósito fora daqui, porque mudam conteúdo real de
-      # página e o Lighthouse deve auditá-las.
-      - name: Classify PR scope
-        id: scope
-        if: github.event_name == 'pull_request'
-        run: |
-          CHANGED=$(git diff --name-only "origin/${{ github.base_ref }}...HEAD")
-          if [ -n "$CHANGED" ] && ! echo "$CHANGED" | grep -qv '^\.routines/'; then
-            echo "routines_only=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "routines_only=false" >> "$GITHUB_OUTPUT"
-          fi
-
-      # Build e cache só em PR (no push a main o Deploy builda o mesmo commit
-      # em seguida — buildar aqui de novo só duplica custo) e pulados também
-      # em PRs que só tocam .routines/** — hronir:doctor/select/astro check
-      # já validam esses arquivos; o build completo (astro build + pagefind +
-      # ranking snapshot) não audita nada que essas outras etapas não cubram.
-      # O cache é condicionado junto para não gravar um .astro vazio sob a
-      # key exata do sha, o que roubaria do Deploy o restore-keys de um
-      # build anterior quente.
-      - name: Cache Astro build state
-        if: github.event_name == 'pull_request' && steps.scope.outputs.routines_only != 'true'
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
-        with:
-          path: .astro
-          key: ${{ runner.os }}-astro-v24-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-astro-v24-
-
       - name: Repo hygiene
         run: npm run check:hygiene
+
+      - name: Changelog and version check
+        run: npm run check:changelog
 
       # Guards against phantom dependencies (imported but undeclared — works
       # today only because some other package pulls it in transitively and
@@ -139,8 +104,64 @@ jobs:
       - name: Astro type check
         run: npx astro check
 
+  # Roda em paralelo ao job `check` acima (não depende dele) — build + pagefind
+  # + Lighthouse são, de longe, a parte mais lenta do pipeline (~2min de build
+  # sozinho localmente; bem mais no runner do CI, mais o Lighthouse em cima).
+  # Rodavam em série no fim do job `check`, então PRs pagavam a soma dos dois;
+  # como um não depende do resultado do outro, rodar em paralelo corta o
+  # tempo de espera para o máximo dos dois em vez da soma. O trade-off: numa
+  # PR que falha em lint/prettier/etc, o build/Lighthouse ainda roda até o
+  # fim (antes era abortado cedo) — aceitável aqui porque minutos de Actions
+  # são de graça em repo público; o que importa é o tempo de espera.
+  build:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 24
+          cache: npm
+
+      - run: npm ci
+
+      # PRs da rotina horária tocam só .routines/** (rate files + journal):
+      # mudam dados de ranking, não a performance das páginas — nem o build
+      # nem o Lighthouse têm o que pegar nelas (ver os gates abaixo). Usa
+      # `...` (merge-base diff, isolando só os commits desta PR) de propósito
+      # — não `..`, usado pelo passo "Rate file deletion guard" do job `check`
+      # para um propósito diferente (deleção contra o main atual). Nota:
+      # esta checagem é deliberadamente mais estreita que o SAFE_PREFIXES do
+      # hronir-autopilot.yml — PRs de draft de edição (src/content/blog/**)
+      # continuam de propósito fora daqui, porque mudam conteúdo real de
+      # página e o Lighthouse deve auditá-las.
+      - name: Classify PR scope
+        id: scope
+        run: |
+          CHANGED=$(git diff --name-only "origin/${{ github.base_ref }}...HEAD")
+          if [ -n "$CHANGED" ] && ! echo "$CHANGED" | grep -qv '^\.routines/'; then
+            echo "routines_only=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "routines_only=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      # Cache condicionado ao scope para não gravar um .astro vazio sob a
+      # key exata do sha, o que roubaria do Deploy o restore-keys de um
+      # build anterior quente.
+      - name: Cache Astro build state
+        if: steps.scope.outputs.routines_only != 'true'
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: .astro
+          key: ${{ runner.os }}-astro-v24-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-astro-v24-
+
       - name: Build
-        if: github.event_name == 'pull_request' && steps.scope.outputs.routines_only != 'true'
+        if: steps.scope.outputs.routines_only != 'true'
         run: npm run build
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -149,5 +170,5 @@ jobs:
       # Build acima (ver Classify) — sem isso, rodaria contra um dist/ velho
       # ou inexistente em PRs que só tocam .routines/**.
       - name: Lighthouse CI
-        if: github.event_name == 'pull_request' && steps.scope.outputs.routines_only != 'true'
+        if: steps.scope.outputs.routines_only != 'true'
         run: npx lhci autorun --config=.lighthouserc.cjs

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -101,6 +101,20 @@ jobs:
         env:
           BASE_REF: ${{ github.event_name == 'pull_request' && format('origin/{0}', github.base_ref) || '' }}
 
+      # `astro check` roda seu próprio `sync()` (regeneração do content
+      # layer) antes de tipar. Restaura (sem salvar — quem salva é o job
+      # `build`, que já grava sob a mesma key) o mesmo cache `.astro/` do
+      # job `build` pra esse sync não começar sempre frio; a cache do
+      # Actions é remota por key, não por filesystem do runner, então os
+      # dois jobs conseguem ler o mesmo blob mesmo rodando em paralelo.
+      - name: Restore Astro build state
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: .astro
+          key: ${{ runner.os }}-astro-v24-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-astro-v24-
+
       - name: Astro type check
         run: npx astro check
 

--- a/.routines/2026-07-16T13-26-15-ci-changelog-guard-parallel-build.md
+++ b/.routines/2026-07-16T13-26-15-ci-changelog-guard-parallel-build.md
@@ -1,0 +1,70 @@
+---
+date: "2026-07-16T13:26:15Z"
+branch: claude/session-t6pk4n
+status: open
+---
+
+# Sessão 2026-07-16T13-26-15 — CI: guarda de changelog + build em paralelo
+
+Pedido do dono: fazer o CI checar se o bump de versão em `package.json` e a
+entrada de changelog correspondente estão presentes, e avaliar como deixar o
+CI mais rápido.
+
+## O que foi feito
+
+1. **`scripts/check-changelog.mjs`** (novo, `npm run check:changelog`, passo
+   "Changelog and version check" no `check.yml`) — checa as duas direções da
+   convenção "`package.json`'s version é a fonte única" (ver
+   `changelog/0.1.0.md`):
+   - versão atual de `package.json` sem `changelog/<versão>.md`
+     correspondente → erro (bump sem changelog);
+   - `changelog/<versão>.md` descrevendo uma versão à frente da atual em
+     `package.json` → erro (changelog sem bump);
+   - frontmatter de cada entrada validado: campos obrigatórios
+     `type`/`version`/`date`/`description`, `type` igual a `"Changelog
+     Entry"`, e `version` do frontmatter batendo com o nome do arquivo.
+   - Testado manualmente as duas direções de falha antes de integrar ao CI
+     (ambas disparam com a mensagem certa).
+
+2. **`check.yml` dividido em dois jobs paralelos** — `check` (hygiene,
+   changelog, depcheck, prettier, lint, testes, hronir select/doctor, guard
+   de deleção de rate file, link check, translation check, astro check) e
+   `build` (classify scope, cache, `npm run build`, Lighthouse CI), sem
+   dependência entre eles. Antes rodavam em série no mesmo job — build local
+   sozinho já leva ~2min, e Lighthouse (3 runs × 5 páginas) some em cima
+   disso; medido localmente para calibrar a decisão (`time npm run build`).
+   Como um não depende do resultado do outro, paralelizar corta o tempo de
+   espera da PR para o máximo dos dois em vez da soma. `build` continua
+   pulando build/Lighthouse pra PRs `routines_only` (mesma lógica de
+   "Classify PR scope" de antes) e não roda em push (só PR — Deploy já
+   builda o mesmo commit depois).
+   - Trade-off registrado em comentário no workflow: numa PR que falha em
+     lint/prettier/etc., o job `build` ainda roda até o fim (antes o job
+     único abortava cedo nesse ponto e nunca chegava no Build). Aceitável
+     aqui porque minutos de Actions são de graça em repo público — o que
+     importa é o tempo de espera, não o consumo.
+   - Não verificado se há branch protection exigindo checks nomeados
+     especificamente (não tenho acesso às settings do repo por aqui); o job
+     `check` manteve o mesmo id de antes de propósito, mas o novo job
+     `build` é um nome novo — se havia required status check apontando pro
+     antigo step "Build" dentro do job único, vale conferir/ajustar nas
+     settings do GitHub depois do merge.
+
+## Validação local
+
+- `npm run check:hygiene`, `npm run check:changelog` — verdes.
+- `npx prettier --check .` nos arquivos tocados — verde.
+- YAML do `check.yml` validado (`js-yaml`) depois da divisão em dois jobs.
+- `check-changelog.mjs` testado manualmente contra os dois casos de erro
+  (bump sem changelog, changelog sem bump) num diretório escrachado fora do
+  repo, antes de integrar.
+
+## O que ficou pra próxima
+
+- Confirmar nas settings do GitHub se branch protection precisa passar a
+  exigir também o novo job `build` como required status check (hoje só
+  `check` provavelmente está marcado).
+- Se quiser reduzir ainda mais o tempo do job `build`: `numberOfRuns: 3` no
+  Lighthouse (calibrado pra reduzir ruído — ver comentário em
+  `.lighthouserc.cjs`) é o próximo maior custo depois do build em si; não
+  mexi nisso agora por ser uma troca de sinal vs. ruído, não só velocidade.

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "prebuild": "node scripts/pregen.mjs",
     "predev": "node scripts/pregen.mjs",
     "check:hygiene": "node scripts/check-hygiene.mjs",
+    "check:changelog": "node scripts/check-changelog.mjs",
     "check:links": "node scripts/check-links.mjs",
     "check:translations": "node scripts/check-translations.mjs",
     "dev": "astro dev",

--- a/scripts/check-changelog.mjs
+++ b/scripts/check-changelog.mjs
@@ -1,0 +1,97 @@
+// CI guard: package.json's `version` is the single source of truth for
+// releases (changelog/<version>.md convention, started at 0.1.0 — see
+// changelog/0.1.0.md). This enforces both directions of that pairing so they
+// can't drift apart:
+//   1. The current package.json version has a matching changelog/<version>.md
+//      (a version bump without its changelog entry).
+//   2. No changelog/*.md entry describes a version ahead of package.json's
+//      current version (a changelog entry without the matching version bump).
+//   3. Every changelog/*.md file's frontmatter `version` matches its
+//      filename and carries the required OKF fields (RFC 0014 §7:
+//      `type` is the only field OKF itself requires; `version`/`date`/
+//      `description` are this convention's own requirements on top of that).
+import { readFileSync, readdirSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import matter from "gray-matter";
+
+const ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
+const CHANGELOG_DIR = join(ROOT, "changelog");
+const VERSION_FILE_RE = /^(\d+)\.(\d+)\.(\d+)\.md$/;
+const REQUIRED_FIELDS = ["type", "version", "date", "description"];
+
+const errors = [];
+
+const pkg = JSON.parse(readFileSync(join(ROOT, "package.json"), "utf-8"));
+const currentVersion = pkg.version;
+const currentMatch = /^(\d+)\.(\d+)\.(\d+)$/.exec(currentVersion);
+if (!currentMatch) {
+  errors.push(`package.json version "${currentVersion}" is not semver x.y.z`);
+}
+const currentParts = currentMatch ? currentMatch.slice(1).map(Number) : null;
+
+function compareParts(a, b) {
+  for (let i = 0; i < 3; i++) {
+    if (a[i] !== b[i]) return a[i] - b[i];
+  }
+  return 0;
+}
+
+const entryFiles = readdirSync(CHANGELOG_DIR).filter((f) =>
+  VERSION_FILE_RE.test(f)
+);
+
+if (currentParts) {
+  const currentEntryFile = `${currentVersion}.md`;
+  if (!entryFiles.includes(currentEntryFile)) {
+    errors.push(
+      `package.json version is "${currentVersion}" but changelog/${currentEntryFile} doesn't exist — ` +
+        `add a changelog entry for it (or revert the version bump if this PR isn't a release).`
+    );
+  }
+}
+
+for (const file of entryFiles) {
+  const path = join(CHANGELOG_DIR, file);
+  const expectedVersion = file.replace(/\.md$/, "");
+  const { data } = matter(readFileSync(path, "utf-8"));
+
+  for (const field of REQUIRED_FIELDS) {
+    if (!data[field]) {
+      errors.push(
+        `changelog/${file}: missing required frontmatter field "${field}"`
+      );
+    }
+  }
+  if (data.type && data.type !== "Changelog Entry") {
+    errors.push(
+      `changelog/${file}: type is "${data.type}", expected "Changelog Entry"`
+    );
+  }
+  if (data.version && String(data.version) !== expectedVersion) {
+    errors.push(
+      `changelog/${file}: frontmatter version "${data.version}" doesn't match filename (expected "${expectedVersion}")`
+    );
+  }
+
+  if (currentParts) {
+    const entryMatch = VERSION_FILE_RE.exec(file);
+    const entryParts = entryMatch.slice(1).map(Number);
+    if (compareParts(entryParts, currentParts) > 0) {
+      errors.push(
+        `changelog/${file} describes version ${expectedVersion}, ahead of package.json's current version "${currentVersion}" — ` +
+          `bump package.json's version to match.`
+      );
+    }
+  }
+}
+
+if (errors.length > 0) {
+  console.error(`\n✗ check-changelog: ${errors.length} issue(s):\n`);
+  for (const e of errors) console.error(`  • ${e}`);
+  process.exit(1);
+}
+
+console.log(
+  `✔ check-changelog: package.json version "${currentVersion}" has a matching changelog entry; ${entryFiles.length} entr${entryFiles.length === 1 ? "y" : "ies"} valid.`
+);

--- a/scripts/check-changelog.mjs
+++ b/scripts/check-changelog.mjs
@@ -10,21 +10,22 @@
 //      filename and carries the required OKF fields (RFC 0014 §7:
 //      `type` is the only field OKF itself requires; `version`/`date`/
 //      `description` are this convention's own requirements on top of that).
-import { readFileSync, readdirSync } from "node:fs";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import matter from "gray-matter";
 
 const ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
 const CHANGELOG_DIR = join(ROOT, "changelog");
-const VERSION_FILE_RE = /^(\d+)\.(\d+)\.(\d+)\.md$/;
+const SEMVER_RE = /^(\d+)\.(\d+)\.(\d+)$/;
+const VERSION_FILE_RE = /^(\d+\.\d+\.\d+)\.md$/;
 const REQUIRED_FIELDS = ["type", "version", "date", "description"];
 
 const errors = [];
 
 const pkg = JSON.parse(readFileSync(join(ROOT, "package.json"), "utf-8"));
 const currentVersion = pkg.version;
-const currentMatch = /^(\d+)\.(\d+)\.(\d+)$/.exec(currentVersion);
+const currentMatch = SEMVER_RE.exec(currentVersion);
 if (!currentMatch) {
   errors.push(`package.json version "${currentVersion}" is not semver x.y.z`);
 }
@@ -37,13 +38,37 @@ function compareParts(a, b) {
   return 0;
 }
 
-const entryFiles = readdirSync(CHANGELOG_DIR).filter((f) =>
-  VERSION_FILE_RE.test(f)
-);
+if (!existsSync(CHANGELOG_DIR)) {
+  console.error(
+    `\n✗ check-changelog: changelog/ directory not found (expected at ${CHANGELOG_DIR})\n`
+  );
+  process.exit(1);
+}
+
+// Every *.md file must match "<major>.<minor>.<patch>.md" exactly. A file
+// that doesn't (typo, prerelease-style suffix, ...) is flagged here rather
+// than silently skipped — otherwise it would bypass every check below,
+// including the ahead-of-version guard.
+const entries = [];
+for (const file of readdirSync(CHANGELOG_DIR)) {
+  if (!file.endsWith(".md")) continue;
+  const match = VERSION_FILE_RE.exec(file);
+  if (!match) {
+    errors.push(
+      `changelog/${file}: filename doesn't match the "<major>.<minor>.<patch>.md" convention`
+    );
+    continue;
+  }
+  entries.push({
+    file,
+    versionString: match[1],
+    parts: match[1].split(".").map(Number),
+  });
+}
 
 if (currentParts) {
   const currentEntryFile = `${currentVersion}.md`;
-  if (!entryFiles.includes(currentEntryFile)) {
+  if (!entries.some((e) => e.file === currentEntryFile)) {
     errors.push(
       `package.json version is "${currentVersion}" but changelog/${currentEntryFile} doesn't exist — ` +
         `add a changelog entry for it (or revert the version bump if this PR isn't a release).`
@@ -51,9 +76,8 @@ if (currentParts) {
   }
 }
 
-for (const file of entryFiles) {
+for (const { file, versionString, parts } of entries) {
   const path = join(CHANGELOG_DIR, file);
-  const expectedVersion = file.replace(/\.md$/, "");
   const { data } = matter(readFileSync(path, "utf-8"));
 
   for (const field of REQUIRED_FIELDS) {
@@ -68,21 +92,30 @@ for (const file of entryFiles) {
       `changelog/${file}: type is "${data.type}", expected "Changelog Entry"`
     );
   }
-  if (data.version && String(data.version) !== expectedVersion) {
+  if (data.version && String(data.version) !== versionString) {
     errors.push(
-      `changelog/${file}: frontmatter version "${data.version}" doesn't match filename (expected "${expectedVersion}")`
+      `changelog/${file}: frontmatter version "${data.version}" doesn't match filename (expected "${versionString}")`
     );
   }
-
-  if (currentParts) {
-    const entryMatch = VERSION_FILE_RE.exec(file);
-    const entryParts = entryMatch.slice(1).map(Number);
-    if (compareParts(entryParts, currentParts) > 0) {
+  // Mirrors the astro:content collection schema's `z.coerce.date()` (see
+  // src/content.config.ts) so a bad date fails here, with an actionable
+  // message, instead of surfacing later as a generic Zod error from
+  // `astro check` for the same file.
+  if (data.date) {
+    const dateValue =
+      data.date instanceof Date ? data.date : new Date(data.date);
+    if (Number.isNaN(dateValue.valueOf())) {
       errors.push(
-        `changelog/${file} describes version ${expectedVersion}, ahead of package.json's current version "${currentVersion}" — ` +
-          `bump package.json's version to match.`
+        `changelog/${file}: frontmatter date "${data.date}" isn't a valid date`
       );
     }
+  }
+
+  if (currentParts && compareParts(parts, currentParts) > 0) {
+    errors.push(
+      `changelog/${file} describes version ${versionString}, ahead of package.json's current version "${currentVersion}" — ` +
+        `bump package.json's version to match.`
+    );
   }
 }
 
@@ -93,5 +126,5 @@ if (errors.length > 0) {
 }
 
 console.log(
-  `✔ check-changelog: package.json version "${currentVersion}" has a matching changelog entry; ${entryFiles.length} entr${entryFiles.length === 1 ? "y" : "ies"} valid.`
+  `✔ check-changelog: package.json version "${currentVersion}" has a matching changelog entry; ${entries.length} entr${entries.length === 1 ? "y" : "ies"} valid.`
 );


### PR DESCRIPTION
## Summary

- Adds `scripts/check-changelog.mjs` (`npm run check:changelog`, wired into `check.yml`) to enforce both directions of the `package.json` version ↔ `changelog/<version>.md` pairing (see `changelog/0.1.0.md`, "package.json's version as the single source of truth"):
  - `package.json`'s current version must have a matching `changelog/<version>.md`.
  - No `changelog/*.md` entry may describe a version ahead of `package.json`'s current version.
  - Each entry's frontmatter must carry `type`/`version`/`date`/`description`, with `type: "Changelog Entry"` and `version` matching the filename.
- Splits `check.yml`'s single job into two parallel jobs: `check` (hygiene, changelog, depcheck, prettier, lint, tests, hronir select/doctor, rate-file deletion guard, link/translation checks, astro check) and `build` (build + Lighthouse CI, same `routines_only` skip logic as before, PR-only). They no longer depend on each other, so PR wait time drops to roughly the slower of the two instead of their sum — `npm run build` alone measures ~2min locally, plus Lighthouse on top of that.

## Trade-off

Since `build` no longer waits on `check`, a PR that fails an early check (e.g. prettier) still runs the full build + Lighthouse to completion instead of aborting early. Fine here since GitHub Actions minutes are free on this public repo and latency is what matters.

## Note

I didn't have visibility into this repo's branch protection settings. The `check` job kept its existing id, but `build` is a new job — if branch protection has specific required status checks configured, it may be worth adding `build` to that list after this merges.

## Test plan

- [x] `npm run check:hygiene` and `npm run check:changelog` pass locally
- [x] Manually verified `check-changelog.mjs` fails correctly in both directions (version bump without changelog entry, changelog entry ahead of `package.json` version) in a scratch directory
- [x] `npx prettier --check` on touched files
- [x] Validated `check.yml` YAML after the job split
- [ ] CI run on this PR (will watch)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_01LKdgYG863kxgC7sua65LqH)_