### PR TITLE
research(blog): reconstrói a genealogia do caso de Conde em 1963

### DIFF
--- a/docs/research/conde-ufo-genealogy-1963.md
+++ b/docs/research/conde-ufo-genealogy-1963.md
@@ -1,0 +1,374 @@
+# Genealogia da notícia — Conde, Bahia, novembro de 1963
+
+Este relatório complementa o caderno `docs/research/conde-ufo-1963.md` e o
+ensaio `src/content/blog/conde-ufo-1963.md` da PR #1478.
+
+A pergunta aqui é deliberadamente anterior à investigação americana:
+
+> **qual era a forma mais antiga da notícia, e por qual caminho ela chegou à
+> Rádio Tupi do Rio em 8 de novembro de 1963?**
+
+Pesquisa realizada em 8 de agosto de 2026. O documento separa fatos
+confirmados, inferências testáveis, resultados negativos de busca e documentos
+que ainda precisam ser obtidos.
+
+## Conclusão provisória
+
+A versão registrada pelo FBIS a partir da Rádio Tupi em 8 de novembro de 1963
+não parece ser, necessariamente, a primeira forma da história.
+
+A evidência contemporânea mais importante para isso é a crônica de Stanislaw
+Ponte Preta publicada na edição Nordeste do *Última Hora* em 14 de novembro.
+Ele escreve que as **primeiras notícias chegadas a Salvador** diziam que em
+Conde havia caído **um satélite** e que, "pouco depois", as notícias já diziam
+que era **um satélite tripulado**. Em seguida, satiriza a continuação da cadeia,
+imaginando que, de Salvador para o Rio, aquilo já chegaria como disco voador
+fazendo vítimas e, dali para o mundo, como invasão marciana.
+
+A crônica é humorística e não é um relatório factual de apuração. Portanto ela
+não permite datar cada mutação nem provar que a cadeia ocorreu exatamente como
+a sátira descreve. Mas é uma fonte brasileira contemporânea, escrita apenas
+seis dias depois do registro da Tupi, e constitui evidência de que **já circulava
+em Salvador a memória de versões menos elaboradas da história**.
+
+O primeiro marco com data e hora que conseguimos documentar diretamente
+continua sendo o cabeçalho do FBIS:
+
+`RIO DE JANEIRO RADIO TUPI IN PORTUGUESE 2330 8 NOV 63 W`
+
+O significado exato do `W` e a convenção de fuso do cabeçalho ainda não foram
+estabelecidos nesta pesquisa. Por isso este relatório evita converter `2330`
+em horário local sem fonte para a convenção do FBIS.
+
+## O que sabemos, em ordem cronológica
+
+### Antes de 8 de novembro — versão ainda não localizada diretamente
+
+Stanislaw registra retrospectivamente que as primeiras notícias recebidas em
+Salvador falavam em **satélite** e, pouco depois, em **satélite tripulado**.
+Ainda não localizamos uma nota, telegrama, script de rádio ou página de jornal
+anterior ao registro da Tupi que contenha essas versões.
+
+Fonte primária contemporânea:
+
+- *Última Hora — Edição do Nordeste*, 14 nov. 1963, "A Guerra dos Mundos na
+  Versão Baiana", Stanislaw Ponte Preta:
+  https://hemeroteca-pdf.bn.gov.br/765147/per765147_1963_00477.pdf
+
+### 7 de novembro — amostra pesquisada, sem ocorrência relevante no OCR
+
+Foi consultada a edição Nordeste do *Última Hora* correspondente a 7 de
+novembro de 1963 (`00470`) com buscas por termos como `Conde` e `satélite`.
+Não apareceu ocorrência relevante ao caso no OCR consultável.
+
+Isso é **resultado negativo limitado**, não prova de ausência: OCR de jornal
+antigo falha, nomes podem estar grafados de outra forma e a notícia pode ter
+circulado em outro veículo ou no rádio antes de aparecer em jornal.
+
+- https://hemeroteca-pdf.bn.gov.br/765147/per765147_1963_00470.pdf
+
+### 8 de novembro — Rádio Tupi / FBIS
+
+O FBIS registra a Rádio Tupi do Rio transmitindo uma versão já altamente
+elaborada. O texto contém:
+
+- grande esfera metálica;
+- queda no centro da cidade;
+- buraco de quatro metros;
+- aberturas semelhantes a janelas cobertas por vidro grosso;
+- um corpo humano;
+- roupas pesadas;
+- inscrições indecifráveis.
+
+Documento oficial:
+
+- `EOP-UAP-D001_NASC-Inquiry-into-Bahia-Brazil-Incident_November-13-1963.pdf`
+- https://www.war.gov/medialink/ufo/release_05/Aug_07/documents/EOP-UAP-D001_NASC-Inquiry-into-Bahia-Brazil-Incident_November-13-1963.pdf
+
+A edição Nordeste do *Última Hora* de 8 de novembro (`00471`) também foi
+pesquisada por OCR sem ocorrência relevante localizada. Novamente, isso não
+exclui circulação por rádio, agência, telegrama ou outro jornal.
+
+- https://hemeroteca-pdf.bn.gov.br/765147/per765147_1963_00471.pdf
+
+### 9 de novembro — o desmentido já está no Diário de Notícias
+
+O A-628 americano registra que o cônsul Harold Midkiff posteriormente remeteu
+um recorte do *Diário de Notícias* de Salvador de **9 de novembro de 1963**.
+Segundo o resumo diplomático, o jornal dizia que o Ministério da Aeronáutica
+negava categoricamente a existência de objeto estranho em Conde.
+
+A página original desse fascículo ainda não foi obtida. Portanto, até ela
+aparecer, a formulação correta é sempre "segundo o A-628".
+
+A edição Nordeste do *Última Hora* de 9 de novembro (`00472`) foi pesquisada
+por OCR e não devolveu ocorrência relevante localizada.
+
+- https://hemeroteca-pdf.bn.gov.br/765147/per765147_1963_00472.pdf
+
+### 10 de novembro — amostra pesquisada
+
+A edição Nordeste do *Última Hora* (`00473`) foi pesquisada. Não foi localizada
+ocorrência do caso. A edição contém noticiário espacial não relacionado ao caso,
+o que é útil apenas para mostrar que `satélite` era vocabulário jornalístico
+corrente, não para explicar a origem do rumor.
+
+- https://hemeroteca-pdf.bn.gov.br/765147/per765147_1963_00473.pdf
+
+### 11 de novembro — Jornal da Bahia vai a Conde
+
+O A-628 registra um segundo recorte, agora do *Jornal da Bahia* de **11 de
+novembro de 1963**. O título é traduzido no documento americano como:
+
+> **The Airship that wasn't there**
+
+O relatório diz que um repórter foi a Conde e que o único subproduto
+"newsworthy" da viagem foi testar o posto telegráfico: enviou uma mensagem a
+Salvador por um transmissor Morse antigo e recebeu resposta cinco minutos
+depois.
+
+Ainda faltam a página original, o título em português e o nome do repórter.
+
+### 11 a 13 de novembro — outras edições do Última Hora
+
+Foram consultadas as edições Nordeste `00474`, `00475` e `00476`. As buscas de
+OCR não localizaram notícia anterior sobre Conde. Há noticiário espacial
+independente — inclusive sobre lançamentos que ocorrem **depois** da transmissão
+da Tupi —, portanto não apareceu nessa amostra um evento orbital óbvio capaz de
+explicar diretamente a notícia de 8 de novembro.
+
+- 11 nov.: https://hemeroteca-pdf.bn.gov.br/765147/per765147_1963_00474.pdf
+- 12 nov.: https://hemeroteca-pdf.bn.gov.br/765147/per765147_1963_00475.pdf
+- 13 nov.: https://hemeroteca-pdf.bn.gov.br/765147/per765147_1963_00476.pdf
+
+Este não é um levantamento orbital exaustivo. A conclusão é apenas negativa e
+estreita: **nas edições consultadas, não apareceu um candidato evidente**.
+
+### 13 de novembro — o papel americano vira uma pergunta
+
+No próprio documento do FBIS há a anotação manuscrita:
+
+> `a curious report. Please recheck now.`
+
+Outra anotação, datada de `11/13`, registra o acionamento do Departamento de
+Estado em relação à embaixada. Esse detalhe torna material a passagem
+
+`transmissão → registro → dúvida → nova investigação`.
+
+### 14 de novembro — duas cadeias se encontram
+
+No mesmo dia:
+
+1. Stanislaw publica "A Guerra dos Mundos na Versão Baiana" e registra a
+   sequência `satélite → satélite tripulado → disco voador → vítimas →
+   marcianos` como sátira da transmissão da notícia;
+2. Harold Midkiff, do consulado em Salvador, envia o telegrama nº 157 relatando
+   que jornalistas e outras pessoas haviam ido à região e não encontraram os
+   objetos descritos;
+3. Midkiff diz que a história parecia ter sido fabricada no Rio;
+4. o Secretário de Segurança Pública especulava sobre balão meteorológico, mas
+   nenhum avistamento desse tipo havia sido verificado;
+5. os recortes de 9 e 11 de novembro são enviados por malote.
+
+### 20 de novembro — A-628 preserva a apuração
+
+A embaixada no Rio envia ao Departamento de Estado o Airgram A-628,
+incorporando a resposta de Midkiff e resumindo os dois jornais baianos.
+
+Documento oficial:
+
+- `DOS-UAP-D002_Diplomatic-Cable_Brazil_November-20-1963.pdf`
+- https://www.war.gov/medialink/ufo/release_05/Aug_07/documents/DOS-UAP-D002_Diplomatic-Cable_Brazil_November-20-1963.pdf
+
+## A nova hipótese: talvez exista uma rota interna dos Diários Associados
+
+A pesquisa abriu uma hipótese mais específica sobre o salto
+`Salvador → Rádio Tupi do Rio`.
+
+A Biblioteca Nacional registra que o **Diário de Notícias de Salvador** foi
+incorporado aos **Diários Associados** de Assis Chateaubriand em 1943. A
+Brasiliana Fotográfica, com base no CPDOC, lista no mesmo conglomerado o
+*Diário de Notícias* de Salvador, o *Estado da Bahia*, a **Rádio Sociedade da
+Bahia**, a **Rádio Tupi do Rio** e a **Agência Meridional**, esta com matriz no
+Rio e sucursais pelo país.
+
+Fontes:
+
+- BNDigital, história do Diário de Notícias de Salvador:
+  https://bndigital.bn.gov.br/artigos/diario-de-noticias-salvador-1875/
+- Brasiliana Fotográfica / FBN, Diários Associados:
+  https://brasilianafotografica.bn.gov.br/?p=36105
+
+Há ainda uma evidência institucional importante sobre o funcionamento da
+Tupi. Em depoimento publicado pela Associação Brasileira de Imprensa, Décio
+Luiz relata que, ao trabalhar no jornal falado da Rádio Tupi, o noticiário era
+baseado em material fornecido pela **Agência Meridional** e pela reportagem do
+*Diário da Noite*. Ele atribui a vantagem jornalística da emissora justamente
+ao fato de pertencer aos Diários Associados, com correspondentes de Norte a
+Sul do Brasil.
+
+- ABI, "Bastidores: Décio Luiz":
+  https://www.abi.org.br/bastidores-decio-luiz/
+
+### O que isso permite dizer — e o que não permite
+
+Permite formular uma rota candidata:
+
+```text
+informação local / telegrama / correspondente
+              ↓
+Salvador: Diário de Notícias / Rádio Sociedade / outro veículo associado
+              ↓
+Agência Meridional / rede interna dos Diários Associados
+              ↓
+Rádio Tupi, Rio
+              ↓
+FBIS
+```
+
+**Não permite dizer que foi isso que aconteceu.**
+
+Não foi localizado ainda o boletim da Agência Meridional, o script da Rádio
+Tupi, uma transmissão da Rádio Sociedade da Bahia ou uma notícia anterior do
+*Diário de Notícias* que demonstre essa cadeia no caso de Conde.
+
+O valor da hipótese é transformar uma pergunta vaga — "como a notícia foi de
+Salvador ao Rio?" — em uma busca documental concreta.
+
+## Balão meteorológico: contexto existe, caso específico não
+
+O Decreto nº 52.667, de **11 de outubro de 1963**, que aprovou o regimento do
+Serviço de Meteorologia, mostra que a estrutura brasileira da época incluía
+uma **Seção de Aerologia**, com competência para pesquisas e métodos de
+**sondagens da atmosfera**, e um **Distrito de Meteorologia do Leste com sede
+em Salvador**, abrangendo Bahia e Sergipe.
+
+Fontes oficiais:
+
+- Planalto: https://www.planalto.gov.br/ccivil_03/Atos/decretos/1963/D52667.html
+- Câmara: https://www2.camara.leg.br/legin/fed/decret/1960-1969/decreto-52667-11-outubro-1963-392920-publicacaooriginal-1-pe.html
+
+Isso torna um equipamento de sondagem atmosférica uma categoria perfeitamente
+real no contexto regional de 1963. **Não foi encontrado, porém, nenhum registro
+de lançamento, perda ou recuperação de balão associado a Conde em 8 de
+novembro.**
+
+Portanto o decreto melhora o contexto, mas não confirma a solução narrada por
+Stanislaw nem a especulação registrada por Midkiff.
+
+## O maior vazio documental agora está antes da Tupi
+
+A investigação americana está relativamente bem documentada. O vazio que mais
+importa está entre uma possível observação/boato local e a transmissão da Rádio
+Tupi.
+
+As perguntas prioritárias passam a ser:
+
+1. **Qual é o primeiro registro conhecido da palavra `satélite` ligada a Conde?**
+2. **Quando entra `tripulado`?**
+3. **A esfera, o buraco, o corpo e as inscrições aparecem todos de uma vez na
+   Tupi ou já existiam em alguma fonte anterior?**
+4. **Quem alimentou a Tupi?** Agência Meridional, correspondente, outra rádio,
+   telefone, telegrama, jornal ou outra cadeia?
+5. **Houve algum objeto físico banal na origem ou a história nasceu inteiramente
+   como informação?**
+
+## O que precisa ser pedido aos arquivos
+
+O IGHB informa possuir as coleções completas ou abrangentes que cobrem a
+janela necessária:
+
+- *Diário de Notícias* — 1875–1980;
+- *Estado da Bahia* — 1933–1969;
+- *Jornal da Bahia* — 1959–1994;
+- *A Tarde* — desde 1912.
+
+Fonte:
+
+- https://www.ighb.org.br/biblioteca
+
+A próxima consulta não deve pedir apenas as duas páginas já conhecidas por
+citação americana. O pedido ideal é uma **janela**, porque a origem pode estar
+um ou dois dias antes:
+
+### Diário de Notícias — Salvador
+
+Solicitar **7, 8, 9, 10 e 11 de novembro de 1963**, com prioridade absoluta
+para 8 e 9. Procurar:
+
+- Conde;
+- satélite;
+- satélite tripulado;
+- balão;
+- meteorologia / sondagem;
+- disco voador / objeto estranho;
+- notas telegráficas;
+- créditos da Agência Meridional.
+
+### Jornal da Bahia
+
+Solicitar **7 a 12 de novembro de 1963**, com prioridade para 11. Objetivos:
+
+- obter o título original de "The Airship that wasn't there";
+- identificar o repórter enviado a Conde;
+- verificar se a matéria reconstrói versões anteriores do rumor;
+- procurar referências a outros jornais, rádios, telegramas ou agências.
+
+### Estado da Bahia
+
+Solicitar **7 a 10 de novembro de 1963**. Como outro jornal dos Diários
+Associados em Salvador, pode revelar se a notícia circulou internamente na
+rede antes ou junto do *Diário de Notícias*.
+
+### A Tarde
+
+Solicitar **7 a 11 de novembro de 1963** como comparação independente da rede
+dos Associados. Uma ocorrência ali ajudaria a distinguir circulação geral em
+Salvador de circulação interna ao conglomerado.
+
+### Arquivos de rádio/agência
+
+Procurar, se preservados:
+
+- scripts ou livros de transmissão da Rádio Tupi em 8 nov. 1963;
+- boletins da Agência Meridional de 7–9 nov. 1963;
+- material da Rádio Sociedade da Bahia no mesmo período;
+- correspondência ou arquivos editoriais dos Diários Associados sobre Conde.
+
+Esse conjunto é mais valioso agora do que procurar novos resumos ufológicos
+posteriores.
+
+## Resultado negativo que vale preservar
+
+Nesta rodada **não foi localizado online**:
+
+- o primeiro despacho ou nota com a versão `satélite`;
+- a primeira versão `satélite tripulado`;
+- o script da Rádio Tupi;
+- boletim correspondente da Agência Meridional;
+- o recorte original do *Diário de Notícias* de 9/11;
+- o recorte original do *Jornal da Bahia* de 11/11;
+- registro meteorológico que ligue um balão específico a Conde.
+
+Essas ausências não diminuem a investigação. Elas definem exatamente onde a
+cadeia documental quebra hoje.
+
+## Consequência editorial para o ensaio
+
+A revisão futura do post pode ganhar uma mudança importante de foco:
+
+- a Rádio Tupi deixa de parecer o nascimento da história e passa a ser o
+  **primeiro fóssil detalhado que temos**;
+- Stanislaw passa a funcionar como uma testemunha contemporânea de que versões
+  menores — `satélite`, depois `satélite tripulado` — circulavam na memória da
+  imprensa de Salvador;
+- a arquitetura dos Diários Associados oferece uma hipótese concreta para o
+  caminho até o Rio, explicitamente marcada como hipótese;
+- o próximo grande achado não é um documento americano novo, mas uma pequena
+  nota baiana anterior a 8 de novembro.
+
+Se essa nota aparecer, será possível transformar a sequência abstrata
+
+`notícia → circulação → exagero`
+
+em uma genealogia documentada, detalhe por detalhe.

--- a/docs/research/conde-ufo-genealogy-1963.md
+++ b/docs/research/conde-ufo-genealogy-1963.md
@@ -15,8 +15,8 @@ precisam ser obtidos.
 > **Nota metodológica:** a primeira rodada usou busca OCR por termos como
 > `Conde` e `satélite` como triagem. Essa técnica se mostrou insuficiente para
 > testar a genealogia da história. Uma segunda rodada releu as edições por
-> páginas e temas, procurando o conteúdo semântico de cada notícia e possíveis
-> fontes para cada detalhe da versão da Tupi. O resultado está documentado em
+> páginas e temas, tratando cada edição como um documento a ser resumido antes
+> da comparação com Conde. O resultado está documentado em
 > `docs/research/conde-ufo-semantic-reading-1963.md` e passa a prevalecer sobre
 > qualquer formulação anterior que tratasse a ausência de palavras-chave como
 > verificação editorial suficiente.
@@ -106,7 +106,7 @@ Na página policial, uma matéria sobre três estátuas de figuras da mitologia
 grega roubadas no Recife relata que elas foram enterradas em um campo de
 futebol num **buraco de quatro metros de profundidade**.
 
-É exatamente a profundidade atribuída, horas depois no registro do FBIS, ao
+É exatamente a profundidade atribuída, no registro do FBIS do mesmo dia, ao
 buraco aberto pela suposta esfera em Conde.
 
 Isso **não prova influência, cópia ou montagem**. A matéria é recifense, a edição
@@ -353,8 +353,8 @@ para 8 e 9.
 Objetivos:
 
 - resumir a edição inteira;
-- localizar qualquer narrativa que possa ser ancestral do caso, independentemente
-  do vocabulário;
+- localizar qualquer narrativa que possa ser ancestral do caso,
+  independentemente do vocabulário;
 - mapear a origem de cada detalhe da versão da Tupi;
 - identificar notas telegráficas e créditos da Agência Meridional;
 - procurar se a expressão ou imagem de um buraco de quatro metros aparece na

--- a/docs/research/conde-ufo-genealogy-1963.md
+++ b/docs/research/conde-ufo-genealogy-1963.md
@@ -9,8 +9,17 @@ A pergunta aqui é deliberadamente anterior à investigação americana:
 > Rádio Tupi do Rio em 8 de novembro de 1963?**
 
 Pesquisa realizada em 8 de agosto de 2026. O documento separa fatos
-confirmados, inferências testáveis, resultados negativos de busca e documentos
-que ainda precisam ser obtidos.
+confirmados, inferências testáveis, resultados negativos e documentos que ainda
+precisam ser obtidos.
+
+> **Nota metodológica:** a primeira rodada usou busca OCR por termos como
+> `Conde` e `satélite` como triagem. Essa técnica se mostrou insuficiente para
+> testar a genealogia da história. Uma segunda rodada releu as edições por
+> páginas e temas, procurando o conteúdo semântico de cada notícia e possíveis
+> fontes para cada detalhe da versão da Tupi. O resultado está documentado em
+> `docs/research/conde-ufo-semantic-reading-1963.md` e passa a prevalecer sobre
+> qualquer formulação anterior que tratasse a ausência de palavras-chave como
+> verificação editorial suficiente.
 
 ## Conclusão provisória
 
@@ -55,26 +64,29 @@ Fonte primária contemporânea:
   Versão Baiana", Stanislaw Ponte Preta:
   https://hemeroteca-pdf.bn.gov.br/765147/per765147_1963_00477.pdf
 
-### 7 de novembro — amostra pesquisada, sem ocorrência relevante no OCR
+### 7 de novembro — negativo semântico no Última Hora Nordeste
 
-Foi consultada a edição Nordeste do *Última Hora* correspondente a 7 de
-novembro de 1963 (`00470`) com buscas por termos como `Conde` e `satélite`.
-Não apareceu ocorrência relevante ao caso no OCR consultável.
+A edição 00470 foi relida por páginas e temas. Ela está concentrada em política,
+estiagem no Nordeste, polícia, economia, esportes, vida social e o desastre da
+mina de Peine.
 
-Isso é **resultado negativo limitado**, não prova de ausência: OCR de jornal
-antigo falha, nomes podem estar grafados de outra forma e a notícia pode ter
-circulado em outro veículo ou no rádio antes de aparecer em jornal.
+Não foi identificada uma nota que, mesmo usando vocabulário diferente, pareça
+ser uma versão ancestral do caso de Conde.
+
+Isso é **resultado negativo limitado a este veículo**, não prova de ausência no
+sistema de informação de Salvador: a notícia pode ter circulado por rádio,
+agência, telefone, telegrama ou outro jornal.
 
 - https://hemeroteca-pdf.bn.gov.br/765147/per765147_1963_00470.pdf
 
-### 8 de novembro — Rádio Tupi / FBIS
+### 8 de novembro — Rádio Tupi / FBIS e uma coincidência inesperada
 
 O FBIS registra a Rádio Tupi do Rio transmitindo uma versão já altamente
 elaborada. O texto contém:
 
 - grande esfera metálica;
 - queda no centro da cidade;
-- buraco de quatro metros;
+- **buraco de quatro metros de profundidade**;
 - aberturas semelhantes a janelas cobertas por vidro grosso;
 - um corpo humano;
 - roupas pesadas;
@@ -85,11 +97,37 @@ Documento oficial:
 - `EOP-UAP-D001_NASC-Inquiry-into-Bahia-Brazil-Incident_November-13-1963.pdf`
 - https://www.war.gov/medialink/ufo/release_05/Aug_07/documents/EOP-UAP-D001_NASC-Inquiry-into-Bahia-Brazil-Incident_November-13-1963.pdf
 
-A edição Nordeste do *Última Hora* de 8 de novembro (`00471`) também foi
-pesquisada por OCR sem ocorrência relevante localizada. Novamente, isso não
-exclui circulação por rádio, agência, telegrama ou outro jornal.
+A releitura semântica da edição Nordeste do *Última Hora* de 8 de novembro
+(00471) não encontrou uma notícia explicitamente identificável como Conde.
+Encontrou, porém, uma coincidência textual que a busca por palavras-chave não
+havia revelado.
+
+Na página policial, uma matéria sobre três estátuas de figuras da mitologia
+grega roubadas no Recife relata que elas foram enterradas em um campo de
+futebol num **buraco de quatro metros de profundidade**.
+
+É exatamente a profundidade atribuída, horas depois no registro do FBIS, ao
+buraco aberto pela suposta esfera em Conde.
+
+Isso **não prova influência, cópia ou montagem**. A matéria é recifense, a edição
+é Nordeste e não há ainda uma rota documental que a ligue à pessoa que redigiu
+ou leu a notícia na Tupi. Coincidência permanece a hipótese padrão.
+
+Mas a correspondência é específica o suficiente para ser preservada como pista
+e abre uma pergunta que não existia antes:
+
+> a história de Conde foi apenas ampliada ao circular, ou algum detalhe de sua
+> versão fantástica foi incorporado de outra notícia contemporânea?
+
+A mesma edição também dá destaque ao salvamento dos mineiros de Peine — homens
+soterrados vivos, mortos ainda no fundo da mina e uma cápsula de resgate. Essa
+vizinhança é muito mais frouxa que a coincidência dos quatro metros e **não é
+tratada como evidência de origem**; serve apenas para documentar o ambiente
+narrativo que uma leitura semântica permite enxergar.
 
 - https://hemeroteca-pdf.bn.gov.br/765147/per765147_1963_00471.pdf
+- relatório específico:
+  `docs/research/conde-ufo-semantic-reading-1963.md`
 
 ### 9 de novembro — o desmentido já está no Diário de Notícias
 
@@ -101,17 +139,25 @@ negava categoricamente a existência de objeto estranho em Conde.
 A página original desse fascículo ainda não foi obtida. Portanto, até ela
 aparecer, a formulação correta é sempre "segundo o A-628".
 
-A edição Nordeste do *Última Hora* de 9 de novembro (`00472`) foi pesquisada
-por OCR e não devolveu ocorrência relevante localizada.
+A releitura por páginas da edição Nordeste do *Última Hora* de 9 de novembro
+(00472) não identificou uma matéria sobre Conde. O contraste é informativo: o
+assunto já era concreto o suficiente em Salvador para produzir um desmentido
+institucional no *Diário de Notícias*, mas não aparece neste outro veículo.
+
+Isso é compatível com circulação desigual entre jornais ou com passagem inicial
+por rádio/agência em vez de difusão impressa geral.
 
 - https://hemeroteca-pdf.bn.gov.br/765147/per765147_1963_00472.pdf
 
-### 10 de novembro — amostra pesquisada
+### 10 de novembro — satélite e sondagem já são vocabulário cotidiano
 
-A edição Nordeste do *Última Hora* (`00473`) foi pesquisada. Não foi localizada
-ocorrência do caso. A edição contém noticiário espacial não relacionado ao caso,
-o que é útil apenas para mostrar que `satélite` era vocabulário jornalístico
-corrente, não para explicar a origem do rumor.
+A releitura da edição 00473 não identificou o caso de Conde, mas encontrou uma
+matéria anunciando o futuro lançamento do **Explorer 18** pela NASA. O jornal o
+chama de `satélite` e diz que ele faria `sondagens no espaço interplanetário`.
+
+A notícia é posterior à transmissão da Tupi e portanto não explica sua origem.
+Ela é útil para outro ponto: `satélite`, `sondagem`, foguetes e exploração
+espacial eram vocabulário jornalístico corrente naquela semana.
 
 - https://hemeroteca-pdf.bn.gov.br/765147/per765147_1963_00473.pdf
 
@@ -129,20 +175,24 @@ depois.
 
 Ainda faltam a página original, o título em português e o nome do repórter.
 
-### 11 a 13 de novembro — outras edições do Última Hora
+### 11 a 13 de novembro — negativos semânticos no Última Hora
 
-Foram consultadas as edições Nordeste `00474`, `00475` e `00476`. As buscas de
-OCR não localizaram notícia anterior sobre Conde. Há noticiário espacial
-independente — inclusive sobre lançamentos que ocorrem **depois** da transmissão
-da Tupi —, portanto não apareceu nessa amostra um evento orbital óbvio capaz de
-explicar diretamente a notícia de 8 de novembro.
+As edições Nordeste 00474, 00475 e 00476 foram novamente examinadas por páginas
+e temas, não apenas por ocorrências literais.
+
+Não apareceu nelas uma narrativa que possa ser identificada com segurança como
+uma etapa anterior do caso de Conde.
+
+O negativo é interessante porque, nesse intervalo, sabemos por outras fontes
+que o *Jornal da Bahia* já enviara um repórter a Conde, o governo americano
+começava a pedir verificação e a circulação já era suficiente para Stanislaw
+publicar sua crônica no dia 14. A ausência no *Última Hora Nordeste*, portanto,
+não significa ausência do caso: mostra que a circulação não era uniforme entre
+veículos.
 
 - 11 nov.: https://hemeroteca-pdf.bn.gov.br/765147/per765147_1963_00474.pdf
 - 12 nov.: https://hemeroteca-pdf.bn.gov.br/765147/per765147_1963_00475.pdf
 - 13 nov.: https://hemeroteca-pdf.bn.gov.br/765147/per765147_1963_00476.pdf
-
-Este não é um levantamento orbital exaustivo. A conclusão é apenas negativa e
-estreita: **nas edições consultadas, não apareceu um candidato evidente**.
 
 ### 13 de novembro — o papel americano vira uma pergunta
 
@@ -264,13 +314,17 @@ Tupi.
 
 As perguntas prioritárias passam a ser:
 
-1. **Qual é o primeiro registro conhecido da palavra `satélite` ligada a Conde?**
-2. **Quando entra `tripulado`?**
-3. **A esfera, o buraco, o corpo e as inscrições aparecem todos de uma vez na
-   Tupi ou já existiam em alguma fonte anterior?**
-4. **Quem alimentou a Tupi?** Agência Meridional, correspondente, outra rádio,
+1. **Qual é o primeiro registro de qualquer história identificável como Conde,
+   mesmo que ainda não use a palavra `satélite`?**
+2. **Quando a história passa a ser chamada de `satélite`?**
+3. **Quando entra `tripulado`?**
+4. **Qual é a genealogia independente de cada detalhe da Tupi — esfera, quatro
+   metros, janelas, vidro grosso, corpo, roupa e inscrições?**
+5. **A coincidência dos quatro metros aparece também em outros jornais ou
+   teletipos?**
+6. **Quem alimentou a Tupi?** Agência Meridional, correspondente, outra rádio,
    telefone, telegrama, jornal ou outra cadeia?
-5. **Houve algum objeto físico banal na origem ou a história nasceu inteiramente
+7. **Houve algum objeto físico banal na origem ou a história nasceu inteiramente
    como informação?**
 
 ## O que precisa ser pedido aos arquivos
@@ -288,22 +342,23 @@ Fonte:
 - https://www.ighb.org.br/biblioteca
 
 A próxima consulta não deve pedir apenas as duas páginas já conhecidas por
-citação americana. O pedido ideal é uma **janela**, porque a origem pode estar
-um ou dois dias antes:
+citação americana. Deve pedir **edições completas por janela de datas** e cada
+edição deve ser resumida semanticamente antes de qualquer busca textual.
 
 ### Diário de Notícias — Salvador
 
 Solicitar **7, 8, 9, 10 e 11 de novembro de 1963**, com prioridade absoluta
-para 8 e 9. Procurar:
+para 8 e 9.
 
-- Conde;
-- satélite;
-- satélite tripulado;
-- balão;
-- meteorologia / sondagem;
-- disco voador / objeto estranho;
-- notas telegráficas;
-- créditos da Agência Meridional.
+Objetivos:
+
+- resumir a edição inteira;
+- localizar qualquer narrativa que possa ser ancestral do caso, independentemente
+  do vocabulário;
+- mapear a origem de cada detalhe da versão da Tupi;
+- identificar notas telegráficas e créditos da Agência Meridional;
+- procurar se a expressão ou imagem de um buraco de quatro metros aparece na
+  rede dos Associados.
 
 ### Jornal da Bahia
 
@@ -311,8 +366,9 @@ Solicitar **7 a 12 de novembro de 1963**, com prioridade para 11. Objetivos:
 
 - obter o título original de "The Airship that wasn't there";
 - identificar o repórter enviado a Conde;
-- verificar se a matéria reconstrói versões anteriores do rumor;
-- procurar referências a outros jornais, rádios, telegramas ou agências.
+- reconstruir versões anteriores do rumor;
+- procurar referências a outros jornais, rádios, telegramas ou agências;
+- resumir as edições completas, não apenas buscar `Conde`.
 
 ### Estado da Bahia
 
@@ -342,7 +398,8 @@ posteriores.
 
 Nesta rodada **não foi localizado online**:
 
-- o primeiro despacho ou nota com a versão `satélite`;
+- o primeiro despacho ou nota com a versão simples da história;
+- a primeira versão `satélite`;
 - a primeira versão `satélite tripulado`;
 - o script da Rádio Tupi;
 - boletim correspondente da Agência Meridional;
@@ -350,25 +407,37 @@ Nesta rodada **não foi localizado online**:
 - o recorte original do *Jornal da Bahia* de 11/11;
 - registro meteorológico que ligue um balão específico a Conde.
 
-Essas ausências não diminuem a investigação. Elas definem exatamente onde a
-cadeia documental quebra hoje.
+A releitura semântica acrescenta uma nuance importante ao negativo: no
+*Última Hora Nordeste* não apareceu um ancestral identificável de Conde entre
+7 e 13 de novembro, **mas apareceu uma possível fonte contemporânea para um dos
+detalhes mais específicos da versão fantástica — o buraco de quatro metros**.
+
+Essas ausências e correspondências definem melhor onde a cadeia documental
+quebra e o que deve ser testado em outros acervos.
 
 ## Consequência editorial para o ensaio
 
-A revisão futura do post pode ganhar uma mudança importante de foco:
+A revisão futura do post pode ganhar duas mudanças de foco:
 
 - a Rádio Tupi deixa de parecer o nascimento da história e passa a ser o
   **primeiro fóssil detalhado que temos**;
-- Stanislaw passa a funcionar como uma testemunha contemporânea de que versões
-  menores — `satélite`, depois `satélite tripulado` — circulavam na memória da
-  imprensa de Salvador;
-- a arquitetura dos Diários Associados oferece uma hipótese concreta para o
-  caminho até o Rio, explicitamente marcada como hipótese;
-- o próximo grande achado não é um documento americano novo, mas uma pequena
-  nota baiana anterior a 8 de novembro.
+- além de perguntar como a história cresceu, passa a ser legítimo perguntar
+  **de onde vieram os próprios detalhes que a fizeram crescer**.
 
-Se essa nota aparecer, será possível transformar a sequência abstrata
+A arquitetura dos Diários Associados oferece uma hipótese concreta para o
+caminho até o Rio, explicitamente marcada como hipótese. A coincidência do
+buraco de quatro metros oferece uma primeira pista de que detalhes podem ter
+uma genealogia própria, também ainda sem causalidade demonstrada.
+
+Se conseguirmos obter as edições baianas completas e repetir a leitura
+semântica, será possível testar duas coisas diferentes:
 
 `notícia → circulação → exagero`
 
-em uma genealogia documentada, detalhe por detalhe.
+ou, talvez,
+
+`fluxo de notícias → fragmentos → montagem → circulação`.
+
+Por enquanto, a segunda linha é apenas uma pergunta de pesquisa. O mérito do
+novo método é justamente permitir que ela apareça sem fingir que já foi
+respondida.

--- a/docs/research/conde-ufo-semantic-reading-1963.md
+++ b/docs/research/conde-ufo-semantic-reading-1963.md
@@ -1,0 +1,269 @@
+# Leitura semântica dos jornais — Conde, novembro de 1963
+
+Este relatório corrige e aprofunda a metodologia usada em
+`docs/research/conde-ufo-genealogy-1963.md`.
+
+A primeira rodada tratou as edições do *Última Hora — Edição do Nordeste* de
+7 a 13 de novembro de 1963 principalmente como corpus pesquisável por OCR,
+procurando termos como `Conde`, `satélite` e variantes. Isso é útil como triagem,
+mas é insuficiente para a pergunta histórica que realmente importa.
+
+Se a história mudou enquanto circulava, a versão anterior pode usar palavras
+completamente diferentes. E, se a versão da Rádio Tupi foi montada a partir de
+fragmentos de outras notícias, procurar somente palavras ligadas a Conde é
+quase o método perfeito para não perceber isso.
+
+A segunda rodada, portanto, releu o conteúdo das edições por páginas e temas,
+procurando reconstruir **o que o jornal estava contando naquele dia**, inclusive
+notícias sem ligação aparente com Conde.
+
+## Resultado principal
+
+A releitura encontrou uma coincidência textual muito específica na edição de
+**8 de novembro de 1963**, o mesmo dia da transmissão da Rádio Tupi registrada
+pelo FBIS.
+
+O documento do FBIS transcreve a Tupi dizendo:
+
+> `A LARGE METAL SPHERE FELL IN THE CENTER OF THE CITY, GOUGING A HOLE FOUR METERS DEEP.`
+
+Ou seja: a esfera teria aberto um **buraco de quatro metros de profundidade**.
+
+Na edição Nordeste do *Última Hora* de 8 de novembro, uma matéria policial do
+Recife sobre o roubo de três estátuas de figuras da mitologia grega conta que
+os ladrões, sem conseguir vendê-las, as enterraram em um campo de futebol.
+A matéria diz que as estátuas foram enterradas num **buraco de quatro metros de
+profundidade**.
+
+Fonte:
+
+- *Última Hora — Edição do Nordeste*, 8 nov. 1963, edição 00471, p. 8;
+- https://hemeroteca-pdf.bn.gov.br/765147/per765147_1963_00471.pdf
+
+Documento comparado:
+
+- FBIS / Rádio Tupi, 8 nov. 1963;
+- https://www.war.gov/medialink/ufo/release_05/Aug_07/documents/EOP-UAP-D001_NASC-Inquiry-into-Bahia-Brazil-Incident_November-13-1963.pdf
+
+### O que isso significa
+
+Por enquanto, **não sabemos**.
+
+Não há evidência de que a pessoa que escreveu ou leu a notícia da Rádio Tupi
+tenha visto essa matéria. A edição é a Nordeste, a matéria policial é recifense
+e ainda não foi demonstrada uma rota editorial entre esse texto e a Tupi.
+
+Portanto a hipótese padrão continua sendo simplesmente coincidência.
+
+Mas a coincidência é específica o suficiente para ser preservada como pista.
+`quatro metros de profundidade` não é apenas o mesmo número: é a mesma medida
+aplicada a um **buraco**, no mesmo dia em que a Tupi transmite a versão de
+Conde.
+
+Ela cria uma pergunta nova:
+
+> **a história de Conde foi apenas ampliada ao circular, ou alguma versão foi
+> montada com detalhes disponíveis em outras notícias?**
+
+Essa pergunta não apareceria numa busca por `Conde` ou `satélite`.
+
+## Outra vizinhança narrativa em 8 de novembro
+
+A mesma edição dá destaque ao salvamento dos mineiros de Peine, na Alemanha.
+Onze homens haviam permanecido soterrados vivos por quase catorze dias; a
+reportagem também fala dos mineiros mortos que permaneceram no fundo da mina e
+da cápsula usada no resgate.
+
+Isso coloca, na mesma edição, uma narrativa de:
+
+- pessoas soterradas;
+- homens debaixo da terra;
+- mortos no fundo;
+- cápsula de salvamento;
+- e uma matéria policial com um buraco de quatro metros.
+
+É tentador olhar retrospectivamente para `esfera + buraco de quatro metros +
+corpo humano` e imaginar uma montagem de fragmentos.
+
+**Não há evidência suficiente para dizer isso.** A semelhança do buraco é
+precisa; a associação com os mineiros é muito mais frouxa. O relatório registra
+a vizinhança porque a metodologia agora é justamente observar o ambiente
+narrativo, sem promovê-lo a causalidade.
+
+## 7 de novembro — negativo semântico
+
+A edição 00470 foi relida por páginas e temas. Ela está concentrada em política
+local e nacional, estiagem no Nordeste, disputas policiais, economia, esportes,
+vida social e o desastre da mina de Peine.
+
+Não foi identificada uma nota que, mesmo usando vocabulário diferente, pareça
+ser uma versão ancestral do caso de Conde.
+
+Esse resultado é mais forte que `a busca por Conde falhou`, mas continua tendo
+limites: é **um jornal**, não o sistema de informação de Salvador, e a notícia
+pode ter circulado primeiro por rádio, agência, telefone ou telegrama.
+
+## 8 de novembro — negativo direto, positivo contextual
+
+A edição 00471 também não contém, na leitura realizada, uma notícia claramente
+referível a Conde antes da transmissão da Tupi.
+
+Mas a leitura semântica produziu o achado do **buraco de quatro metros**, além de
+mostrar que narrativas de soterramento, corpos e tecnologia ocupavam espaço
+relevante no mesmo número.
+
+Isso muda a classificação da edição de 8/11:
+
+- **negativa** para um ancestral explícito de Conde;
+- **positiva** para possíveis elementos narrativos contemporâneos que merecem
+  comparação.
+
+## 9 de novembro — o silêncio do Última Hora contrasta com o desmentido em Salvador
+
+A edição 00472 foi relida sem que aparecesse uma matéria identificável como o
+caso de Conde.
+
+No entanto, segundo o A-628 americano, nesse mesmo dia o *Diário de Notícias*
+de Salvador já publicava uma negativa categórica do Ministério da Aeronáutica
+sobre o objeto.
+
+Esse contraste é informativo. O assunto já era suficientemente concreto em
+Salvador para produzir um desmentido institucional, mas ainda não aparece na
+edição Nordeste do *Última Hora* que conseguimos ler.
+
+Isso é compatível com uma circulação concentrada em determinados veículos,
+rádio/agência ou na rede dos Diários Associados, em vez de uma história já
+onipresente na imprensa nordestina.
+
+## 10 de novembro — o vocabulário espacial estava ativo, mas depois da Tupi
+
+A edição dominical 00473 contém uma matéria anunciando o futuro lançamento do
+**Explorer 18** pela NASA. O jornal o chama de `satélite` e diz que ele faria
+`sondagens no espaço interplanetário`.
+
+A notícia é posterior à transmissão da Rádio Tupi e portanto não explica a
+origem da versão de 8 de novembro.
+
+Ainda assim, ela é útil para evitar uma leitura anacrônica: `satélite`,
+`sondagem`, exploração espacial e foguetes eram vocabulário jornalístico
+absolutamente cotidiano naquela semana.
+
+Fonte:
+
+- *Última Hora — Edição do Nordeste*, 10 nov. 1963, edição 00473;
+- https://hemeroteca-pdf.bn.gov.br/765147/per765147_1963_00473.pdf
+
+## 11 a 13 de novembro — nenhum ancestral explícito identificado
+
+As edições 00474, 00475 e 00476 foram novamente examinadas por páginas e temas,
+não apenas por ocorrências literais.
+
+Não apareceu nelas uma narrativa que possa ser identificada com segurança como
+uma etapa anterior do caso de Conde.
+
+O negativo é interessante sobretudo porque, nesse intervalo, sabemos por outras
+fontes que:
+
+- o *Jornal da Bahia* já enviara um repórter a Conde;
+- o governo americano estava começando a pedir verificação;
+- o caso já havia produzido suficiente circulação para Stanislaw escrever sua
+  crônica no dia 14.
+
+Portanto, a ausência no *Última Hora Nordeste* não significa ausência do caso.
+Ela mostra que a circulação não era uniforme entre veículos.
+
+## O que esta releitura muda na pesquisa
+
+A pesquisa não deve mais perguntar apenas:
+
+> `onde aparece Conde?`
+
+Ela precisa fazer, para cada edição:
+
+1. um resumo independente de todas as notícias relevantes;
+2. uma reconstrução do vocabulário e das imagens narrativas do dia;
+3. só depois uma comparação com cada detalhe da versão da Tupi;
+4. registrar tanto correspondências quanto ausências;
+5. distinguir coincidência, possível influência e influência demonstrada.
+
+Isso é especialmente importante porque a versão da Tupi contém vários detalhes
+independentes:
+
+- esfera metálica;
+- centro da cidade;
+- buraco de quatro metros de profundidade;
+- janelas com vidro grosso;
+- corpo humano;
+- roupas pesadas;
+- inscrições indecifráveis.
+
+Cada detalhe deve ganhar sua própria genealogia.
+
+## Hipóteses abertas pelo buraco de quatro metros
+
+Em ordem de parcimônia:
+
+### H0 — coincidência
+
+Duas notícias independentes usaram a mesma profundidade para dois buracos.
+Continua sendo a explicação padrão enquanto não houver elo documental.
+
+### H1 — fonte ou fórmula jornalística comum
+
+O detalhe pode ter circulado em teletipos, despachos ou textos reaproveitados,
+sem que uma matéria tenha copiado diretamente a outra.
+
+### H2 — contaminação narrativa
+
+Alguém envolvido na circulação da história de Conde pode ter incorporado um
+detalhe lido ou ouvido em outra notícia.
+
+### H3 — montagem deliberada
+
+A versão fantástica poderia ter sido construída combinando elementos de
+notícias diferentes.
+
+Esta é a hipótese mais sedutora e, atualmente, a menos demonstrada. Não deve
+entrar no ensaio como conclusão sem uma cadeia documental muito melhor.
+
+## Próximo passo nos acervos
+
+Para *Diário de Notícias*, *Jornal da Bahia*, *Estado da Bahia* e *A Tarde*, a
+consulta deve pedir **edições completas**, não recortes localizados por palavra.
+
+O procedimento ideal é:
+
+`edição completa → resumo semântico independente → mapa de detalhes → comparação`
+
+Só depois disso vale usar busca textual como ferramenta auxiliar.
+
+O mesmo princípio deve ser aplicado, se forem encontrados, a scripts da Rádio
+Tupi, boletins da Agência Meridional e material da Rádio Sociedade da Bahia.
+
+## Consequência editorial
+
+O caso começa a admitir uma segunda camada narrativa para o post.
+
+A primeira é a que já tínhamos:
+
+`história → rádio → FBIS → burocracia → arquivo → internet`
+
+A nova pergunta é anterior:
+
+`de onde vieram os próprios detalhes da história?`
+
+Se algum deles puder ser rastreado até outra notícia contemporânea, o ensaio
+deixa de mostrar apenas uma história sendo amplificada. Passa a mostrar uma
+história talvez sendo **montada com pedaços do próprio fluxo de notícias**.
+
+Por enquanto, só temos uma coincidência concreta e surpreendente:
+
+**em 8 de novembro de 1963, o mesmo dia em que a Rádio Tupi fala de uma esfera
+que abriu um buraco de quatro metros de profundidade em Conde, o *Última Hora
+Nordeste* publica uma história totalmente diferente sobre estátuas roubadas
+enterradas num buraco de quatro metros de profundidade.**
+
+Isso não resolve o mistério.
+
+Mas é exatamente o tipo de coisa que uma leitura semântica encontra e uma busca
+por palavras-chave perde.

--- a/docs/research/conde-ufo-semantic-reading-1963.md
+++ b/docs/research/conde-ufo-semantic-reading-1963.md
@@ -15,7 +15,9 @@ quase o método perfeito para não perceber isso.
 
 A segunda rodada, portanto, releu o conteúdo das edições por páginas e temas,
 procurando reconstruir **o que o jornal estava contando naquele dia**, inclusive
-notícias sem ligação aparente com Conde.
+notícias sem ligação aparente com Conde. A unidade de análise passa a ser a
+**edição inteira**: primeiro um resumo independente do conteúdo, depois a
+comparação com o caso. Busca textual fica apenas como ferramenta auxiliar.
 
 ## Resultado principal
 


### PR DESCRIPTION
## Posição na pilha

Base: #1478 (`essay/conde-ufo-recursivo`).

Esta PR não publica nem reescreve ainda o ensaio. Ela aprofunda a pesquisa histórica para descobrir o que existia **antes** da versão registrada pelo FBIS a partir da Rádio Tupi em 8 de novembro de 1963.

## Pergunta de pesquisa

Qual era a forma mais antiga da notícia e por qual caminho ela chegou de Conde/Salvador à Rádio Tupi do Rio?

O objetivo é conseguir datar, se possível, quando aparecem sucessivamente:

`Satélite → satélite tripulado → disco/esfera → vítimas/corpo → inscrições`

## O que foi encontrado

- Stanislaw Ponte Preta, em 14/11/1963, registra que as **primeiras notícias chegadas a Salvador** falavam em `satélite` e que `pouco depois` já se falava em `satélite tripulado`. Como é crônica humorística, isso é evidência contemporânea de circulação, não cronologia exata comprovada.
- O primeiro marco diretamente datado que permanece localizado é o registro do FBIS da Rádio Tupi: `2330 8 NOV 63 W`. A PR evita converter a hora para fuso local sem antes documentar a convenção do FBIS.
- As edições Nordeste do *Última Hora* de 7 a 13/11 foram consultadas por OCR para `Conde`, `satélite` e variantes. Nenhuma ocorrência relevante anterior à crônica de 14/11 foi localizada. O relatório trata isso explicitamente como resultado negativo limitado, não prova de ausência.
- Apareceu uma hipótese documental nova para a rota `Salvador → Rio`: o *Diário de Notícias* de Salvador, a Rádio Sociedade da Bahia e a Rádio Tupi pertenciam aos Diários Associados, que também operavam a Agência Meridional. Depoimento publicado pela ABI registra que o jornalismo da Tupi era alimentado por notícias da Meridional e pela rede nacional do grupo. A rota é plausível e agora testável, mas **não está provada para o caso de Conde**.
- O Decreto nº 52.667/1963 confirma que havia estrutura de aerologia/sondagem atmosférica e um Distrito de Meteorologia do Leste sediado em Salvador, abrangendo Bahia e Sergipe. Isso contextualiza a hipótese de balão, mas não foi encontrado registro de um balão específico perdido ou recuperado em Conde.
- A amostra de noticiário espacial consultada entre 10 e 13/11 contém lançamentos posteriores à transmissão da Tupi, sem candidato evidente que explique o rumor. Isso não é um levantamento orbital exaustivo.

## Novo artefato

`docs/research/conde-ufo-genealogy-1963.md`

O relatório contém:

- cronologia 7–20/11 com grau de evidência;
- resultados negativos das buscas em periódicos digitalizados;
- hipótese Diários Associados / Agência Meridional;
- contexto meteorológico de 1963;
- separação explícita entre fato, inferência e hipótese;
- lista exata dos documentos que ainda faltam;
- plano de consulta ao IGHB por **janelas de datas**, e não apenas pelos dois dias já citados no arquivo americano.

## Próxima pesquisa documental

Pedir aos acervos, prioritariamente:

- *Diário de Notícias* (Salvador): 7–11/11/1963;
- *Jornal da Bahia*: 7–12/11/1963;
- *Estado da Bahia*: 7–10/11/1963;
- *A Tarde*: 7–11/11/1963;
- se preservados, scripts/livros da Rádio Tupi, boletins da Agência Meridional e material da Rádio Sociedade da Bahia de 7–9/11.

O principal documento procurado agora não é outro relatório americano: é uma pequena notícia baiana anterior à Tupi que permita observar a mutação da história acontecendo.

## Estado

Draft, empilhada sobre #1478. Nenhum merge foi feito.