### PR TITLE
ux: filter EN search results by lang:en

### DIFF
--- a/.routines/2026-07-29T05-05-13-ux-ui-run.md
+++ b/.routines/2026-07-29T05-05-13-ux-ui-run.md
@@ -1,0 +1,11 @@
+---
+date: "2026-07-29T05:05:13Z"
+branch: ux-ui/run-2026-07-29T05-00-22
+status: open
+---
+
+# Sessão 2026-07-29T05-05-13 — UX/UI
+
+Issues fechadas: #1386
+O que foi feito: adicionado `data-filter="lang:en"` ao `<pagefind-searchbox>` em `src/pages/search.astro`, espelhando o filtro já existente em `pt/search.astro` (`lang:pt`). A página de busca EN não filtrava por idioma, misturando resultados PT nos resultados EN. Confirmado no `dist/search/index.html` pós-build que o atributo foi renderizado corretamente, sem afetar `pt/search.astro`.
+CI local: astro check ✅ (0 erros) · prettier ✅ · build ✅

--- a/src/pages/search.astro
+++ b/src/pages/search.astro
@@ -9,7 +9,7 @@ import PageLayout from "../layouts/PageLayout.astro";
   </hgroup>
 
   <fieldset role="search" class="search-fieldset">
-    <pagefind-searchbox></pagefind-searchbox>
+    <pagefind-searchbox data-filter="lang:en"></pagefind-searchbox>
   </fieldset>
 
   <p class="search-hint" id="search-hint">Type a word or phrase to search through all essays.</p>


### PR DESCRIPTION
Closes #1386

## Summary
- `src/pages/search.astro` had a bare `<pagefind-searchbox>` with no filter, while `src/pages/pt/search.astro` already scopes results with `data-filter="lang:pt"`. The EN search page returned PT results mixed in.
- Added `data-filter="lang:en"` to the EN searchbox, mirroring the PT page.

## Test plan
- [x] `npx astro check` — 0 errors (pre-existing warnings only)
- [x] `npx prettier --check .` — passes
- [x] `npm run build` — completes, pagefind indexes built
- [x] Verified `dist/search/index.html` renders `data-filter="lang:en"` and `dist/pt/search/index.html` is unchanged (`lang:pt`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MxMiWm5kDBorzTjjR2cnnZ)_