### PR TITLE
ux: abrir seção do ano ao usar link de âncora em /archive/

### DIFF
--- a/.routines/2026-07-23T05-05-10-ux-ui-run.md
+++ b/.routines/2026-07-23T05-05-10-ux-ui-run.md
@@ -1,0 +1,14 @@
+---
+date: "2026-07-23T05:05:10Z"
+branch: ux-ui/run-2026-07-23T05-00-04
+status: open
+---
+
+# Sessão 2026-07-23T05-05-10 — UX/UI
+
+Issues fechadas: #1328
+O que foi feito: links "pular para o ano" em /archive/ agora forçam
+`details.open = true` na seção-alvo (via hash na carga inicial e
+`hashchange`), corrigindo o caso em que o clique rolava até uma seção
+recolhida sem abri-la. Aplicado nos 4 arquivos (EN/PT × index/paginado).
+CI local: astro check ✅ · prettier ✅ · build ✅

--- a/src/pages/archive/index.astro
+++ b/src/pages/archive/index.astro
@@ -313,8 +313,10 @@ const archiveLd = {
     const sections = document.querySelectorAll('.archive-year');
     function openHashSection() {
       if (!location.hash) return;
-      var target = document.querySelector(location.hash);
-      if (target && target.tagName === 'DETAILS') target.open = true;
+      try {
+        var target = document.querySelector(location.hash);
+        if (target && target.tagName === 'DETAILS') target.open = true;
+      } catch (e) {}
     }
     openHashSection();
     window.addEventListener('hashchange', openHashSection);

--- a/src/pages/archive/index.astro
+++ b/src/pages/archive/index.astro
@@ -311,6 +311,13 @@ const archiveLd = {
     const buttons = document.querySelectorAll('[data-type-filter]');
     const rows = document.querySelectorAll('tr[data-type]');
     const sections = document.querySelectorAll('.archive-year');
+    function openHashSection() {
+      if (!location.hash) return;
+      var target = document.querySelector(location.hash);
+      if (target && target.tagName === 'DETAILS') target.open = true;
+    }
+    openHashSection();
+    window.addEventListener('hashchange', openHashSection);
     buttons.forEach(function (btn) {
       btn.addEventListener('click', function () {
         var type = btn.getAttribute('data-type-filter');

--- a/src/pages/archive/page/[n].astro
+++ b/src/pages/archive/page/[n].astro
@@ -333,8 +333,10 @@ const archiveLd = {
     const sections = document.querySelectorAll('.archive-year');
     function openHashSection() {
       if (!location.hash) return;
-      var target = document.querySelector(location.hash);
-      if (target && target.tagName === 'DETAILS') target.open = true;
+      try {
+        var target = document.querySelector(location.hash);
+        if (target && target.tagName === 'DETAILS') target.open = true;
+      } catch (e) {}
     }
     openHashSection();
     window.addEventListener('hashchange', openHashSection);

--- a/src/pages/archive/page/[n].astro
+++ b/src/pages/archive/page/[n].astro
@@ -331,6 +331,13 @@ const archiveLd = {
     const buttons = document.querySelectorAll('[data-type-filter]');
     const rows = document.querySelectorAll('tr[data-type]');
     const sections = document.querySelectorAll('.archive-year');
+    function openHashSection() {
+      if (!location.hash) return;
+      var target = document.querySelector(location.hash);
+      if (target && target.tagName === 'DETAILS') target.open = true;
+    }
+    openHashSection();
+    window.addEventListener('hashchange', openHashSection);
     buttons.forEach(function (btn) {
       btn.addEventListener('click', function () {
         var type = btn.getAttribute('data-type-filter');

--- a/src/pages/pt/archive/index.astro
+++ b/src/pages/pt/archive/index.astro
@@ -317,6 +317,13 @@ const years = [...byYear.keys()].sort((a, b) => b - a);
     const buttons = document.querySelectorAll('[data-type-filter]');
     const rows = document.querySelectorAll('tr[data-type]');
     const sections = document.querySelectorAll('.archive-year');
+    function openHashSection() {
+      if (!location.hash) return;
+      var target = document.querySelector(location.hash);
+      if (target && target.tagName === 'DETAILS') target.open = true;
+    }
+    openHashSection();
+    window.addEventListener('hashchange', openHashSection);
     buttons.forEach(function (btn) {
       btn.addEventListener('click', function () {
         var type = btn.getAttribute('data-type-filter');

--- a/src/pages/pt/archive/index.astro
+++ b/src/pages/pt/archive/index.astro
@@ -319,8 +319,10 @@ const years = [...byYear.keys()].sort((a, b) => b - a);
     const sections = document.querySelectorAll('.archive-year');
     function openHashSection() {
       if (!location.hash) return;
-      var target = document.querySelector(location.hash);
-      if (target && target.tagName === 'DETAILS') target.open = true;
+      try {
+        var target = document.querySelector(location.hash);
+        if (target && target.tagName === 'DETAILS') target.open = true;
+      } catch (e) {}
     }
     openHashSection();
     window.addEventListener('hashchange', openHashSection);

--- a/src/pages/pt/archive/page/[n].astro
+++ b/src/pages/pt/archive/page/[n].astro
@@ -339,8 +339,10 @@ const years = [...byYear.keys()].sort((a, b) => b - a);
     const sections = document.querySelectorAll('.archive-year');
     function openHashSection() {
       if (!location.hash) return;
-      var target = document.querySelector(location.hash);
-      if (target && target.tagName === 'DETAILS') target.open = true;
+      try {
+        var target = document.querySelector(location.hash);
+        if (target && target.tagName === 'DETAILS') target.open = true;
+      } catch (e) {}
     }
     openHashSection();
     window.addEventListener('hashchange', openHashSection);

--- a/src/pages/pt/archive/page/[n].astro
+++ b/src/pages/pt/archive/page/[n].astro
@@ -337,6 +337,13 @@ const years = [...byYear.keys()].sort((a, b) => b - a);
     const buttons = document.querySelectorAll('[data-type-filter]');
     const rows = document.querySelectorAll('tr[data-type]');
     const sections = document.querySelectorAll('.archive-year');
+    function openHashSection() {
+      if (!location.hash) return;
+      var target = document.querySelector(location.hash);
+      if (target && target.tagName === 'DETAILS') target.open = true;
+    }
+    openHashSection();
+    window.addEventListener('hashchange', openHashSection);
     buttons.forEach(function (btn) {
       btn.addEventListener('click', function () {
         var type = btn.getAttribute('data-type-filter');


### PR DESCRIPTION
## Summary

Closes #1328.

- Cada ano em `/archive/` é um `<details>` fechado por padrão (exceto o mais
  recente). Os links "pular para o ano" apontam para `#archive-<year>`, ou
  seja, o próprio `<details>` — o navegador rolava até ele mas não o
  expandia, deixando o leitor numa seção vazia até clicar de novo.
- Adicionado um `openHashSection()` que força `details.open = true` no
  `<details>` cujo id bate com `location.hash`, chamado uma vez no load
  (cobre navegação direta com hash) e em `hashchange` (cobre clique na nav
  já com a página carregada).
- Aplicado nos 4 arquivos que compartilham essa estrutura: EN/PT ×
  index/paginado (`src/pages/archive/index.astro`,
  `src/pages/pt/archive/index.astro`, `src/pages/archive/page/[n].astro`,
  `src/pages/pt/archive/page/[n].astro`).
- Comportamento default (só o primeiro ano aberto ao carregar) inalterado.

## Test plan

- [x] `npx astro check` — 0 erros (warnings pré-existentes inalterados)
- [x] `npx prettier --check .` — passa
- [x] `npm run build` — build completo, incl. prebuild/pregen e pagefind
- [x] Confirmado no HTML gerado (`dist/archive/index.html`,
      `dist/pt/archive/index.html`, `dist/archive/page/2/index.html`,
      `dist/pt/archive/page/2/index.html`) que o script `openHashSection`
      está presente nas 4 páginas


---
_Generated by [Claude Code](https://claude.ai/code/session_01MQf42bP19V4nCnWSt3gDTX)_