### PR TITLE
fix(music): code review fixes for generate-music-posts.mjs (PR #1232)

### DIFF
--- a/scripts/check-hygiene.mjs
+++ b/scripts/check-hygiene.mjs
@@ -35,6 +35,7 @@ const ROOT_ALLOWLIST = new Set([
   "astro.config.mjs",
   "package-lock.json",
   "package.json",
+  "skills-lock.json",
   "tsconfig.json",
 ]);
 

--- a/scripts/generate-music-posts.mjs
+++ b/scripts/generate-music-posts.mjs
@@ -9,10 +9,18 @@
  *                                                 songs, needs SUNO_CLERK_COOKIE
  */
 
-import { writeFileSync, existsSync, mkdirSync, readdirSync, readFileSync, statSync } from "fs";
+import {
+  writeFileSync,
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  statSync,
+} from "fs";
 import { join, dirname } from "path";
 import { fileURLToPath } from "url";
 import { mintBearerToken } from "./lib/suno-auth.mjs";
+import { parseFrontmatter } from "./lib/content.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = join(__dirname, "..");
@@ -83,20 +91,22 @@ function fmtYamlStr(str) {
 
 function parseTags(raw) {
   if (!raw) return [];
-  return raw
-    .split(/[,;\n]/) // some style prompts use newlines as the real separator
-    // between clauses (e.g. "Genre: X\nTempo: Y\nInstruments: Z"), not just
-    // commas — splitting on comma alone leaves multi-line fragments that
-    // blow past RFC 0011's 40-char genre-label limit.
-    .map((t) => t.trim())
-    .filter(Boolean)
-    // RFC 0011 / content.config.ts: genre labels max 40 chars each — drop
-    // anything longer instead of writing frontmatter the Zod schema will
-    // reject at build time.
-    .filter((t) => t.length <= 40)
-    // RFC 0011 / content.config.ts: max 5 genres per post (not 6 — the
-    // schema's actual cap).
-    .slice(0, 5);
+  return (
+    raw
+      .split(/[,;\n]/) // some style prompts use newlines as the real separator
+      // between clauses (e.g. "Genre: X\nTempo: Y\nInstruments: Z"), not just
+      // commas — splitting on comma alone leaves multi-line fragments that
+      // blow past RFC 0011's 40-char genre-label limit.
+      .map((t) => t.trim())
+      .filter(Boolean)
+      // RFC 0011 / content.config.ts: genre labels max 40 chars each — drop
+      // anything longer instead of writing frontmatter the Zod schema will
+      // reject at build time.
+      .filter((t) => t.length <= 40)
+      // RFC 0011 / content.config.ts: max 5 genres per post (not 6 — the
+      // schema's actual cap).
+      .slice(0, 5)
+  );
 }
 
 function makeMdx(clip) {
@@ -119,6 +129,12 @@ function makeMdx(clip) {
     ? `sunoImageUrl: ${fmtYamlStr(clip.image_url)}`
     : "";
 
+  // Only written when a clip is known-private (--include-private): marks
+  // the mirrored stub so a private/unpublished Suno song is never
+  // indistinguishable, in the committed file itself, from an intentional
+  // public mirror.
+  const privateYaml = clip.is_public === false ? `sunoPrivate: true` : "";
+
   const lyricsSection = lyrics
     ? `## Letra\n\n\`\`\`\n${lyrics}\n\`\`\``
     : `## Letra\n\n<!-- Cole a letra aqui -->`;
@@ -131,6 +147,7 @@ date: ${date}
 postType: music
 sunoId: ${clip.id}
 ${imageYaml}
+${privateYaml}
 ${genreYaml}
 ${durationYaml}
 tags:
@@ -156,8 +173,8 @@ function findMirroredSunoIds() {
   const ids = new Set();
   const scanFile = (path) => {
     const raw = readFileSync(path, "utf8");
-    const m = raw.match(/^sunoId:\s*([^\r\n]+)$/m);
-    if (m) ids.add(m[1].trim());
+    const sunoId = parseFrontmatter(raw).get("sunoId");
+    if (sunoId) ids.add(sunoId);
   };
   for (const entry of readdirSync(OUT_DIR, { withFileTypes: true })) {
     const full = join(OUT_DIR, entry.name);
@@ -212,7 +229,10 @@ async function fetchPublicClips() {
 // sees. /api/feed/v3 (cursor-paginated, POST) is the actual "my library"
 // feed, returning every generation regardless of visibility.
 async function fetchAllClipsIncludingPrivate(jwt) {
-  const auth = { Authorization: `Bearer ${jwt}`, "Content-Type": "application/json" };
+  const auth = {
+    Authorization: `Bearer ${jwt}`,
+    "Content-Type": "application/json",
+  };
   const clips = [];
   const seen = new Set();
   let cursor = null;
@@ -251,16 +271,44 @@ async function fetchClipDetail(id, jwt) {
 async function main() {
   mkdirSync(OUT_DIR, { recursive: true });
 
+  const alreadyMirrored = findMirroredSunoIds();
+  let created = 0;
+  let skipped = 0;
+
   let clips;
   if (INCLUDE_PRIVATE) {
-    console.log(`Buscando TODAS as músicas (públicas e privadas) de @${HANDLE} no Suno…`);
+    console.log(
+      `Buscando TODAS as músicas (públicas e privadas) de @${HANDLE} no Suno…`
+    );
     const jwt = await mintBearerToken();
     const basics = await fetchAllClipsIncludingPrivate(jwt);
-    console.log(`${basics.length} músicas encontradas (biblioteca completa). Buscando detalhes…`);
+    // Filter already-mirrored clips out before the per-clip detail fetch
+    // below — it's a real network round trip + sleep per clip, and
+    // re-fetching detail for clips that will just be skipped afterward
+    // wastes more work on every re-run as the mirrored set grows.
+    const unmirrored = basics.filter((c) => !alreadyMirrored.has(c.id));
+    skipped += basics.length - unmirrored.length;
+    console.log(
+      `${basics.length} música(s) encontradas (biblioteca completa), ${unmirrored.length} ainda não espelhadas. Buscando detalhes…`
+    );
     clips = [];
-    for (const c of basics) {
-      const detail = await fetchClipDetail(c.id, jwt);
-      clips.push({ ...c, metadata: detail.metadata ?? c.metadata, is_public: detail.is_public ?? c.is_public });
+    for (const c of unmirrored) {
+      try {
+        const detail = await fetchClipDetail(c.id, jwt);
+        clips.push({
+          ...c,
+          metadata: detail.metadata ?? c.metadata,
+          is_public: detail.is_public ?? c.is_public,
+        });
+      } catch (e) {
+        // One clip's detail fetch failing (deleted clip, transient error)
+        // shouldn't abort the whole batch and lose every other clip's
+        // progress — skip it and keep going.
+        console.error(
+          `  aviso: falha ao buscar detalhes de ${c.id}: ${e.message}`
+        );
+        skipped++;
+      }
       await sleep(150);
     }
   } else {
@@ -269,10 +317,6 @@ async function main() {
   }
 
   console.log(`${clips.length} música(s) para considerar.`);
-
-  const alreadyMirrored = findMirroredSunoIds();
-  let created = 0;
-  let skipped = 0;
 
   for (const clip of clips) {
     if (alreadyMirrored.has(clip.id)) {
@@ -308,12 +352,14 @@ async function main() {
     mkdirSync(dir, { recursive: true });
     const content = makeMdx(clip);
     writeFileSync(filepath, content, "utf8");
-    console.log(`  criado: ${slug}/v-${stamp}.mdx${clip.is_public ? "" : " (privado no Suno)"}`);
+    console.log(
+      `  criado: ${slug}/v-${stamp}.mdx${clip.is_public === false ? " (privado no Suno)" : ""}`
+    );
     created++;
   }
 
   console.log(`\nPronto: ${created} criados, ${skipped} já existiam.`);
-  if (created > 0 && !INCLUDE_PRIVATE) {
+  if (created > 0) {
     console.log(
       `\nAgora edite os novos arquivos em src/content/blog/ e adicione\nsuas notas em cada seção "## Notas do compositor".`
     );

--- a/scripts/lib/suno-auth.mjs
+++ b/scripts/lib/suno-auth.mjs
@@ -24,7 +24,9 @@ export async function mintBearerToken(cookie = process.env.SUNO_CLERK_COOKIE) {
   const session = body?.response?.sessions?.[0];
   const jwt = session?.last_active_token?.jwt;
   if (!jwt) {
-    throw new Error("No active session/token in Clerk response — cookie may be invalid or expired.");
+    throw new Error(
+      "No active session/token in Clerk response — cookie may be invalid or expired."
+    );
   }
   return jwt;
 }

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -116,6 +116,10 @@ const postSchema = ({ image }: SchemaContext) =>
     duration: z.number().optional(),
     /** Album art URL from the Suno API (stored at stub-generation time). */
     sunoImageUrl: z.string().url().optional(),
+    /** True when the source Suno clip was private/unpublished at
+     *  mirror-time (--include-private). Marks the stub so a private song
+     *  is never indistinguishable from an intentional public mirror. */
+    sunoPrivate: z.boolean().optional(),
     /** Additional Suno renditions of the same music post, beyond the
      *  primary sunoId/genre/sunoStyle/duration/sunoImageUrl above — for a
      *  post that sets the same text to music more than once. Each entry


### PR DESCRIPTION
## Summary

Code review fixes for #1232, targeting its branch so they can merge straight into that PR.

- **CI-breaking**: `skills-lock.json` wasn't in `check-hygiene.mjs`'s `ROOT_ALLOWLIST` — `npm run check:hygiene` fails on this diff as-is. Added it to the allowlist.
- **Privacy**: `--include-private` mirrors Suno clips regardless of visibility into the public, git-tracked `src/content/blog/` — but nothing in the generated frontmatter recorded a clip's original visibility, only a transient `console.log` line. Added a `sunoPrivate: true` frontmatter field (and the matching `content.config.ts` schema entry) written whenever a mirrored clip was private/unpublished on Suno.
- **Efficiency/correctness**: in the `--include-private` path, `alreadyMirrored` was computed *after* the per-clip detail-fetch loop, so every re-run re-fetched full detail (HTTP call + 150ms sleep) for clips that were already mirrored and would just be skipped. Now filtered out before the detail fetch.
- **Robustness**: the `--include-private` detail-fetch loop had no per-clip error handling — one clip failing (deleted clip, transient error) aborted the entire batch with no partial-progress summary. Now isolated in a try/catch; a failing clip is logged and skipped, the rest of the batch continues.
- **Reuse**: `findMirroredSunoIds()` hand-rolled a frontmatter regex that (unlike `scripts/lib/content.mjs`'s existing `parseFrontmatter()`) didn't strip quotes around the `sunoId` value. Switched to the shared helper.
- **Minor**: the "edit new files / run `hronir:select`" follow-up reminder was being suppressed specifically when `--include-private` was used, even though those stubs need identical follow-up. Removed the suppression. Also fixed a truthy-vs-`undefined` check that could mislabel a clip of unknown visibility as "(privado no Suno)" in the console log.
- Ran `npx prettier --write` on `scripts/lib/suno-auth.mjs`, which wasn't formatted.

## Test plan

- [x] `npm run check:hygiene` — passes (was failing before this fix)
- [x] `npx prettier --check .` — passes
- [x] `npm run hronir:select` — ran clean
- [x] `npm run hronir:doctor` — 0 inconsistências
- [x] `npm run build` — 3057 pages, no schema errors (schema addition for `sunoPrivate` is additive/optional, doesn't affect existing content)
- [x] `node --check` on all touched `.mjs` files


---
_Generated by [Claude Code](https://claude.ai/code/session_012dgkwYZTL1EZLWVNTWHVwh)_