### PR TITLE
ux: botão de copiar visível em touch + tema Mermaid reage à navegação

### DIFF
--- a/.routines/2026-08-04T05-07-03-ux-ui-run.md
+++ b/.routines/2026-08-04T05-07-03-ux-ui-run.md
@@ -1,0 +1,16 @@
+---
+date: "2026-08-04T05:07:03Z"
+branch: ux-ui/run-2026-08-04T05-00-41
+status: open
+---
+
+# Sessão 2026-08-04T05-07-03 — UX/UI
+
+Issues fechadas: #1405, #1406
+O que foi feito: botão de copiar código agora fica sempre visível
+(opacity 1) em dispositivos sem hover confiável (`@media (hover: none)`,
+mantendo o comportamento hover/focus-visible em desktop). Diagramas
+Mermaid reavaliam o tema (`document.documentElement.dataset.theme`) a
+cada render, não só na primeira chamada — evita diagramas com tema
+congelado após troca de dark/light + navegação SPA.
+CI local: astro check ✅ (0 erros) · prettier ✅ · build ✅ (3805 páginas)

--- a/src/components/CodeCopyEnhancer.astro
+++ b/src/components/CodeCopyEnhancer.astro
@@ -111,4 +111,9 @@ const ariaCopyLabel = lang === "pt" ? "Copiar código" : "Copy code";
   .code-copy:focus-visible {
     opacity: 1;
   }
+  @media (hover: none) {
+    .code-copy {
+      opacity: 1;
+    }
+  }
 </style>

--- a/src/components/MermaidEnhancer.astro
+++ b/src/components/MermaidEnhancer.astro
@@ -7,7 +7,7 @@
 ---
 
 <script>
-  let initialized = false;
+  let initializedTheme: string | undefined;
 
   async function render() {
     // Astro's default Shiki pipeline emits mermaid blocks as
@@ -33,14 +33,15 @@
     if (targets.length === 0) return;
 
     const { default: mermaid } = await import("mermaid");
-    if (!initialized) {
-      const dark = document.documentElement.dataset.theme === "dark";
+    const dark = document.documentElement.dataset.theme === "dark";
+    const theme = dark ? "dark" : "neutral";
+    if (initializedTheme !== theme) {
       mermaid.initialize({
         startOnLoad: false,
-        theme: dark ? "dark" : "neutral",
+        theme,
         securityLevel: "strict",
       });
-      initialized = true;
+      initializedTheme = theme;
     }
     try {
       await mermaid.run({ nodes: targets });


### PR DESCRIPTION
## Summary

- `src/components/CodeCopyEnhancer.astro`: `.code-copy` agora tem
  `@media (hover: none) { opacity: 1 }`, mantendo-se sempre visível em
  dispositivos sem hover confiável (tablets/celulares). Comportamento em
  desktop (hover/focus-visible) inalterado.
- `src/components/MermaidEnhancer.astro`: o tema (`dark`/`neutral`) agora é
  relido de `document.documentElement.dataset.theme` a cada chamada de
  `render()`, e `mermaid.initialize()` só é re-chamado quando o tema mudou
  desde a última renderização — corrige diagramas que ficavam com o tema
  congelado após o usuário trocar dark/light e navegar via view transitions
  para uma página com um diagrama ainda não renderizado.

Closes #1405
Closes #1406

## Test plan

- [x] `npx astro check` — 0 erros
- [x] `npx prettier --check .` — ok
- [x] `npm run build` — build completo (3805 páginas), sem erros
- [x] Confirmado no HTML/CSS gerado: `@media (hover:none){.code-copy{opacity:1}}`
      presente no CSS compilado
- [x] Confirmado no JS gerado: `MermaidEnhancer` recompara o tema
      (`i!==a&&(n.initialize(...),i=a)`) em vez de inicializar uma única vez

---
_Generated by [Claude Code](https://claude.ai/code/session_01TrKQ6BvHitE2Hof3qSdJoh)_