### PR TITLE
ux: a11y do toggle de view e tooltips μ/σ/ordinal do ranking

### DIFF
--- a/.routines/2026-08-03T13-40-23-ux-ui-run.md
+++ b/.routines/2026-08-03T13-40-23-ux-ui-run.md
@@ -1,0 +1,17 @@
+---
+date: "2026-08-03T13:40:23Z"
+branch: ux-ui/run-2026-08-03T13-33-36
+status: open
+---
+
+# Sessão 2026-08-03T13-40-23 — UX/UI
+
+Issues fechadas: #1387, #1388
+O que foi feito: RankingView.astro — botão "view-toggle" ganhou `aria-pressed`
+e alterna o label entre "Standard view"/"Technical view" (dicionário exposto
+via `data-technical-label`/`data-standard-label` no elemento, lido no
+script client-side); os `<abbr>` de μ/σ/ordinal ganharam `tabindex="0"` +
+`data-tooltip` (componente nativo do Pico, já usado em HomeAuthorRail.astro)
+para expor a explicação também a teclado/toque, mantendo o `title` original
+como fallback.
+CI local: astro check ✅ (0 erros) · prettier ✅ · build ✅ (dist verificado em EN e PT)

--- a/src/components/RankingView.astro
+++ b/src/components/RankingView.astro
@@ -262,7 +262,14 @@ function snapshotElo(key: string): { elo: number; peak: number } | null {
 {rows.length > 0 && (
   <div class="rank-table-header">
     <p class="rank-caption">{strings.tableCaption}</p>
-    <button class="view-toggle" id="view-toggle" type="button">
+    <button
+      class="view-toggle"
+      id="view-toggle"
+      type="button"
+      aria-pressed="false"
+      data-technical-label={strings.technicalViewLabel}
+      data-standard-label={strings.standardViewLabel}
+    >
       {strings.standardViewLabel}
     </button>
   </div>
@@ -277,13 +284,13 @@ function snapshotElo(key: string): { elo: number; peak: number } | null {
           <th scope="col" class="col-confidence">{strings.thConfidence}</th>
           <th scope="col" class="col-elo tech-col sortable" data-sort="elo" aria-sort="none" tabindex="0">{strings.thElo}</th>
           <th scope="col" class="col-mu tech-col">
-            <abbr title={strings.muTip}>{strings.thMu}</abbr>
+            <abbr title={strings.muTip} data-tooltip={strings.muTip} tabindex="0">{strings.thMu}</abbr>
           </th>
           <th scope="col" class="col-sigma tech-col">
-            <abbr title={strings.sigmaTip}>{strings.thSigma}</abbr>
+            <abbr title={strings.sigmaTip} data-tooltip={strings.sigmaTip} tabindex="0">{strings.thSigma}</abbr>
           </th>
           <th scope="col" class="col-ordinal tech-col">
-            <abbr title={strings.ordinalTip}>{strings.thOrdinal}</abbr>
+            <abbr title={strings.ordinalTip} data-tooltip={strings.ordinalTip} tabindex="0">{strings.thOrdinal}</abbr>
           </th>
           <th scope="col" class="col-record tech-col sortable" data-sort="record" aria-sort="none" tabindex="0">{strings.thRecord}</th>
         </tr>
@@ -956,6 +963,13 @@ function snapshotElo(key: string): { elo: number; peak: number } | null {
     if (toggleBtn.dataset.hasListener) return;
     toggleBtn.dataset.hasListener = "true";
 
+    const technicalLabel = toggleBtn.dataset.technicalLabel ?? toggleBtn.textContent ?? "";
+    const standardLabel = toggleBtn.dataset.standardLabel ?? toggleBtn.textContent ?? "";
+    const applyState = (isStandard: boolean) => {
+      toggleBtn.setAttribute("aria-pressed", String(isStandard));
+      toggleBtn.textContent = isStandard ? technicalLabel : standardLabel;
+    };
+
     // Technical view is the default. URL param "view=standard" switches to simplified.
     const urlParams = new URLSearchParams(window.location.search);
     const isStandard = urlParams.get("view") === "standard";
@@ -963,6 +977,7 @@ function snapshotElo(key: string): { elo: number; peak: number } | null {
       table.dataset.view = "standard";
       toggleBtn.classList.add("active");
     }
+    applyState(isStandard);
 
     toggleBtn.addEventListener("click", () => {
       const current = table.dataset.view === "standard";
@@ -970,6 +985,7 @@ function snapshotElo(key: string): { elo: number; peak: number } | null {
         // Switch back to technical (default)
         delete table.dataset.view;
         toggleBtn.classList.remove("active");
+        applyState(false);
         const params = new URLSearchParams(window.location.search);
         params.delete("view");
         const newUrl =
@@ -981,6 +997,7 @@ function snapshotElo(key: string): { elo: number; peak: number } | null {
         // Switch to standard (simplified)
         table.dataset.view = "standard";
         toggleBtn.classList.add("active");
+        applyState(true);
         const params = new URLSearchParams(window.location.search);
         params.set("view", "standard");
         history.replaceState(null, "", window.location.pathname + "?" + params.toString() + window.location.hash);


### PR DESCRIPTION
Closes #1387, closes #1388

## Summary
- `src/components/RankingView.astro:265` — the "view-toggle" button always rendered the static `standardViewLabel` text and had no `aria-pressed`, so neither a screen reader nor a sighted mouse user got any signal that clicking it had changed state (the only feedback was the table's columns changing). The button now ships `aria-pressed="false"` server-side and both translated labels (`data-technical-label`/`data-standard-label`) as `data-*`, since the client script that flips state on click has no access to the server's `lang`. The click handler now toggles `aria-pressed` and swaps the button's visible text between "Standard view"/"Technical view" (or the PT equivalents) to match the actual state.
- `src/components/RankingView.astro:279-287` — the μ/σ/ordinal column headers explained themselves only through the native `title` attribute on a non-focusable `<abbr>`, which only fires on mouse hover — invisible to keyboard and touch users. Added `tabindex="0"` plus Pico's built-in `data-tooltip` component (already used in `HomeAuthorRail.astro`), which fires on both `:hover` and `:focus`. The original `title` attribute is kept as a fallback per the issue's invariant.

## Test plan
- [x] `npx astro check` — 0 errors (pre-existing warnings only)
- [x] `npx prettier --check .` — all files formatted
- [x] `npm run build` — full build incl. pagefind indexing
- [x] Verified generated HTML in both `dist/ranking/index.html` (EN) and `dist/pt/ranking/index.html` (PT): `aria-pressed`, `data-technical-label`/`data-standard-label`, and `data-tooltip` all render with the correct translated strings on each side.

---
_Generated by [Claude Code](https://claude.ai/code/session_01C5XxXYwZ6UDiaghP7Y5qkH)_