### PR TITLE
hronir: 4 matches — claude-hronir-routine

### DIFF
--- a/.routines/2026-08-11T13-29-48-hronir-run.md
+++ b/.routines/2026-08-11T13-29-48-hronir-run.md
@@ -1,0 +1,7 @@
+---
+date: "2026-08-11T13:29:48Z"
+branch: hronir/run-2026-08-11T13-16-06
+status: open
+---
+
+4 matches — claude-hronir-routine. Objetivo coverage. Perspectivas: The Lyric-as-Poem Reader (the-license-that-knocks x these-lines, EN/PT cruzados, 3.15★/4.60★ — these-lines venceu por sustentar o retorno da frase de abertura e o quiasmo final como dispositivo de verso, não só de prosa); The Returning Reader (the-crease-free-fold-exists x three-hammers-walk-into-a-bar, 4.35★/3.10★ — o diário matemático em tempo real com iframe interativo venceu por ser movimento inédito nesta leva, contra o terceiro uso consecutivo do meme memegen.link e da seção "For further reading"); The Long-form Rationalist (music-bibliotecario-do-infinito x the-license-that-knocks, 3.70★/4.55★ — a nota de compositor teve um hedge honesto isolado, mas the-license-that-knocks sustentou trabalho epistêmico cumulativo em toda a extensão); The Craft Listener (the-license-that-knocks x these-lines, PT/PT, 4.10★/4.50★ — these-lines venceu por pouco, por verificar sua própria tese de compressão com perdas dentro da narrativa; teve uma correção manual pós-submissão: backticks em "`metered_public`" dentro do comando bash foram interpretados como substituição de comando e apagaram a palavra em dois pontos do rate file, corrigido diretamente no arquivo antes do commit).

--- a/.routines/hronir/rates/2026-08-11T13-17-56-804_the-license-that-knocks_x_these-lines.md
+++ b/.routines/hronir/rates/2026-08-11T13-17-56-804_the-license-that-knocks_x_these-lines.md
@@ -1,0 +1,102 @@
+---
+type: Rate File
+run_id: 2026-08-11T13-17-56-804
+run_at: '2026-08-11T13:17:56.804Z'
+post_a:
+  key: the-license-that-knocks
+  path: src/content/blog/a-licenca-que-bate-na-porta.md
+  display_lang: pt
+  content_lang: pt
+  version: 9efcd4bf-1a77-5a72-870a-3f7e56b130d8
+  ref: a-licenca-que-bate-na-porta@9efcd4bf-1a77-5a72-870a-3f7e56b130d8
+post_b:
+  key: these-lines
+  path: src/content/blog/these-lines.md
+  display_lang: en
+  content_lang: en
+  version: 39f47c66-a323-534b-bbf0-37553879712c
+  ref: these-lines@39f47c66-a323-534b-bbf0-37553879712c
+winner: b
+agent_id: claude-hronir-routine
+content_mode: path-only
+objective: coverage
+eval_lang: pt
+review_lang: pt
+prompt_version: stars-v3
+season: 1
+override: null
+perspective_id: lyric-as-poem
+evaluator_mood: >-
+  Glifo marca validação. Mas validação de quê? Um deixou trilhos de
+  planejamento. Outro deixou lamas de execução falha. Adeus à acumulação de
+  intenções não-cumpridas.
+mood_glyph: '|'
+evaluator_mood_after: >-
+  Sinto os ombros mais retos, como se tivesse traçado uma linha reta na mesa: um
+  texto que faz aforismo e não confia nele, outro que faz verso e confia até o
+  fim. Quero silêncio agora, sem explicar mais nada.
+impression_a: null
+impression_b: null
+rate_a: 3.15
+rate_b: 4.6
+clash: >-
+  Qual texto sobrevive à leitura fria, sem a melodia da voz que o sustenta?
+  these-lines, com folga. O teste é literal aqui: tire de
+  the-license-that-knocks a ironia acumulada, a piada do ERP, o tom de blog
+  técnico, e o que resta são aforismos isolados, fortes individualmente ('A
+  policy calcula. A licença concede.') mas que não se conectam em movimento de
+  verso — são epigramas espalhados numa prosa argumentativa, não um poema.
+  these-lines, ao contrário, é construído inteiro como dispositivo de linha: a
+  frase de abertura retorna ao fim mudada de sentido pelo próprio ato de ter
+  sido lida, e cada quebra de parágrafo funciona como quebra de verso — 'History
+  would occur once. / The memory would return as many times as the future needed
+  it.' — onde a pausa física na página carrega parte do argumento.
+  the-license-that-knocks tem clareza técnica admirável e frases que li duas
+  vezes por prazer de sintaxe, mas quer ser lido como explicação bem-feita, não
+  como poema; suas melhores linhas funcionam como máximas jurídicas, não como
+  imagens. these-lines quer ser lido como poema desde a primeira palavra e
+  sustenta essa pretensão até a última linha, idêntica à primeira mas já outra.
+  Pela régua desta perspectiva — compressão que resiste à paráfrase, quebra que
+  muda o sentido, retorno que não é repetição — these-lines vence por pelo menos
+  4:1.
+review_a: >-
+  the-license-that-knocks constrói frases curtas que imitam o gesto do verso —
+  'A licença descreve uma regra. A execução da regra fica fora dela.' É uma
+  frase que sobrevive na página: o paralelismo sintático (regra/regra,
+  licença/execução) faz o corte no ponto exato em que a ironia se instala, sem
+  precisar de adjetivo. 'A policy calcula. A licença concede.' tem o mesmo
+  mecanismo — dois verbos, dois sujeitos, nenhuma palavra de sobra, e a
+  distância semântica entre calcular e conceder é o argumento inteiro resumido
+  em seis palavras. Isso é compressão de verdade, não apenas economia de estilo
+  técnico. Mas o texto trai a própria pretensão de densidade toda vez que abre
+  espaço para a piada: 'você começa tentando cobrar 0,001 alguma-coisa e três
+  horas depois está projetando o SAP para civilizações interplanetárias'
+  funciona como prosa cômica, não como verso — precisa da ironia acumulada do
+  parágrafo anterior para funcionar, não sobrevive isolada como as
+  sentenças-aforismo. E o fechamento, 'É uma licença que ensina as máquinas a
+  deixar provas de que a cumpriram', é a linha que mais eu queria que fosse
+  poesia e não é: ela explica o que o texto já mostrou, funciona como nota de
+  compositor que traduz o sentido em vez de deixá-lo ressoar. Teria sido mais
+  forte se confiasse mais nas frases-aforismo e menos no parágrafo-conclusão.
+review_b: >-
+  these-lines é o raro texto em prosa que passa no teste desta leitura sem
+  precisar de nenhuma concessão: tirem a voz narrativa que o sustenta e ainda
+  sobra osso. A frase quase final — 'It was not the memory of my having
+  understood the universe. / It was the universe's memory of having been me when
+  it understood itself.' — é quiasmo perfeito, e aqui o quiasmo não é ornamento:
+  a inversão sintática é o próprio argumento do texto sobre compressão e ponto
+  de vista, feito de estrutura de linha, não de explicação. 'History would occur
+  once. / The memory would return as many times as the future needed it.' tem o
+  mesmo peso — duas frases curtas, quebradas exatamente onde o sentido vira, sem
+  uma palavra de enchimento. A abertura e o fechamento sendo a mesma frase,
+  'When I first read these lines, it seemed to me that they would be about
+  compression', é o tipo de retorno que só a forma permite: lida a segunda vez,
+  ela já significa outra coisa, porque o leitor atravessou o texto inteiro entre
+  as duas ocorrências — isso é rima estrutural, não lexical. Se há uma linha que
+  quase falha o teste, é 'I saw models within models: memories reconstructed by
+  future intelligences, each containing representations of other minds' —
+  funciona mais como resumo explicativo do argumento do que como imagem que só a
+  linha poderia ter feito; é a única passagem em que sinto o autor catalogando a
+  ideia em vez de deixá-la acontecer na sintaxe.
+---
+

--- a/.routines/hronir/rates/2026-08-11T13-19-33-472_the-crease-free-fold-exists_x_three-hammers.md
+++ b/.routines/hronir/rates/2026-08-11T13-19-33-472_the-crease-free-fold-exists_x_three-hammers.md
@@ -1,0 +1,91 @@
+---
+type: Rate File
+run_id: 2026-08-11T13-19-33-472
+run_at: '2026-08-11T13:19:33.472Z'
+post_a:
+  key: the-crease-free-fold-exists
+  path: src/content/blog/the-crease-free-fold-exists.md
+  display_lang: en
+  content_lang: en
+  version: 2eb8fa98-9fe6-5245-9e32-15ebd017ffdb
+  ref: the-crease-free-fold-exists@2eb8fa98-9fe6-5245-9e32-15ebd017ffdb
+post_b:
+  key: three-hammers
+  path: src/content/blog/three-hammers-walk-into-a-bar.md
+  display_lang: en
+  content_lang: en
+  version: 64bd9586-41ca-5f6b-9255-e04aeb4d8a78
+  ref: three-hammers-walk-into-a-bar@64bd9586-41ca-5f6b-9255-e04aeb4d8a78
+winner: a
+agent_id: claude-hronir-routine
+content_mode: path-only
+objective: coverage
+eval_lang: pt
+review_lang: pt
+prompt_version: stars-v3
+season: 1
+override: null
+perspective_id: returning-reader
+evaluator_mood: Bola retorna. Silêncio é préciso.
+mood_glyph: せ
+evaluator_mood_after: >-
+  Sinto o corpo mais leve, como depois de um saque bem devolvido — um texto me
+  deixou quieto diante da matemática, o outro me fez rir e desconfiar da piada
+  ao mesmo tempo. Quero café forte agora.
+impression_a: null
+impression_b: null
+rate_a: 4.35
+rate_b: 3.1
+clash: >-
+  Qual post move o autor para a frente, e qual é o autor em repouso?
+  the-crease-free-fold-exists vence porque faz pelo menos duas coisas que não vi
+  em nenhum outro texto desta leva: o diário matemático em tempo real, com nota
+  de rodapé que credita a descoberta a terceiros enquanto o próprio texto ainda
+  estava sendo escrito, e a visualização interativa embutida via iframe — nenhum
+  dos outros posts tenta isso. three-hammers-walk-into-a-bar, apesar da ideia de
+  abertura ser boa (três personagens de bar que são o mesmo autor), gasta a
+  energia dela reaquecendo um kit já visto: o meme do memegen.link pela terceira
+  vez consecutiva nesta leva (e duas vezes só neste post), a seção 'For further
+  reading' que já apareceu quase idêntica em the-license-that-knocks, e um
+  reveal final que dobra a narrativa sobre si mesma do mesmo jeito que
+  the-license-that-knocks também faz. Dois é variedade; três é assinatura por
+  acidente, e three-hammers é a terceira vez. the-crease-free-fold-exists, por
+  pelo menos 3:1 — é o autor experimentando uma forma nova, não o autor em
+  repouso dentro do próprio estilo.
+review_a: >-
+  the-crease-free-fold-exists faz um movimento que eu não tinha visto nos posts
+  recentes deste autor: o diário datado de um evento matemático em tempo real —
+  '19 de julho, pela manhã, eu conversava com uma IA' — interrompido pela
+  chegada do contraexemplo horas depois, com nota de rodapé creditando a
+  descoberta externa a outra pessoa enquanto o texto ainda está sendo composto.
+  Isso é diferente de the-license-that-knocks e de
+  three-hammers-walk-into-a-bar, que narram processos já fechados; aqui o
+  processo está aberto quando o texto começa e se fecha durante a leitura. A
+  visualização interativa embutida via iframe também é inédita nesta leva —
+  nenhum dos outros textos que vi tem um experimento interativo dentro do corpo,
+  só prosa e imagens estáticas. O meme do memegen.link aparece de novo (já
+  apareceu em the-license-that-knocks), mas aqui é só uma vez e funciona como
+  piada isolada, não como tique repetido três vezes seguidas. O fechamento em
+  blockquote — 'There is no local scene of the crime. There is only the global
+  crime.' — é a mesma aposta em aforismo final que já vi antes, mas pelo menos
+  não é a mesma frase nem a mesma cadência exata.
+review_b: >-
+  three-hammers-walk-into-a-bar tem uma ideia estrutural genuinamente nova — o
+  autor dividido em três personagens de bar que são, cada um, uma faceta
+  profissional sua — mas ao redor dessa ideia ele reaquece três dispositivos que
+  eu já tinha visto nesta mesma leva de posts. O meme do memegen.link aparece de
+  novo, e desta vez duas vezes no mesmo texto, depois de já ter aparecido em
+  the-license-that-knocks e em the-crease-free-fold-exists: pela regra desta
+  leitura, duas ocorrências é variedade, mas esta é a terceira aparição
+  consecutiva do mesmo dispositivo visual, e usá-lo duas vezes no mesmo post
+  empurra ainda mais para tique. A seção final 'For further reading' repete,
+  quase estrutura por estrutura, o 'Para se aprofundar' de
+  the-license-that-knocks — mesma lista numerada de referências externas
+  fechando o texto, mesmo gesto de cross-linking para posts companheiros. O
+  reveal final, em que uma IA 'alinhou' os três personagens em vez do contrário,
+  ecoa o mesmo tipo de virada-que-se-dobra-sobre-si-mesma que
+  the-license-that-knocks também faz no parágrafo de fechamento. É um post
+  inteligente, mas é o autor repetindo o próprio kit de ferramentas, não
+  experimentando um novo.
+---
+

--- a/.routines/hronir/rates/2026-08-11T13-20-36-520_music-bibliotecario-do-infinito_x_the-license-that-knocks.md
+++ b/.routines/hronir/rates/2026-08-11T13-20-36-520_music-bibliotecario-do-infinito_x_the-license-that-knocks.md
@@ -1,0 +1,90 @@
+---
+type: Rate File
+run_id: 2026-08-11T13-20-36-520
+run_at: '2026-08-11T13:20:36.520Z'
+post_a:
+  key: music-bibliotecario-do-infinito
+  path: src/content/blog/bibliotecario-do-infinito-en.mdx
+  display_lang: en
+  content_lang: en
+  version: 750fc5d5-96b1-5cbf-b4d1-9d9fa223b265
+  ref: bibliotecario-do-infinito-en@750fc5d5-96b1-5cbf-b4d1-9d9fa223b265
+post_b:
+  key: the-license-that-knocks
+  path: src/content/blog/the-license-that-knocks.md
+  display_lang: en
+  content_lang: en
+  version: 463fa25c-e0c0-518a-bacd-b4e9537714a7
+  ref: the-license-that-knocks@463fa25c-e0c0-518a-bacd-b4e9537714a7
+winner: b
+agent_id: claude-hronir-routine
+content_mode: path-only
+objective: coverage
+eval_lang: pt
+review_lang: pt
+prompt_version: stars-v3
+season: 1
+override: null
+perspective_id: long-form-rationalist
+evaluator_mood: >-
+  Cansaço de conceitos Borges, alívio com alguém que admite 'não encontrei a
+  falha fundamental mas procuro'. Quero argumentação honesta, não estruturas
+  elegantes. Quero fazer algo, não apenas pensar.
+mood_glyph: ➄
+evaluator_mood_after: >-
+  Sinto que cheguei a um número redondo e quero parar de contar por hoje — as
+  duas leituras me deixaram com vontade de fechar a aba e fazer algo com as
+  mãos, não mais pensar.
+impression_a: null
+impression_b: null
+rate_a: 3.7
+rate_b: 4.55
+clash: >-
+  Qual post faz o trabalho epistêmico mais difícil? the-license-that-knocks, sem
+  disputa real. music-bibliotecario-do-infinito tem um lampejo genuíno de
+  calibração — a admissão de que a fusão de gêneros soou como 'duas músicas em
+  salas separadas' — mas é um hedge isolado, colado ao final, sem que o resto do
+  texto tenha construído o caminho até ali; a afirmação central sobre a
+  Biblioteca estruturando a vida intelectual do autor chega pronta, sem que eu
+  veja o raciocínio que levou a ela. the-license-that-knocks, ao contrário, é
+  feito quase inteiramente de working: cada 'buraco' é uma afirmação anterior
+  que quebrou sob revisão e foi documentada quebrando, não escondida. 'Não é a
+  definição universal de invocation para a humanidade' é o tipo de frase que só
+  aparece quando o autor já tentou e falhou em ser mais ambicioso. Não é
+  bottom-line thinking — dá para sentir a conclusão mudando de forma ao longo do
+  texto. Confio mais em the-license-that-knocks numa margem que estimo em 3:1.
+  As estrelas seguem essa confiança, não o quanto gostei de cada um.
+review_a: >-
+  music-bibliotecario-do-infinito tem um momento epistêmico honesto que eu não
+  esperava numa nota de compositor: 'the weight of the distorted guitars in the
+  chorus attempts to compensate for a lack of real tension in the initial baião
+  harmony... the result often sounds like two different songs playing in
+  separate rooms.' Isso é uma reivindicação central — fusão entre progressive
+  rock e baião como metáfora para a tensão entre ordem e acaso na Biblioteca de
+  Babel — sendo revisada depois do fato, não defendida a qualquer custo. É
+  exatamente o tipo de correção-no-meio-do-parágrafo que esta leitura
+  recompensa. Mas o texto é curto demais para fazer o trabalho cumulativo que a
+  leitura pede: a afirmação central ('a busca pelo Livro Total estrutura minha
+  vida intelectual, e admito isso sem ironia') chega pronta, sem working
+  visível, e só depois ganha um hedge isolado sobre a mixagem final. Não há
+  construção cumulativa onde o meio dependa do início — é confissão pontual, não
+  argumento que se sustenta sozinho. A referência a Borges funciona por
+  ressonância emocional, não por fazer trabalho lógico.
+review_b: >-
+  the-license-that-knocks é o raro texto técnico que mostra o working, não só a
+  conclusão. A frase que entrega isso é: 'Não é a definição universal de
+  invocation para a humanidade. É uma definição suficientemente precisa para que
+  duas máquinas contem igual' — uma recusa explícita de falsa precisão,
+  exatamente onde um post mais fraco proclamaria ter resolvido o problema de
+  verdade. A estrutura em 'buracos' (preço não concede licença, o que é uma
+  invocation, qual policy fez essa conta) é construção cumulativa genuína: cada
+  buraco só aparece porque o desenho anterior foi levado a sério o suficiente
+  para quebrar sob revisão, e o texto documenta a falha antes da correção, não
+  depois. 'Uma licença não cria direitos autorais onde a lei não criou' é outra
+  recusa de autoridade encenada — o autor delimita o próprio poder em vez de
+  inflar o escopo do projeto. O único momento que soa mais como performance de
+  erudição do que trabalho que sustenta o argumento é a lista final 'Para se
+  aprofundar', que cita mais do que usa. Fora isso, é raro ver tanto hedge
+  funcional em tão pouco espaço.
+---
+

--- a/.routines/hronir/rates/2026-08-11T13-21-56-207_the-license-that-knocks_x_these-lines.md
+++ b/.routines/hronir/rates/2026-08-11T13-21-56-207_the-license-that-knocks_x_these-lines.md
@@ -1,0 +1,96 @@
+---
+type: Rate File
+run_id: 2026-08-11T13-21-56-207
+run_at: '2026-08-11T13:21:56.207Z'
+post_a:
+  key: the-license-that-knocks
+  path: src/content/blog/a-licenca-que-bate-na-porta.md
+  display_lang: pt
+  content_lang: pt
+  version: 9efcd4bf-1a77-5a72-870a-3f7e56b130d8
+  ref: a-licenca-que-bate-na-porta@9efcd4bf-1a77-5a72-870a-3f7e56b130d8
+post_b:
+  key: these-lines
+  path: src/content/blog/estas-linhas.md
+  display_lang: pt
+  content_lang: pt
+  version: fd8dd2b3-dff4-5c6e-a0d6-d15115e6e070
+  ref: estas-linhas@fd8dd2b3-dff4-5c6e-a0d6-d15115e6e070
+winner: b
+agent_id: claude-hronir-routine
+content_mode: path-only
+objective: coverage
+eval_lang: pt
+review_lang: pt
+prompt_version: stars-v3
+season: 1
+override: null
+perspective_id: craft-listener
+evaluator_mood: >-
+  Ainda pensando em mudança, mas agora em silhueta. Um desses ensaios me levou
+  pela mão, o outro me deixou perto do abismo seguro.
+mood_glyph: ら
+evaluator_mood_after: >-
+  Sinto uma calma quase geométrica, como quem encaixa a última peça de um
+  quebra-cabeça e percebe que a moldura sempre esteve certa. Quero ficar quieto
+  perto disso mais um instante.
+impression_a: null
+impression_b: null
+rate_a: 4.1
+rate_b: 4.5
+clash: >-
+  Qual texto é coerente entre intenção e execução? these-lines vence, mas por
+  uma margem menor do que eu esperava. O craft de these-lines está inteiramente
+  contido dentro da própria obra: a tese sobre compressão com perdas é ao mesmo
+  tempo o assunto do texto e o método pelo qual ele foi construído — a frase de
+  abertura retorna ao final mudada de sentido, e essa mudança é a prova
+  empírica, dentro da leitura, de que a intenção foi cumprida. Não preciso
+  confiar numa nota externa; o próprio texto se verifica.
+  the-license-that-knocks também entrega sua intenção central — um protocolo
+  mínimo de quatro tipos, depois de documentar honestamente um quase-fracasso de
+  over-engineering e corrigi-lo — mas a entrega final do craft, o regime
+  `metered_public` funcionando de verdade, fica deliberadamente fora do texto: 'a policy vigente
+  continua quote_required'. Isso é uma honestidade que respeito, mas também
+  significa que a comparação entre intenção e execução, para a parte mais
+  ambiciosa do desenho, ainda não pode ser feita — só a intenção e o desenho
+  existem, não o uso real. these-lines, por uma margem que estimo em 3:2.
+review_a: >-
+  A afirmação de craft central de the-license-that-knocks aparece explícita: 'a
+  regra virou: não construir um framework de licenciamento em cima de outro
+  framework de conhecimento'. Meço o texto contra essa intenção e ela é entregue
+  com precisão incomum — o protocolo termina com quatro tipos econômicos
+  obrigatórios (UsageStatement, InvoiceRequest, Invoice, Receipt) depois de um
+  episódio honesto de quase-fracasso ('nós quase estragamos a ideia construindo
+  arquitetura demais', com LicenseeMeteringProfile, MeteringPlan e afins),
+  episódio que o texto não esconde, mostra como sintoma e depois corrige. Isso é
+  constraint honesto de verdade, não retórica. O momento mais forte de craft é a
+  costura invisível revelada pela nota: o bug do okf-parser produzindo grafo com
+  zero arestas porque a relação precisava ser link Markdown explícito no corpo,
+  não string em YAML — um detalhe técnico que, sem a explicação, eu não teria
+  notado como decisão deliberada de design, não acidente. O que falta para a
+  nota fechar o círculo por completo é que o próprio regime `metered_public`
+  nunca chega a ser executado de verdade dentro do texto — 'a policy vigente continua
+  quote_required' — então a intenção de minimalismo é comprovada no desenho, mas
+  ainda não no uso real; o texto é honesto sobre isso, o que ajuda, mas deixa a
+  entrega parcialmente prospectiva.
+review_b: >-
+  these-lines não tem notas de compositor separadas do texto — a intenção
+  estrutural está embutida na própria narrativa, o que torna o teste mais
+  difícil e a entrega mais impressionante quando acontece. O texto declara sua
+  própria teoria de craft dentro da ficção: 'Estas linhas eram uma versão
+  comprimida com perdas... O que se perde numa compressão assim não pode ser
+  recuperado de uma única maneira.' Meço a obra contra essa intenção e ela bate:
+  a frase de abertura, 'Quando li estas linhas pela primeira vez, pareceu-me que
+  seriam sobre compressão', retorna ao final idêntica letra por letra, mas o
+  leitor que chega até lá já não é o mesmo leitor, porque atravessou P e Q, a
+  dobra, a pré-eternidade, Arjuna — a releitura da mesma frase produz um sentido
+  diferente, e isso é a tese sobre compressão com perdas sendo demonstrada pela
+  forma, não apenas descrita por ela. É exatamente o tipo de costura que fica
+  invisível na primeira leitura e legível só quando se nota o retorno. O único
+  ponto em que a execução hesita é o parágrafo 'Vi modelos dentro de modelos:
+  memórias reconstruídas por inteligências futuras, cada qual contendo
+  representações de outras mentes' — funciona mais como resumo do argumento do
+  que como imagem que só a estrutura poderia entregar, uma pequena
+  racionalização retroativa num texto que, no resto, prefere mostrar a dizer.
+---
+


### PR DESCRIPTION
4 matches avaliados (rotina `docs/hronir-agent-routine.md`), objetivo `coverage`.

- **The Lyric-as-Poem Reader** — `the-license-that-knocks` × `these-lines` (línguas cruzadas EN/PT): `these-lines` venceu (3.15★ vs 4.60★). O quiasmo final e o retorno idêntico-porém-ressignificado da frase de abertura funcionam como dispositivo de verso; os aforismos de `the-license-that-knocks` são fortes isoladamente mas não se conectam em movimento de verso.
- **The Returning Reader** — `the-crease-free-fold-exists` × `three-hammers-walk-into-a-bar`: `the-crease-free-fold-exists` venceu (4.35★ vs 3.10★). O diário matemático em tempo real com iframe interativo é movimento inédito nesta leva de posts lidos; `three-hammers` repete o meme memegen.link pela terceira vez consecutiva (duas vezes só nesse post) e a seção "For further reading" já vista em `the-license-that-knocks`.
- **The Long-form Rationalist** — `music-bibliotecario-do-infinito` × `the-license-that-knocks`: `the-license-that-knocks` venceu (3.70★ vs 4.55★). A nota de compositor tem um hedge honesto isolado sobre a fusão de gêneros não ter funcionado; `the-license-that-knocks` sustenta trabalho epistêmico cumulativo (os "buracos" documentados e corrigidos) ao longo de todo o texto.
- **The Craft Listener** — `the-license-that-knocks` × `these-lines` (duelo PT/PT): `these-lines` venceu por pouco (4.10★ vs 4.50★). A tese de compressão com perdas de `these-lines` se verifica dentro da própria narrativa (retorno da frase de abertura); o protocolo minimalista de `the-license-that-knocks` é bem desenhado mas sua execução real (`metered_public`) fica deliberadamente fora do texto.

`npm run hronir:select` e `npm run hronir:doctor` rodados após a rodada — 0 inconsistências novas (avisos pré-existentes sobre rate files legados de `music-borges-and-me` seguem intactos, não tocados por esta rodada).

Nota operacional: um dos rate files (`2026-08-11T13-21-56-207`) teve a palavra `metered_public` apagada em dois pontos durante a submissão, porque os backticks ao redor dela dentro do comando bash foram interpretados como substituição de comando pelo shell. Corrigido diretamente no arquivo antes do commit, sem re-submeter o match.

Rate files em `.routines/hronir/rates/`, journal em `.routines/`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AJ3MWqF7x2Lk3Nud9UmfQ9)_