### PR TITLE
ux: coordena Escape entre dropdowns e drawer, aria-modal + focus trap

### DIFF
--- a/.routines/2026-08-12T05-08-46-ux-ui-run.md
+++ b/.routines/2026-08-12T05-08-46-ux-ui-run.md
@@ -1,0 +1,34 @@
+---
+date: "2026-08-12T05:08:46Z"
+branch: ux-ui/run-2026-08-12T05-00-58
+status: open
+---
+
+# Sessão 2026-08-12T05-08-46 — UX/UI
+
+Issues fechadas: #1522, #1523
+
+O que foi feito: as duas issues tratavam do mesmo par de componentes
+(`Header.astro` + `GlobalMusicPlayer.astro`) e foram resolvidas juntas numa
+sessão só:
+
+- Criado `src/lib/overlay-stack.ts` — pilha compartilhada em `window` para
+  coordenar overlays independentes. Cada overlay empilha seu id ao abrir e
+  desempilha ao fechar; um handler de Escape só age se seu id estiver no
+  topo da pilha.
+- `Header.astro`: os dropdowns `details.dropdown` agora empilham/desempilham
+  via evento nativo `toggle`; `closeOpenDropdowns` só fecha no Escape se
+  `header-dropdown` for o topo da pilha (#1522).
+- `GlobalMusicPlayer.astro`: o drawer de fila (`#gmp-drawer`) empilha/desempilha
+  em todos os pontos de abertura/fechamento (botão, clique fora, Escape,
+  seleção de item, fechar o player); Escape só fecha o drawer se
+  `gmp-drawer` for o topo da pilha (#1522). Adicionado `aria-modal="true"`
+  ao drawer e um focus trap Tab/Shift+Tab escopado a `#gmp-drawer` quando
+  aberto (#1523).
+
+CI local: astro check ✅ (0 erros) · prettier ✅ · build ✅ · testes unitários
+✅ (162/162) · verificado em navegador real (Playwright/Chromium) contra o
+build estático: Escape único com dropdown+drawer abertos fecha só o drawer
+(mais recente); segundo Escape fecha o dropdown; Tab no último item do
+drawer volta ao primeiro; Shift+Tab no primeiro vai ao último; foco nunca
+sai do drawer enquanto ele está aberto.

--- a/src/components/GlobalMusicPlayer.astro
+++ b/src/components/GlobalMusicPlayer.astro
@@ -191,7 +191,7 @@ try {
   >
 </div>
 
-<div id="gmp-drawer" hidden role="dialog" aria-label={L.queueDialog}>
+<div id="gmp-drawer" hidden role="dialog" aria-modal="true" aria-label={L.queueDialog}>
   <div class="gmp-drawer-header">
     <span>{L.queueLabel}</span>
     <button id="gmp-drawer-close" type="button" aria-label={L.closeQueue}>✕</button>
@@ -200,6 +200,8 @@ try {
 </div>
 
 <script>
+  import { pushOverlay, removeOverlay, isTopOverlay } from "../lib/overlay-stack";
+
   const SONG_RE = /suno\.com\/song\/([0-9a-fA-F-]{36})/;
   const REPEAT_OFF = "off";
   const REPEAT_ALL = "all";
@@ -470,6 +472,7 @@ try {
           item.addEventListener("click", () => {
             playSong(qIdx);
             drawerEl.hidden = true;
+            removeOverlay("gmp-drawer");
           });
           drawerList.appendChild(item);
         });
@@ -627,31 +630,58 @@ try {
         renderDrawer();
         drawerEl.hidden = !drawerEl.hidden;
         if (wasHidden && !drawerEl.hidden) {
+          pushOverlay("gmp-drawer");
           const firstItem = drawerList.querySelector<HTMLButtonElement>(".gmp-drawer-item");
           (firstItem ?? drawerCloseBtn).focus();
+        } else if (!wasHidden && drawerEl.hidden) {
+          removeOverlay("gmp-drawer");
         }
       });
 
       drawerCloseBtn.addEventListener("click", () => {
         drawerEl.hidden = true;
+        removeOverlay("gmp-drawer");
       });
 
       document.addEventListener("click", (e) => {
         if (!drawerEl.hidden && !drawerEl.contains(e.target as Node) && e.target !== queueBtn) {
           drawerEl.hidden = true;
+          removeOverlay("gmp-drawer");
         }
       });
 
       document.addEventListener("keydown", (e) => {
-        if (e.key === "Escape" && !drawerEl.hidden) {
+        if (drawerEl.hidden) return;
+
+        if (e.key === "Escape") {
+          if (!isTopOverlay("gmp-drawer")) return;
           drawerEl.hidden = true;
+          removeOverlay("gmp-drawer");
           queueBtn.focus();
+          return;
+        }
+
+        if (e.key === "Tab") {
+          const focusable = drawerEl.querySelectorAll<HTMLElement>(
+            'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
+          );
+          if (!focusable.length) return;
+          const first = focusable[0];
+          const last = focusable[focusable.length - 1];
+          if (e.shiftKey && document.activeElement === first) {
+            e.preventDefault();
+            last.focus();
+          } else if (!e.shiftKey && document.activeElement === last) {
+            e.preventDefault();
+            first.focus();
+          }
         }
       });
 
       closeBtn.addEventListener("click", () => {
         audio.pause();
         player.hidden = true;
+        if (!drawerEl.hidden) removeOverlay("gmp-drawer");
         drawerEl.hidden = true;
         player.removeAttribute("data-playing-id");
         document.body.classList.remove("gmp-active");

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -180,6 +180,8 @@ const secondaryCurrent = secondaryLinks.some((link) => isCurrent(link.href));
 </header>
 
 <script>
+  import { pushOverlay, removeOverlay, isTopOverlay } from '../lib/overlay-stack';
+
   function syncMusicBtn(audio: HTMLAudioElement | null) {
     const btns = document.querySelectorAll<HTMLButtonElement>('.nav-music-btn');
     btns.forEach((btn) => {
@@ -294,17 +296,37 @@ const secondaryCurrent = secondaryLinks.some((link) => isCurrent(link.href));
 
   function closeOpenDropdowns(event: KeyboardEvent) {
     if (event.key !== 'Escape') return;
+    if (!isTopOverlay('header-dropdown')) return;
     const openDropdowns = document.querySelectorAll<HTMLDetailsElement>('details.dropdown[open]');
     openDropdowns.forEach((details) => {
       details.removeAttribute('open');
       details.querySelector('summary')?.focus();
     });
+    removeOverlay('header-dropdown');
   }
 
   if (!win.__dropdownEscBound) {
     win.__dropdownEscBound = true;
     document.addEventListener('keydown', closeOpenDropdowns);
   }
+
+  function bindDropdownOverlayTracking() {
+    document.querySelectorAll<HTMLDetailsElement>('details.dropdown').forEach((details) => {
+      if (details.dataset.overlayBound === '1') return;
+      details.dataset.overlayBound = '1';
+      details.addEventListener('toggle', () => {
+        if (details.open) pushOverlay('header-dropdown');
+        else removeOverlay('header-dropdown');
+      });
+    });
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', bindDropdownOverlayTracking);
+  } else {
+    bindDropdownOverlayTracking();
+  }
+  document.addEventListener('astro:page-load', bindDropdownOverlayTracking);
 </script>
 
 <style>

--- a/src/lib/__tests__/overlay-stack.test.ts
+++ b/src/lib/__tests__/overlay-stack.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+
+// overlay-stack.ts reads/writes `window.__overlayStack` lazily inside each
+// function call (not at import time), so aliasing `window` to `globalThis`
+// is enough to exercise it under node:test -- no DOM/jsdom needed.
+(globalThis as unknown as { window: typeof globalThis }).window = globalThis;
+
+const { pushOverlay, removeOverlay, isTopOverlay } =
+  await import("../overlay-stack.ts");
+
+describe("overlay-stack", () => {
+  beforeEach(() => {
+    (globalThis as unknown as { __overlayStack?: string[] }).__overlayStack =
+      undefined;
+  });
+
+  it("nothing is on top before anything is pushed", () => {
+    assert.equal(isTopOverlay("a"), false);
+  });
+
+  it("the most recently pushed id is on top", () => {
+    pushOverlay("a");
+    pushOverlay("b");
+    assert.equal(isTopOverlay("b"), true);
+    assert.equal(isTopOverlay("a"), false);
+  });
+
+  it("re-pushing an id already on the stack moves it to the top instead of duplicating it", () => {
+    pushOverlay("a");
+    pushOverlay("b");
+    pushOverlay("a");
+    assert.equal(isTopOverlay("a"), true);
+    removeOverlay("a");
+    // if "a" had been duplicated instead of moved, it would still be on top here
+    assert.equal(isTopOverlay("b"), true);
+  });
+
+  it("removing the top overlay reveals the one beneath it", () => {
+    pushOverlay("a");
+    pushOverlay("b");
+    removeOverlay("b");
+    assert.equal(isTopOverlay("a"), true);
+  });
+
+  it("removing an id that isn't on the stack is a no-op", () => {
+    pushOverlay("a");
+    removeOverlay("nonexistent");
+    assert.equal(isTopOverlay("a"), true);
+  });
+});

--- a/src/lib/overlay-stack.ts
+++ b/src/lib/overlay-stack.ts
@@ -1,0 +1,34 @@
+// Coordinates Escape-key handling between independently-registered overlay
+// listeners (Header dropdowns, music player queue drawer) so a single
+// Escape press closes only the most-recently-opened overlay instead of
+// every open overlay at once. Each overlay pushes its id when it opens and
+// removes it when it closes; an Escape handler should act only if its id is
+// on top of the stack.
+declare global {
+  interface Window {
+    __overlayStack?: string[];
+  }
+}
+
+function stack(): string[] {
+  if (!window.__overlayStack) window.__overlayStack = [];
+  return window.__overlayStack;
+}
+
+export function pushOverlay(id: string): void {
+  const s = stack();
+  const i = s.indexOf(id);
+  if (i !== -1) s.splice(i, 1);
+  s.push(id);
+}
+
+export function removeOverlay(id: string): void {
+  const s = stack();
+  const i = s.indexOf(id);
+  if (i !== -1) s.splice(i, 1);
+}
+
+export function isTopOverlay(id: string): boolean {
+  const s = stack();
+  return s.length > 0 && s[s.length - 1] === id;
+}


### PR DESCRIPTION
Closes #1522, Closes #1523

## O que foi feito

As duas issues tratam do mesmo par de componentes (`Header.astro` +
`GlobalMusicPlayer.astro`), então foram resolvidas juntas nesta sessão.

**#1522 — Escape competindo entre Header e drawer do music player**

`Header.astro` e `GlobalMusicPlayer.astro` registravam cada um seu próprio
listener de `keydown` para `Escape`, sem coordenação: com o dropdown do
Header e o drawer de fila do player abertos ao mesmo tempo, um único Escape
fechava os dois de uma vez. Criado `src/lib/overlay-stack.ts` — uma pilha
compartilhada em `window` onde cada overlay empilha seu id ao abrir e
desempilha ao fechar; um handler de Escape só age se seu id estiver no topo
da pilha. Os dropdowns do Header empilham/desempilham via evento nativo
`toggle`; o drawer do player empilha/desempilha em todos os pontos de
abertura/fechamento (botão, clique fora, Escape, seleção de item, fechar o
player).

**#1523 — drawer de fila sem `aria-modal` nem focus trap**

`#gmp-drawer` ganhou `aria-modal="true"`. Adicionado um focus trap
Tab/Shift+Tab escopado ao drawer quando aberto: `Tab` no último elemento
focável volta ao primeiro, `Shift+Tab` no primeiro vai ao último — sem
afetar a navegação por Tab do resto da página quando o drawer está
fechado.

## Invariantes respeitados

- Comportamento isolado de cada painel inalterado (Escape já funcionava
  corretamente quando só um dos dois estava aberto; abrir/fechar por clique
  continua igual).
- Nenhuma dependência nova.

## Validação

- `npx astro check` — 0 erros
- `npx prettier --check .` — ok
- `npm run build` — build completo; conferido `aria-modal="true"` no HTML
  gerado em EN (`dist/index.html`) e PT (`dist/pt/index.html`)
- `npm test` — 162/162 testes unitários passando
- `npm run check:hygiene` — ok
- Verificado em navegador real (Playwright/Chromium) contra o build
  estático: abrir o dropdown do Header + o drawer do player e apertar
  Escape uma vez fecha só o drawer (mais recente); um segundo Escape fecha
  o dropdown; `Tab` no último item do drawer volta ao primeiro;
  `Shift+Tab` no primeiro vai ao último; o foco nunca sai do drawer
  enquanto ele está aberto.


---
_Generated by [Claude Code](https://claude.ai/code/session_017ntwhjCr8rCtpCP9Sx1vHb)_