### PR TITLE
ux: fix overlapping fixed widgets on mobile

### DIFF
--- a/.routines/2026-07-30T05-00-20-ux-ui-run.md
+++ b/.routines/2026-07-30T05-00-20-ux-ui-run.md
@@ -1,0 +1,17 @@
+---
+date: "2026-07-30T05:00:20Z"
+branch: ux-ui/run-2026-07-30T05-00-20
+status: open
+---
+
+# Sessão 2026-07-30T05-00-20 — UX/UI
+
+Issues fechadas: #1404
+O que foi feito: unificado o empilhamento vertical dos três widgets fixos do
+canto inferior direito (BackToTop, share FAB do PostActionBar, toast do
+LanguageSwitcher) via variáveis CSS compartilhadas em `src/styles/tokens.css`,
+removendo o gate `@media (min-width: 600px)` que deixava o FAB sobreposto ao
+BackToTop abaixo de 600px, e posicionando o toast acima de ambos em qualquer
+largura.
+CI local: astro check ✅ (0 erros) · prettier ✅ · build ✅ (dist verificado
+para ambas as strings CSS em EN e PT)

--- a/src/components/BackToTop.astro
+++ b/src/components/BackToTop.astro
@@ -12,8 +12,8 @@ const text = lang === 'pt' ? '↑ Topo' : '↑ Top';
 <style>
   .back-to-top {
     position: fixed;
-    bottom: 1.5rem;
-    right: 1.5rem;
+    bottom: var(--fixed-stack-bottom-back-to-top);
+    right: var(--fixed-stack-right-wide);
     padding: 0.5rem 0.75rem;
     background: var(--pico-background-color);
     color: var(--pico-muted-color);

--- a/src/components/LanguageSwitcher.astro
+++ b/src/components/LanguageSwitcher.astro
@@ -98,7 +98,7 @@ const ariaTable = Object.fromEntries(
           const s = document.createElement('style');
           s.id = 'lg-toast-style';
           s.textContent =
-            '#lg-toast{position:fixed;bottom:1.25rem;right:1rem;z-index:100;' +
+            '#lg-toast{position:fixed;bottom:var(--fixed-stack-bottom-toast);right:var(--fixed-stack-right);z-index:100;' +
             'background:var(--pico-card-background-color,#fdfdfd);' +
             'border:1px solid var(--pico-muted-border-color,#ccc);' +
             'border-radius:.5rem;padding:.55rem .9rem;font-size:.82rem;' +
@@ -107,6 +107,7 @@ const ariaTable = Object.fromEntries(
             'animation:lgIn .25s ease;max-width:calc(100vw - 2rem);}' +
             '@keyframes lgIn{from{transform:translateY(.5rem);opacity:0}to{transform:translateY(0);opacity:1}}' +
             '@media (prefers-reduced-motion: reduce){#lg-toast{animation:none}}' +
+            '@media (min-width: 600px){#lg-toast{right:var(--fixed-stack-right-wide)}}' +
             '#lg-toast a{white-space:nowrap;font-weight:500;}' +
             '#lg-toast button{background:none;border:none;cursor:pointer;padding:0 .2rem;' +
             'color:var(--pico-muted-color);font-size:1.1em;line-height:1;}';

--- a/src/components/PostActionBar.astro
+++ b/src/components/PostActionBar.astro
@@ -36,8 +36,8 @@ const errorLabel = t(lang, "post.copyError");
 <style>
   .share-fab {
     position: fixed;
-    right: 1rem;
-    bottom: 1rem;
+    right: var(--fixed-stack-right);
+    bottom: var(--fixed-stack-bottom-share-fab);
     z-index: 40;
     width: 44px;
     height: 44px;
@@ -71,11 +71,14 @@ const errorLabel = t(lang, "post.copyError");
     white-space: nowrap;
     border: 0;
   }
-  /* Stack the share FAB above the BackToTop pill so they don't overlap. */
+  /*
+   * The FAB already sits above the BackToTop pill at every width (shared
+   * bottom offset in tokens.css); only the right inset widens to match the
+   * reading column's margin on larger viewports.
+   */
   @media (min-width: 600px) {
     .share-fab {
-      bottom: 4.25rem;
-      right: 1.5rem;
+      right: var(--fixed-stack-right-wide);
     }
   }
 </style>

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -52,9 +52,7 @@
 :root {
   /* Slightly softer corners than Pico's default 0.25rem. */
   --pico-border-radius: 0.375rem;
-}
 
-:root {
   /*
    * Shared stacking offsets for the fixed bottom-right widgets that can
    * appear together on a post (BackToTop pill, PostActionBar share FAB,

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -53,3 +53,18 @@
   /* Slightly softer corners than Pico's default 0.25rem. */
   --pico-border-radius: 0.375rem;
 }
+
+:root {
+  /*
+   * Shared stacking offsets for the fixed bottom-right widgets that can
+   * appear together on a post (BackToTop pill, PostActionBar share FAB,
+   * LanguageSwitcher redirect toast). Bottom-to-top order: back-to-top,
+   * share FAB, toast — kept in sync with each component's z-index so the
+   * three never overlap, at any viewport width (see issue #1404).
+   */
+  --fixed-stack-right: 1rem;
+  --fixed-stack-right-wide: 1.5rem;
+  --fixed-stack-bottom-back-to-top: 1.5rem;
+  --fixed-stack-bottom-share-fab: 4.25rem;
+  --fixed-stack-bottom-toast: 7.5rem;
+}


### PR DESCRIPTION
Closes #1404

## Summary
- `BackToTop.astro`, `PostActionBar.astro`'s share FAB, and `LanguageSwitcher.astro`'s redirect toast all position themselves `fixed` in the bottom-right corner, independently of each other. The FAB's "stack above BackToTop" adjustment was gated behind `@media (min-width: 600px)`, so below that width the FAB (`bottom: 1rem`) and the BackToTop pill (`bottom: 1.5rem`) visually overlapped. The toast (`bottom: 1.25rem`) wasn't coordinated with either.
- Added shared CSS custom properties in `src/styles/tokens.css` (`--fixed-stack-right`, `--fixed-stack-right-wide`, `--fixed-stack-bottom-back-to-top`, `--fixed-stack-bottom-share-fab`, `--fixed-stack-bottom-toast`) defining one consistent vertical stack (back-to-top → FAB → toast, bottom to top) that applies at every viewport width, not just ≥600px.
- `PostActionBar.astro`: the FAB's `bottom` offset is no longer breakpoint-gated — it always sits above the BackToTop pill; only the `right` inset still widens at ≥600px to match the reading column margin (unchanged desktop behavior).
- `LanguageSwitcher.astro`: the toast's inline-injected `<style>` string now reads the same shared variables and sits above the FAB at any width.

## Test plan
- [x] `npx astro check` — 0 errors (pre-existing warnings only)
- [x] `npx prettier --check .` — passes
- [x] `npm run build` — completes; verified `dist/index.html` (EN) and `dist/pt/index.html` (PT) both render the new `var(--fixed-stack-*)` declarations for the toast, and `dist/_astro/BlogPostPage.*.css` / `PageLayout.*.css` for BackToTop/share-fab
- [x] `npm run check:hygiene` — clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01M1GXa8tgYvS8xC5iwUki2n)_