### PR TITLE
ux: adiciona HronirReviews à página de post PT

### DIFF
--- a/.routines/2026-07-18T05-05-50-ux-ui-run.md
+++ b/.routines/2026-07-18T05-05-50-ux-ui-run.md
@@ -1,0 +1,19 @@
+---
+date: "2026-07-18T05:05:50Z"
+branch: ux-ui/run-2026-07-18T05-00-32
+status: open
+---
+
+# Sessão 2026-07-18T05-05-50 — UX/UI
+
+Issues fechadas: #1243
+O que foi feito: `src/pages/pt/blog/[...slug].astro` não importava nem
+renderizava `HronirReviews` (a versão EN sim). Adicionado o import e
+`{translationKey && <HronirReviews translationKey={translationKey} lang={lang} />}`
+na mesma posição relativa usada pela página EN (entre `AuthorBio` e
+`RelatedPosts`).
+CI local: astro check ✅ (0 erros, warnings pré-existentes) · prettier ✅ · build ✅
+Verificação pós-build: `dist/pt/blog/666/index.html` e `dist/blog/666-en/index.html`
+(post de música com `translationKey: music-666` e duelos avaliados) mostram o
+widget `.hronir-reviews`, com heading "Avaliações Hrönir" em PT e "Hrönir Reviews"
+em EN.

--- a/src/pages/pt/blog/[...slug].astro
+++ b/src/pages/pt/blog/[...slug].astro
@@ -12,6 +12,7 @@ import RelatedPosts from '../../../components/RelatedPosts.astro';
 import AuthorBio from '../../../components/AuthorBio.astro';
 import Breadcrumbs from '../../../components/Breadcrumbs.astro';
 import { getRankByKey } from '../../../lib/hronir-rank';
+import HronirReviews from '../../../components/HronirReviews.astro';
 import Comments from '../../../components/Comments.astro';
 import SeriesContext from '../../../components/SeriesContext.astro';
 import PostActionBar from '../../../components/PostActionBar.astro';
@@ -291,6 +292,8 @@ const musicRecordings = allTracks.map((tr) => ({
       </article>
 
       <AuthorBio lang={lang} />
+
+      {translationKey && <HronirReviews translationKey={translationKey} lang={lang} />}
 
       <RelatedPosts currentId={post.id} tags={tags ?? []} lang={lang} postType={postType} />
 


### PR DESCRIPTION
Closes #1243

## O que mudou

`src/pages/pt/blog/[...slug].astro` não importava nem renderizava o
componente `HronirReviews` — a versão EN estrutural desta página
(`src/pages/blog/[...slug].astro`) já o fazia. Um leitor de post em
português nunca via o widget de avaliações Hrönir do próprio post, mesmo
quando ele tem `translationKey` e está ranqueado.

- Adicionado `import HronirReviews from '../../../components/HronirReviews.astro';`
- Adicionado `{translationKey && <HronirReviews translationKey={translationKey} lang={lang} />}`
  na mesma posição relativa usada pela página EN (entre `<AuthorBio />` e
  `<RelatedPosts />`).

Nenhuma mudança no componente `HronirReviews.astro` em si — só sua
presença na árvore de render PT.

## Validação

- `npx astro check` → 0 erros (warnings pré-existentes, não relacionados)
- `npx prettier --check .` → ok
- `npm run build` → build completo (astro build + pagefind + ranking snapshot)
- Conferido no HTML gerado: `dist/pt/blog/666/index.html` e
  `dist/blog/666-en/index.html` (post de música com `translationKey: music-666`
  e duelos avaliados) mostram `.hronir-reviews`, com heading "Avaliações
  Hrönir" em PT e "Hrönir Reviews" em EN — sem vazamento de string entre
  idiomas.


---
_Generated by [Claude Code](https://claude.ai/code/session_01BrxVf2zZFG2LSSqT41dygj)_