### PR TITLE
ux: âncora de heading visível em touch + badges de perspectiva seguem tema manual

### DIFF
--- a/.routines/2026-08-05T05-08-10-ux-ui-run.md
+++ b/.routines/2026-08-05T05-08-10-ux-ui-run.md
@@ -1,0 +1,15 @@
+---
+date: "2026-08-05T05:08:10Z"
+branch: ux-ui/run-2026-08-05T05-00-42
+status: open
+---
+
+# Sessão 2026-08-05T05-08-10 — UX/UI
+
+Issues fechadas: #1462, #1464
+O que foi feito: âncora "#" de heading agora fica visível em dispositivos
+sem hover confiável (`@media (hover: none)`, mesmo padrão do
+CodeCopyEnhancer); badges de perspectiva (hue) passaram a seguir o tema
+escolhido manualmente (`[data-theme="dark"]`) em vez de só
+`prefers-color-scheme`, nos 4 locais apontados pela issue.
+CI local: astro check ✅ (0 erros novos) · prettier ✅ · build ✅

--- a/src/components/HronirReviews.astro
+++ b/src/components/HronirReviews.astro
@@ -355,11 +355,9 @@ const vsLabel        = "vs";
     border: 1px solid var(--pico-muted-border-color);
   }
 
-  @media (prefers-color-scheme: dark) {
-    .tag-perspective {
-      background: hsl(var(--ph, 200), 40%, 20%);
-      color: hsl(var(--ph, 200), 70%, 75%);
-    }
+  [data-theme="dark"] .tag-perspective {
+    background: hsl(var(--ph, 200), 40%, 20%);
+    color: hsl(var(--ph, 200), 70%, 75%);
   }
 
   .hronir-moods {

--- a/src/layouts/PageLayout.astro
+++ b/src/layouts/PageLayout.astro
@@ -302,6 +302,11 @@ const personLd = {
       .heading-anchor:focus {
         opacity: 0.7;
       }
+      @media (hover: none) {
+        .heading-anchor {
+          opacity: 0.7;
+        }
+      }
       .footnotes {
         margin-top: 4rem;
         padding-top: 1.5rem;

--- a/src/pages/ranking/perspectives/[id].astro
+++ b/src/pages/ranking/perspectives/[id].astro
@@ -147,11 +147,9 @@ const crumbs = [
     background: hsl(var(--ph, 200), 55%, 88%);
     color: hsl(var(--ph, 200), 45%, 28%);
   }
-  @media (prefers-color-scheme: dark) {
-    .persp-badge {
-      background: hsl(var(--ph, 200), 40%, 20%);
-      color: hsl(var(--ph, 200), 70%, 75%);
-    }
+  [data-theme="dark"] .persp-badge {
+    background: hsl(var(--ph, 200), 40%, 20%);
+    color: hsl(var(--ph, 200), 70%, 75%);
   }
 
   .empty-state {

--- a/src/pages/ranking/posts/[key].astro
+++ b/src/pages/ranking/posts/[key].astro
@@ -362,11 +362,9 @@ function fmtDate(iso: string): string {
     color: hsl(var(--ph, 200), 45%, 28%);
     text-decoration: none;
   }
-  @media (prefers-color-scheme: dark) {
-    .persp-badge {
-      background: hsl(var(--ph, 200), 40%, 20%);
-      color: hsl(var(--ph, 200), 70%, 75%);
-    }
+  [data-theme="dark"] .persp-badge {
+    background: hsl(var(--ph, 200), 40%, 20%);
+    color: hsl(var(--ph, 200), 70%, 75%);
   }
   .persp-rank-num {
     font-family: var(--pico-font-family-monospace);
@@ -478,11 +476,9 @@ function fmtDate(iso: string): string {
     background: hsl(var(--ph, 200), 55%, 88%);
     color: hsl(var(--ph, 200), 45%, 28%);
   }
-  @media (prefers-color-scheme: dark) {
-    .duel-perspective {
-      background: hsl(var(--ph, 200), 40%, 20%);
-      color: hsl(var(--ph, 200), 70%, 75%);
-    }
+  [data-theme="dark"] .duel-perspective {
+    background: hsl(var(--ph, 200), 40%, 20%);
+    color: hsl(var(--ph, 200), 70%, 75%);
   }
   .duel-analysis-link {
     font-size: 0.78rem;


### PR DESCRIPTION
Closes #1462, Closes #1464

## O que mudou

**#1462 — âncora "#" de heading invisível em touch/teclado**
`src/layouts/PageLayout.astro`: adicionada `@media (hover: none) { .heading-anchor { opacity: 0.7; } }`, mesmo padrão já usado em `CodeCopyEnhancer.astro`. O link de âncora do heading agora fica visível em dispositivos sem hover confiável.

Decisão registrada no PR (conforme pedido na issue): manter `tabIndex: -1` / `aria-hidden="true"` como estão — tornar o link focável por teclado ficou fora de escopo desta rodada, para não misturar a mudança de visibilidade (CSS puro) com uma mudança de semântica de foco que merece avaliação própria.

**#1464 — badges de perspectiva ignoram o toggle manual de dark mode**
Nos 4 locais apontados pela issue, troquei `@media (prefers-color-scheme: dark)` por `[data-theme="dark"]`, seguindo a convenção já usada em `RankingView.astro`:
- `src/components/HronirReviews.astro` (`.tag-perspective`)
- `src/pages/ranking/posts/[key].astro` (`.persp-badge` e `.duel-perspective`)
- `src/pages/ranking/perspectives/[id].astro` (`.persp-badge`)

Sem fallback duplicado de `prefers-color-scheme`: o bootstrap inline em `PageLayout.astro` já seta `data-theme` no `<html>` antes do paint (usando `localStorage` ou, na ausência dele, a preferência do SO) — então `[data-theme="dark"]` sozinho já cobre tanto quem nunca tocou no toggle quanto quem trocou manualmente.

## Validação

- `npx astro check` — 0 erros/warnings novos (78 hints pré-existentes)
- `npx prettier --check .` — ok
- `npm run build` — build completo (incl. prebuild/pregen e pagefind)
- Conferido no `dist/` gerado, em página EN e PT, que os dois seletores/regras aparecem corretamente no HTML e no CSS bundlado.

---
_Generated by [Claude Code](https://claude.ai/code/session_017m7BdxMPennXfBdPrE9UaR)_