### PR TITLE
fix(music): address code-review findings on PR #1251's music layout

### DIFF
--- a/src/components/BlogPostPage.astro
+++ b/src/components/BlogPostPage.astro
@@ -23,6 +23,7 @@ import { isPublished } from '../lib/publish';
 import {
   DEFAULT_LANG,
   locale as localeFor,
+  postUrl,
   t,
   targetCopy,
   urlPrefix,
@@ -54,6 +55,7 @@ const {
 } = post.data;
 
 const postLang = (lang ?? DEFAULT_LANG) as 'en' | 'pt';
+const isMusic = postType === 'music';
 const minutesRead: number | undefined = remarkPluginFrontmatter.minutesRead;
 const wordCount: number | undefined = minutesRead ? minutesRead * 200 : undefined;
 const hasMath: boolean = !!remarkPluginFrontmatter.hasMath;
@@ -63,14 +65,8 @@ const MS_PER_DAY = 24 * 60 * 60 * 1000;
 const showUpdated =
   lastModified && lastModified.valueOf() - date.valueOf() > MS_PER_DAY;
 
-function postUrl(entry: CollectionEntry<'blog'>): string {
-  const entryLang = entry.data.lang ?? DEFAULT_LANG;
-  const slug = entry.data.slug ?? entry.id;
-  return entryLang === 'pt' ? `/pt/blog/${slug}/` : `/blog/${slug}/`;
-}
-
 const rankInfo = translationKey ? getRankByKey().get(translationKey) : undefined;
-const rankLabel = postLang === 'pt' ? 'ranking Hrönir' : 'Hrönir rank';
+const rankLabel = t(postLang, 'post.rankLabel');
 const rankHref =
   postLang === 'pt'
     ? '/pt/ranking/'
@@ -93,10 +89,15 @@ const sameLangPosts = allPosts
       (entry.data.lang ?? DEFAULT_LANG) === postLang,
   )
   .sort((a, b) => a.data.date.valueOf() - b.data.date.valueOf());
-const postIdx = sameLangPosts.findIndex((entry) => entry.id === post.id);
-const prevPost = postIdx > 0 ? sameLangPosts[postIdx - 1] : null;
+const nonMusicSameLangPosts = sameLangPosts.filter(
+  (entry) => entry.data.postType !== 'music',
+);
+const postIdx = nonMusicSameLangPosts.findIndex((entry) => entry.id === post.id);
+const prevPost = postIdx > 0 ? nonMusicSameLangPosts[postIdx - 1] : null;
 const nextPost =
-  postIdx < sameLangPosts.length - 1 ? sameLangPosts[postIdx + 1] : null;
+  postIdx < nonMusicSameLangPosts.length - 1
+    ? nonMusicSameLangPosts[postIdx + 1]
+    : null;
 const prevNav = prevPost
   ? { href: postUrl(prevPost), title: prevPost.data.title, date: prevPost.data.date }
   : null;
@@ -104,14 +105,12 @@ const nextNav = nextPost
   ? { href: postUrl(nextPost), title: nextPost.data.title, date: nextPost.data.date }
   : null;
 
-const musicSameLangPosts =
-  postType === 'music'
-    ? sameLangPosts.filter((entry) => entry.data.postType === 'music')
-    : [];
-const musicIdx =
-  postType === 'music'
-    ? musicSameLangPosts.findIndex((entry) => entry.id === post.id)
-    : -1;
+const musicSameLangPosts = isMusic
+  ? sameLangPosts.filter((entry) => entry.data.postType === 'music')
+  : [];
+const musicIdx = isMusic
+  ? musicSameLangPosts.findIndex((entry) => entry.id === post.id)
+  : -1;
 const prevMusicPost = musicIdx > 0 ? musicSameLangPosts[musicIdx - 1] : null;
 const nextMusicPost =
   musicIdx !== -1 && musicIdx < musicSameLangPosts.length - 1
@@ -144,7 +143,7 @@ const translationLinks = translationSiblings.map((entry) => {
 });
 
 const allTracks =
-  postType === 'music'
+  isMusic
     ? [
         ...(sunoId
           ? [{ label: title, sunoId, sunoImageUrl, genre, duration }]
@@ -185,7 +184,7 @@ const musicRecordings = allTracks.map((track) => ({
 }));
 
 const musicIndexHref = postLang === 'pt' ? '/pt/musicas/' : '/music/';
-const musicIndexLabel = postLang === 'pt' ? 'Música' : 'Music';
+const musicIndexLabel = t(postLang, 'music.indexLabel');
 ---
 
 <PageLayout
@@ -213,31 +212,27 @@ const musicIndexLabel = postLang === 'pt' ? 'Música' : 'Music';
   }
 
   {
-    postType !== 'music' && (
+    !isMusic && (
       <progress
         id="read-progress"
         max="100"
         value="0"
-        aria-label={postLang === 'pt' ? 'Progresso de leitura' : 'Reading progress'}
+        aria-label={t(postLang, 'post.readingProgress')}
       />
     )
   }
 
   {
-    postType !== 'music' && (
+    !isMusic && (
       <aside class="border-rail" aria-hidden="true">
-        <span>
-          {postLang === 'pt'
-            ? 'NOTAS · DA · FRONTEIRA'
-            : 'NOTES · FROM · THE · BORDER'}
-        </span>
+        <span>{t(postLang, 'post.borderRailText')}</span>
       </aside>
     )
   }
 
-  <div class:list={['post-grid', { 'music-post-grid': postType === 'music' }]}>
+  <div class:list={[isMusic ? 'music-post-grid' : 'post-grid']}>
     {
-      postType !== 'music' && (
+      !isMusic && (
         <aside class="toc-col" aria-label={t(postLang, 'toc.label')}>
           <TableOfContents headings={headings} lang={postLang} sidebar />
         </aside>
@@ -249,7 +244,7 @@ const musicIndexLabel = postLang === 'pt' ? 'Música' : 'Music';
         lang={postLang}
         items={[
           { name: t(postLang, 'nav.home'), href: `${urlPrefix(postLang)}/` },
-          postType === 'music'
+          isMusic
             ? { name: musicIndexLabel, href: musicIndexHref }
             : {
                 name: t(postLang, 'nav.archive'),
@@ -260,18 +255,17 @@ const musicIndexLabel = postLang === 'pt' ? 'Música' : 'Music';
       />
 
       <article
-        class:list={{ 'music-post-article': postType === 'music' }}
+        class:list={{ 'music-post-article': isMusic }}
         data-pagefind-body
         data-pagefind-filter={`lang:${postLang}`}
         lang={postLang}
       >
         {
-          postType === 'music' ? (
+          isMusic ? (
             <MusicPostLayout
               title={title}
               description={description}
               date={date}
-              locale={locale}
               lang={postLang}
               tracks={allTracks}
               rankHref={rankInfo ? rankHref : undefined}
@@ -445,14 +439,9 @@ const musicIndexLabel = postLang === 'pt' ? 'Música' : 'Music';
       }
 
       {
-        postType === 'music' ? (
-          <nav
-            class="music-post-nav"
-            aria-label={postLang === 'pt' ? 'Navegação musical' : 'Music navigation'}
-          >
-            <a href={musicIndexHref}>
-              ← {postLang === 'pt' ? 'Todas as músicas' : 'All music'}
-            </a>
+        isMusic ? (
+          <nav class="music-post-nav" aria-label={t(postLang, 'music.navLabel')}>
+            <a href={musicIndexHref}>← {t(postLang, 'music.allMusic')}</a>
             <div class="music-post-nav-adjacent">
               {prevMusicNav && (
                 <a href={prevMusicNav.href} rel="prev">
@@ -550,7 +539,7 @@ const musicIndexLabel = postLang === 'pt' ? 'Música' : 'Music';
 
 <style>
   :global(.music-post-grid) {
-    display: block !important;
+    display: block;
     max-width: 76rem;
     margin-inline: auto;
   }

--- a/src/components/MusicPostLayout.astro
+++ b/src/components/MusicPostLayout.astro
@@ -1,5 +1,5 @@
 ---
-import { t } from "../lib/i18n";
+import { locale as localeFor, t } from "../lib/i18n";
 import { formatDuration } from "../lib/suno";
 
 interface Track {
@@ -14,7 +14,6 @@ interface Props {
   title: string;
   description?: string;
   date: Date;
-  locale: string;
   lang: "en" | "pt";
   tracks: Track[];
   rankHref?: string;
@@ -26,7 +25,6 @@ const {
   title,
   description,
   date,
-  locale,
   lang,
   tracks,
   rankHref,
@@ -34,6 +32,7 @@ const {
   rankTitle,
 } = Astro.props;
 
+const locale = localeFor(lang);
 const primary = tracks[0];
 // Suno's actual CDN pattern is `image_<id>.jpeg` (prefix, not suffix) --
 // confirmed against live data in data/suno-catalog.jsonl. This fallback

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -1,3 +1,4 @@
+import type { CollectionEntry } from "astro:content";
 import { DEFAULT_LANG as _DEFAULT_LANG, LANG_META } from "./languages.mjs";
 
 export { DEFAULT_LANG } from "./languages.mjs";
@@ -22,6 +23,12 @@ const UI_KEYS = [
   "music.variants",
   "music.onSuno",
   "music.coverAlt",
+  "music.indexLabel",
+  "music.navLabel",
+  "music.allMusic",
+  "post.rankLabel",
+  "post.readingProgress",
+  "post.borderRailText",
   "archive.jumpToYear",
   "post.continueReading",
   "post.minutesRead",
@@ -126,6 +133,12 @@ export const LANGUAGES: Record<string, LangConfig> = {
       "music.variants": "Versions of this composition",
       "music.onSuno": "Open on Suno",
       "music.coverAlt": "Cover for",
+      "music.indexLabel": "Music",
+      "music.navLabel": "Music navigation",
+      "music.allMusic": "All music",
+      "post.rankLabel": "Hrönir rank",
+      "post.readingProgress": "Reading progress",
+      "post.borderRailText": "NOTES · FROM · THE · BORDER",
       "post.continueReading": "Continue reading →",
       "post.minutesRead": "min read",
       "post.updated": "updated",
@@ -222,6 +235,12 @@ export const LANGUAGES: Record<string, LangConfig> = {
       "music.variants": "Versões desta composição",
       "music.onSuno": "Abrir no Suno",
       "music.coverAlt": "Capa de",
+      "music.indexLabel": "Música",
+      "music.navLabel": "Navegação musical",
+      "music.allMusic": "Todas as músicas",
+      "post.rankLabel": "ranking Hrönir",
+      "post.readingProgress": "Progresso de leitura",
+      "post.borderRailText": "NOTAS · DA · FRONTEIRA",
       "post.continueReading": "Continuar lendo →",
       "post.minutesRead": "min de leitura",
       "post.updated": "atualizado",
@@ -332,6 +351,12 @@ export function locale(lang: string | undefined): string {
 
 export function urlPrefix(lang: string | undefined): string {
   return configFor(lang).urlPrefix;
+}
+
+export function postUrl(entry: CollectionEntry<"blog">): string {
+  const lang = entry.data.lang ?? _DEFAULT_LANG;
+  const slug = entry.data.slug ?? entry.id;
+  return `${urlPrefix(lang)}/blog/${slug}/`;
 }
 
 export function supportedLangs(): string[] {

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -1,7 +1,7 @@
 ---
 import { getCollection, type CollectionEntry } from 'astro:content';
 import BlogPostPage from '../../components/BlogPostPage.astro';
-import { DEFAULT_LANG } from '../../lib/i18n';
+import { DEFAULT_LANG, postUrl } from '../../lib/i18n';
 import { isPublished } from '../../lib/publish';
 
 export async function getStaticPaths() {
@@ -15,12 +15,6 @@ export async function getStaticPaths() {
 }
 
 type Props = CollectionEntry<'blog'>;
-
-function postUrl(post: CollectionEntry<'blog'>): string {
-  const lang = post.data.lang ?? DEFAULT_LANG;
-  const slug = post.data.slug ?? post.id;
-  return lang === 'pt' ? `/pt/blog/${slug}/` : `/blog/${slug}/`;
-}
 
 const post = Astro.props;
 if ((post.data.lang ?? DEFAULT_LANG) === 'pt') {

--- a/src/pages/pt/blog/[...slug].astro
+++ b/src/pages/pt/blog/[...slug].astro
@@ -1,7 +1,7 @@
 ---
 import { getCollection, type CollectionEntry } from 'astro:content';
 import BlogPostPage from '../../../components/BlogPostPage.astro';
-import { DEFAULT_LANG } from '../../../lib/i18n';
+import { DEFAULT_LANG, postUrl } from '../../../lib/i18n';
 import { isPublished } from '../../../lib/publish';
 
 export async function getStaticPaths() {
@@ -15,12 +15,6 @@ export async function getStaticPaths() {
 }
 
 type Props = CollectionEntry<'blog'>;
-
-function postUrl(post: CollectionEntry<'blog'>): string {
-  const lang = post.data.lang ?? DEFAULT_LANG;
-  const slug = post.data.slug ?? post.id;
-  return lang === 'pt' ? `/pt/blog/${slug}/` : `/blog/${slug}/`;
-}
 
 const post = Astro.props;
 if ((post.data.lang ?? DEFAULT_LANG) !== 'pt') {


### PR DESCRIPTION
## O que muda

Correções encontradas na revisão de código de #1251 (`design/music-post-layout`), aplicadas diretamente sobre essa branch:

- **`BlogPostPage.astro`**: a navegação genérica anterior/próximo (`PostNav`, usada por posts que não são música) vinha de uma lista sem filtro por `postType`, então um ensaio publicado perto de uma Music Post na mesma língua podia mostrar essa Music Post como "anterior"/"próximo" — a mesma correção já existia para a navegação musical (`musicSameLangPosts`), só não tinha sido aplicada ao caso geral;
- **`postUrl()`** estava definida de forma idêntica três vezes (`BlogPostPage.astro` e os dois adaptadores `[...slug].astro`); consolidada em `src/lib/i18n.ts` e importada nos três lugares;
- seis strings de UI em `BlogPostPage.astro` (aria-labels, rótulo de ranking, texto do border-rail, navegação musical) usavam ternários `postLang === 'pt' ? ... : ...` em vez do mecanismo `t()`/`UI_KEYS` que o próprio arquivo já usa em todo o resto — adicionadas as chaves que faltavam em `i18n.ts` e trocados os ternários por `t(postLang, ...)`;
- `postType === 'music'` era recalculado em ~12 pontos diferentes do arquivo; agora computado uma vez como `isMusic` e reutilizado;
- `MusicPostLayout` recebia tanto `lang` quanto `locale` como props, embora `locale` seja 100% derivável de `lang` via `src/lib/i18n.ts`; a prop `locale` foi removida, o componente deriva internamente;
- o grid do post aplicava `post-grid` e `music-post-grid` simultaneamente, com `!important` no segundo para cancelar o `grid-template-columns` do primeiro — agora aplica exatamente uma classe por tipo de post, sem `!important`.

Não altera design, conteúdo ou schema — apenas comportamento incorreto/duplicação de código introduzidos na própria PR #1251.

## Verificação

- `npx astro check` — 0 erros, 0 warnings
- `npm test` — 152/152 testes passando
- `npm run build` — build completo sem erros
- `npm run hronir:doctor` — sem inconsistências
- `npx prettier --check .` — ok
- Inspeção manual do HTML gerado (`dist/`) para um post de música PT, uma Music Post EN multi-track e um ensaio PT, confirmando: grid class única aplicada corretamente, aria-labels traduzidos, `PostNav` do ensaio não mostrando posts de música como vizinhos, e a tracklist de versões musicais mantida como antes.

## Achados reportados mas não corrigidos aqui (fora do escopo deste fix)

- Em `MusicPostLayout.astro`, apenas a versão primária (`tracks[0]`) exibe gênero/capa/link direto pro Suno; as demais versões na tracklist só mostram título/duração/play. Isso bate com a descrição da própria PR #1251 ("tracklist compacta"), então tratei como decisão de design a confirmar com quem revisar, não como bug.
- `BlogPostPage.astro` agora renderiza `<HronirReviews>` também em posts PT com `translationKey` (antes só ocorria no lado EN). O componente já é preparado para qualquer idioma (locale, hrefs pt/en corretos), então pode ser uma correção de paridade intencional da própria unificação — sinalizando para confirmação, não revertido.
- O script client-side de drop-cap agora exclui `.music-post-article` (`:not(.music-post-article)`), o que é coerente com a nova tipografia própria dos posts de música, mas não estava listado explicitamente na descrição da PR #1251.
- Duplicação do mecanismo de bind-and-dispatch de `gp:play` entre `BlogPostPage.astro` e `GlobalMusicPlayer.astro`, e recomputação O(n) da coleção de posts por página (`getSeriesContext` + `sameLangPosts` + `translationSiblings`) a cada build — ambos de baixo risco/impacto atual, mas deixados de fora por exigirem mudanças mais amplas que o escopo deste fix.


---
_Generated by [Claude Code](https://claude.ai/code/session_017yaJDps7BgyywTeVocvKB1)_