### PR TITLE
ux: foco/Esc no painel de fila do player e avatar eager na home

### DIFF
--- a/.routines/2026-08-07T05-06-04-ux-ui-run.md
+++ b/.routines/2026-08-07T05-06-04-ux-ui-run.md
@@ -1,0 +1,26 @@
+---
+date: "2026-08-07T05:06:04Z"
+branch: claude/ecstatic-hawking-dyyb54
+status: open
+---
+
+# Sessão 2026-08-07T05-06-04 — UX/UI
+
+Issues fechadas: #1470, #1469
+O que foi feito:
+- #1470: `HomeAuthorRail.astro` — avatar do rail lateral da home trocou
+  `loading="lazy"` por `loading="eager" fetchpriority="high"` (é visível no
+  carregamento inicial em telas ≥1100px); capas de livros mais abaixo mantidas
+  como `lazy`.
+- #1469: `GlobalMusicPlayer.astro` — painel de fila (`#gmp-drawer`, role
+  dialog) agora move o foco para o primeiro item ao abrir (ou para o botão de
+  fechar se a fila estiver vazia) e fecha com Esc devolvendo o foco ao botão
+  que abriu o painel. Fechamento por clique fora/botão de fechar preservados.
+
+Também nesta rodada: mesclado (merge commit) o PR #1468, que já estava com
+CI verde e fechava #1463 de uma sessão anterior desta mesma rotina.
+
+CI local: astro check ✅ (0 erros, 78 hints pré-existentes) · prettier ✅ ·
+build ✅ (confirmado no `dist/` gerado: atributo `loading="eager"
+fetchpriority="high"` no avatar em EN e PT; `"Escape"` presente no bundle JS
+do music player).

--- a/src/components/GlobalMusicPlayer.astro
+++ b/src/components/GlobalMusicPlayer.astro
@@ -623,8 +623,13 @@ try {
       });
 
       queueBtn.addEventListener("click", () => {
+        const wasHidden = drawerEl.hidden;
         renderDrawer();
         drawerEl.hidden = !drawerEl.hidden;
+        if (wasHidden && !drawerEl.hidden) {
+          const firstItem = drawerList.querySelector<HTMLButtonElement>(".gmp-drawer-item");
+          (firstItem ?? drawerCloseBtn).focus();
+        }
       });
 
       drawerCloseBtn.addEventListener("click", () => {
@@ -634,6 +639,13 @@ try {
       document.addEventListener("click", (e) => {
         if (!drawerEl.hidden && !drawerEl.contains(e.target as Node) && e.target !== queueBtn) {
           drawerEl.hidden = true;
+        }
+      });
+
+      document.addEventListener("keydown", (e) => {
+        if (e.key === "Escape" && !drawerEl.hidden) {
+          drawerEl.hidden = true;
+          queueBtn.focus();
         }
       });
 

--- a/src/components/HomeAuthorRail.astro
+++ b/src/components/HomeAuthorRail.astro
@@ -17,7 +17,7 @@ const recent = await fetchGoodreadsBooks().then((b) => recentBooks(b, 3)).catch(
 
 <aside class="home-author-rail" aria-label={t(lang, 'author.aboutEyebrow')}>
   <div class="rail-avatar" data-tooltip="Franklin Baldo" data-placement="bottom">
-    <img src="/avatar.png" alt="Franklin Baldo" width="96" height="96" loading="lazy" decoding="async" />
+    <img src="/avatar.png" alt="Franklin Baldo" width="96" height="96" loading="eager" fetchpriority="high" decoding="async" />
   </div>
 
   <p class="rail-eyebrow"><small>{t(lang, 'author.aboutEyebrow')}</small></p>


### PR DESCRIPTION
Closes #1469
Closes #1470

## O que mudou

- **#1470** — `src/components/HomeAuthorRail.astro`: o avatar da home
  (`.rail-avatar img`) usava `loading="lazy"`, mas o rail lateral é
  `position: sticky` e fica dentro do viewport inicial em telas ≥1100px.
  Trocado para `loading="eager" fetchpriority="high"`, sem alterar
  `width`/`height` (evita reintroduzir CLS). As capas de livros mais abaixo no
  mesmo rail continuam `loading="lazy"`, fora da dobra inicial.
- **#1469** — `src/components/GlobalMusicPlayer.astro`: o painel de fila
  (`#gmp-drawer`, `role="dialog"`) não tinha equivalente de teclado para o
  padrão ARIA Dialog. Agora:
  - ao abrir, o foco move para o primeiro item da fila (ou para o botão de
    fechar, se a fila estiver vazia);
  - `Escape` fecha o painel e devolve o foco ao botão que o abriu
    (`#gmp-queue-btn`).
  - Fechamento por clique fora e pelo botão `#gmp-drawer-close` preservados
    sem alteração.

Também nesta rodada: mesclado (merge commit) o PR #1468, já com CI verde,
fechando #1463 de uma sessão anterior desta mesma rotina.

## Validação

- `npx astro check` — 0 erros novos (78 hints pré-existentes)
- `npx prettier --check .` — ok
- `npm run build` — build completo (incl. prebuild/pregen e pagefind)
- Conferido no `dist/` gerado: `<img>` do avatar em `dist/index.html` (EN) e
  `dist/pt/index.html` (PT) com `loading="eager" fetchpriority="high"`; o
  bundle JS do player contém a lógica de `"Escape"` e a nova chamada de
  `.focus()`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01S7yebfukDWhHu8TkjJnY7x)_