### PR TITLE
ux: filter EN search results by lang:en

### DIFF
--- a/.routines/2026-07-28T05-05-39-ux-ui-run.md
+++ b/.routines/2026-07-28T05-05-39-ux-ui-run.md
@@ -1,0 +1,11 @@
+---
+date: "2026-07-28T05:05:39Z"
+branch: claude/ecstatic-hawking-rf9kdo
+status: open
+---
+
+# Sessão 2026-07-28T05-05-39 — UX/UI
+
+Issues fechadas: #1386
+O que foi feito: adicionado `data-filter="lang:en"` ao `<pagefind-searchbox>` de `src/pages/search.astro`, espelhando o filtro já existente em `src/pages/pt/search.astro` (`lang:pt`) — a página de busca EN retornava resultados PT misturados por falta desse filtro.
+CI local: astro check ✅ (0 erros) · prettier ✅ · build ✅ (confirmado em dist/search/index.html e dist/pt/search/index.html)

--- a/src/pages/search.astro
+++ b/src/pages/search.astro
@@ -9,7 +9,7 @@ import PageLayout from "../layouts/PageLayout.astro";
   </hgroup>
 
   <fieldset role="search" class="search-fieldset">
-    <pagefind-searchbox></pagefind-searchbox>
+    <pagefind-searchbox data-filter="lang:en"></pagefind-searchbox>
   </fieldset>
 
   <p class="search-hint" id="search-hint">Type a word or phrase to search through all essays.</p>


### PR DESCRIPTION
## Summary
- `src/pages/pt/search.astro` scopes results with `data-filter="lang:pt"`, but `src/pages/search.astro` had no filter at all — the EN search page returned PT posts mixed in with EN results.
- Added `data-filter="lang:en"` to the `<pagefind-searchbox>` in `src/pages/search.astro`, mirroring the PT page.

Closes #1386

## Test plan
- [x] `npx astro check` — 0 errors
- [x] `npx prettier --check .` — all files formatted
- [x] `npm run build` — full build incl. pagefind indexing
- [x] Verified generated HTML: `dist/search/index.html` has `data-filter="lang:en"`, `dist/pt/search/index.html` still has `data-filter="lang:pt"`


---
_Generated by [Claude Code](https://claude.ai/code/session_01Gyynq47LAhEWB8RkXASq85)_