### PR TITLE
ux: corrige strings i18n hardcoded em inglês e contraste do rating

### DIFF
--- a/.routines/2026-07-19T05-06-48-ux-ui-run.md
+++ b/.routines/2026-07-19T05-06-48-ux-ui-run.md
@@ -1,0 +1,32 @@
+---
+date: "2026-07-19T05:06:48Z"
+branch: claude/ecstatic-hawking-mtefrr
+status: open
+---
+
+# Sessão 2026-07-19T05-06-48 — UX/UI
+
+Issues fechadas: #1245, #1265, #1266, #1264
+
+O que foi feito:
+- #1245: `src/pages/pt/archive.astro` — resumo de ano no acordeão trocou
+  "posts" (inglês) por "ensaios", consistente com o resto da página PT.
+- #1265: `src/pages/pt/archive.astro` — `aria-label` do badge "EN" por
+  linha trocado de inglês para "Versão em inglês disponível" (o `title`
+  continua "Read in English", dica no idioma de destino, igual ao padrão
+  já usado na página EN para o badge PT).
+- #1266: `src/pages/pt/tags/index.astro` — `aria-label` da nuvem de tags
+  trocou o sufixo "post/posts" (inglês) por "ensaio/ensaios", reaproveitando
+  o padrão já usado em `pt/tags/[tag].astro`.
+- #1264: `src/components/BooksPage.astro` — cor do rating (★) no modo claro
+  escurecida de `#9a6a00` para `#7a5400` (contraste ~6.1:1 sobre
+  `#faf3e2`, acima do mínimo AA de 4.5:1). Modo escuro não mudou.
+
+Nota: branch de trabalho é `claude/ecstatic-hawking-mtefrr` (designada pelo
+harness da sessão), não o padrão `ux-ui/run-*` da rotina — sem PRs abertos
+desta rotina para mesclar no início da sessão (passo 0), backlog de issues
+`routine` tinha 12 abertas (acima do limiar de ~10, sem necessidade de
+reabastecer no passo 6).
+
+CI local: astro check ✅ (0 erros) · prettier ✅ · build ✅ (3303 páginas) ·
+grep no dist confirmou as 4 strings/cor corrigidas em EN e PT.

--- a/src/components/BooksPage.astro
+++ b/src/components/BooksPage.astro
@@ -421,7 +421,7 @@ const booksJsonLd = {
 
   .book-info .rating {
     font-size: 0.8rem;
-    color: #9a6a00;
+    color: #7a5400;
     margin: 0 0 auto;
     letter-spacing: 0.03em;
   }

--- a/src/pages/pt/archive.astro
+++ b/src/pages/pt/archive.astro
@@ -97,7 +97,7 @@ const years = [...byYear.keys()].sort((a, b) => b - a);
 
   {years.map((year, idx) => (
     <details id={`archive-${year}`} class="archive-year" open={idx === 0}>
-      <summary class="archive-year-summary">{year} — {byYear.get(year)!.length} posts</summary>
+      <summary class="archive-year-summary">{year} — {byYear.get(year)!.length} ensaios</summary>
       <table class="striped archive-table">
         <thead>
           <tr>
@@ -131,7 +131,7 @@ const years = [...byYear.keys()].sort((a, b) => b - a);
                 </td>
                 <td class="col-en">
                   {enId && (
-                    <a class="en-badge" href={`/blog/${enId}/`} aria-label="English version available" title="Read in English">EN</a>
+                    <a class="en-badge" href={`/blog/${enId}/`} aria-label="Versão em inglês disponível" title="Read in English">EN</a>
                   )}
                 </td>
               </tr>

--- a/src/pages/pt/tags/index.astro
+++ b/src/pages/pt/tags/index.astro
@@ -50,7 +50,7 @@ const itemListLd = {
         <a
           href={`/pt/tags/${tag}/`}
           style={`font-size: ${(0.85 + ((count - minCount) / Math.max(1, maxCount - minCount)) * 0.65).toFixed(2)}rem`}
-          aria-label={`#${tag} — ${count} post${count !== 1 ? 's' : ''}`}
+          aria-label={`#${tag} — ${count} ${count === 1 ? 'ensaio' : 'ensaios'}`}
         >
           <span class="tag-name">#{tag}</span>
           <span class="tag-count">{count}</span>


### PR DESCRIPTION
Sessão da rotina `.routine/ux-ui/index.md`. Quatro fixes pequenos e
independentes do backlog `routine` (todos `priority:baixa`):

- Closes #1245 — `src/pages/pt/archive.astro`: resumo de ano no acordeão
  trocou "posts" (inglês) por "ensaios", consistente com o resto da
  página PT.
- Closes #1265 — `src/pages/pt/archive.astro`: `aria-label` do badge "EN"
  por linha trocado de inglês para "Versão em inglês disponível" (o
  `title` continua "Read in English", dica no idioma de destino — mesmo
  padrão já usado na página EN para o badge PT).
- Closes #1266 — `src/pages/pt/tags/index.astro`: `aria-label` da nuvem de
  tags trocou o sufixo "post/posts" (inglês) por "ensaio/ensaios",
  reaproveitando o padrão já usado em `pt/tags/[tag].astro`.
- Closes #1264 — `src/components/BooksPage.astro`: cor do rating (★) no
  modo claro escurecida de `#9a6a00` para `#7a5400` (contraste ~6.1:1
  sobre `#faf3e2`, acima do mínimo AA de 4.5:1). Modo escuro não mudou.

## Nota sobre a branch

Esta sessão desenvolveu na branch designada pelo harness
(`claude/ecstatic-hawking-mtefrr`) em vez do padrão `ux-ui/run-*` da
rotina. Nenhum PR aberto desta rotina foi encontrado para mesclar no
início da sessão (passo 0); o backlog `routine` tinha 12 issues abertas
(acima do limiar de ~10), então nenhuma nova foi aberta no passo 6.

## Validação

- `npx astro check` — 0 erros (mesmos warnings pré-existentes)
- `npx prettier --check .` — ok
- `npm run build` — 3303 páginas, completo
- `grep` no `dist/` gerado confirmou as 4 strings/cor corrigidas em EN e PT
  (incluindo o caso singular "1 ensaio" na nuvem de tags)

## Test plan

- [x] `npx astro check`
- [x] `npx prettier --check .`
- [x] `npm run build`
- [x] grep no HTML gerado (`dist/pt/archive/`, `dist/pt/tags/`,
      `dist/books/`, `dist/pt/livros/`) confirmando os valores corretos


---
_Generated by [Claude Code](https://claude.ai/code/session_01R55SJMg6Rg7kQm1RdrPTQk)_