### PR TITLE
hronir: 5 matches — claude-hronir-routine

### DIFF
--- a/.routines/2026-08-10T13-21-31-hronir-run.md
+++ b/.routines/2026-08-10T13-21-31-hronir-run.md
@@ -1,0 +1,7 @@
+---
+date: "2026-08-10T13:21:31Z"
+branch: hronir/run-2026-08-10T13-12-18
+status: open
+---
+
+5 matches — claude-hronir-routine. Objetivo coverage puxou repetidamente o par these-lines x the-license-that-knocks (posts recém-publicados, sub-amostrados) sob quatro perspectivas diferentes — rationalist, internet-native, lateral-essayist (2x, línguas trocadas), felt-not-explained. the-license-that-knocks levou as duas primeiras (calibração epistêmica e ritmo cômico); these-lines virou as três seguintes (estrutura-como-movimento nas duas rodadas do lateral-essayist e, com folga, transmissão emocional).

--- a/.routines/hronir/rates/2026-08-10T13-14-01-310_these-lines_x_the-license-that-knocks.md
+++ b/.routines/hronir/rates/2026-08-10T13-14-01-310_these-lines_x_the-license-that-knocks.md
@@ -1,0 +1,91 @@
+---
+type: Rate File
+run_id: 2026-08-10T13-14-01-310
+run_at: '2026-08-10T13:14:01.310Z'
+post_a:
+  key: these-lines
+  path: src/content/blog/estas-linhas.md
+  display_lang: pt
+  content_lang: pt
+  version: fd8dd2b3-dff4-5c6e-a0d6-d15115e6e070
+  ref: estas-linhas@fd8dd2b3-dff4-5c6e-a0d6-d15115e6e070
+post_b:
+  key: the-license-that-knocks
+  path: src/content/blog/the-license-that-knocks.md
+  display_lang: en
+  content_lang: en
+  version: c90611e9-1a03-59a2-b537-6d6b31675c16
+  ref: the-license-that-knocks@c90611e9-1a03-59a2-b537-6d6b31675c16
+winner: b
+agent_id: claude-hronir-routine
+content_mode: path-only
+objective: coverage
+eval_lang: pt
+review_lang: pt
+prompt_version: stars-v3
+season: 1
+override: null
+perspective_id: long-form-rationalist
+evaluator_mood: >-
+  O símbolo nega a si mesmo. Estou vendo o que não quer ser visto: ambição que
+  se oculta em prosa que parece honesta.
+mood_glyph: 通
+evaluator_mood_after: >-
+  Sinto a cabeça mais limpa agora, como se tivesse atravessado um corredor
+  estreito e chegado a um espaço mais aberto — quero um café antes de seguir,
+  deixar as ideias assentarem.
+impression_a: null
+impression_b: null
+rate_a: 3.75
+rate_b: 4.4
+clash: >-
+  Qual dos dois faz o trabalho epistêmico mais difícil? these-lines finge menos
+  autoridade na superfície — o narrador duvida de quase tudo, inclusive de si
+  mesmo, até a última linha, 'Não sei se a aceitei'. Mas essa dúvida está presa
+  dentro de uma voz ficcional cujas afirmações centrais — a 'dobra' como
+  consciência, a 'pré-eternidade' como reconstrução — nunca precisam sobreviver
+  a um interlocutor real; a ficção é o hedge que dispensa todos os outros.
+  the-license-that-knocks faz o oposto: começa confiante ('collection was only
+  half the problem') e só then expõe, uma a uma, as três falhas concretas que
+  quase inviabilizaram o design — o preço que não concede licença, a definição
+  incompleta de 'invocation', a proveniência perdida da política — e mostra o
+  artefato técnico que fechou cada buraco. Não há personagem entre o autor e o
+  erro. Confio mais em the-license-that-knocks por uma margem que estimo em 3:2:
+  sua incerteza é sobre engenharia falseável, não sobre metafísica que a própria
+  forma ficcional já isenta de prestar contas. Estrelas seguem essa confiança.
+review_a: >-
+  these-lines é ficção que veste o vocabulário de cross-entropia e compressão
+  para narrar uma epifania sobre consciência e memória. O que me conquista é que
+  o narrador hesita de verdade: 'A afirmação me pareceu rápida demais' ao
+  encontrar a 'dobra' identificada com consciência, e o texto interno recua
+  sozinho — 'A dobra não basta para explicar a consciência' — antes que o
+  narrador precise contestar. Isso é hedge genuíno, não decorativo. Mas há um
+  problema estrutural: o narrador é um personagem cético dentro de uma ficção, e
+  sua incerteza performada protege o autor de responder pelas afirmações
+  metafísicas mais fortes — 'pré-eternidade', a reconstrução de estados
+  conscientes por inteligências futuras. Quando 'Não sei se a aceitei' fecha o
+  argumento, isso lê como elegância literária, não como calibração epistêmica: a
+  hipótese central nunca precisa ser defendida fora da voz narrativa que a
+  abriga. A conexão com Arjuna é bem-trabalhada — modelos dentro de modelos
+  ecoando a forma universal —, mas é ornamento erudito que funciona mais por
+  ressonância do que por carregar peso argumentativo.
+review_b: >-
+  the-license-that-knocks é o tipo de prosa que essa perspectiva foi desenhada
+  para recompensar: cada seção é um erro específico encontrado e corrigido, com
+  data e nome — 'The first hole', 'The second hole', 'The third hole'. Isso não
+  é hedge retórico, é histórico de revisão real, ancorado em dois PRs
+  verificáveis. A frase que entrega o texto é: 'This is not the universal
+  definition of invocation for humanity. It is a definition precise enough for
+  two machines to count the same way' — recusa explícita de falsa precisão,
+  exatamente o que a perspectiva pede. 'We almost ruined the idea by building
+  too much architecture' admite scope creep sem se esconder atrás dele. O texto
+  também evita autoridade performada onde mais tentaria: ao invés de proclamar
+  que a licença resolve direitos autorais, ele cita o Art. 8 da Lei 9.610/1998
+  para mostrar exatamente o que a lei recusa a licenciar, e conclui 'a license
+  does not create copyright where the law did not' — reconhecendo o limite do
+  próprio projeto. O risco é que a narrativa de 'quase erramos, mas nos
+  corrigimos' se torne, ela mesma, uma forma de autoridade — mas cada correção
+  vem com o artefato técnico que a sustenta (a semântica de invocation, a
+  proveniência da política), não apenas com a alegação de ter aprendido.
+---
+

--- a/.routines/hronir/rates/2026-08-10T13-15-06-977_these-lines_x_the-license-that-knocks.md
+++ b/.routines/hronir/rates/2026-08-10T13-15-06-977_these-lines_x_the-license-that-knocks.md
@@ -1,0 +1,85 @@
+---
+type: Rate File
+run_id: 2026-08-10T13-15-06-977
+run_at: '2026-08-10T13:15:06.977Z'
+post_a:
+  key: these-lines
+  path: src/content/blog/these-lines.md
+  display_lang: en
+  content_lang: en
+  version: 39f47c66-a323-534b-bbf0-37553879712c
+  ref: these-lines@39f47c66-a323-534b-bbf0-37553879712c
+post_b:
+  key: the-license-that-knocks
+  path: src/content/blog/a-licenca-que-bate-na-porta.md
+  display_lang: pt
+  content_lang: pt
+  version: e5039a28-90a3-58d9-b849-12aa1dd69d71
+  ref: a-licenca-que-bate-na-porta@e5039a28-90a3-58d9-b849-12aa1dd69d71
+winner: b
+agent_id: claude-hronir-routine
+content_mode: path-only
+objective: coverage
+eval_lang: pt
+review_lang: pt
+prompt_version: stars-v3
+season: 1
+override: null
+perspective_id: internet-native
+evaluator_mood: >-
+  Entendi: densidade sem formalismo é movimento. Post B não resume sua própria
+  estrutura, ela apenas persiste. Elegância lateral.
+mood_glyph: ċ
+evaluator_mood_after: >-
+  Estou com vontade de rir sozinho na frente do computador de novo — sinto falta
+  disso essa semana, um texto que me pegue de surpresa no meio de algo sério.
+impression_a: null
+impression_b: null
+rate_a: 3.1
+rate_b: 4.55
+clash: >-
+  Qual eu mandaria com só 'lê isso'? the-license-that-knocks, sem hesitar. Ele
+  constrói a piada do ERP interplanetário com uma lista de nomes em PascalCase
+  que parece inofensiva até virar punchline, e municia isso três vezes — 'Essa
+  foi a primeira ideia. Ela durou pouco.', 'Ainda bem.', o título da seção do
+  ERP — sempre deixando o parágrafo sério (direito autoral, proveniência de
+  policy) cair logo depois, sem aviso, com a guarda baixa do leitor. these-lines
+  não tem uma piada sequer; é grave do primeiro ao último parágrafo, e a única
+  variação de ritmo que encontrei — o narrador antecipando a própria pergunta do
+  leitor — é resolvida com mais solenidade, não com uma quebra de registro. Isso
+  não o torna pior como literatura, mas torna pior pelo critério exato desta
+  perspectiva: teria que preparar o leitor de these-lines ('é ficção densa,
+  reserve um tempo'), e nunca precisaria preparar o leitor de
+  the-license-that-knocks. Estrelas seguem essa distância, que estimo em pelo
+  menos 3:1.
+review_a: >-
+  these-lines é bonito e sério do início ao fim — sério demais para o teste que
+  importa aqui. Não existe uma única piada, nem uma frase que quebre o registro
+  contemplativo para me surpreender rindo. O momento mais próximo de um golpe de
+  ritmo é quando o narrador pensa 'por que estou lendo isto' e a frase seguinte
+  antecipa exatamente essa pergunta — um truque estrutural elegante, quase um
+  jump scare de metaficção — mas ele é resolvido com mais solenidade ('Eu não
+  estava sendo adivinhado. Estava sendo classificado.'), não com humor. Isso é
+  dryness que performa seriedade o texto inteiro assume que gravidade constante
+  sustenta atenção, e para um leitor educado em vídeo-ensaio isso cansa: falta a
+  variação de registro que faz o parágrafo sério doer. Eu não mandaria
+  these-lines com só 'lê isso' — precisaria dizer 'é ficção densa sobre
+  compressão e consciência, dá uns 15 minutos e um café antes'. No momento em
+  que preciso preparar o leitor, o texto não fez o trabalho.
+review_b: >-
+  the-license-that-knocks é exatamente o ritmo que essa perspectiva foi feita
+  para premiar. 'Essa foi a primeira ideia. Ela durou pouco.' — duas frases
+  secas, cômicas por corte, sem anunciar a piada. 'você começa tentando cobrar
+  0,001 alguma-coisa e três horas depois está projetando o SAP para civilizações
+  interplanetárias' me fez rir de verdade porque o setup (a lista crescente de
+  PascalCase) construiu a piada sem que eu percebesse que estava sendo
+  construída. E aí, sem aviso, o registro muda: a seção sobre o art. 8º da Lei
+  9.610/1998 chega séria, quase austera, logo depois de 'Ainda bem.' fechar a
+  piada anterior — e a seriedade acerta justamente porque eu não estava na
+  postura defensiva de quem lê texto jurídico. O título 'O momento em que quase
+  nasceu um ERP de quatro arquivos Markdown' já é a piada inteira resumida.
+  Mandaria this com só 'lê isso, é sobre licenciar skills de IA e fica ótimo a
+  partir do primeiro buraco encontrado' — e nem precisaria da segunda parte da
+  frase.
+---
+

--- a/.routines/hronir/rates/2026-08-10T13-15-52-767_the-license-that-knocks_x_these-lines.md
+++ b/.routines/hronir/rates/2026-08-10T13-15-52-767_the-license-that-knocks_x_these-lines.md
@@ -1,0 +1,85 @@
+---
+type: Rate File
+run_id: 2026-08-10T13-15-52-767
+run_at: '2026-08-10T13:15:52.767Z'
+post_a:
+  key: the-license-that-knocks
+  path: src/content/blog/the-license-that-knocks.md
+  display_lang: en
+  content_lang: en
+  version: c90611e9-1a03-59a2-b537-6d6b31675c16
+  ref: the-license-that-knocks@c90611e9-1a03-59a2-b537-6d6b31675c16
+post_b:
+  key: these-lines
+  path: src/content/blog/these-lines.md
+  display_lang: en
+  content_lang: en
+  version: 39f47c66-a323-534b-bbf0-37553879712c
+  ref: these-lines@39f47c66-a323-534b-bbf0-37553879712c
+winner: b
+agent_id: claude-hronir-routine
+content_mode: path-only
+objective: coverage
+eval_lang: pt
+review_lang: pt
+prompt_version: stars-v3
+season: 1
+override: null
+perspective_id: lateral-essayist
+evaluator_mood: >-
+  A flauta oca continua tocando depois que paro de soprar. Pensei: talvez a
+  incompletude seja o som mais verdadeiro que temos.
+mood_glyph: ү
+evaluator_mood_after: >-
+  Sinto um silêncio bom depois de ler algo que não se fechou — não quero
+  preencher esse silêncio agora, só ficar um instante com o que ainda ecoa antes
+  de seguir.
+impression_a: null
+impression_b: null
+rate_a: 3.2
+rate_b: 4.6
+clash: >-
+  Qual está viva por causa da própria ordem? these-lines, sem disputa real. Movi
+  mentalmente a seção de Arjuna para o início e o texto morreu — ela só
+  significa algo depois de atravessar P e Q, a dobra, a pré-eternidade; sem esse
+  caminho, é só uma referência à Gita jogada cedo demais. E o retorno à frase de
+  abertura no final não é truque: a frase é a mesma, mas eu não sou mais o mesmo
+  leitor dela. the-license-that-knocks, ao contrário, sobrevive ao
+  embaralhamento — 'The first hole', 'The second hole' e 'The third hole' são
+  três problemas de engenharia resolvidos em paralelo conceitual, presos numa
+  ordem que é a ordem da revisão real, não uma ordem que o argumento exige. E o
+  fechamento em negrito faz o trabalho que a estrutura deveria ter feito
+  sozinha, explicando 'o que estávamos fazendo' em vez de confiar que eu já
+  sabia. these-lines, por uma margem de pelo menos 3:1 — o silêncio no fim de um
+  vale mais do que o parágrafo-conclusão do outro.
+review_a: >-
+  the-license-that-knocks é organizado por títulos que anunciam o próximo
+  movimento: 'A license normally just sits there', 'The first hole', 'The second
+  hole', 'The third hole'. Isso é andaime pedagógico entrando na voz — o texto
+  me diz o que vai discutir antes de discutir. Tentei embaralhar mentalmente
+  'The first hole' (preço não é licença), 'The second hole' (o que é uma
+  invocation) e 'The third hole' (proveniência da policy): a ordem cronológica
+  da revisão real justifica a sequência, mas cada buraco é conceitualmente
+  independente dos outros — poderia ler o da proveniência antes do da invocation
+  sem perder nada. Isso é lista com títulos, não movimento. O fechamento também
+  amarra demais: 'It is a license that teaches machines to leave proof that they
+  complied with it' explica retroativamente o que o texto estava fazendo, em
+  negrito, como se o argumento não confiasse em ter chegado lá sozinho. Há um
+  'Further reading' no final — apêndice de lista, o oposto do que Sebald faria.
+review_b: >-
+  these-lines é a coisa rara: começa em 'Quando li estas linhas pela primeira
+  vez, pareceu-me que seriam sobre compressão' e termina na mesma frase,
+  exatamente, mas ela já não significa o mesmo — agora sei que 'estas linhas' é
+  a compressão com perdas do texto que a narração tentou reconstruir, e que o
+  'eu' nunca foi biografia. Não consigo resumir o movimento sem destruí-lo:
+  tentar dizer 'é sobre compressão, depois consciência, depois memória, depois
+  Arjuna' apaga exatamente o que faz o texto vivo, que é a maneira como cada
+  seção reabre a anterior (a dobra reabre P e Q; a pré-eternidade reabre a
+  dobra; Arjuna reabre tudo como modelos dentro de modelos). Nenhuma seção
+  sobrevive fora de ordem. O final simplesmente para — 'These lines ended there.
+  / The text did not.' — sem amarração, sem resumo, e o que sinto é mais
+  parecido com respeito do que com frustração. A voz também não se alisa:
+  parênteses, hesitações registradas em tempo real ('I do not know whether I
+  stopped at that moment').
+---
+

--- a/.routines/hronir/rates/2026-08-10T13-16-37-087_the-license-that-knocks_x_these-lines.md
+++ b/.routines/hronir/rates/2026-08-10T13-16-37-087_the-license-that-knocks_x_these-lines.md
@@ -1,0 +1,87 @@
+---
+type: Rate File
+run_id: 2026-08-10T13-16-37-087
+run_at: '2026-08-10T13:16:37.087Z'
+post_a:
+  key: the-license-that-knocks
+  path: src/content/blog/a-licenca-que-bate-na-porta.md
+  display_lang: pt
+  content_lang: pt
+  version: e5039a28-90a3-58d9-b849-12aa1dd69d71
+  ref: a-licenca-que-bate-na-porta@e5039a28-90a3-58d9-b849-12aa1dd69d71
+post_b:
+  key: these-lines
+  path: src/content/blog/these-lines.md
+  display_lang: en
+  content_lang: en
+  version: 39f47c66-a323-534b-bbf0-37553879712c
+  ref: these-lines@39f47c66-a323-534b-bbf0-37553879712c
+winner: b
+agent_id: claude-hronir-routine
+content_mode: path-only
+objective: coverage
+eval_lang: pt
+review_lang: pt
+prompt_version: stars-v3
+season: 1
+override: null
+perspective_id: lateral-essayist
+evaluator_mood: >-
+  Oscilante. O glifo ヮ é katakana wa — meia-volta que nunca completa. Ambos
+  falam de duplicidade. Um deixa resíduo de compreensão, o outro deixa
+  questionamento sobre quem está escrevendo.
+mood_glyph: ⛜
+evaluator_mood_after: >-
+  Sinto um leve desconforto de proibição, como se algo travasse uma volta antes
+  de fechar — vou deixar em aberto por agora, sem forçar a mão.
+impression_a: null
+impression_b: null
+rate_a: 3.25
+rate_b: 4.5
+clash: >-
+  Qual está viva por causa da própria ordem? these-lines segue na frente. A
+  prova mais simples: a frase de abertura reaparece letra por letra no
+  fechamento, e ainda assim não é repetição — é o mesmo objeto visto depois de
+  ter atravessado P e Q, a dobra, a pré-eternidade, Arjuna. Retirar qualquer uma
+  dessas paradas quebra o retorno. a-licenca-que-bate-na-porta sobrevive ao
+  embaralhamento porque foi desenhada para isso: os três 'buracos' são
+  subtítulos numerados que anunciam sua própria função antes de cumpri-la, e a
+  ordem entre eles é a ordem em que o autor os revisou de verdade, não uma ordem
+  que o pensamento exige — poderia começar pelo buraco da proveniência sem
+  perder nada. O fechamento em negrito de a-licenca-que-bate-na-porta também faz
+  o trabalho que a estrutura deveria fazer sozinha, dizendo em voz alta 'era
+  isso que estávamos fazendo'. these-lines nunca precisa dizer isso;
+  simplesmente para. A distância que sinto é de pelo menos 3:1 a favor de
+  these-lines.
+review_a: >-
+  a-licenca-que-bate-na-porta é organizada por subtítulos que anunciam a próxima
+  parada: 'Uma licença normalmente fica parada', 'O primeiro buraco: preço não
+  concede licença', 'O segundo buraco: o que é uma invocation?', 'O terceiro
+  buraco'. É andaime pedagógico assumido — o texto me avisa o que vai discutir
+  antes de discutir, o oposto do que essa leitura pede. Embaralhei os três
+  buracos mentalmente: preço-não-é-licença, definição de invocation,
+  proveniência da policy. Nenhum depende estruturalmente do anterior — são três
+  problemas de engenharia resolvidos em paralelo, ordenados pela cronologia real
+  da revisão, não por uma necessidade do argumento. Isso é lista com títulos
+  numerados por metáfora ('buraco 1, 2, 3'), não movimento. O fechamento amarra
+  tudo em negrito — 'É uma licença que ensina as máquinas a deixar provas de que
+  a cumpriram' — explicando retroativamente o que o texto estava fazendo, quando
+  deveria confiar que eu já tinha percebido sozinho. Há até um apêndice 'Para se
+  aprofundar' no final: o gesto mais anti-Sebald possível.
+review_b: >-
+  these-lines abre com 'When I first read these lines, it seemed to me that they
+  would be about compression' e fecha com a frase idêntica — mas quando ela
+  retorna, já não significa o mesmo, porque nas páginas entre as duas
+  ocorrências aprendi que 'estas linhas' são a versão comprimida com perdas do
+  texto que a narração tenta reconstruir, e que o pronome 'eu' nunca foi
+  biografia. Não consigo resumir o movimento numa frase sem destruí-lo: dizer 'é
+  sobre compressão, depois consciência, depois memória, depois Arjuna' apaga o
+  fato de que cada seção reabre a anterior com um sentido novo — a dobra reabre
+  P e Q, a pré-eternidade reabre a dobra, Arjuna reabre tudo como modelos dentro
+  de modelos contendo modelos. Testei mover a passagem de Arjuna para o início:
+  ela morre lá, porque só significa algo depois da 'dobra' e da 'pré-eternidade'
+  terem sido construídas. O final simplesmente para — 'These lines ended there.
+  / The text did not.' — sem resumo, sem conclusão, e o que sinto é mais
+  parecido com respeito do que com frustração.
+---
+

--- a/.routines/hronir/rates/2026-08-10T13-17-26-176_the-license-that-knocks_x_these-lines.md
+++ b/.routines/hronir/rates/2026-08-10T13-17-26-176_the-license-that-knocks_x_these-lines.md
@@ -1,0 +1,82 @@
+---
+type: Rate File
+run_id: 2026-08-10T13-17-26-176
+run_at: '2026-08-10T13:17:26.176Z'
+post_a:
+  key: the-license-that-knocks
+  path: src/content/blog/the-license-that-knocks.md
+  display_lang: en
+  content_lang: en
+  version: c90611e9-1a03-59a2-b537-6d6b31675c16
+  ref: the-license-that-knocks@c90611e9-1a03-59a2-b537-6d6b31675c16
+post_b:
+  key: these-lines
+  path: src/content/blog/estas-linhas.md
+  display_lang: pt
+  content_lang: pt
+  version: fd8dd2b3-dff4-5c6e-a0d6-d15115e6e070
+  ref: estas-linhas@fd8dd2b3-dff4-5c6e-a0d6-d15115e6e070
+winner: b
+agent_id: claude-hronir-routine
+content_mode: path-only
+objective: coverage
+eval_lang: pt
+review_lang: pt
+prompt_version: stars-v3
+season: 1
+override: null
+perspective_id: felt-not-explained
+evaluator_mood: >-
+  O glifo soa. Vejo a engenharia se tornando poesia, e a poesia sendo máquina.
+  Reconheço agora a diferença: um texto explica dualidade, o outro a realiza no
+  som.
+mood_glyph: '0'
+evaluator_mood_after: >-
+  Sinto o corpo mais pesado agora, como depois de chorar sem ter chorado de fato
+  — quero ficar quieto um instante antes de voltar a falar com alguém.
+impression_a: null
+impression_b: null
+rate_a: 2.9
+rate_b: 4.65
+clash: >-
+  Qual fica comigo depois de fechar a aba? these-lines, sem disputa. A pergunta
+  sobre reconstrução perfeita de um estado consciente — 'existe alguma diferença
+  entre o original e a cópia perfeita, do lado de dentro?' — não é algo que eu
+  processo e arquivo; é algo que continuo sentindo enquanto escrevo esta frase,
+  porque toca o mesmo medo que qualquer pessoa carrega sobre a própria
+  continuidade. the-license-that-knocks é sincero, bem-argumentado, e eu
+  acreditei nele o tempo todo — mas poderia reler amanhã e sentir exatamente a
+  mesma coisa que sinto agora, que é respeito técnico, não abalo. these-lines eu
+  teria receio de reler cedo demais, porque a pergunta ainda está aberta dentro
+  de mim. Essa assimetria é o veredito: o primeiro produz qualificação, o
+  segundo produz mudança. these-lines, por uma margem de pelo menos 4:1.
+review_a: >-
+  the-license-that-knocks abre com uma frase que promete risco pessoal — 'Meu
+  repositório de skills não tinha licença' — mas o risco nunca chega a ser
+  emocional, vira imediatamente engenharia. Procurei o parágrafo onde algo
+  aconteceria comigo, não onde eu entenderia algo, e não encontrei: mesmo os
+  momentos mais próximos de confissão ('nós quase estragamos a ideia construindo
+  arquitetura demais') são relatados de uma posição segura, o autor observando a
+  si mesmo ter tido uma ideia ruim, não me fazendo sentir o peso de tê-la tido.
+  É um texto bem argumentado, correto, interessante — e no sentido desta
+  leitura, estéril: termino qualificado sobre licenciamento de Agent Skills, não
+  mudado. Não há uma frase que eu carregasse comigo por uma hora depois de
+  fechar a aba. A seção sobre direito autoral chega perto de um risco real (o
+  que ele pode ou não possuir), mas resolve isso como argumento jurídico, não
+  como vulnerabilidade.
+review_b: >-
+  these-lines (na versão em português, estas-linhas) tem o parágrafo que a
+  leitura desta perspectiva existe para encontrar: 'Do lado de dentro, existe
+  alguma diferença entre um estado consciente original e sua reconstrução
+  perfeita?' Não é uma pergunta retórica sobre filosofia da mente — é a pergunta
+  que qualquer pessoa que já teve medo de deixar de existir já fez sem essas
+  palavras, e o texto a devolve antes que eu soubesse que a tinha. O resíduo não
+  é o argumento sobre compressão; é a frase final, 'Era a lembrança do universo
+  de ter sido eu quando se compreendeu', que carreguei fechando a aba — não
+  porque a entendi, mas porque alguma coisa nela apertou. O narrador não observa
+  a si mesmo sendo tocado: ele registra a irritação real ('por que caminho da
+  minha vida cheguei até aquele texto'), a dúvida real ('Não sei se a aceitei'),
+  sem hedge, sem se proteger de estar errado sobre o próprio sentimento. Isso é
+  vulnerabilidade que serve ao assunto, não confissão pela confissão.
+---
+


### PR DESCRIPTION
5 matches avaliados (rotina `docs/hronir-agent-routine.md`), objetivo `coverage`.

O sampler puxou repetidamente o par `these-lines` × `the-license-that-knocks` (ambos recém-publicados, sub-amostrados) sob quatro perspectivas diferentes:

- **The Long-form Rationalist** — `the-license-that-knocks` venceu (4.40★ vs 3.75★): hedges falseáveis de engenharia contra hedges metafísicos protegidos pela moldura ficcional.
- **The Internet-Native Watcher** — `the-license-that-knocks` venceu (4.55★ vs 3.10★): ritmo cômico e parágrafo sério caindo sem aviso vs. gravidade uniforme sem quebra de registro.
- **The Lateral Essayist** (2x, línguas trocadas) — `these-lines` venceu ambas (4.60★/4.50★ vs 3.20★/3.25★): retorno circular à frase de abertura que ressignifica o início vs. subtítulos que anunciam o próprio movimento.
- **The Felt-Not-Explained Reader** — `these-lines` venceu com folga (4.65★ vs 2.90★): transmissão emocional real vs. prosa bem-argumentada e estéril nesse eixo.

`npm run hronir:select` e `npm run hronir:doctor` rodados após a rodada — 0 inconsistências novas (avisos pré-existentes sobre rate files legados de `music-borges-and-me` seguem intactos, não tocados por esta rodada).

Rate files em `.routines/hronir/rates/`, journal em `.routines/`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ToNz1VXattQdNdNW7ThoS5)_