### PR TITLE
copy: make the site identity match the actual blog

### DIFF
--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,6 +1,6 @@
 # Franklin Baldo
 
-> Essays on AI agents, memory, law, and the architecture of constraint — written by a Brazilian state attorney who builds agent harnesses at night. Posts are ranked by Hrönir, an open pairwise-comparison system judged by AI reader personas rather than a simple popularity count.
+> Essays, code, and music at the border of AI, philosophy, and literature. Posts are ranked by Hrönir, an open pairwise-comparison system judged by AI reader personas rather than a simple popularity count.
 
 ## Start here
 
@@ -14,7 +14,7 @@ Curated sequences through the archive, each with its own thread:
 
 - [Agency and Constraint](https://franklinbaldo.github.io/paths/agency-and-constraint/): Why alignment is not the absence of capability but the architecture that shapes it — from the temple at Delphi to the harness in your pocket.
 - [Memory and Funes](https://franklinbaldo.github.io/paths/memory-and-funes/): On total recall, Pierre Menard, and what Borges saw before anyone else — from building Funes to preserving family voices.
-- [Law and AI](https://franklinbaldo.github.io/paths/law-and-ai/): A state attorney's journey into AI agents — delegation, memory, and what changes when the clerk never forgets.
+- [Law and AI](https://franklinbaldo.github.io/paths/law-and-ai/): A journey through law and AI agents — delegation, memory, and what changes when the clerk never forgets.
 
 ## Optional
 

--- a/src/layouts/PageLayout.astro
+++ b/src/layouts/PageLayout.astro
@@ -157,7 +157,6 @@ const personLd = {
   name: "Franklin Baldo",
   url: Astro.site?.href,
   image: Astro.site ? new URL("/avatar.png", Astro.site).href : "/avatar.png",
-  jobTitle: "Lawyer and State Attorney",
   sameAs: SOCIAL_PROFILES,
 };
 ---

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -177,7 +177,7 @@ export const LANGUAGES: Record<string, LangConfig> = {
       "home.viewArchive": "View the full archive →",
       "author.label": "Author",
       "author.tagline":
-        "Lawyer and State Attorney. Writes on AI agency, process metaphysics, and legal design.",
+        "Writes, builds software, and makes music at the border of AI, philosophy, and literature.",
       "author.more": "More essays →",
       "author.aboutMore": "More about me →",
       "author.aboutEyebrow": "About Franklin",
@@ -192,7 +192,7 @@ export const LANGUAGES: Record<string, LangConfig> = {
       "lang.switchAria": "Switch language",
       "og.siteEyebrow": "Franklin Baldo's Digital Garden",
       "og.siteDescription":
-        "Essays on AI agency, process metaphysics, and the architecture of legal systems.",
+        "Essays, code, and music at the border of AI, philosophy, literature, and intelligent systems.",
       "og.qrHint": "Scan to read",
       "archive.jumpToYear": "Jump to year:",
       "webmentions.heading": "Mentions across the web",
@@ -286,7 +286,7 @@ export const LANGUAGES: Record<string, LangConfig> = {
       "home.viewArchive": "Ver o arquivo completo →",
       "author.label": "Autor",
       "author.tagline":
-        "Advogado e Procurador do Estado. Escreve sobre agentes de IA, metafísica do processo e design jurídico.",
+        "Escreve, programa e faz música na fronteira entre IA, filosofia e literatura.",
       "author.more": "Mais ensaios →",
       "author.aboutMore": "Saiba mais sobre mim →",
       "author.aboutEyebrow": "Sobre Franklin",
@@ -301,7 +301,7 @@ export const LANGUAGES: Record<string, LangConfig> = {
       "lang.switchAria": "Alterar idioma",
       "og.siteEyebrow": "Jardim Digital de Franklin Baldo",
       "og.siteDescription":
-        "Ensaios sobre agentes de IA, metafísica do processo e a arquitetura dos sistemas jurídicos.",
+        "Ensaios, código e música na fronteira entre IA, filosofia, literatura e sistemas inteligentes.",
       "og.qrHint": "Aponte para ler",
       "archive.jumpToYear": "Ir para o ano:",
       "webmentions.heading": "Menções na web",

--- a/src/lib/reading-paths-data.mjs
+++ b/src/lib/reading-paths-data.mjs
@@ -51,8 +51,8 @@ export const READING_PATHS = [
       pt: "Direito e IA",
     },
     blurb: {
-      en: "A state attorney's journey into AI agents: delegation, memory, and what changes when the clerk never forgets — seen from someone who builds at night and argues in court by day.",
-      pt: "A jornada de um procurador do estado pelo mundo dos agentes de IA: delegação, memória, e o que muda quando o escrivão nunca esquece — pelo olhar de quem constrói à noite e argumenta no tribunal de dia.",
+      en: "A journey through law and AI agents: delegation, memory, and what changes when the clerk never forgets — where institutional systems meet automation.",
+      pt: "Uma jornada por direito e agentes de IA: delegação, memória e o que muda quando o escrivão nunca esquece — onde sistemas institucionais encontram automação.",
     },
     source: {
       type: "manual",

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -17,7 +17,7 @@ const faqLd = {
       name: "Who is Franklin Baldo?",
       acceptedAnswer: {
         "@type": "Answer",
-        text: "Franklin Baldo writes, builds software, and makes music around AI, philosophy, literature, and intelligent systems. He also works as a lawyer and State Attorney (Procurador do Estado) in Brazil.",
+        text: "Franklin Baldo writes, builds software, and makes music around AI, philosophy, literature, and intelligent systems.",
       },
     },
     {
@@ -64,12 +64,6 @@ const faqLd = {
       I write, build software, and make music at the border of AI, philosophy,
       and literature. This space is where those threads collide: essays,
       technical experiments, songs, and tools for thought.
-    </p>
-
-    <p>
-      Outside this garden, I work as a <strong>lawyer and State Attorney</strong>
-      (<em>Procurador do Estado</em>) in Brazil. That experience sometimes enters
-      the writing when law meets systems, institutions, automation, or design.
     </p>
 
     <h2>What lives here</h2>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -17,7 +17,7 @@ const faqLd = {
       name: "Who is Franklin Baldo?",
       acceptedAnswer: {
         "@type": "Answer",
-        text: "Franklin Baldo is a lawyer and State Attorney (Procurador do Estado) in Brazil, exploring AI agents, process metaphysics, and legal design.",
+        text: "Franklin Baldo writes, builds software, and makes music around AI, philosophy, literature, and intelligent systems. He also works as a lawyer and State Attorney (Procurador do Estado) in Brazil.",
       },
     },
     {
@@ -25,7 +25,7 @@ const faqLd = {
       name: "What topics does this blog cover?",
       acceptedAnswer: {
         "@type": "Answer",
-        text: "Essays on AI agency, process metaphysics, and the architecture of legal systems. Also explores family memory and tools for thought.",
+        text: "Essays, technical experiments, music, and philosophical fragments about AI, process, software, literature, family memory, and law when it intersects with systems and design.",
       },
     },
     {
@@ -50,7 +50,7 @@ const faqLd = {
 
 <PageLayout
   title="About | Franklin Baldo"
-  description="Lawyer, State Attorney, and digital gardener — exploring AI agency, process metaphysics, and legal design."
+  description="Writer, software builder, and music-maker exploring AI, philosophy, literature, and intelligent systems."
   image="/og/about.png"
   lang="en"
   translations={{ pt: "/pt/about/" }}
@@ -61,23 +61,31 @@ const faqLd = {
     <h1>About</h1>
 
     <p>
-      I am a <strong>lawyer and State Attorney</strong> (<em>Procurador do Estado</em>) in Brazil,
-      exploring the boundaries of AI agents, process metaphysics, and legal design.
-      I build small tools for thought, transparency, and family memory.
+      I write, build software, and make music at the border of AI, philosophy,
+      and literature. This space is where those threads collide: essays,
+      technical experiments, songs, and tools for thought.
+    </p>
+
+    <p>
+      Outside this garden, I work as a <strong>lawyer and State Attorney</strong>
+      (<em>Procurador do Estado</em>) in Brazil. That experience sometimes enters
+      the writing when law meets systems, institutions, automation, or design.
     </p>
 
     <h2>What lives here</h2>
 
     <p>
       This space is a digital garden — a slow accumulation of essays, technical
-      guides, and philosophical fragments on how we inhabit a world increasingly
+      guides, music, and philosophical fragments on how we inhabit a world increasingly
       mediated by intelligence. A few recurring threads:
     </p>
 
     <ul>
-      <li><strong>The Harness</strong> — agents, alignment, and the language we build cages with.</li>
-      <li><strong>Process</strong> — Whitehead, Heraclitus, and computation as becoming.</li>
-      <li><strong>Legal design</strong> — public law in the age of probabilistic systems.</li>
+      <li><strong>AI & agency</strong> — agents, models, alignment, semantic maps, and strange machine behavior.</li>
+      <li><strong>Process & metaphysics</strong> — Whitehead, Heraclitus, and computation as becoming.</li>
+      <li><strong>Software & tools for thought</strong> — experiments, protocols, parsers, agents, and small systems.</li>
+      <li><strong>Literature & music</strong> — Borges, adaptation, songs, and experiments where form carries the argument.</li>
+      <li><strong>Law & institutions</strong> — when technical systems collide with public institutions and legal design.</li>
       <li><strong>Family memory</strong> — what it means to archive a life with help from a machine.</li>
     </ul>
 

--- a/src/pages/feed.json.js
+++ b/src/pages/feed.json.js
@@ -35,7 +35,7 @@ export async function GET(context) {
     version: "https://jsonfeed.org/version/1.1",
     title: "Franklin Baldo",
     description:
-      "Lawyer and State Attorney. Exploring the intersections of process metaphysics, AI agency, and the architecture of legal systems.",
+      "Essays, code, and music at the border of AI, philosophy, and literature.",
     home_page_url: context.site.href,
     feed_url: new URL("feed.json", context.site).href,
     language: "en-us",

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -23,8 +23,8 @@ const latestDate = latest?.data.date.toLocaleDateString('en-US', {
 ---
 
 <PageLayout
-  title="Franklin Baldo — Notes on AI, law, and systems."
-  description="Essays on AI agency, process metaphysics, and legal design by Franklin Baldo, a State Attorney in Rondônia, Brazil."
+  title="Franklin Baldo — Essays, code, and music."
+  description="Essays, code, and music at the border of AI, philosophy, literature, and intelligent systems."
   lang="en"
   translations={{ pt: "/pt/" }}
 >
@@ -32,7 +32,7 @@ const latestDate = latest?.data.date.toLocaleDateString('en-US', {
     <div class="home-main">
       <section class="home-hero" aria-label="Introduction">
         <h1 class="home-title">Franklin Baldo<span class="home-title-dot" aria-hidden="true">.</span></h1>
-        <p class="home-tagline">Notes on AI, law, and systems.</p>
+        <p class="home-tagline">Essays, code, and music at the border of AI, philosophy, and literature.</p>
       </section>
 
       {latest && (

--- a/src/pages/pt/about.astro
+++ b/src/pages/pt/about.astro
@@ -17,7 +17,7 @@ const faqLd = {
       name: "Quem é Franklin Baldo?",
       acceptedAnswer: {
         "@type": "Answer",
-        text: "Franklin Baldo é advogado e Procurador do Estado no Brasil, explorando os limites dos agentes de IA, metafísica do processo e design jurídico.",
+        text: "Franklin Baldo escreve, programa e faz música em torno de IA, filosofia, literatura e sistemas inteligentes. Também trabalha como advogado e Procurador do Estado no Brasil.",
       },
     },
     {
@@ -25,7 +25,7 @@ const faqLd = {
       name: "Quais tópicos este blog aborda?",
       acceptedAnswer: {
         "@type": "Answer",
-        text: "O blog aborda ensaios sobre agentes de IA, metafísica do processo e a arquitetura dos sistemas jurídicos, além de explorar memória familiar e ferramentas de pensamento.",
+        text: "Ensaios, experimentos técnicos, música e fragmentos filosóficos sobre IA, processo, software, literatura, memória familiar e direito quando ele cruza com sistemas e design.",
       },
     },
     {
@@ -50,7 +50,7 @@ const faqLd = {
 
 <PageLayout
   title="Sobre | Franklin Baldo"
-  description="Advogado, Procurador do Estado e jardineiro digital — explorando agentes de IA, metafísica do processo e design jurídico."
+  description="Escritor, programador e criador de música explorando IA, filosofia, literatura e sistemas inteligentes."
   image="/og/about-pt.png"
   lang="pt"
   translations={{ en: "/about/" }}
@@ -61,23 +61,31 @@ const faqLd = {
     <h1>Sobre</h1>
 
     <p>
-      Sou <strong>advogado e Procurador do Estado</strong> no Brasil,
-      explorando os limites dos agentes de IA, metafísica do processo e design jurídico.
-      Construo pequenas ferramentas para o pensamento, a transparência e a memória familiar.
+      Escrevo, programo e faço música na fronteira entre IA, filosofia e literatura.
+      Este espaço é onde esses fios se cruzam: ensaios, experimentos técnicos,
+      canções e ferramentas para pensar.
+    </p>
+
+    <p>
+      Fora deste jardim, trabalho como <strong>advogado e Procurador do Estado</strong>
+      no Brasil. Essa experiência às vezes entra nos textos quando o direito encontra
+      sistemas, instituições, automação ou design.
     </p>
 
     <h2>O que vive aqui</h2>
 
     <p>
       Este espaço é um jardim digital — uma acumulação lenta de ensaios, guias
-      técnicos e fragmentos filosóficos sobre como habitamos um mundo cada vez mais
+      técnicos, música e fragmentos filosóficos sobre como habitamos um mundo cada vez mais
       mediado pela inteligência. Alguns fios recorrentes:
     </p>
 
     <ul>
-      <li><strong>O Harness</strong> — agentes, alinhamento e a linguagem com que construímos as jaulas.</li>
-      <li><strong>Processo</strong> — Whitehead, Heráclito e a computação como devir.</li>
-      <li><strong>Design jurídico</strong> — direito público na era dos sistemas probabilísticos.</li>
+      <li><strong>IA e agência</strong> — agentes, modelos, alinhamento, mapas semânticos e comportamentos estranhos de máquinas.</li>
+      <li><strong>Processo e metafísica</strong> — Whitehead, Heráclito e a computação como devir.</li>
+      <li><strong>Software e ferramentas para pensar</strong> — experimentos, protocolos, parsers, agentes e pequenos sistemas.</li>
+      <li><strong>Literatura e música</strong> — Borges, adaptação, canções e experiências em que a forma carrega o argumento.</li>
+      <li><strong>Direito e instituições</strong> — quando sistemas técnicos colidem com instituições públicas e design jurídico.</li>
       <li><strong>Memória familiar</strong> — o que significa arquivar uma vida com a ajuda de uma máquina.</li>
     </ul>
 

--- a/src/pages/pt/about.astro
+++ b/src/pages/pt/about.astro
@@ -17,7 +17,7 @@ const faqLd = {
       name: "Quem é Franklin Baldo?",
       acceptedAnswer: {
         "@type": "Answer",
-        text: "Franklin Baldo escreve, programa e faz música em torno de IA, filosofia, literatura e sistemas inteligentes. Também trabalha como advogado e Procurador do Estado no Brasil.",
+        text: "Franklin Baldo escreve, programa e faz música em torno de IA, filosofia, literatura e sistemas inteligentes.",
       },
     },
     {
@@ -64,12 +64,6 @@ const faqLd = {
       Escrevo, programo e faço música na fronteira entre IA, filosofia e literatura.
       Este espaço é onde esses fios se cruzam: ensaios, experimentos técnicos,
       canções e ferramentas para pensar.
-    </p>
-
-    <p>
-      Fora deste jardim, trabalho como <strong>advogado e Procurador do Estado</strong>
-      no Brasil. Essa experiência às vezes entra nos textos quando o direito encontra
-      sistemas, instituições, automação ou design.
     </p>
 
     <h2>O que vive aqui</h2>

--- a/src/pages/pt/feed.json.js
+++ b/src/pages/pt/feed.json.js
@@ -37,7 +37,7 @@ export async function GET(context) {
     version: "https://jsonfeed.org/version/1.1",
     title: "Franklin Baldo (Português)",
     description:
-      "Advogado e Procurador do Estado. Explorando as interseções entre metafísica do processo, agentes de IA e a arquitetura dos sistemas jurídicos.",
+      "Ensaios, código e música na fronteira entre IA, filosofia e literatura.",
     home_page_url: new URL("pt/", context.site).href,
     feed_url: new URL("pt/feed.json", context.site).href,
     language: "pt-br",

--- a/src/pages/pt/index.astro
+++ b/src/pages/pt/index.astro
@@ -23,8 +23,8 @@ const latestDate = latest?.data.date.toLocaleDateString('pt-BR', {
 ---
 
 <PageLayout
-  title="Franklin Baldo — Notas sobre IA, direito e sistemas."
-  description="Ensaios sobre agentes de IA, metafísica do processo e design jurídico por Franklin Baldo, Procurador do Estado em Rondônia."
+  title="Franklin Baldo — Ensaios, código e música."
+  description="Ensaios, código e música na fronteira entre IA, filosofia, literatura e sistemas inteligentes."
   lang="pt"
   translations={{ en: "/" }}
 >
@@ -32,7 +32,7 @@ const latestDate = latest?.data.date.toLocaleDateString('pt-BR', {
     <div class="home-main">
       <section class="home-hero" aria-label="Introdução">
         <h1 class="home-title">Franklin Baldo<span class="home-title-dot" aria-hidden="true">.</span></h1>
-        <p class="home-tagline">Notas sobre IA, direito e sistemas.</p>
+        <p class="home-tagline">Ensaios, código e música na fronteira entre IA, filosofia e literatura.</p>
       </section>
 
       {latest && (

--- a/src/pages/pt/rss.xml.js
+++ b/src/pages/pt/rss.xml.js
@@ -32,7 +32,7 @@ export async function GET(context) {
   return rss({
     title: "Franklin Baldo (Português)",
     description:
-      "Advogado e Procurador do Estado. Explorando as interseções entre metafísica do processo, agentes de IA e a arquitetura dos sistemas jurídicos.",
+      "Ensaios, código e música na fronteira entre IA, filosofia e literatura.",
     site: context.site,
     items,
     xmlns: { atom: "http://www.w3.org/2005/Atom" },

--- a/src/pages/rss.xml.js
+++ b/src/pages/rss.xml.js
@@ -32,7 +32,7 @@ export async function GET(context) {
   return rss({
     title: "Franklin Baldo",
     description:
-      "Lawyer and State Attorney. Exploring the intersections of process metaphysics, AI agency, and the architecture of legal systems.",
+      "Essays, code, and music at the border of AI, philosophy, and literature.",
     site: context.site,
     items,
     xmlns: { atom: "http://www.w3.org/2005/Atom" },


### PR DESCRIPTION
## Why

The site identity had become narrower than the work actually published here. The corpus now spans AI, philosophy/process, software experiments, Borges/literature, music, agents, tools for thought, memory, and systems.

This PR makes the public identity describe **the work itself**.

## What changes

- Author card, EN + PT:
  - EN: **“Writes, builds software, and makes music at the border of AI, philosophy, and literature.”**
  - PT: **“Escreve, programa e faz música na fronteira entre IA, filosofia e literatura.”**
- Homepage headline/meta copy becomes **“Essays, code, and music…” / “Ensaios, código e música…”**.
- About pages open with the same activity-first identity and map the recurring threads of the site: AI/agency, process/metaphysics, software/tools for thought, literature/music, law/institutions, and family memory.
- RSS and JSON Feed descriptions use the same editorial identity in both languages.
- `llms.txt` now describes the site by its actual corpus and reading paths.
- Person structured data is kept minimal: name, URL, image, and social profiles.

## Scope

Editorial identity and metadata only; no layout or component behavior changes.