### PR TITLE
ux: anunciar filtro de tipo do Arquivo para leitores de tela

### DIFF
--- a/.routines/2026-08-11T05-00-41-ux-ui-run.md
+++ b/.routines/2026-08-11T05-00-41-ux-ui-run.md
@@ -1,0 +1,24 @@
+---
+date: "2026-08-11T05:00:41Z"
+branch: ux-ui/run-2026-08-11T05-00-41
+status: open
+---
+
+# Sessão 2026-08-11T05-00-41 — UX/UI
+
+Issues fechadas: #1471
+
+O que foi feito: adicionado elemento `role="status" aria-live="polite"`
+(oculto via `.sr-only`) próximo ao filtro de tipo de post no Arquivo, que
+anuncia a contagem pós-filtro ("N of/de M posts") para leitores de tela.
+Aplicado nas 4 páginas que replicam essa lógica de filtro:
+`archive/index.astro`, `archive/page/[n].astro`, `pt/archive/index.astro`,
+`pt/archive/page/[n].astro` (o issue citava só as duas páginas de índice,
+mas as páginas paginadas têm o mesmo script duplicado e o mesmo gap de
+acessibilidade). A palavra "of"/"de" reaproveita a chave i18n `post.of`
+existente; "posts" é literal nas duas línguas, seguindo o precedente já
+usado em `post.allInSeries` PT.
+
+CI local: astro check ✅ (0 erros) · prettier --check . ✅ · build ✅
+(confirmado no HTML gerado: `data-of="of"` em EN, `data-of="de"` em PT,
+nas 4 rotas — index e page/2 de ambos os idiomas).

--- a/src/pages/archive/index.astro
+++ b/src/pages/archive/index.astro
@@ -86,6 +86,13 @@ const archiveLd = {
       );
     })}
   </div>
+  <span
+    id="archive-filter-status"
+    class="sr-only"
+    role="status"
+    aria-live="polite"
+    data-of={t("en", "post.of")}
+  ></span>
 
   {years.length > 1 && (
     <nav class="year-jump" aria-label="Jump to year">
@@ -305,12 +312,24 @@ const archiveLd = {
   }
   .nav-btn:hover:not(.nav-disabled) { border-color: var(--pico-primary); }
   .nav-disabled { color: var(--pico-muted-color); cursor: default; border-color: transparent; background: transparent; }
+  .sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
 </style>
 <script is:inline>
   (function () {
     const buttons = document.querySelectorAll('[data-type-filter]');
     const rows = document.querySelectorAll('tr[data-type]');
     const sections = document.querySelectorAll('.archive-year');
+    const status = document.getElementById('archive-filter-status');
     function openHashSection() {
       if (!location.hash) return;
       try {
@@ -326,13 +345,19 @@ const archiveLd = {
         buttons.forEach(function (b) { b.setAttribute('aria-pressed', 'false'); b.classList.remove('active'); });
         btn.setAttribute('aria-pressed', 'true');
         btn.classList.add('active');
+        var visibleCount = 0;
         rows.forEach(function (row) {
-          row.style.display = (type === 'all' || row.getAttribute('data-type') === type) ? '' : 'none';
+          var match = type === 'all' || row.getAttribute('data-type') === type;
+          row.style.display = match ? '' : 'none';
+          if (match) visibleCount++;
         });
         sections.forEach(function (sec) {
           var hasVisible = Array.from(sec.querySelectorAll('tr[data-type]')).some(function (r) { return r.style.display !== 'none'; });
           sec.style.display = hasVisible ? '' : 'none';
         });
+        if (status) {
+          status.textContent = visibleCount + ' ' + status.getAttribute('data-of') + ' ' + rows.length + ' posts';
+        }
       });
     });
   })();

--- a/src/pages/archive/page/[n].astro
+++ b/src/pages/archive/page/[n].astro
@@ -104,6 +104,13 @@ const archiveLd = {
       );
     })}
   </div>
+  <span
+    id="archive-filter-status"
+    class="sr-only"
+    role="status"
+    aria-live="polite"
+    data-of={t("en", "post.of")}
+  ></span>
 
   {years.length > 1 && (
     <nav class="year-jump" aria-label="Jump to year">
@@ -325,12 +332,24 @@ const archiveLd = {
   }
   .nav-btn:hover:not(.nav-disabled) { border-color: var(--pico-primary); }
   .nav-disabled { color: var(--pico-muted-color); cursor: default; border-color: transparent; background: transparent; }
+  .sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
 </style>
 <script is:inline>
   (function () {
     const buttons = document.querySelectorAll('[data-type-filter]');
     const rows = document.querySelectorAll('tr[data-type]');
     const sections = document.querySelectorAll('.archive-year');
+    const status = document.getElementById('archive-filter-status');
     function openHashSection() {
       if (!location.hash) return;
       try {
@@ -346,13 +365,19 @@ const archiveLd = {
         buttons.forEach(function (b) { b.setAttribute('aria-pressed', 'false'); b.classList.remove('active'); });
         btn.setAttribute('aria-pressed', 'true');
         btn.classList.add('active');
+        var visibleCount = 0;
         rows.forEach(function (row) {
-          row.style.display = (type === 'all' || row.getAttribute('data-type') === type) ? '' : 'none';
+          var match = type === 'all' || row.getAttribute('data-type') === type;
+          row.style.display = match ? '' : 'none';
+          if (match) visibleCount++;
         });
         sections.forEach(function (sec) {
           var hasVisible = Array.from(sec.querySelectorAll('tr[data-type]')).some(function (r) { return r.style.display !== 'none'; });
           sec.style.display = hasVisible ? '' : 'none';
         });
+        if (status) {
+          status.textContent = visibleCount + ' ' + status.getAttribute('data-of') + ' ' + rows.length + ' posts';
+        }
       });
     });
   })();

--- a/src/pages/pt/archive/index.astro
+++ b/src/pages/pt/archive/index.astro
@@ -92,6 +92,13 @@ const years = [...byYear.keys()].sort((a, b) => b - a);
       );
     })}
   </div>
+  <span
+    id="archive-filter-status"
+    class="sr-only"
+    role="status"
+    aria-live="polite"
+    data-of={t("pt", "post.of")}
+  ></span>
 
   {years.length > 1 && (
     <nav class="year-jump" aria-label="Ir para o ano">
@@ -311,12 +318,24 @@ const years = [...byYear.keys()].sort((a, b) => b - a);
   }
   .nav-btn:hover:not(.nav-disabled) { border-color: var(--pico-primary); }
   .nav-disabled { color: var(--pico-muted-color); cursor: default; border-color: transparent; background: transparent; }
+  .sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
 </style>
 <script is:inline>
   (function () {
     const buttons = document.querySelectorAll('[data-type-filter]');
     const rows = document.querySelectorAll('tr[data-type]');
     const sections = document.querySelectorAll('.archive-year');
+    const status = document.getElementById('archive-filter-status');
     function openHashSection() {
       if (!location.hash) return;
       try {
@@ -332,13 +351,19 @@ const years = [...byYear.keys()].sort((a, b) => b - a);
         buttons.forEach(function (b) { b.setAttribute('aria-pressed', 'false'); b.classList.remove('active'); });
         btn.setAttribute('aria-pressed', 'true');
         btn.classList.add('active');
+        var visibleCount = 0;
         rows.forEach(function (row) {
-          row.style.display = (type === 'all' || row.getAttribute('data-type') === type) ? '' : 'none';
+          var match = type === 'all' || row.getAttribute('data-type') === type;
+          row.style.display = match ? '' : 'none';
+          if (match) visibleCount++;
         });
         sections.forEach(function (sec) {
           var hasVisible = Array.from(sec.querySelectorAll('tr[data-type]')).some(function (r) { return r.style.display !== 'none'; });
           sec.style.display = hasVisible ? '' : 'none';
         });
+        if (status) {
+          status.textContent = visibleCount + ' ' + status.getAttribute('data-of') + ' ' + rows.length + ' posts';
+        }
       });
     });
   })();

--- a/src/pages/pt/archive/page/[n].astro
+++ b/src/pages/pt/archive/page/[n].astro
@@ -110,6 +110,13 @@ const years = [...byYear.keys()].sort((a, b) => b - a);
       );
     })}
   </div>
+  <span
+    id="archive-filter-status"
+    class="sr-only"
+    role="status"
+    aria-live="polite"
+    data-of={t("pt", "post.of")}
+  ></span>
 
   {years.length > 1 && (
     <nav class="year-jump" aria-label="Ir para o ano">
@@ -331,12 +338,24 @@ const years = [...byYear.keys()].sort((a, b) => b - a);
   }
   .nav-btn:hover:not(.nav-disabled) { border-color: var(--pico-primary); }
   .nav-disabled { color: var(--pico-muted-color); cursor: default; border-color: transparent; background: transparent; }
+  .sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
 </style>
 <script is:inline>
   (function () {
     const buttons = document.querySelectorAll('[data-type-filter]');
     const rows = document.querySelectorAll('tr[data-type]');
     const sections = document.querySelectorAll('.archive-year');
+    const status = document.getElementById('archive-filter-status');
     function openHashSection() {
       if (!location.hash) return;
       try {
@@ -352,13 +371,19 @@ const years = [...byYear.keys()].sort((a, b) => b - a);
         buttons.forEach(function (b) { b.setAttribute('aria-pressed', 'false'); b.classList.remove('active'); });
         btn.setAttribute('aria-pressed', 'true');
         btn.classList.add('active');
+        var visibleCount = 0;
         rows.forEach(function (row) {
-          row.style.display = (type === 'all' || row.getAttribute('data-type') === type) ? '' : 'none';
+          var match = type === 'all' || row.getAttribute('data-type') === type;
+          row.style.display = match ? '' : 'none';
+          if (match) visibleCount++;
         });
         sections.forEach(function (sec) {
           var hasVisible = Array.from(sec.querySelectorAll('tr[data-type]')).some(function (r) { return r.style.display !== 'none'; });
           sec.style.display = hasVisible ? '' : 'none';
         });
+        if (status) {
+          status.textContent = visibleCount + ' ' + status.getAttribute('data-of') + ' ' + rows.length + ' posts';
+        }
       });
     });
   })();


### PR DESCRIPTION
Closes #1471

## O que foi feito

Adiciona um elemento `role="status" aria-live="polite"` (oculto visualmente
via `.sr-only`, não `display:none`) próximo ao filtro de tipo de post
(`.type-filter`) na página Arquivo. Ao clicar em um botão de filtro, o
elemento é atualizado com a contagem pós-filtro (ex. `"3 of 12 posts"` em
EN, `"3 de 12 posts"` em PT), fechando a lacuna de WCAG 4.1.3 (status
messages) apontada na issue: leitores de tela não recebiam nenhum feedback
de que a tabela havia sido filtrada.

Aplicado nas 4 páginas que implementam essa mesma lógica de filtro
(a issue citava só as duas páginas de índice, mas `archive/page/[n].astro`
e `pt/archive/page/[n].astro` duplicam o script idêntico e tinham o mesmo
gap):

- `src/pages/archive/index.astro`
- `src/pages/archive/page/[n].astro`
- `src/pages/pt/archive/index.astro`
- `src/pages/pt/archive/page/[n].astro`

A palavra "of"/"de" reaproveita a chave i18n `post.of` já existente
(passada via `data-of` no elemento, já que o script `is:inline` não tem
acesso ao `t()` do servidor). "posts" é literal nas duas línguas, seguindo
o precedente já usado em `post.allInSeries` (PT: "Todos os *posts* desta
série").

## Invariantes respeitados

- Comportamento visual da filtragem inalterado — só foi adicionado o
  anúncio para leitores de tela.
- Paridade i18n entre as páginas EN e PT.
- Nenhuma dependência nova.

## Validação

- `npx astro check` — 0 erros
- `npx prettier --check .` — ok
- `npm run build` — build completo (astro build + pagefind + ranking
  snapshot); conferido o HTML gerado nas 4 rotas (`data-of="of"` em EN,
  `data-of="de"` em PT).

---
_Generated by [Claude Code](https://claude.ai/code/session_017cVgS4zYQMknivjiSmcMVk)_