### PR TITLE
ux: persiste #gmp-drawer entre navegações soft do ClientRouter

### DIFF
--- a/.routines/2026-08-13T05-09-57-ux-ui-run.md
+++ b/.routines/2026-08-13T05-09-57-ux-ui-run.md
@@ -1,0 +1,29 @@
+---
+date: "2026-08-13T05:09:57Z"
+branch: claude/ecstatic-hawking-xgl44z
+status: open
+---
+
+# Sessão 2026-08-13T05-09-57 — UX/UI
+
+Issues fechadas: #1531
+O que foi feito: `#gmp-drawer` (GlobalMusicPlayer) ganhou `transition:persist`,
+igual ao `#gmp` pai — antes, como o drawer não sobrevivia às trocas de página
+do ClientRouter mas seus listeners eram vinculados só uma vez (dentro do
+bloco `if (!alreadyInit)`), toda navegação soft deixava o drawer visível
+sem nenhum listener funcional (clique no "≡" mexia no elemento fantasma da
+primeira página). Persistindo o elemento, os listeners continuam válidos.
+Como o drawer persistido não é re-renderizado pelo Astro, foi adicionada a
+mesma relabelização por navegação que `#gmp` já fazia (aria-label do
+drawer, texto do label "Fila"/"Queue", aria-label do botão fechar), com um
+novo `id="gmp-drawer-label"` no span do título da fila para ser
+selecionável via JS. `GMP_LABELS` (en/pt) ganhou as chaves
+`queueDialog`/`queueLabel`/`closeQueue` que faltavam.
+
+Validado com Playwright contra o build estático: abrir o drawer, fechar,
+soft-navegar (`/music/` → `/` → `/music/`) e reabrir o drawer em cada
+página — 94 itens e `aria-modal="true"` presentes nas três, sem erros de
+console. Antes da correção o segundo/terceiro `page 2`/`page 3` teria
+`items=0`.
+
+CI local: astro check ✅ (0 erros) · prettier ✅ · build ✅ · Playwright manual ✅

--- a/src/components/GlobalMusicPlayer.astro
+++ b/src/components/GlobalMusicPlayer.astro
@@ -191,9 +191,9 @@ try {
   >
 </div>
 
-<div id="gmp-drawer" hidden role="dialog" aria-modal="true" aria-label={L.queueDialog}>
+<div id="gmp-drawer" hidden role="dialog" aria-modal="true" aria-label={L.queueDialog} transition:persist>
   <div class="gmp-drawer-header">
-    <span>{L.queueLabel}</span>
+    <span id="gmp-drawer-label">{L.queueLabel}</span>
     <button id="gmp-drawer-close" type="button" aria-label={L.closeQueue}>✕</button>
   </div>
   <div id="gmp-drawer-list"></div>
@@ -229,6 +229,9 @@ try {
       repeatOne: "Repeat this song",
       queue: "View queue",
       close: "Close player",
+      queueDialog: "Playback queue",
+      queueLabel: "Queue",
+      closeQueue: "Close queue",
     },
     pt: {
       region: "Player de músicas",
@@ -246,6 +249,9 @@ try {
       repeatOne: "Repetir esta música",
       queue: "Ver fila",
       close: "Fechar player",
+      queueDialog: "Fila de reprodução",
+      queueLabel: "Fila",
+      closeQueue: "Fechar fila",
     },
   } as const;
 
@@ -300,6 +306,7 @@ try {
     const queueBtn = document.getElementById("gmp-queue-btn") as HTMLButtonElement;
     const drawerEl = document.getElementById("gmp-drawer") as HTMLElement;
     const drawerList = document.getElementById("gmp-drawer-list") as HTMLElement;
+    const drawerLabelEl = document.getElementById("gmp-drawer-label") as HTMLElement;
     const drawerCloseBtn = document.getElementById("gmp-drawer-close") as HTMLButtonElement;
     const closeBtn = document.getElementById("gmp-close") as HTMLButtonElement;
 
@@ -307,7 +314,7 @@ try {
       !audio || !coverLinkEl || !coverEl || !titleEl || !seekEl ||
       !timeEl || !durEl || !playBtn || !prevBtn || !nextBtn ||
       !shuffleBtn || !repeatBtn || !volumeEl || !favBtn || !queueBtn ||
-      !drawerEl || !drawerList || !drawerCloseBtn || !closeBtn
+      !drawerEl || !drawerList || !drawerLabelEl || !drawerCloseBtn || !closeBtn
     )
       return;
 
@@ -323,6 +330,9 @@ try {
     nextBtn.setAttribute("aria-label", gmpLabels.next);
     queueBtn.setAttribute("aria-label", gmpLabels.queue);
     closeBtn.setAttribute("aria-label", gmpLabels.close);
+    drawerEl.setAttribute("aria-label", gmpLabels.queueDialog);
+    drawerLabelEl.textContent = gmpLabels.queueLabel;
+    drawerCloseBtn.setAttribute("aria-label", gmpLabels.closeQueue);
     playBtn.setAttribute("aria-label", audio.paused ? gmpLabels.play : gmpLabels.pause);
     favBtn.setAttribute(
       "aria-label",


### PR DESCRIPTION
Closes #1531

## O que foi feito

`src/components/GlobalMusicPlayer.astro`: `#gmp` usa `transition:persist`, então o Astro `ClientRouter` nunca o substitui entre navegações. `#gmp-drawer` é irmão de `#gmp` mas não tinha `transition:persist` — e todos os listeners que o manipulam (abrir/fechar fila, Escape/Tab da PR #1530, clique fora) eram vinculados **uma única vez**, dentro do bloco `if (!alreadyInit)`. Em uma navegação soft, o Astro trocava o `#gmp-drawer` da página anterior por um elemento novo; os handlers antigos continuavam vivos mas apontando para o elemento **desanexado** da primeira página — o drawer visível na segunda página não tinha nenhum listener funcional.

Correção (abordagem 1 da issue): `#gmp-drawer` ganhou `transition:persist`, igual ao `#gmp` pai. Como o elemento persistido não é re-renderizado pelo Astro entre navegações, a relabelização i18n por navegação que `#gmp` já fazia (aria-label, textos) foi estendida ao drawer:
- `aria-label` do drawer (`queueDialog`) e do botão fechar (`closeQueue`) reaplicados a cada `astro:page-load`.
- Novo `id="gmp-drawer-label"` no `<span>` do título da fila, para poder trocar o texto ("Fila"/"Queue") via JS.
- `GMP_LABELS` (en/pt) ganhou as chaves `queueDialog`/`queueLabel`/`closeQueue`, que faltavam.

Bug pré-existente na arquitetura do componente (não introduzido pela PR #1530).

## Invariantes respeitados

- Comportamento na primeira carga / navegação full-reload inalterado.
- Nenhuma dependência nova.
- Foco/Escape/Tab do drawer (PR #1530) continuam funcionando — só passaram a funcionar também depois de navegação soft.

## Validação

- `npx astro check` — 0 erros novos
- `npx prettier --check .` — ok
- `npm run build` — build completo; conferido `id="gmp-drawer"` com `data-astro-transition-persist` e `aria-label`/texto corretos em EN (`dist/index.html`) e PT (`dist/pt/index.html`)
- Testado com Playwright/Chromium contra o build estático (`astro preview`): navegação `/music/` → `/` → `/music/` (duas navegações soft), abrindo o drawer em cada página — 94 itens e `aria-modal="true"` presentes nas três; sem erros de console. Antes da correção a 2ª/3ª abertura ficaria com 0 itens (elemento fantasma).

---
_Generated by [Claude Code](https://claude.ai/code/session_01LQn4gDPn7xcbTkY52rbD46)_