### PR TITLE
seo: add JSON Feed (feed.json) alongside RSS

### DIFF
--- a/.routines/2026-07-27T12-40-06-ux-ui-run.md
+++ b/.routines/2026-07-27T12-40-06-ux-ui-run.md
@@ -1,0 +1,17 @@
+---
+date: "2026-07-27T12:40:06Z"
+branch: ux-ui/run-2026-07-27T12-34-50
+status: open
+---
+
+# Sessão 2026-07-27T12-40-06 — UX/UI
+
+Issues fechadas: #1084
+O que foi feito: adicionado JSON Feed (`feed.json`) ao lado do RSS existente —
+`src/pages/feed.json.js` (EN) e `src/pages/pt/feed.json.js` (PT) reaproveitam
+a mesma consulta de posts publicados de `rss.xml.js`; `<link rel="alternate"
+type="application/feed+json">` adicionado em `PageLayout.astro` ao lado do
+link RSS existente.
+CI local: astro check ✅ (0 erros) · prettier ✅ · build ✅ (feed.json e
+pt/feed.json gerados, validados contra o schema JSON Feed 1.1 — campos
+obrigatórios version/title/items[].id/content_html/url presentes)

--- a/src/layouts/PageLayout.astro
+++ b/src/layouts/PageLayout.astro
@@ -189,6 +189,7 @@ const personLd = {
     <link rel="canonical" href={canonical.href} />
     <link rel="alternate" type="application/rss+xml" title={lang === 'pt' ? 'Franklin Baldo (Português)' : 'Franklin Baldo'} href={rssUrl} />
     <link rel="alternate" type="application/rss+xml" title={lang === 'pt' ? 'Franklin Baldo (English)' : 'Franklin Baldo (Português)'} href={new URL(lang === 'pt' ? 'rss.xml' : 'pt/rss.xml', Astro.site)} />
+    <link rel="alternate" type="application/feed+json" title={lang === 'pt' ? 'Franklin Baldo (Português)' : 'Franklin Baldo'} href={new URL(lang === 'pt' ? 'pt/feed.json' : 'feed.json', Astro.site)} />
     <link rel="sitemap" href="/sitemap-index.xml" />
     {hasMath && <link rel="stylesheet" href="/katex/katex.min.css" />}
 

--- a/src/pages/feed.json.js
+++ b/src/pages/feed.json.js
@@ -1,0 +1,48 @@
+import { getCollection, render } from "astro:content";
+import { experimental_AstroContainer as AstroContainer } from "astro/container";
+import { loadRenderers } from "astro:container";
+import { getContainerRenderer as getMdxRenderer } from "@astrojs/mdx";
+import { isPublished } from "../lib/publish";
+
+export async function GET(context) {
+  const posts = (await getCollection("blog"))
+    .filter((post) => isPublished(post))
+    .filter((post) => (post.data.lang ?? "en") === "en")
+    .sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf());
+
+  const renderers = await loadRenderers([getMdxRenderer()]);
+  const container = await AstroContainer.create({ renderers });
+
+  const items = await Promise.all(
+    posts.map(async (post) => {
+      const { Content } = await render(post);
+      const body = await container.renderToString(Content);
+      const url = new URL(`/blog/${post.data.slug ?? post.id}/`, context.site)
+        .href;
+      return {
+        id: url,
+        url,
+        title: post.data.title,
+        content_html: body,
+        summary: post.data.description,
+        date_published: post.data.date.toISOString(),
+        tags: post.data.tags ?? [],
+      };
+    })
+  );
+
+  const feed = {
+    version: "https://jsonfeed.org/version/1.1",
+    title: "Franklin Baldo",
+    description:
+      "Lawyer and State Attorney. Exploring the intersections of process metaphysics, AI agency, and the architecture of legal systems.",
+    home_page_url: context.site.href,
+    feed_url: new URL("feed.json", context.site).href,
+    language: "en-us",
+    items,
+  };
+
+  return new Response(JSON.stringify(feed, null, 2), {
+    headers: { "Content-Type": "application/feed+json; charset=utf-8" },
+  });
+}

--- a/src/pages/pt/feed.json.js
+++ b/src/pages/pt/feed.json.js
@@ -1,0 +1,50 @@
+import { getCollection, render } from "astro:content";
+import { experimental_AstroContainer as AstroContainer } from "astro/container";
+import { loadRenderers } from "astro:container";
+import { getContainerRenderer as getMdxRenderer } from "@astrojs/mdx";
+import { isPublished } from "../../lib/publish";
+
+export async function GET(context) {
+  const posts = (await getCollection("blog"))
+    .filter((post) => isPublished(post))
+    .filter((post) => (post.data.lang ?? "en") === "pt")
+    .sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf());
+
+  const renderers = await loadRenderers([getMdxRenderer()]);
+  const container = await AstroContainer.create({ renderers });
+
+  const items = await Promise.all(
+    posts.map(async (post) => {
+      const { Content } = await render(post);
+      const body = await container.renderToString(Content);
+      const url = new URL(
+        `/pt/blog/${post.data.slug ?? post.id}/`,
+        context.site
+      ).href;
+      return {
+        id: url,
+        url,
+        title: post.data.title,
+        content_html: body,
+        summary: post.data.description,
+        date_published: post.data.date.toISOString(),
+        tags: post.data.tags ?? [],
+      };
+    })
+  );
+
+  const feed = {
+    version: "https://jsonfeed.org/version/1.1",
+    title: "Franklin Baldo (Português)",
+    description:
+      "Advogado e Procurador do Estado. Explorando as interseções entre metafísica do processo, agentes de IA e a arquitetura dos sistemas jurídicos.",
+    home_page_url: new URL("pt/", context.site).href,
+    feed_url: new URL("pt/feed.json", context.site).href,
+    language: "pt-br",
+    items,
+  };
+
+  return new Response(JSON.stringify(feed, null, 2), {
+    headers: { "Content-Type": "application/feed+json; charset=utf-8" },
+  });
+}


### PR DESCRIPTION
Closes #1084

## Summary
- Add `src/pages/feed.json.js` (EN) and `src/pages/pt/feed.json.js` (PT), reusing the same published-post query and rendering already used by `rss.xml.js` / `pt/rss.xml.js` — no new dependency, just a structured `Response` per the [JSON Feed 1.1](https://www.jsonfeed.org/version/1.1/) spec.
- Add `<link rel="alternate" type="application/feed+json">` in `PageLayout.astro`, next to the existing RSS `<link>`, localized per `lang`.

## Test plan
- [x] `npx astro check` — 0 errors (pre-existing warnings unaffected)
- [x] `npx prettier --check .` — clean
- [x] `npm run build` — full build succeeds, `dist/feed.json` and `dist/pt/feed.json` generated
- [x] Verified generated HTML: `<link rel="alternate" type="application/feed+json">` present and correctly localized on both `dist/index.html` and `dist/pt/index.html`
- [x] Validated both feed JSON files against the JSON Feed 1.1 required-field schema (`version`, `title`, `items[].id/content_html/url`) with a script


---
_Generated by [Claude Code](https://claude.ai/code/session_01847aMnLp6R8PLLjrrm1BVs)_