### PR TITLE
fix: make the changelog readable and structurally correct

### DIFF
--- a/changelog/0.1.0.md
+++ b/changelog/0.1.0.md
@@ -6,43 +6,40 @@ description: Starts changelog/versioning tracking; RFC 0017 retires the `version
 tags: [changelog, rfc-0017, hronir]
 ---
 
-# 0.1.0
+### What changed
 
-## What changed
-
-- **Changelog and versioning tracking starts here.** This repo now keeps
-  one changelog entry per version under `changelog/<version>.md`, written
-  as [OKF](../docs/okf/README.md) markdown (`type` is the required field,
-  here `Changelog Entry`), with `package.json`'s `version` as the single
-  source of truth. No prior history is reconstructed — tracking starts at
-  this entry.
-- **RFC 0017 — end of the `version` duel**
-  (`docs/rfcs/0017-fim-do-duelo-de-versoes.md`). Hrönir retires the
-  `version` duel (competing candidates for the same post's public URL)
-  while keeping the `work` duel (comparing different essays) as the
-  system's operational core. Version lineage becomes git's job
-  exclusively — a work (`key`) and its current language representations
-  are the only identity axes left.
-- **Fase 0-1 of the migration:** 151 of 153 legacy directories
-  (`<slug>/v-<timestamp>.mdx`) flattened to a single file (`<slug>.mdx`,
+- **Changelog and version tracking start here.** The repository now keeps one
+  entry per version under `changelog/<version>.md`, written as
+  [OKF markdown](https://github.com/franklinbaldo/franklinbaldo.github.io/blob/main/docs/okf/README.md)
+  (`type` is the required field, here `Changelog Entry`), with
+  `package.json`'s `version` as the single source of truth. No prior history is
+  reconstructed — tracking starts with this release.
+- **[RFC 0017 — end of the `version` duel](https://github.com/franklinbaldo/franklinbaldo.github.io/blob/main/docs/rfcs/0017-fim-do-duelo-de-versoes.md).**
+  Hrönir retires the `version` duel (competing candidates for the same post's
+  public URL) while keeping the `work` duel (comparing different essays) as
+  the system's operational core. Version lineage becomes git's job
+  exclusively — a work (`key`) and its current language representations are
+  the only identity axes left.
+- **Migration phases 0–1:** 151 of 153 legacy directories
+  (`<slug>/v-<timestamp>.mdx`) were flattened to a single file (`<slug>.mdx`,
   or `<slug>/index.mdx` when local media is attached), with an auditable
   manifest (`src/generated/migration-0017-survivors.json` —
   `selectedFrom`/`selectedUuid`/`selectedSha256` per slug) and a preserved,
   idempotent migration script
   (`scripts/oneoff/2026-07-15-rfc-0017-fase1-flatten.mjs`). Two slugs
   (`delegando-para-agentes`, `the-art-of-delegation`) are deliberately left
-  out — an editorial decision (which draft is canonical) is still pending,
-  not a mechanical blocker.
-- **Public version-duel surface removed:** the `blogVersions` collection,
-  the `/blog/<slug>/v/<uuid>/` routes (EN/PT), the `/ranking/version-trials/`
-  and `/ranking/versions/<key>/` pages, the "Edit history" section on a
-  work's dossier, and version-duel rendering on `/ranking/battles/<id>/`.
-  Pulled forward from RFC 0017's Fase 3 into this same delivery so the
-  permalink break is deliberate and atomic instead of a partial
+  out — an editorial decision about which draft is canonical is still
+  pending, rather than a mechanical blocker.
+- **The public version-duel surface was removed:** the `blogVersions`
+  collection, the `/blog/<slug>/v/<uuid>/` routes (EN/PT), the
+  `/ranking/version-trials/` and `/ranking/versions/<key>/` pages, the “Edit
+  history” section on a work's dossier, and version-duel rendering on
+  `/ranking/battles/<id>/`. This was pulled forward from RFC 0017's phase 3 so
+  the permalink break would be deliberate and atomic instead of a partial
   degradation across phases (build page count: 4514 → 2964).
-- **`hronir:doctor`** now validates a rate file's `key` against live works
-  (replacing the old version-path/UUID tolerance check, now obsolete) —
-  found no new issues, only pre-existing `stars-v1` data debt from an
-  abandoned experimental phase, recorded as a non-blocking warning.
+- **`hronir:doctor`** now validates a rate file's `key` against live works,
+  replacing the obsolete version-path/UUID tolerance check. It found no new
+  issues, only pre-existing `stars-v1` data debt from an abandoned
+  experimental phase, recorded as a non-blocking warning.
 
-See PR #1203 for the full diff.
+[View PR #1203 for the full diff.](https://github.com/franklinbaldo/franklinbaldo.github.io/pull/1203)

--- a/scripts/check-changelog.mjs
+++ b/scripts/check-changelog.mjs
@@ -10,6 +10,9 @@
 //      filename and carries the required OKF fields (RFC 0014 §7:
 //      `type` is the only field OKF itself requires; `version`/`date`/
 //      `description` are this convention's own requirements on top of that).
+//   4. Entry bodies start at heading level 3: the changelog page supplies the
+//      page h1 and each release's h2, so h1/h2 inside an entry would duplicate
+//      or flatten the rendered document outline.
 import { existsSync, readFileSync, readdirSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -36,6 +39,27 @@ function compareParts(a, b) {
     if (a[i] !== b[i]) return a[i] - b[i];
   }
   return 0;
+}
+
+function findShallowHeadingLine(content) {
+  let fenceMarker = null;
+  const lines = content.split(/\r?\n/);
+
+  for (let index = 0; index < lines.length; index++) {
+    const line = lines[index].trimStart();
+    const fence = /^(`{3,}|~{3,})/.exec(line);
+
+    if (fence) {
+      const marker = fence[1][0];
+      if (fenceMarker === null) fenceMarker = marker;
+      else if (fenceMarker === marker) fenceMarker = null;
+      continue;
+    }
+
+    if (fenceMarker === null && /^#{1,2}\s+/.test(line)) return index + 1;
+  }
+
+  return null;
 }
 
 if (!existsSync(CHANGELOG_DIR)) {
@@ -78,7 +102,7 @@ if (currentParts) {
 
 for (const { file, versionString, parts } of entries) {
   const path = join(CHANGELOG_DIR, file);
-  const { data } = matter(readFileSync(path, "utf-8"));
+  const { data, content } = matter(readFileSync(path, "utf-8"));
 
   for (const field of REQUIRED_FIELDS) {
     if (!data[field]) {
@@ -109,6 +133,14 @@ for (const { file, versionString, parts } of entries) {
         `changelog/${file}: frontmatter date "${data.date}" isn't a valid date`
       );
     }
+  }
+
+  const shallowHeadingLine = findShallowHeadingLine(content);
+  if (shallowHeadingLine !== null) {
+    errors.push(
+      `changelog/${file}:${shallowHeadingLine}: entry headings must start at level 3 (###); ` +
+        `the rendered changelog already supplies the page h1 and release h2.`
+    );
   }
 
   if (currentParts && compareParts(parts, currentParts) > 0) {

--- a/src/pages/changelog/index.astro
+++ b/src/pages/changelog/index.astro
@@ -15,93 +15,210 @@ const fmt = new Intl.DateTimeFormat("en-US", {
   year: "numeric",
   month: "long",
   day: "numeric",
+  timeZone: "UTC",
 });
+
+const repositoryUrl = "https://github.com/franklinbaldo/franklinbaldo.github.io";
 ---
 
 <PageLayout
   title="Changelog | Franklin Baldo"
-  description="Release notes for this repo — what changed, version by version."
+  description="Release notes for the site and Hrönir, listed version by version."
   lang="en"
+  breadcrumb={[
+    { name: "Home", item: new URL("/", Astro.site).href },
+    { name: "Changelog", item: new URL("/changelog/", Astro.site).href },
+  ]}
 >
-  <hgroup>
+  <header class="changelog-intro">
     <h1>Changelog</h1>
-    <p>
-      <small>
-        One entry per version, as
-        <a href="https://github.com/franklinbaldo/franklinbaldo.github.io/blob/main/docs/okf/README.md"
-          >OKF</a
-        > markdown — see
-        <a href="https://github.com/franklinbaldo/franklinbaldo.github.io/tree/main/changelog"
-          >changelog/</a
-        > for the raw files.
-      </small>
-    </p>
-  </hgroup>
+    <p>Release notes for the site and Hrönir, newest first.</p>
+    <nav class="changelog-resources" aria-label="Changelog resources">
+      <a href={`${repositoryUrl}/tree/main/changelog`}>Source files</a>
+      <span aria-hidden="true">·</span>
+      <a href={`${repositoryUrl}/blob/main/docs/okf/README.md`}>Changelog format</a>
+    </nav>
+  </header>
 
-  {
-    rendered.map(({ entry, Content }) => (
-      <article id={entry.data.version} class="changelog-entry">
-        <header>
-          <hgroup>
-            <h2>
-              <a href={`#${entry.data.version}`}>{entry.data.version}</a>
-            </h2>
-            <p>
-              <small>
-                <time datetime={entry.data.date.toISOString()}>
-                  {fmt.format(entry.data.date)}
-                </time>
-              </small>
-            </p>
-          </hgroup>
-          {entry.data.tags && entry.data.tags.length > 0 && (
-            <p class="changelog-tags">
-              {entry.data.tags.map((tag) => (
-                <span class="tag-pill">#{tag}</span>
-              ))}
-            </p>
-          )}
-        </header>
-        <div class="prose">
-          <Content />
-        </div>
-      </article>
-    ))
-  }
+  <div class="changelog-list">
+    {
+      rendered.map(({ entry, Content }) => {
+        const anchor = `version-${entry.data.version}`;
+
+        return (
+          <article id={anchor} class="changelog-entry">
+            <header class="release-header">
+              <div>
+                <p class="release-label">Release</p>
+                <h2>
+                  <a
+                    href={`#${anchor}`}
+                    aria-label={`Permanent link to version ${entry.data.version}`}
+                  >
+                    <span aria-hidden="true">v</span>
+                    {entry.data.version}
+                  </a>
+                </h2>
+              </div>
+              <time datetime={entry.data.date.toISOString()}>
+                {fmt.format(entry.data.date)}
+              </time>
+            </header>
+
+            <p class="release-summary">{entry.data.description}</p>
+
+            {entry.data.tags && entry.data.tags.length > 0 && (
+              <ul class="changelog-tags" aria-label="Release tags">
+                {entry.data.tags.map((tag) => (
+                  <li>#{tag}</li>
+                ))}
+              </ul>
+            )}
+
+            <div class="prose">
+              <Content />
+            </div>
+          </article>
+        );
+      })
+    }
+  </div>
 </PageLayout>
 
 <style>
+  .changelog-intro {
+    max-width: 46rem;
+    margin-bottom: 3rem;
+  }
+
+  .changelog-intro h1 {
+    margin-bottom: 0.5rem;
+  }
+
+  .changelog-intro > p {
+    margin-bottom: 0.65rem;
+    color: var(--pico-muted-color);
+    font-size: 1.05rem;
+  }
+
+  .changelog-resources {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.45rem;
+    align-items: center;
+    font-size: 0.85rem;
+  }
+
+  .changelog-list {
+    max-width: 52rem;
+  }
+
   .changelog-entry {
-    margin-bottom: 2.5rem;
-    padding-bottom: 2rem;
-    border-bottom: 1px solid var(--pico-muted-border-color);
+    position: relative;
+    padding: 0 0 3rem 2rem;
+    border-left: 1px solid var(--pico-muted-border-color);
   }
+
+  .changelog-entry::before {
+    position: absolute;
+    top: 0.55rem;
+    left: -0.36rem;
+    width: 0.68rem;
+    height: 0.68rem;
+    border: 2px solid var(--pico-background-color);
+    border-radius: 50%;
+    background: var(--pico-primary);
+    content: "";
+  }
+
   .changelog-entry:last-child {
-    border-bottom: none;
+    padding-bottom: 0;
   }
-  .changelog-entry h2 {
-    margin-bottom: 0.25rem;
+
+  .release-header {
+    display: flex;
+    gap: 1rem;
+    align-items: flex-start;
+    justify-content: space-between;
+    margin-bottom: 0.8rem;
   }
-  .changelog-entry h2 a {
-    text-decoration: none;
+
+  .release-label {
+    margin: 0 0 0.1rem;
+    color: var(--pico-muted-color);
+    font-size: 0.7rem;
+    font-weight: 600;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+  }
+
+  .release-header h2 {
+    margin: 0;
+    font-size: clamp(1.45rem, 4vw, 1.9rem);
+  }
+
+  .release-header h2 a {
     color: inherit;
+    text-decoration: none;
   }
-  .changelog-entry h2 a:hover {
+
+  .release-header h2 a:hover {
     color: var(--pico-primary);
   }
+
+  .release-header time {
+    padding-top: 0.35rem;
+    color: var(--pico-muted-color);
+    font-size: 0.82rem;
+    font-variant-numeric: tabular-nums;
+    white-space: nowrap;
+  }
+
+  .release-summary {
+    max-width: 48rem;
+    margin-bottom: 0.75rem;
+    font-size: 1.05rem;
+  }
+
   .changelog-tags {
-    margin: 0.25rem 0 1rem;
-  }
-  .tag-pill {
-    display: inline-block;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.45rem 0.75rem;
+    padding: 0;
+    margin: 0 0 1.5rem;
+    color: var(--pico-muted-color);
     font-size: 0.72rem;
-    color: var(--pico-muted-color);
-    margin-right: 0.5rem;
+    list-style: none;
   }
-  .prose :global(h2) {
-    font-size: 1rem;
+
+  .prose :global(h3) {
+    margin-top: 1.75rem;
+    font-size: 0.78rem;
+    letter-spacing: 0.08em;
     text-transform: uppercase;
-    letter-spacing: 0.04em;
     color: var(--pico-muted-color);
+  }
+
+  .prose :global(li + li) {
+    margin-top: 0.85rem;
+  }
+
+  .prose :global(p:last-child) {
+    margin-bottom: 0;
+  }
+
+  @media (max-width: 34rem) {
+    .changelog-entry {
+      padding-left: 1.35rem;
+    }
+
+    .release-header {
+      display: block;
+    }
+
+    .release-header time {
+      display: block;
+      padding-top: 0.35rem;
+    }
   }
 </style>


### PR DESCRIPTION
## What changed

- removes the duplicated release title (`0.1.0` was rendered both by the page and by the Markdown body)
- gives the changelog a compact release timeline with clearer date, summary, and tags
- fixes release-note links so they point to the actual RFC, OKF documentation, and PR instead of broken site-relative paths or plain text
- normalizes the release copy and pins date formatting to UTC
- extends `check:changelog` to reject h1/h2 headings inside entry bodies, preserving the page outline (`h1` page → `h2` release → `h3` section)

## Why

The published page currently reads like raw Markdown embedded inside another document: duplicated headings, flattened hierarchy, and references that are not usable links. This keeps the source-file model while making the public changelog work as an actual release history.