### PR TITLE
ux: fix RSS locale link and about.astro copy contradiction

### DIFF
--- a/.routines/2026-07-21T05-06-05-ux-ui-run.md
+++ b/.routines/2026-07-21T05-06-05-ux-ui-run.md
@@ -1,0 +1,15 @@
+---
+date: "2026-07-21T05:06:05Z"
+branch: claude/ecstatic-hawking-vnlero
+status: open
+---
+
+# Sessão 2026-07-21T05-06-05 — UX/UI
+
+Issues fechadas: #1292, #1293
+O que foi feito: AuthorBio.astro agora gera o link RSS via urlPrefix(lang)
+(EN -> /rss.xml, PT -> /pt/rss.xml), corrigindo o link que sempre apontava
+para o feed em inglês em posts PT. about.astro corrigido para não afirmar
+que "todos os ensaios" têm versão em português (contradizia o próprio FAQ
+da página e a versão PT).
+CI local: astro check ✅ (0 erros) · prettier ✅ · build ✅ (verificado grep no dist/ EN e PT)

--- a/src/components/AuthorBio.astro
+++ b/src/components/AuthorBio.astro
@@ -7,6 +7,7 @@ interface Props {
 
 const { lang } = Astro.props;
 const homeHref = `${urlPrefix(lang)}/`;
+const rssHref = `${urlPrefix(lang)}/rss.xml`;
 ---
 
 <aside class="author-bio">
@@ -24,7 +25,7 @@ const homeHref = `${urlPrefix(lang)}/`;
     <ul class="bio-links">
       <li><a href="https://github.com/franklinbaldo" rel="me noopener" target="_blank">GitHub</a></li>
       <li><a href="https://twitter.com/franklinbaldo" rel="me noopener" target="_blank">Twitter</a></li>
-      <li><a href="/rss.xml">RSS</a></li>
+      <li><a href={rssHref}>RSS</a></li>
     </ul>
     <footer>
       <a href={homeHref}>{t(lang, 'author.more')}</a>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -81,7 +81,7 @@ const faqLd = {
       <li><strong>Family memory</strong> — what it means to archive a life with help from a machine.</li>
     </ul>
 
-    <p>All essays are available in both English and Portuguese.</p>
+    <p>Most essays are in English; key essays have Portuguese versions.</p>
 
     <h2>Find me</h2>
 


### PR DESCRIPTION
## Summary

Two small, independent i18n/copy fixes from the UX/UI routine backlog.

- **`src/components/AuthorBio.astro`** (Closes #1292): the RSS link at the
  bottom of every post always pointed to `/rss.xml`, even on PT posts. Now
  reuses the already-imported `urlPrefix(lang)` helper (same pattern as
  `HomeAuthorRail.astro`, `Footer.astro`, `PageLayout.astro`) so PT posts
  link to `/pt/rss.xml`.
- **`src/pages/about.astro`** (Closes #1293): the page claimed "All essays
  are available in both English and Portuguese", contradicting its own FAQ
  JSON-LD three lines above and the PT version of the same page. Reworded
  to match both.

## Test plan

- [x] `npx astro check` — 0 errors
- [x] `npx prettier --check .` — clean
- [x] `npm run build` — full build succeeds
- [x] Verified generated HTML: `dist/blog/a-single-song/index.html` has
      `href="/rss.xml"`, `dist/pt/blog/veu-do-infinito/index.html` has
      `href="/pt/rss.xml"`
- [x] Verified `dist/about/index.html` no longer contains the "all essays"
      claim and now matches the FAQ/PT framing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ThmkX5KydJ6vUa7AG36Rm

---
_Generated by [Claude Code](https://claude.ai/code/session_015ThmkX5KydJ6vUa7AG36Rm)_