### PR TITLE
ux: navegação por teclado nas capas de Favoritos/Recently-played

### DIFF
--- a/.routines/2026-08-06T05-06-28-ux-ui-run.md
+++ b/.routines/2026-08-06T05-06-28-ux-ui-run.md
@@ -1,0 +1,12 @@
+---
+date: "2026-08-06T05:06:28Z"
+branch: ux-ui/run-2026-08-06T05-00-32
+status: open
+---
+
+# Sessão 2026-08-06T05-06-28 — UX/UI
+
+Issues fechadas: #1463
+O que foi feito: capas de Favoritos/Recently-played no player de música (music.astro e pt/musicas.astro) agora são focáveis por teclado (tabindex=0, role=button, aria-label, keydown Enter/Espaço), via helper compartilhado bindPlayTrigger em cada página.
+Também mesclado nesta rodada: PR #1466 (issues #1462 e #1464, já prontas de sessão anterior).
+CI local: astro check ✅ (0 erros, 78 hints pré-existentes) · prettier ✅ · build ✅

--- a/src/pages/music.astro
+++ b/src/pages/music.astro
@@ -344,6 +344,21 @@ const showGenreChips =
     });
   }
 
+  function bindPlayTrigger(el: HTMLElement, sunoId: string, title: string) {
+    el.tabIndex = 0;
+    el.setAttribute("role", "button");
+    el.setAttribute("aria-label", `Play ${title}`);
+    const trigger = () =>
+      document.dispatchEvent(new CustomEvent("gp:play", { detail: { sunoId, title } }));
+    el.addEventListener("click", trigger);
+    el.addEventListener("keydown", (e: KeyboardEvent) => {
+      if (e.key === "Enter" || e.key === " ") {
+        e.preventDefault();
+        trigger();
+      }
+    });
+  }
+
   function renderFavoritesSection() {
     const section = document.getElementById("favorites-section") as HTMLElement | null;
     const grid = document.getElementById("favorites-grid") as HTMLElement | null;
@@ -364,9 +379,7 @@ const showGenreChips =
       img.alt = source.dataset.title || "";
       img.width = 80; img.height = 80;
       img.style.cssText = "width:100%;aspect-ratio:1/1;object-fit:cover;border-radius:var(--pico-border-radius);cursor:pointer";
-      img.addEventListener("click", () =>
-        document.dispatchEvent(new CustomEvent("gp:play", { detail: { sunoId: id, title: source.dataset.title } }))
-      );
+      bindPlayTrigger(img, id, source.dataset.title || "");
       const title = document.createElement("p");
       title.style.cssText = "font-size:0.8rem;margin:0.25rem 0 0;white-space:nowrap;overflow:hidden;text-overflow:ellipsis";
       title.textContent = source.dataset.title || "";
@@ -395,9 +408,7 @@ const showGenreChips =
       img.src = source.dataset.image || "";
       img.alt = source.dataset.title || "";
       img.style.cssText = "width:56px;height:56px;object-fit:cover;border-radius:var(--pico-border-radius);cursor:pointer;flex-shrink:0";
-      img.addEventListener("click", () =>
-        document.dispatchEvent(new CustomEvent("gp:play", { detail: { sunoId: id, title: source.dataset.title } }))
-      );
+      bindPlayTrigger(img, id, source.dataset.title || "");
       item.appendChild(img);
       rail.appendChild(item);
       // Continue listening badge

--- a/src/pages/pt/musicas.astro
+++ b/src/pages/pt/musicas.astro
@@ -378,6 +378,21 @@ const showGenreChips =
     });
   }
 
+  function bindPlayTrigger(el: HTMLElement, sunoId: string, title: string) {
+    el.tabIndex = 0;
+    el.setAttribute("role", "button");
+    el.setAttribute("aria-label", `Tocar ${title}`);
+    const trigger = () =>
+      document.dispatchEvent(new CustomEvent("gp:play", { detail: { sunoId, title } }));
+    el.addEventListener("click", trigger);
+    el.addEventListener("keydown", (e: KeyboardEvent) => {
+      if (e.key === "Enter" || e.key === " ") {
+        e.preventDefault();
+        trigger();
+      }
+    });
+  }
+
   function renderFavoritesSection() {
     const section = document.getElementById("favorites-section") as HTMLElement | null;
     const grid = document.getElementById("favorites-grid") as HTMLElement | null;
@@ -398,9 +413,7 @@ const showGenreChips =
       img.alt = source.dataset.title || "";
       img.width = 80; img.height = 80;
       img.style.cssText = "width:100%;aspect-ratio:1/1;object-fit:cover;border-radius:var(--pico-border-radius);cursor:pointer";
-      img.addEventListener("click", () =>
-        document.dispatchEvent(new CustomEvent("gp:play", { detail: { sunoId: id, title: source.dataset.title } }))
-      );
+      bindPlayTrigger(img, id, source.dataset.title || "");
       const title = document.createElement("p");
       title.style.cssText = "font-size:0.8rem;margin:0.25rem 0 0;white-space:nowrap;overflow:hidden;text-overflow:ellipsis";
       title.textContent = source.dataset.title || "";
@@ -429,9 +442,7 @@ const showGenreChips =
       img.src = source.dataset.image || "";
       img.alt = source.dataset.title || "";
       img.style.cssText = "width:56px;height:56px;object-fit:cover;border-radius:var(--pico-border-radius);cursor:pointer;flex-shrink:0";
-      img.addEventListener("click", () =>
-        document.dispatchEvent(new CustomEvent("gp:play", { detail: { sunoId: id, title: source.dataset.title } }))
-      );
+      bindPlayTrigger(img, id, source.dataset.title || "");
       item.appendChild(img);
       rail.appendChild(item);
       if (id === currentId) {


### PR DESCRIPTION
Closes #1463

## O que mudou

`src/pages/music.astro` (`renderFavoritesSection`/`renderHistorySection`) e
`src/pages/pt/musicas.astro` (mesmo par de funções): as capas dos trilhos de
Favoritos e Recently played/Continue ouvindo criavam `<img>` dinamicamente
com `cursor:pointer` e um listener `click` que disparava `gp:play`, mas sem
nenhum equivalente de teclado.

Extraí um helper `bindPlayTrigger(el, sunoId, title)` em cada página (a
lógica é idêntica nos dois trilhos daquela página, como sugerido na issue) que:

- seta `tabIndex = 0` e `role="button"` no elemento
- seta `aria-label` descritivo (`Play ${title}` em EN, `Tocar ${title}` em PT)
- mantém o listener `click` existente
- adiciona um listener `keydown` que dispara o mesmo evento `gp:play` em
  Enter/Espaço

Comportamento de clique/touch e layout visual não mudam — só adiciona os
atributos e o listener de teclado.

## Validação

- `npx astro check` — 0 erros novos (78 hints pré-existentes, mesma baseline
  do PR #1466)
- `npx prettier --check .` — ok
- `npm run build` — build completo (incl. prebuild/pregen e pagefind)
- Conferido nos bundles JS gerados (`dist/_astro/...`) que tanto a versão EN
  quanto a PT contêm `role`/`button` e os `aria-label` corretos por idioma
  (`Play ${title}` vs `Tocar ${title}`) — como essas seções são renderizadas
  client-side a partir do `localStorage`, o HTML estático do `dist/` não as
  contém; a verificação precisou ser no bundle JS em vez do HTML.

## Também nesta rodada

Mesclado (com merge commit) o PR #1466, que já estava com CI verde e fechava
#1462 e #1464 de uma sessão anterior desta mesma rotina.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q3xZpow5VynsEwRSmBdZ9e)_