### PR TITLE
feat(game): beta pública do Rug Pull Simulator

### DIFF
--- a/src/pages/games/index.astro
+++ b/src/pages/games/index.astro
@@ -1,0 +1,68 @@
+---
+import PageLayout from "../../layouts/PageLayout.astro";
+---
+
+<PageLayout
+  title="Games"
+  description="Small interactive experiments and games published inside Franklin Baldo's digital garden."
+  lang="en"
+>
+  <header class="games-head">
+    <p class="games-kicker">Interactive experiments</p>
+    <h1>Games</h1>
+    <p>Small things that are easier to understand by playing them.</p>
+  </header>
+
+  <section class="games-grid" aria-label="Available games">
+    <article class="game-card">
+      <p class="game-card-tag">PLAYABLE PROTOTYPE</p>
+      <h2><a href="/games/rug-pull/">Rug Pull Simulator</a></h2>
+      <p>
+        You already bought the shitcoin. Read the creator, investigate the evidence,
+        and decide whether to stay for the pump or get out before the dev does.
+      </p>
+      <footer>
+        <a href="/games/rug-pull/" role="button">Enter Telegram →</a>
+      </footer>
+    </article>
+  </section>
+</PageLayout>
+
+<style>
+  .games-head {
+    max-width: 720px;
+    margin: 2rem 0 2.5rem;
+  }
+
+  .games-head h1 {
+    margin: 0.25rem 0;
+  }
+
+  .games-kicker,
+  .game-card-tag {
+    margin: 0;
+    color: var(--pico-muted-color);
+    font-size: 0.72rem;
+    font-weight: 800;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+  }
+
+  .games-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(min(100%, 320px), 1fr));
+    gap: 1rem;
+  }
+
+  .game-card {
+    margin: 0;
+  }
+
+  .game-card h2 {
+    margin-top: 0.35rem;
+  }
+
+  .game-card footer {
+    margin-top: 1.25rem;
+  }
+</style>

--- a/src/rug-pull/__tests__/strategies.test.ts
+++ b/src/rug-pull/__tests__/strategies.test.ts
@@ -1,0 +1,78 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { applyAction, createGame, summarizeGame } from "../engine";
+
+function finishWithHolds(seed: string) {
+  let state = createGame(seed);
+  for (let guard = 0; guard < 80 && state.status === "playing"; guard += 1) {
+    state = applyAction(state, { type: "hold" });
+  }
+  assert.notEqual(state.status, "playing", `seed ${seed} did not terminate`);
+  return state;
+}
+
+test("seed corpus contains rug and non-rug endings", () => {
+  const statuses = new Set<string>();
+
+  for (let index = 0; index < 120; index += 1) {
+    statuses.add(finishWithHolds(`ending-${index}`).status);
+  }
+
+  assert.ok(statuses.has("rugged"), "expected at least one rug ending");
+  assert.ok(
+    statuses.has("survived") || statuses.has("collapsed"),
+    "expected at least one non-rug ending"
+  );
+});
+
+test("creator archetypes produce distinct hidden causal histories", () => {
+  const byArchetype = new Map<string, Set<string>>();
+
+  for (let index = 0; index < 120; index += 1) {
+    const summary = summarizeGame(finishWithHolds(`archetype-${index}`));
+    const notes = byArchetype.get(summary.archetype) ?? new Set<string>();
+    for (const item of summary.creatorTimeline) notes.add(item.note);
+    byArchetype.set(summary.archetype, notes);
+  }
+
+  assert.equal(byArchetype.size, 4);
+  for (const notes of byArchetype.values()) {
+    assert.ok(
+      notes.size >= 2,
+      "each archetype should leave more than one causal note"
+    );
+  }
+});
+
+test("selling early and holding the same seed can produce different player outcomes", () => {
+  const seed = "decision-matters";
+  const earlyExit = applyAction(createGame(seed), {
+    type: "sell",
+    fraction: 1,
+  });
+  const held = finishWithHolds(seed);
+
+  const earlySummary = summarizeGame(earlyExit);
+  const heldSummary = summarizeGame(held);
+
+  assert.notEqual(earlySummary.finalValue, heldSummary.finalValue);
+  assert.equal(earlySummary.status, "exited");
+});
+
+test("research evidence never exposes the archetype label during play", () => {
+  let state = createGame("no-spoilers");
+  state = applyAction(state, { type: "investigate", kind: "creator" });
+
+  const publicText = state.feed
+    .map((event) => `${event.label} ${event.text}`)
+    .join(" ")
+    .toLowerCase();
+  for (const forbidden of [
+    "sociopath",
+    "true_believer",
+    "desperate_dev",
+    "accidental_success",
+  ]) {
+    assert.equal(publicText.includes(forbidden), false);
+  }
+});


### PR DESCRIPTION
## Release candidate da stack

Esta é a última fatia da primeira versão jogável do **Rug Pull Simulator**.

## Esta fatia

- adiciona `/games/` como landing page dos experimentos interativos;
- expõe o Rug Pull Simulator em `/games/rug-pull/`;
- acrescenta testes de diversidade estratégica: endings rug/non-rug, quatro arquétipos, causal histories e ausência de spoiler do arquétipo no feed;
- valida que decisões diferentes do jogador alteram o resultado;
- mantém seed/replay para reproduzir uma partida.

## Stack

1. #1514 — GDD;
2. #1515 — engine seedado;
3. #1516 — vertical slice web jogável;
4. #1517 — hardening, descoberta e corpus estratégico.

## Validação cumulativa

Antes de voltar a esta base empilhada, a stack foi validada cumulativamente contra `main` no head `b683ea0bb345a67bbea5a59e33b3d7c5bacb230b`.

No run cumulativo final, `repo hygiene`, changelog/version, dependency check, Prettier, lint e **unit tests** passaram; o corpus de seeds agora contém tanto finais de rug terminal quanto finais non-rug. O build Astro da mesma stack já havia passado em uma rodada cumulativa anterior; o último run ainda seguia nos gates globais mais demorados quando a PR foi recolocada sobre #1516.

Nenhum merge foi feito. Esta PR representa a primeira versão pronta para experimentação local.