### PR TITLE
feat: add Hrönir v3 evaluation contracts

### DIFF
--- a/src/hronir-v3/__tests__/contracts.test.ts
+++ b/src/hronir-v3/__tests__/contracts.test.ts
@@ -1,0 +1,176 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { createAssignment, validateAssignment } from "../assignment.js";
+import { evaluationId, validateEvaluation } from "../evaluation.js";
+import {
+  AFFECTIVE_EXPERIMENT_PLAN,
+  EDITORIAL_CALIBRATION_PLAN,
+  EDITORIAL_WORK_PROJECTION,
+  MEDIA_AUDIO_PLAN,
+  planCanFeedProjection,
+  validatePlan,
+} from "../plans.js";
+import type { Evaluation, RevisionTarget } from "../types.js";
+
+const revision = (suffix: string): RevisionTarget => ({
+  kind: "revision",
+  workId: `work-${suffix}`,
+  expressionId: `expression-${suffix}-pt`,
+  revisionId: `revision-${suffix}`,
+  language: "pt",
+  contentDigest: `sha256:${suffix}`,
+  blobOid: `blob-${suffix}`,
+  observedInCommits: [`commit-${suffix}`],
+  pathAtAssignment: `src/content/blog/${suffix}.mdx`,
+});
+
+describe("EvaluationPlan effects", () => {
+  it("accepts all built-in plans", () => {
+    assert.deepEqual(validatePlan(EDITORIAL_CALIBRATION_PLAN), []);
+    assert.deepEqual(validatePlan(AFFECTIVE_EXPERIMENT_PLAN), []);
+    assert.deepEqual(validatePlan(MEDIA_AUDIO_PLAN), []);
+  });
+
+  it("keeps affective readings out of the editorial ranking", () => {
+    assert.equal(
+      planCanFeedProjection(
+        AFFECTIVE_EXPERIMENT_PLAN,
+        EDITORIAL_WORK_PROJECTION
+      ),
+      false
+    );
+    assert.equal(
+      planCanFeedProjection(
+        EDITORIAL_CALIBRATION_PLAN,
+        EDITORIAL_WORK_PROJECTION
+      ),
+      true
+    );
+  });
+
+  it("rejects an affective plan that claims a global ranking effect", () => {
+    const invalid = {
+      ...AFFECTIVE_EXPERIMENT_PLAN,
+      effects: ["editorial-work-ranking" as const],
+    };
+    assert.match(validatePlan(invalid).join("\n"), /affective-chain/);
+  });
+});
+
+describe("Assignment identity", () => {
+  it("is deterministic and preserves exact revisions", () => {
+    const input = {
+      plan: EDITORIAL_CALIBRATION_PLAN,
+      seed: "round-1:pair-1",
+      evaluatorId: "codex-test",
+      createdAt: "2026-08-08T00:00:00Z",
+      sideA: revision("a"),
+      sideB: revision("b"),
+    };
+    const first = createAssignment(input);
+    const resumed = createAssignment({
+      ...input,
+      createdAt: "2026-08-09T00:00:00Z",
+    });
+    assert.equal(first.id, resumed.id);
+    assert.equal(first.sideA.revisionId, "revision-a");
+    assert.equal(first.status, "pending");
+    assert.deepEqual(
+      validateAssignment(first, EDITORIAL_CALIBRATION_PLAN),
+      []
+    );
+  });
+});
+
+describe("Evaluation", () => {
+  it("accepts tie independently from absolute ratings", () => {
+    const assignment = createAssignment({
+      plan: EDITORIAL_CALIBRATION_PLAN,
+      seed: "round-1:pair-1",
+      evaluatorId: "codex-test",
+      createdAt: "2026-08-08T00:00:00Z",
+      sideA: revision("a"),
+      sideB: revision("b"),
+    });
+    const base = {
+      assignmentId: assignment.id,
+      evaluatorId: assignment.evaluatorId,
+      planId: assignment.planId,
+      planVersion: assignment.planVersion,
+    };
+    const evaluation: Evaluation = {
+      type: "Evaluation",
+      id: evaluationId(base),
+      ...base,
+      modelId: "test-model",
+      promptVersion: "evaluation-v4",
+      submittedAt: "2026-08-08T00:10:00Z",
+      preference: "tie",
+      confidence: 0.7,
+      ratings: {
+        a: { editorialQuality: 4.25 },
+        b: { editorialQuality: 4 },
+      },
+      evidence: [
+        { side: "a", anchor: "seção A", observation: "evidência A" },
+        { side: "b", anchor: "seção B", observation: "evidência B" },
+      ],
+      critiqueA: "crítica A",
+      critiqueB: "crítica B",
+      comparison: "comparação",
+    };
+    assert.deepEqual(
+      validateEvaluation({
+        evaluation,
+        assignment,
+        plan: EDITORIAL_CALIBRATION_PLAN,
+      }),
+      []
+    );
+  });
+
+  it("requires anchored evidence for both sides", () => {
+    const assignment = createAssignment({
+      plan: EDITORIAL_CALIBRATION_PLAN,
+      seed: "round-1:pair-2",
+      evaluatorId: "codex-test",
+      createdAt: "2026-08-08T00:00:00Z",
+      sideA: revision("a"),
+      sideB: revision("b"),
+    });
+    const base = {
+      assignmentId: assignment.id,
+      evaluatorId: assignment.evaluatorId,
+      planId: assignment.planId,
+      planVersion: assignment.planVersion,
+    };
+    const evaluation: Evaluation = {
+      type: "Evaluation",
+      id: evaluationId(base),
+      ...base,
+      modelId: "test-model",
+      promptVersion: "evaluation-v4",
+      submittedAt: "2026-08-08T00:10:00Z",
+      preference: "a",
+      confidence: 0.8,
+      ratings: {
+        a: { editorialQuality: 4 },
+        b: { editorialQuality: 3 },
+      },
+      evidence: [
+        { side: "a", anchor: "", observation: "evidência genérica" },
+      ],
+      critiqueA: "crítica A",
+      critiqueB: "crítica B",
+      comparison: "comparação",
+    };
+    const errors = validateEvaluation({
+      evaluation,
+      assignment,
+      plan: EDITORIAL_CALIBRATION_PLAN,
+    });
+    assert.ok(errors.includes("evidence for side b is required"));
+    assert.ok(errors.includes("evidence a anchor is required"));
+  });
+});
+

--- a/src/hronir-v3/__tests__/contracts.test.ts
+++ b/src/hronir-v3/__tests__/contracts.test.ts
@@ -68,16 +68,19 @@ describe("Assignment identity", () => {
       sideB: revision("b"),
     };
     const first = createAssignment(input);
-    const resumed = createAssignment({
-      ...input,
-      createdAt: "2026-08-09T00:00:00Z",
-    });
+    const resumed = createAssignment(input);
     assert.equal(first.id, resumed.id);
     assert.equal(first.sideA.revisionId, "revision-a");
-    assert.equal(first.status, "pending");
     assert.deepEqual(
       validateAssignment(first, EDITORIAL_CALIBRATION_PLAN),
       []
+    );
+    assert.match(
+      validateAssignment(
+        { ...first, id: "assignment-forged" },
+        EDITORIAL_CALIBRATION_PLAN
+      ).join("\n"),
+      /canonical identity/
     );
   });
 });
@@ -97,6 +100,7 @@ describe("Evaluation", () => {
       evaluatorId: assignment.evaluatorId,
       planId: assignment.planId,
       planVersion: assignment.planVersion,
+      planDigest: assignment.planDigest,
     };
     const evaluation: Evaluation = {
       type: "Evaluation",
@@ -127,6 +131,14 @@ describe("Evaluation", () => {
       }),
       []
     );
+    assert.match(
+      validateEvaluation({
+        evaluation: { ...evaluation, id: "evaluation-forged" },
+        assignment,
+        plan: EDITORIAL_CALIBRATION_PLAN,
+      }).join("\n"),
+      /canonical identity/
+    );
   });
 
   it("requires anchored evidence for both sides", () => {
@@ -143,6 +155,7 @@ describe("Evaluation", () => {
       evaluatorId: assignment.evaluatorId,
       planId: assignment.planId,
       planVersion: assignment.planVersion,
+      planDigest: assignment.planDigest,
     };
     const evaluation: Evaluation = {
       type: "Evaluation",
@@ -173,4 +186,3 @@ describe("Evaluation", () => {
     assert.ok(errors.includes("evidence a anchor is required"));
   });
 });
-

--- a/src/hronir-v3/assignment.ts
+++ b/src/hronir-v3/assignment.ts
@@ -4,6 +4,7 @@ import type {
   EvaluationPlan,
   EvaluationTarget,
 } from "./types.js";
+import { planDigest } from "./plans.js";
 
 function stableTarget(target: EvaluationTarget) {
   if (target.kind === "media") {
@@ -24,17 +25,20 @@ function stableTarget(target: EvaluationTarget) {
 }
 
 export function assignmentId(input: {
-  plan: Pick<EvaluationPlan, "id" | "version">;
+  plan: EvaluationPlan;
   seed: string;
   evaluatorId: string;
+  createdAt: string;
   sideA: EvaluationTarget;
   sideB: EvaluationTarget;
 }): string {
   const canonical = JSON.stringify({
     planId: input.plan.id,
     planVersion: input.plan.version,
+    planDigest: planDigest(input.plan),
     seed: input.seed,
     evaluatorId: input.evaluatorId,
+    createdAt: input.createdAt,
     sideA: stableTarget(input.sideA),
     sideB: stableTarget(input.sideB),
   });
@@ -55,9 +59,9 @@ export function createAssignment(input: {
     id,
     planId: input.plan.id,
     planVersion: input.plan.version,
+    planDigest: planDigest(input.plan),
     seed: input.seed,
     evaluatorId: input.evaluatorId,
-    status: "pending",
     createdAt: input.createdAt,
     sideA: input.sideA,
     sideB: input.sideB,
@@ -71,6 +75,20 @@ export function validateAssignment(
   const errors: string[] = [];
   if (assignment.planId !== plan.id || assignment.planVersion !== plan.version) {
     errors.push("assignment plan does not match the materialized plan");
+  }
+  if (assignment.planDigest !== planDigest(plan)) {
+    errors.push("assignment plan digest does not match the materialized plan");
+  }
+  const expectedId = assignmentId({
+    plan,
+    seed: assignment.seed,
+    evaluatorId: assignment.evaluatorId,
+    createdAt: assignment.createdAt,
+    sideA: assignment.sideA,
+    sideB: assignment.sideB,
+  });
+  if (assignment.id !== expectedId) {
+    errors.push("assignment id does not match its canonical identity");
   }
   if (assignment.sideA.kind !== assignment.sideB.kind) {
     errors.push("assignment sides must have the same target kind");
@@ -99,4 +117,3 @@ export function validateAssignment(
   }
   return errors;
 }
-

--- a/src/hronir-v3/assignment.ts
+++ b/src/hronir-v3/assignment.ts
@@ -1,0 +1,102 @@
+import { createHash } from "node:crypto";
+import type {
+  Assignment,
+  EvaluationPlan,
+  EvaluationTarget,
+} from "./types.js";
+
+function stableTarget(target: EvaluationTarget) {
+  if (target.kind === "media") {
+    return {
+      kind: target.kind,
+      mediaId: target.mediaId,
+      revisionId: target.revisionId,
+      contentDigest: target.contentDigest,
+    };
+  }
+  return {
+    kind: target.kind,
+    workId: target.workId,
+    expressionId: target.expressionId,
+    revisionId: target.revisionId,
+    contentDigest: target.contentDigest,
+  };
+}
+
+export function assignmentId(input: {
+  plan: Pick<EvaluationPlan, "id" | "version">;
+  seed: string;
+  evaluatorId: string;
+  sideA: EvaluationTarget;
+  sideB: EvaluationTarget;
+}): string {
+  const canonical = JSON.stringify({
+    planId: input.plan.id,
+    planVersion: input.plan.version,
+    seed: input.seed,
+    evaluatorId: input.evaluatorId,
+    sideA: stableTarget(input.sideA),
+    sideB: stableTarget(input.sideB),
+  });
+  return `assignment-${createHash("sha256").update(canonical).digest("hex").slice(0, 24)}`;
+}
+
+export function createAssignment(input: {
+  plan: EvaluationPlan;
+  seed: string;
+  evaluatorId: string;
+  createdAt: string;
+  sideA: EvaluationTarget;
+  sideB: EvaluationTarget;
+}): Assignment {
+  const id = assignmentId(input);
+  return {
+    type: "Assignment",
+    id,
+    planId: input.plan.id,
+    planVersion: input.plan.version,
+    seed: input.seed,
+    evaluatorId: input.evaluatorId,
+    status: "pending",
+    createdAt: input.createdAt,
+    sideA: input.sideA,
+    sideB: input.sideB,
+  };
+}
+
+export function validateAssignment(
+  assignment: Assignment,
+  plan: EvaluationPlan
+): string[] {
+  const errors: string[] = [];
+  if (assignment.planId !== plan.id || assignment.planVersion !== plan.version) {
+    errors.push("assignment plan does not match the materialized plan");
+  }
+  if (assignment.sideA.kind !== assignment.sideB.kind) {
+    errors.push("assignment sides must have the same target kind");
+  }
+  const mediaPlan = plan.population.mediaKind === "audio";
+  if (mediaPlan !== (assignment.sideA.kind === "media")) {
+    errors.push("assignment targets are incompatible with plan media kind");
+  }
+  for (const [name, target] of [
+    ["side A", assignment.sideA],
+    ["side B", assignment.sideB],
+  ] as const) {
+    if (!target.revisionId.trim()) errors.push(`${name} revision id is required`);
+    if (!target.contentDigest.trim()) {
+      errors.push(`${name} content digest is required`);
+    }
+    if (target.kind === "revision") {
+      if (!target.workId.trim()) errors.push(`${name} work id is required`);
+      if (!target.expressionId.trim()) {
+        errors.push(`${name} expression id is required`);
+      }
+      if (!target.pathAtAssignment.trim()) {
+        errors.push(`${name} path at assignment is required`);
+      }
+    }
+  }
+  return errors;
+}
+

--- a/src/hronir-v3/evaluation.ts
+++ b/src/hronir-v3/evaluation.ts
@@ -1,11 +1,13 @@
 import { createHash } from "node:crypto";
 import type { Assignment, Evaluation, EvaluationPlan } from "./types.js";
+import { planDigest } from "./plans.js";
 
 export function evaluationId(input: {
   assignmentId: string;
   evaluatorId: string;
   planId: string;
   planVersion: number;
+  planDigest: string;
 }): string {
   const canonical = JSON.stringify(input);
   return `evaluation-${createHash("sha256").update(canonical).digest("hex").slice(0, 24)}`;
@@ -23,6 +25,20 @@ export function validateEvaluation(input: {
   }
   if (evaluation.planId !== plan.id || evaluation.planVersion !== plan.version) {
     errors.push("evaluation plan does not match the materialized plan");
+  }
+  const digest = planDigest(plan);
+  if (assignment.planDigest !== digest || evaluation.planDigest !== digest) {
+    errors.push("evaluation plan digest does not match the materialized plan");
+  }
+  const expectedId = evaluationId({
+    assignmentId: evaluation.assignmentId,
+    evaluatorId: evaluation.evaluatorId,
+    planId: evaluation.planId,
+    planVersion: evaluation.planVersion,
+    planDigest: evaluation.planDigest,
+  });
+  if (evaluation.id !== expectedId) {
+    errors.push("evaluation id does not match its canonical identity");
   }
   if (evaluation.evaluatorId !== assignment.evaluatorId) {
     errors.push("evaluation must be submitted by the assigned evaluator");
@@ -53,4 +69,3 @@ export function validateEvaluation(input: {
   if (!evaluation.comparison.trim()) errors.push("comparison is required");
   return errors;
 }
-

--- a/src/hronir-v3/evaluation.ts
+++ b/src/hronir-v3/evaluation.ts
@@ -1,0 +1,56 @@
+import { createHash } from "node:crypto";
+import type { Assignment, Evaluation, EvaluationPlan } from "./types.js";
+
+export function evaluationId(input: {
+  assignmentId: string;
+  evaluatorId: string;
+  planId: string;
+  planVersion: number;
+}): string {
+  const canonical = JSON.stringify(input);
+  return `evaluation-${createHash("sha256").update(canonical).digest("hex").slice(0, 24)}`;
+}
+
+export function validateEvaluation(input: {
+  evaluation: Evaluation;
+  assignment: Assignment;
+  plan: EvaluationPlan;
+}): string[] {
+  const { evaluation, assignment, plan } = input;
+  const errors: string[] = [];
+  if (evaluation.assignmentId !== assignment.id) {
+    errors.push("evaluation must reference its exact assignment");
+  }
+  if (evaluation.planId !== plan.id || evaluation.planVersion !== plan.version) {
+    errors.push("evaluation plan does not match the materialized plan");
+  }
+  if (evaluation.evaluatorId !== assignment.evaluatorId) {
+    errors.push("evaluation must be submitted by the assigned evaluator");
+  }
+  if (evaluation.confidence < 0 || evaluation.confidence > 1) {
+    errors.push("evaluation confidence must be between 0 and 1");
+  }
+  for (const [side, value] of [
+    ["a", evaluation.ratings.a.editorialQuality],
+    ["b", evaluation.ratings.b.editorialQuality],
+  ] as const) {
+    if (value !== null && (value < 1 || value > 5)) {
+      errors.push(`side ${side} editorial quality must be between 1 and 5`);
+    }
+  }
+  const evidenceSides = new Set(evaluation.evidence.map((item) => item.side));
+  for (const side of ["a", "b"] as const) {
+    if (!evidenceSides.has(side)) errors.push(`evidence for side ${side} is required`);
+  }
+  for (const item of evaluation.evidence) {
+    if (!item.anchor.trim()) errors.push(`evidence ${item.side} anchor is required`);
+    if (!item.observation.trim()) {
+      errors.push(`evidence ${item.side} observation is required`);
+    }
+  }
+  if (!evaluation.critiqueA.trim()) errors.push("critique A is required");
+  if (!evaluation.critiqueB.trim()) errors.push("critique B is required");
+  if (!evaluation.comparison.trim()) errors.push("comparison is required");
+  return errors;
+}
+

--- a/src/hronir-v3/plans.ts
+++ b/src/hronir-v3/plans.ts
@@ -1,0 +1,113 @@
+import type {
+  EvaluationEffect,
+  EvaluationPlan,
+  ProjectionDefinition,
+} from "./types.js";
+
+export const EDITORIAL_CALIBRATION_PLAN: EvaluationPlan = {
+  type: "Evaluation Plan",
+  id: "editorial-work-calibration",
+  version: 1,
+  question: "Qual obra oferece a experiência editorial mais forte?",
+  subject: "work",
+  observedThrough: "expression-revision",
+  population: { publishableOnly: true, mediaKind: "text" },
+  languagePolicy: "balanced-expression",
+  lens: { kind: "calibration" },
+  sampling: { policy: "information-gain", cooldownDays: 7 },
+  effects: ["editorial-work-ranking", "revision-attention"],
+  stoppingRule: { assignments: 5 },
+};
+
+export const AFFECTIVE_EXPERIMENT_PLAN: EvaluationPlan = {
+  type: "Evaluation Plan",
+  id: "affective-chain",
+  version: 1,
+  question: "Como estas revisões são recebidas nesta leitura afetiva?",
+  subject: "revision",
+  observedThrough: "expression-revision",
+  population: { publishableOnly: true, mediaKind: "text" },
+  languagePolicy: "balanced-expression",
+  lens: { kind: "affective-chain" },
+  sampling: { policy: "coverage", cooldownDays: 7 },
+  effects: ["affective-experiment"],
+  stoppingRule: { assignments: 5 },
+};
+
+export const MEDIA_AUDIO_PLAN: EvaluationPlan = {
+  type: "Evaluation Plan",
+  id: "media-audio-calibration",
+  version: 1,
+  question: "Qual gravação oferece a experiência musical mais forte?",
+  subject: "media",
+  observedThrough: "media-revision",
+  population: { publishableOnly: true, mediaKind: "audio" },
+  languagePolicy: "not-applicable",
+  lens: { kind: "media" },
+  sampling: { policy: "coverage", cooldownDays: 7 },
+  effects: ["media-ranking"],
+  stoppingRule: { assignments: 5 },
+};
+
+export const BUILTIN_PLANS = [
+  EDITORIAL_CALIBRATION_PLAN,
+  AFFECTIVE_EXPERIMENT_PLAN,
+  MEDIA_AUDIO_PLAN,
+] as const;
+
+export const EDITORIAL_WORK_PROJECTION: ProjectionDefinition = {
+  type: "Projection",
+  id: "editorial-work-ranking",
+  version: 1,
+  acceptsEffects: ["editorial-work-ranking"],
+  mediaKind: "text",
+};
+
+export function validatePlan(plan: EvaluationPlan): string[] {
+  const errors: string[] = [];
+  if (!plan.id.trim()) errors.push("plan id is required");
+  if (!Number.isInteger(plan.version) || plan.version < 1) {
+    errors.push("plan version must be a positive integer");
+  }
+  if (!plan.question.trim()) errors.push("plan question is required");
+  if (plan.effects.length === 0) errors.push("plan must declare effects");
+  if (new Set(plan.effects).size !== plan.effects.length) {
+    errors.push("plan effects must be unique");
+  }
+  if (plan.stoppingRule.assignments < 1) {
+    errors.push("stopping rule must request at least one assignment");
+  }
+  if (plan.sampling.cooldownDays < 0) {
+    errors.push("sampling cooldown cannot be negative");
+  }
+
+  const has = (effect: EvaluationEffect) => plan.effects.includes(effect);
+  if (plan.lens.kind === "affective-chain" && has("editorial-work-ranking")) {
+    errors.push("affective-chain cannot affect the editorial work ranking");
+  }
+  if (plan.lens.kind === "perspective" && has("editorial-work-ranking")) {
+    errors.push("a situated perspective cannot affect the editorial work ranking");
+  }
+  if (plan.population.mediaKind === "audio") {
+    if (plan.observedThrough !== "media-revision" || plan.subject !== "media") {
+      errors.push("audio plans must observe media revisions");
+    }
+    if (plan.effects.some((effect) => effect !== "media-ranking")) {
+      errors.push("audio plans may only affect media projections");
+    }
+  } else if (has("media-ranking")) {
+    errors.push("text plans cannot affect media projections");
+  }
+  return errors;
+}
+
+export function planCanFeedProjection(
+  plan: EvaluationPlan,
+  projection: ProjectionDefinition
+): boolean {
+  if (plan.population.mediaKind !== projection.mediaKind) return false;
+  return projection.acceptsEffects.some((effect) =>
+    plan.effects.includes(effect)
+  );
+}
+

--- a/src/hronir-v3/plans.ts
+++ b/src/hronir-v3/plans.ts
@@ -63,6 +63,30 @@ export const EDITORIAL_WORK_PROJECTION: ProjectionDefinition = {
   mediaKind: "text",
 };
 
+function canonicalize(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(canonicalize);
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([key, child]) => [key, canonicalize(child)])
+    );
+  }
+  return value;
+}
+
+export function planDigest(plan: EvaluationPlan): string {
+  return `sha256:${createHash("sha256")
+    .update(JSON.stringify(canonicalize(plan)))
+    .digest("hex")}`;
+}
+
+export function materializedPlanId(
+  plan: Pick<EvaluationPlan, "id" | "version">
+): string {
+  return `${plan.id}-v${plan.version}`;
+}
+
 export function validatePlan(plan: EvaluationPlan): string[] {
   const errors: string[] = [];
   if (!plan.id.trim()) errors.push("plan id is required");
@@ -110,4 +134,4 @@ export function planCanFeedProjection(
     plan.effects.includes(effect)
   );
 }
-
+import { createHash } from "node:crypto";

--- a/src/hronir-v3/types.ts
+++ b/src/hronir-v3/types.ts
@@ -67,12 +67,19 @@ export interface Assignment {
   id: string;
   planId: string;
   planVersion: number;
+  planDigest: string;
   seed: string;
   evaluatorId: string;
-  status: "pending" | "completed" | "aborted";
   createdAt: string;
   sideA: EvaluationTarget;
   sideB: EvaluationTarget;
+}
+
+export interface AssignmentState {
+  type: "Assignment State";
+  id: string;
+  assignmentId: string;
+  status: "pending" | "completed" | "aborted";
 }
 
 export type Preference = "a" | "b" | "tie" | "incomparable";
@@ -89,6 +96,7 @@ export interface Evaluation {
   assignmentId: string;
   planId: string;
   planVersion: number;
+  planDigest: string;
   evaluatorId: string;
   modelId: string;
   promptVersion: string;

--- a/src/hronir-v3/types.ts
+++ b/src/hronir-v3/types.ts
@@ -1,0 +1,115 @@
+export type EvaluationSubject = "work" | "expression" | "revision" | "media";
+
+export type EvaluationEffect =
+  | "editorial-work-ranking"
+  | "situated-reading"
+  | "affective-experiment"
+  | "media-ranking"
+  | "revision-attention";
+
+export type EvaluationLens =
+  | { kind: "calibration" }
+  | { kind: "perspective"; perspectiveId: string }
+  | { kind: "affective-chain"; perspectiveId?: string }
+  | { kind: "media"; perspectiveId?: string };
+
+export interface EvaluationPlan {
+  type: "Evaluation Plan";
+  id: string;
+  version: number;
+  question: string;
+  subject: EvaluationSubject;
+  observedThrough: "expression-revision" | "media-revision";
+  population: {
+    publishableOnly: boolean;
+    mediaKind: "text" | "audio";
+  };
+  languagePolicy:
+    | "balanced-expression"
+    | "same-language"
+    | "not-applicable";
+  lens: EvaluationLens;
+  sampling: {
+    policy: "coverage" | "information-gain" | "refine-top" | "hunt-worst";
+    cooldownDays: number;
+  };
+  effects: EvaluationEffect[];
+  stoppingRule: {
+    assignments: number;
+  };
+}
+
+export interface RevisionTarget {
+  kind: "revision";
+  workId: string;
+  expressionId: string;
+  revisionId: string;
+  language: string;
+  contentDigest: string;
+  blobOid: string | null;
+  observedInCommits: string[];
+  pathAtAssignment: string;
+}
+
+export interface MediaTarget {
+  kind: "media";
+  workId: string | null;
+  mediaId: string;
+  revisionId: string;
+  mediaKind: "audio";
+  contentDigest: string;
+}
+
+export type EvaluationTarget = RevisionTarget | MediaTarget;
+
+export interface Assignment {
+  type: "Assignment";
+  id: string;
+  planId: string;
+  planVersion: number;
+  seed: string;
+  evaluatorId: string;
+  status: "pending" | "completed" | "aborted";
+  createdAt: string;
+  sideA: EvaluationTarget;
+  sideB: EvaluationTarget;
+}
+
+export type Preference = "a" | "b" | "tie" | "incomparable";
+
+export interface EvaluationEvidence {
+  side: "a" | "b";
+  anchor: string;
+  observation: string;
+}
+
+export interface Evaluation {
+  type: "Evaluation";
+  id: string;
+  assignmentId: string;
+  planId: string;
+  planVersion: number;
+  evaluatorId: string;
+  modelId: string;
+  promptVersion: string;
+  submittedAt: string;
+  preference: Preference;
+  confidence: number;
+  ratings: {
+    a: { editorialQuality: number | null };
+    b: { editorialQuality: number | null };
+  };
+  evidence: EvaluationEvidence[];
+  critiqueA: string;
+  critiqueB: string;
+  comparison: string;
+}
+
+export interface ProjectionDefinition {
+  type: "Projection";
+  id: string;
+  version: number;
+  acceptsEffects: EvaluationEffect[];
+  mediaKind: "text" | "audio";
+}
+


### PR DESCRIPTION
Part of #1501. Advances #1494, #1495, and #1496.

Introduces the pure contracts for EvaluationPlan, Assignment, Assignment State, and Evaluation:

- deterministic Assignment and Evaluation identities;
- canonical, key-order-independent Evaluation Plan digest;
- plan digest bound into Assignment, Evaluation, and their identities;
- validators recalculate canonical IDs and reject caller-supplied aliases;
- Assignment is immutable; operational status belongs to the separate Assignment State contract;
- exact Revision targets retain Work, Expression, revision, digest, blob, commits, language, and assignment-time path;
- declared effects keep affective and media observations out of incompatible projections.

Validation: 6 contract tests passed, including forged Assignment/Evaluation IDs.