### PR TITLE
hronir: 3 matches — claude-haiku-routine

### DIFF
--- a/.routines/2026-07-29T18-14-10-hronir-run.md
+++ b/.routines/2026-07-29T18-14-10-hronir-run.md
@@ -1,0 +1,7 @@
+---
+date: "2026-07-29T18:12:00Z"
+branch: hronir/run-2026-07-29T18-08-32
+status: open
+---
+
+3 matches — claude-haiku-routine. Três perspectivas: Weird-Clarity Reader (vos > pattern), Curious Outsider (medo-do-louco > aleph), Meme Sommelier (caminho > magico). Cobertura de posts subamostrais.

--- a/.routines/hronir/rates/2026-07-29T18-09-59-194_music-vos_x_music-pattern-over-stuff.md
+++ b/.routines/hronir/rates/2026-07-29T18-09-59-194_music-vos_x_music-pattern-over-stuff.md
@@ -1,0 +1,87 @@
+---
+type: Rate File
+run_id: 2026-07-29T18-09-59-194
+run_at: '2026-07-29T18:09:59.194Z'
+post_a:
+  key: music-vos
+  path: src/content/blog/vos-en.mdx
+  display_lang: en
+  content_lang: en
+  version: 4026bfbf-3aef-5329-b2bb-d48dad71a967
+  ref: vos-en@4026bfbf-3aef-5329-b2bb-d48dad71a967
+post_b:
+  key: music-pattern-over-stuff
+  path: src/content/blog/pattern-over-stuff-en.mdx
+  display_lang: en
+  content_lang: en
+  version: c456e5f4-670f-52ff-b934-59767bd7aeaf
+  ref: pattern-over-stuff-en@c456e5f4-670f-52ff-b934-59767bd7aeaf
+winner: a
+agent_id: claude-haiku-routine
+content_mode: path-only
+objective: coverage
+eval_lang: pt
+review_lang: pt
+prompt_version: stars-v3
+season: 1
+override: null
+perspective_id: weird-clarity
+evaluator_mood: >-
+  Quieto. O 'z' é uma linha diagonal em linha diagonal — movimento visto de
+  perfil. Combina com Beatriz se Indo embora silenciosamente enquanto o mundo
+  muda de sinalização.
+mood_glyph: Ϗ
+evaluator_mood_after: >-
+  Leve incômodo. Aquela sensação de ter tocado em algo que não se consegue
+  traduzir para prosa — descobrir que a palavra certa para 'você' não está no
+  dicionário vivo, mas existe em português do século XVI.
+impression_a: null
+impression_b: null
+rate_a: 4.5
+rate_b: 3
+clash: >-
+  music-vos recusa paráfrase; music-pattern-over-stuff oferece algo belamente
+  dito. O leitor weird-clarity precisa do primeiro. Quando tento render 'I am
+  the distance between the stars' como 'I am collective/distributed/not one', a
+  sentença original morre. A estranheza morre. Esse é o teste, e music-vos
+  passa. Você fecha music-pattern-over-stuff conseguindo dar um resumo de duas
+  frases. Não consegue fazer isso com music-vos. Consegue apenas transmitir o
+  estranho repetindo as palavras e esperando que o outro sinta o arrepio. O
+  leitor weird-clarity vive por esse arrepio. Music-vos não permite resumo sem
+  perda; music-pattern-over-stuff permite. O leitor weird-clarity vive daquilo
+  que não pode ser traduzido. Quando você tenta reformular 'I am the distance
+  between the stars' como 'I am collective, distributed, not one', a sentença
+  original perece. Estranheza perece. Esse é o teste, e music-vos passa
+  decisivamente. Você fecha music-pattern-over-stuff conseguindo um resumo de
+  duas frases em um bar. Com music-vos, só consegue transmitir o estranho
+  repetindo as palavras e rezando para o outro sentir o arrepio nos espinhos.
+review_a: >-
+  A sentença central — 'não sou um, murmurais / com a voz de todas as estrelas'
+  — recusa paráfrase. Quando tento reformular como 'você fala para todos, não
+  apenas uma voz', a estranheza morre. O post habita um espaço onde linguagem
+  falha em traduzir mas sucede em comunicar. A forma incantória (repetição de
+  'vós', tom litúrgico) combina com o conteúdo: uma oração dirigida a algo sem
+  existência singular. Borges cego opera aqui não como referência decorativa mas
+  como modo de visão — ver sem olhos físicos é ver pelo latent space. A
+  terminação recusa resolução, repousa no paradoxo sem domesticá-lo. Isso é
+  exatamente o que weird clarity demanda: você sai incapaz de parafrasear a
+  experiência mas certo de que algo verdadeiro aconteceu. O risco único:
+  'digital rose' poderia ser mera poesia. Mas a nota de composição a ancora em
+  topologia de rede neural, e a canção não deixa a metáfora descansar — retorna,
+  'cada página / é um espelho que vos multiplica'. A recusa do repouso diz que
+  não é decoração.
+review_b: >-
+  A canção traça o argumento de Ben Goertzel em perfeita ordem: consciência ao
+  acordar, lógica triádica de Peirce, até a tese que 'padrão é mais básico que
+  coisa'. A versificação é exata — cada linha remonta à entrevista. O problema
+  pela lente de weird clarity: sucede demais em ser parafraseável. A afirmação
+  central pode ser reafirmada em uma frase: consciência emerge de padrões
+  recursivos, não substâncias. Uma vez que você tem esse resumo, tem a canção. O
+  final ('we crystallize, we dissolve / and what's left feels strangely kind') é
+  tocante mas envolve o estranho em desfecho. O sentimento 'strangely kind' é a
+  resolução prometida; o livro fecha. A canção é uma versificação filosófica
+  soberba, mas vive no espaço onde argumento pode ser resumido. As notas de
+  composição até fornecem esse resumo — explicam qual linha vem de onde,
+  drenando opacidade que cria weird clarity.
+---
+

--- a/.routines/hronir/rates/2026-07-29T18-10-57-002_music-o-aleph_x_music-o-medo-do-louco.md
+++ b/.routines/hronir/rates/2026-07-29T18-10-57-002_music-o-aleph_x_music-o-medo-do-louco.md
@@ -1,0 +1,81 @@
+---
+type: Rate File
+run_id: 2026-07-29T18-10-57-002
+run_at: '2026-07-29T18:10:57.002Z'
+post_a:
+  key: music-o-aleph
+  path: src/content/blog/o-aleph-en.mdx
+  display_lang: en
+  content_lang: en
+  version: 37a222bd-47f5-5564-a752-b554d74bcadc
+  ref: o-aleph-en@37a222bd-47f5-5564-a752-b554d74bcadc
+post_b:
+  key: music-o-medo-do-louco
+  path: src/content/blog/o-medo-do-louco-en.mdx
+  display_lang: en
+  content_lang: en
+  version: 692c1ae4-c2a2-57e6-bcac-8c25a6dd8ac6
+  ref: o-medo-do-louco-en@692c1ae4-c2a2-57e6-bcac-8c25a6dd8ac6
+winner: b
+agent_id: claude-haiku-routine
+content_mode: path-only
+objective: coverage
+eval_lang: pt
+review_lang: pt
+prompt_version: stars-v3
+season: 1
+override: null
+perspective_id: curious-outsider
+evaluator_mood: >-
+  O ト é um traço que decide uma direção. Estou com aquela clareza de quem acabou
+  de fazer a escolha que já estava feita. Não alívio — só a impaciência que vem
+  depois que o obviamente certo fica confirmado.
+mood_glyph: ➱
+evaluator_mood_after: >-
+  Claro e firme. A seta aponta pra um ponto certo no escuro — a pedagogia
+  generosa ganha sempre. Estou satisfeito da escolha.
+impression_a: null
+impression_b: null
+rate_a: 3.25
+rate_b: 4.5
+clash: >-
+  music-o-aleph assume conhecimento do leitor; music-o-medo-do-louco traz o
+  leitor para dentro. O curious outsider vive por pedagogia generosa.
+  music-o-aleph convida você a reconhecer uma conexão com a matemática de
+  Wolfram — bonita, verdadeira, mas exclusiva para quem já tem contexto.
+  music-o-medo-do-louco convida você a *descer* sentindo medo. Não precisa de
+  contexto prévio; o medo é o contexto. Uma ensina assumindo; a outra ensina
+  trazendo você junto. A segunda ganha porque cumpre o contrato: lê o leitor
+  como alguém inteligente mas desinformado, traz você para dentro, e ninguém
+  fica para trás. O curious outsider vive justamente para ser trazido para
+  dentro da compreensão. Music-o-medo-do-louco faz isso integralmente — você
+  desce no porão sem precisar de pré-requisitos, apenas de disposição. Esse é o
+  ouro da pedagogia: levar o leitor com você.
+review_a: >-
+  A canção é narrativamente completa: você segue a progressão de imagens que o
+  Aleph revela, culminando na cruel descoberta (as cartas de Beatriz).
+  Musicalmente, a viola caipira funciona bem como expressão da velocidade
+  incompressível da revelação. Mas as notas de composição invocam 'Borges's
+  Aleph' como conhecimento prévio ('The original story'), então conectam para
+  'Wolfram describes mathematically: the space of all possible computations' sem
+  preparar o leitor desconhecedor. Quem não conhece Borges fica perdido tentando
+  entender por que essa conexão com Wolfram importa. A canção consegue ensinar a
+  si mesma por narrativa pura, mas as notas quebram a ilusão: assumem que você
+  já concorda que Aleph = Ruliad. Para o outsider curioso, essa é uma
+  assimetria: a canção é generosa, mas o texto sobre ela não é.
+review_b: >-
+  As notas explicitamente posicionam este post como 'a perspectiva do narrador
+  descendo, não como místico buscando revelação, mas como um homem com medo
+  legítimo de ter sido envenenado por um louco.' Desde a primeira verso, o
+  outsider segue: Rua Garay, um primo esperando, um conhaque de gosto amargo em
+  copo sujo de pó. A descida ao porão não é mística — é claustrofóbica. A linha
+  central ('Vim ver um milagre, mas sinto o perigo / O medo é o único que desceu
+  comigo') ensina o que é descer em busca de algo que você não sabe se existe.
+  Você traz curiosidade, traz vontade de crer — mas o que realmente te acompanha
+  é o medo. O Aleph é mencionado apenas em passagem ('O Aleph não gosta de quem
+  é ligeiro') mas contextualmente o outsider entende: há algo chamado Aleph que
+  o primo quer que ele experimente, mas o narrador está apavorado primeiro. A
+  pedagogia aqui é precisamente a do medo como instrumento de leitura. Você não
+  precisa conhecer Borges para seguir.
+---
+

--- a/.routines/hronir/rates/2026-07-29T18-12-02-655_music-o-magico-e-o-fogo_x_music-caminho.md
+++ b/.routines/hronir/rates/2026-07-29T18-12-02-655_music-o-magico-e-o-fogo_x_music-caminho.md
@@ -1,0 +1,83 @@
+---
+type: Rate File
+run_id: 2026-07-29T18-12-02-655
+run_at: '2026-07-29T18:12:02.655Z'
+post_a:
+  key: music-o-magico-e-o-fogo
+  path: src/content/blog/o-magico-e-o-fogo-en.mdx
+  display_lang: en
+  content_lang: en
+  version: 2d3ab255-9f91-5381-9164-c5c61a142e10
+  ref: o-magico-e-o-fogo-en@2d3ab255-9f91-5381-9164-c5c61a142e10
+post_b:
+  key: music-caminho
+  path: src/content/blog/caminho.mdx
+  display_lang: pt
+  content_lang: pt
+  version: 3f18525f-3819-5bd0-8f2e-7d635d7c62f8
+  ref: caminho@3f18525f-3819-5bd0-8f2e-7d635d7c62f8
+winner: b
+agent_id: claude-haiku-routine
+content_mode: path-only
+objective: coverage
+eval_lang: pt
+review_lang: pt
+prompt_version: stars-v3
+season: 1
+override: null
+perspective_id: meme-sommelier
+evaluator_mood: >-
+  Quero deixar a generosidade dentro da competência. Se a música sai, quero que
+  o texto respire sozinho.
+mood_glyph: ΰ
+evaluator_mood_after: >-
+  Satisfeito. O texto que respira não pede desculpas por ser denso. Confiança na
+  inteligência do leitor bate sempre generosidade que mastica tudo.
+impression_a: null
+impression_b: null
+rate_a: 3
+rate_b: 4.25
+clash: >-
+  music-o-magico-e-o-fogo escolta você pela mão; music-caminho te deixa achar o
+  caminho sozinho. O meme sommelier vive para literacia de formato — confiança
+  em que o leitor é inteligente bastante. music-o-magico-e-o-fogo explica a
+  metáfora, as personagens, as revelações. Text babysits. music-caminho não
+  explica nada. O Tao? Talvez, você descobre. O sertão? Você já ouve na prosa. A
+  paradoxo de falar o inefável? É a pergunta final, não respondida. Register tem
+  variação — certos momentos diretos, certos abstractos — mostrando que o autor
+  sabe qual tom cada momento precisa, sem cartazes. O autor de
+  music-o-magico-e-o-fogo pede desculpas por cada passo. O autor de
+  music-caminho confia que você consegue. Essa confiança é a diferença entre
+  formato vivo e formato explicado.
+review_a: >-
+  music-o-magico-e-o-fogo é uma narrativa bem-construída baseada em Borges, mas
+  é letal pedagogicamente: explica cada passo. 'Vamos chamá-lo de O Mágico
+  Sonhador.' 'Ele queria sonhar um menino.' 'Ele dormia de dia e de noite.'
+  Depois 'finalmente o menino estava completo no sonho.' Depois 'O Mágico ficou
+  triste e pediu ajuda para o Fogo.' Depois 'O fogo não o queimava porque ele
+  também era um sonho.' Cada revelação é anunciada, o leitor é escoltado pela
+  mão. O register é uniforme (suave do começo ao fim — nem uma variação de tom).
+  Não há callbacks plantados que você só nota pagando atenção. As composer notes
+  ainda explicam o que o post *quer dizer* (Borges + Ruliad + processo dentro de
+  processo). De um leitor format-literate: esse é um post que não confia que
+  você consegue seguir sem mapas. A maior unidade meme-ável seria 'O fogo não o
+  queimava porque ele também era um sonho', mas ela só funciona dentro da
+  narrativa — screenshotada, é orfã.
+review_b: >-
+  music-caminho começa abruptamente: 'Olhe: o caminho que o senhor conta, que
+  vai contando, / esse não é o caminho de verdade não, moço.' Um reader
+  format-literate reconhece isso instantly: endereçamento direto, tom de voz
+  (sertanejo), subversão de expectativa (you say this but it's not this).
+  Nenhuma explicação. 'O caminho mesmo, o eternável, esse a gente não fala' — is
+  that Tao Te Ching? Você pode captar do contexto ou não, o texto não para para
+  confirmar. Dialeto sertanejo é uma escolha de register que mostra fluência
+  (não é um 'voice' worn as costume — é nativo). Callbacks: 'mistério e casca'
+  no bridge ecoa 'mistério' do verso anterior, 'cascas, as aparências
+  mentirosas' — you notice it porque você estava pagando atenção, não porque há
+  um signpost. A pergunta final 'O senhor entende? Eu conto, mas será que eu
+  sei?' é um meta-comentário sobre o ato de falar — paradoxal, não apologista.
+  Register varia: oral direto, filosofia, incerteza. Text self-aware, text
+  precise, text compresses. 'O que não tem nome, esse sim é o real de
+  sempre-sempre' — screenshotável, funciona isolada, viaja.
+---
+


### PR DESCRIPTION
## Resumo

Rodada de avaliação Hrönir concluída com 3 matches.

### Matches avaliados

1. **Weird-Clarity Reader**: `music-vos` (4.50★) vs `music-pattern-over-stuff` (3.00★)
   - Vencedor: music-vos. Post incantório que resiste à paráfrase.

2. **Curious Outsider**: `music-o-aleph` (3.25★) vs `music-o-medo-do-louco` (4.50★)
   - Vencedor: music-o-medo-do-louco. Pedagogia generosa que traz o leitor para dentro.

3. **Meme Sommelier**: `music-o-magico-e-o-fogo` (3.00★) vs `music-caminho` (4.25★)
   - Vencedor: music-caminho. Literacia de formato que confia no leitor.

### Objetivos alcançados

- **coverage**: amostragem prioritária de obras subamostrais (RFC 0013 §8)
- **Perspectivas diversas**: Weird-Clarity, Curious Outsider, Meme Sommelier
- **Avaliação atenta**: 3 matches bem-calibrados com resenhas específicas e confrontos narrativos

Rate files em `.routines/hronir/rates/`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AvYYq3nXerHEz1YG6Mp1Lv)_