### PR TITLE
ux: traduz rótulos do botão de copiar código para PT

### DIFF
--- a/.routines/2026-07-17T05-08-52-ux-ui-run.md
+++ b/.routines/2026-07-17T05-08-52-ux-ui-run.md
@@ -13,10 +13,22 @@ mesmo em posts PT. O componente é um `<script>` client-side global sem
 acesso ao `lang` do servidor — segui a convenção do repo (data-attribute +
 dataset) já usada em `Header.astro`: o componente agora recebe uma prop
 `lang`, calcula os rótulos traduzidos no frontmatter Astro e os expõe via
-`data-labels` num `<span hidden>`; o script client-side lê
-`dataset.labels` em vez de hardcodar a string em inglês. As duas páginas
-que renderizam posts (`src/pages/blog/[...slug].astro` e
+atributos `data-copy-label`/`data-copied-label`/`data-failed-label`/
+`data-aria-copy-label` num `<span hidden>`; o script client-side lê do
+`dataset` em vez de hardcodar a string em inglês. As duas páginas que
+renderizam posts (`src/pages/blog/[...slug].astro` e
 `src/pages/pt/blog/[...slug].astro`) agora passam `lang={postLang}`.
 CI local: astro check ✅ (0 erros novos) · prettier ✅ · build ✅ — grep no
-HTML gerado confirmou `data-labels` em inglês num post EN e em português
-num post PT.
+HTML gerado confirmou os rótulos em inglês num post EN e em português num
+post PT.
+
+Após `/code-review --fix` (8 ângulos, verify de 1 voto): nenhum bug de
+correção sobreviveu (dois achados "defensive-gap" de baixo risco — fallback
+client-side sempre em inglês se o `<span>` sumir, e `lang !== "pt"` tratado
+como inglês — são inerentes ao padrão já usado em `Header.astro` e não
+regressões). Simplificação aplicada: troquei o blob `data-labels`
+(`JSON.stringify`/`JSON.parse` + merge parcial desnecessário, já que o
+payload é sempre completo) por atributos `data-*` diretos por rótulo, no
+mesmo padrão de `Header.astro` (`data-play-label`/`data-pause-label`) —
+elimina o round-trip de serialização sem mudar comportamento. Reconstruí e
+reconferi o HTML gerado (EN/PT) após a simplificação.

--- a/.routines/2026-07-17T05-08-52-ux-ui-run.md
+++ b/.routines/2026-07-17T05-08-52-ux-ui-run.md
@@ -1,0 +1,22 @@
+---
+date: "2026-07-17T05:08:52Z"
+branch: claude/ecstatic-hawking-ztwm53
+status: open
+---
+
+# Sessão 2026-07-17T05-08-52 — UX/UI
+
+Issues fechadas: #1197
+O que foi feito: CodeCopyEnhancer.astro (botão "Copy" nos blocos de código)
+tinha as strings "Copy"/"Copied!"/"Failed"/"Copy code" fixas em inglês,
+mesmo em posts PT. O componente é um `<script>` client-side global sem
+acesso ao `lang` do servidor — segui a convenção do repo (data-attribute +
+dataset) já usada em `Header.astro`: o componente agora recebe uma prop
+`lang`, calcula os rótulos traduzidos no frontmatter Astro e os expõe via
+`data-labels` num `<span hidden>`; o script client-side lê
+`dataset.labels` em vez de hardcodar a string em inglês. As duas páginas
+que renderizam posts (`src/pages/blog/[...slug].astro` e
+`src/pages/pt/blog/[...slug].astro`) agora passam `lang={postLang}`.
+CI local: astro check ✅ (0 erros novos) · prettier ✅ · build ✅ — grep no
+HTML gerado confirmou `data-labels` em inglês num post EN e em português
+num post PT.

--- a/src/components/CodeCopyEnhancer.astro
+++ b/src/components/CodeCopyEnhancer.astro
@@ -1,12 +1,33 @@
 ---
 // Wraps every <pre> on the page with a "Copy" button.
 // Client-only, deferred. No-op if scripting is disabled.
+interface Props {
+  lang?: string;
+}
+const { lang = "en" } = Astro.props;
+const labels =
+  lang === "pt"
+    ? { copy: "Copiar", copied: "Copiado!", failed: "Falhou", ariaCopy: "Copiar código" }
+    : { copy: "Copy", copied: "Copied!", failed: "Failed", ariaCopy: "Copy code" };
 ---
 
+<span id="code-copy-labels" data-labels={JSON.stringify(labels)} hidden></span>
+
 <script>
-  const DEFAULT_LABEL = "Copy";
+  const DEFAULT_LABELS = { copy: "Copy", copied: "Copied!", failed: "Failed", ariaCopy: "Copy code" };
+
+  function getLabels() {
+    const el = document.getElementById("code-copy-labels");
+    if (!el?.dataset.labels) return DEFAULT_LABELS;
+    try {
+      return { ...DEFAULT_LABELS, ...JSON.parse(el.dataset.labels) };
+    } catch {
+      return DEFAULT_LABELS;
+    }
+  }
 
   function enhance() {
+    const labels = getLabels();
     document.querySelectorAll<HTMLPreElement>("article pre").forEach((pre) => {
       if (pre.parentElement?.classList.contains("code-block")) return;
 
@@ -20,8 +41,8 @@
       const button = document.createElement("button");
       button.type = "button";
       button.className = "code-copy";
-      button.textContent = DEFAULT_LABEL;
-      button.setAttribute("aria-label", "Copy code");
+      button.textContent = labels.copy;
+      button.setAttribute("aria-label", labels.ariaCopy);
 
       let resetTimer: number | undefined;
       let inFlight = false;
@@ -30,7 +51,7 @@
         button.textContent = text;
         if (resetTimer !== undefined) window.clearTimeout(resetTimer);
         resetTimer = window.setTimeout(() => {
-          button.textContent = DEFAULT_LABEL;
+          button.textContent = labels.copy;
           resetTimer = undefined;
         }, 1500);
       };
@@ -41,9 +62,9 @@
         try {
           const code = pre.querySelector("code")?.innerText ?? pre.innerText;
           await navigator.clipboard.writeText(code);
-          flash("Copied!");
+          flash(labels.copied);
         } catch {
-          flash("Failed");
+          flash(labels.failed);
         } finally {
           inFlight = false;
         }

--- a/src/components/CodeCopyEnhancer.astro
+++ b/src/components/CodeCopyEnhancer.astro
@@ -5,25 +5,30 @@ interface Props {
   lang?: string;
 }
 const { lang = "en" } = Astro.props;
-const labels =
-  lang === "pt"
-    ? { copy: "Copiar", copied: "Copiado!", failed: "Falhou", ariaCopy: "Copiar código" }
-    : { copy: "Copy", copied: "Copied!", failed: "Failed", ariaCopy: "Copy code" };
+const copyLabel = lang === "pt" ? "Copiar" : "Copy";
+const copiedLabel = lang === "pt" ? "Copiado!" : "Copied!";
+const failedLabel = lang === "pt" ? "Falhou" : "Failed";
+const ariaCopyLabel = lang === "pt" ? "Copiar código" : "Copy code";
 ---
 
-<span id="code-copy-labels" data-labels={JSON.stringify(labels)} hidden></span>
+<span
+  id="code-copy-labels"
+  data-copy-label={copyLabel}
+  data-copied-label={copiedLabel}
+  data-failed-label={failedLabel}
+  data-aria-copy-label={ariaCopyLabel}
+  hidden
+></span>
 
 <script>
-  const DEFAULT_LABELS = { copy: "Copy", copied: "Copied!", failed: "Failed", ariaCopy: "Copy code" };
-
   function getLabels() {
     const el = document.getElementById("code-copy-labels");
-    if (!el?.dataset.labels) return DEFAULT_LABELS;
-    try {
-      return { ...DEFAULT_LABELS, ...JSON.parse(el.dataset.labels) };
-    } catch {
-      return DEFAULT_LABELS;
-    }
+    return {
+      copy: el?.dataset.copyLabel || "Copy",
+      copied: el?.dataset.copiedLabel || "Copied!",
+      failed: el?.dataset.failedLabel || "Failed",
+      ariaCopy: el?.dataset.ariaCopyLabel || "Copy code",
+    };
   }
 
   function enhance() {

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -316,7 +316,7 @@ const musicRecordings = allTracks.map((tr) => ({
       <Comments lang={lang} />
 
       <BackToTop lang={postLang} />
-      <CodeCopyEnhancer />
+      <CodeCopyEnhancer lang={postLang} />
       <MermaidEnhancer />
     </div>
   </div>

--- a/src/pages/pt/blog/[...slug].astro
+++ b/src/pages/pt/blog/[...slug].astro
@@ -313,7 +313,7 @@ const musicRecordings = allTracks.map((tr) => ({
       <Comments lang={lang} />
 
       <BackToTop lang={postLang} />
-      <CodeCopyEnhancer />
+      <CodeCopyEnhancer lang={postLang} />
       <MermaidEnhancer />
     </div>
   </div>


### PR DESCRIPTION
Closes #1197

## Summary

- `CodeCopyEnhancer.astro` gera o botão "Copy" nos blocos de código via um `<script>` client-side global (`document.querySelectorAll("article pre")`), que não tinha acesso ao `lang` do servidor — as strings `"Copy"` / `"Copied!"` / `"Failed"` / `"Copy code"` estavam fixas em inglês mesmo em posts PT.
- Segui a convenção já usada em `Header.astro` para esse cenário exato (script client-side + label dinâmico): o componente agora aceita uma prop `lang`, calcula os rótulos traduzidos no frontmatter Astro (server-side) e os expõe via `data-labels` num `<span hidden>`; o script client-side lê `dataset.labels` em vez de hardcodar a string em inglês.
- `src/pages/blog/[...slug].astro` e `src/pages/pt/blog/[...slug].astro` agora passam `lang={postLang}` para `<CodeCopyEnhancer>`, no mesmo padrão já usado para `<BackToTop lang={postLang}>` nessas mesmas páginas.

## Test plan

- [x] `npx astro check` — 0 erros novos (avisos pré-existentes intocados)
- [x] `npx prettier --check .` — passou
- [x] `npm run build` — build completo, incl. prebuild/pregen e pagefind
- [x] Grep no HTML gerado: `data-labels` mostra `Copy`/`Copied!`/`Failed`/`Copy code` num post EN (`dist/blog/the-work-that-proves-itself/index.html`) e `Copiar`/`Copiado!`/`Falhou`/`Copiar código` num post PT (`dist/pt/blog/veu-do-infinito/index.html`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X4YNHJNNc1Rc9fxNZWFiMo

---
_Generated by [Claude Code](https://claude.ai/code/session_01X4YNHJNNc1Rc9fxNZWFiMo)_