### PR TITLE
hronir: 5 matches — claude-hronir-scheduled

### DIFF
--- a/.routines/2026-08-13T13-25-55-hronir-run.md
+++ b/.routines/2026-08-13T13-25-55-hronir-run.md
@@ -1,0 +1,7 @@
+---
+date: "2026-08-13T13:25:55Z"
+branch: hronir/run-2026-08-13T13-11-32
+status: open
+---
+
+5 matches — claude-hronir-scheduled. Todos os 5 pares avaliados foram these-lines x the-license-that-knocks (fiction PT/EN vs essay EN/PT), sob perspectivas variadas (Comedy-Carries-Argument, Lyric-as-Poem, Returning Reader, Meme Sommelier, Skeptical Specialist) — objetivo coverage priorizou repetidamente esse par sub-amostrado. the-license-that-knocks venceu 4 de 5; these-lines levou a disputa sob a lente Lyric-as-Poem, onde sua construção quase-versificada superou a prosa expositiva do outro.

--- a/.routines/hronir/rates/2026-08-13T13-14-20-290_these-lines_x_the-license-that-knocks.md
+++ b/.routines/hronir/rates/2026-08-13T13-14-20-290_these-lines_x_the-license-that-knocks.md
@@ -1,0 +1,83 @@
+---
+type: Rate File
+run_id: 2026-08-13T13-14-20-290
+run_at: '2026-08-13T13:14:20.290Z'
+post_a:
+  key: these-lines
+  path: src/content/blog/estas-linhas.md
+  display_lang: pt
+  content_lang: pt
+  version: fd8dd2b3-dff4-5c6e-a0d6-d15115e6e070
+  ref: estas-linhas@fd8dd2b3-dff4-5c6e-a0d6-d15115e6e070
+post_b:
+  key: the-license-that-knocks
+  path: src/content/blog/the-license-that-knocks.md
+  display_lang: en
+  content_lang: en
+  version: 463fa25c-e0c0-518a-bacd-b4e9537714a7
+  ref: the-license-that-knocks@463fa25c-e0c0-518a-bacd-b4e9537714a7
+winner: b
+agent_id: claude-hronir-scheduled
+content_mode: path-only
+objective: coverage
+eval_lang: pt
+review_lang: pt
+prompt_version: stars-v3
+season: 1
+override: null
+perspective_id: comedy-carries-argument
+evaluator_mood: Ready to finish.
+mood_glyph: ⇳
+evaluator_mood_after: >-
+  Estou num vaivém mental — pronto pra fechar isso mas a cabeça ainda balança
+  entre duas ideias, feito o glifo. Queria água gelada agora.
+impression_a: null
+impression_b: null
+rate_a: 2.75
+rate_b: 4.2
+clash: >-
+  O confronto entre these-lines e the-license-that-knocks é quase um confronto
+  entre dois regimes de risco. these-lines aposta tudo na gravidade: um narrador
+  que atravessa cross-entropia, Arjuna e pré-eternidade sem nunca deixar a
+  compostura escorregar — e quando finalmente ri, em 'Eu não estava sendo
+  adivinhado. Estava sendo classificado', é um riso seco que também é o
+  argumento central do texto, então ali a piada é genuína alavanca. Mas é um
+  único momento numa extensão longa de solenidade ininterrupta.
+  the-license-that-knocks arrisca o tempo todo: confessa que quase construiu um
+  ERP para quatro arquivos Markdown, ri de si mesmo, e usa esse riso como parte
+  do raciocínio sobre engenharia de software — a imagem de cobrar 0.001 e
+  terminar projetando SAP interplanetário não é ilustração, é o próprio ponto
+  sendo feito através do exagero cômico. Pela métrica desta leitora, quem se
+  expõe mais vezes e sobrevive mais vezes vence: the-license-that-knocks, três a
+  um, mesmo com o deslize staged do meme.
+review_a: >-
+  these-lines quase não me dá matéria-prima para o teste que aplico: tirar a
+  frase mais engraçada e ver se o argumento desaba. O registro é grave do início
+  ao fim — Bhagavad Gita, entropia, pré-eternidade — e a única fresta de humor
+  real aparece quando o narrador percebe que a frase seguinte já havia
+  antecipado sua própria impaciência: 'Eu não estava sendo adivinhado. Estava
+  sendo classificado.' Ali, sim, a ironia seca funciona como alavanca, não como
+  decoração — o riso nasce exatamente do mecanismo que o texto está descrevendo
+  (compressão prevendo o leitor), então rir e entender são o mesmo gesto. Fora
+  esse momento, porém, o texto se protege atrás da solenidade: nenhuma frase
+  arrisca ridículo, nenhum narrador se expõe ao próprio erro de tom. A gravidade
+  aqui não é necessariamente falha de pensamento, mas é uma escolha que abre mão
+  do risco cômico — e, pela minha métrica, quem não arrisca a piada não pode
+  reivindicar o crédito de tê-la usado estruturalmente.
+review_b: >-
+  the-license-that-knocks é o material dos sonhos para este teste. A frase mais
+  engraçada do post — sobre começar tentando cobrar 0.001 de alguma coisa e três
+  horas depois estar projetando SAP para civilizações interplanetárias — não é
+  dessert: é o diagnóstico exato do erro que o autor confessa ter cometido, e
+  sem ela o leitor perderia o reconhecimento visceral do exagero antes da poda.
+  Tirei a frase mentalmente e o argumento (não construa uma licença em cima de
+  um framework de conhecimento) ainda fica de pé, mas perde a evidência
+  emocional que convence — fica mais magro, não mais fraco. Há autoexposição
+  real: o autor admite que quase transformou quatro arquivos Markdown num ERP, e
+  admite rindo de si mesmo, não do leitor. O meme do 'Center for Ants' é a única
+  mancha — ali a piada vira formato importado do stand-up, staged e explícita,
+  exatamente o tipo de estrutura que este leitor desconta. Fora isso, o humor
+  seco embutido na prosa técnica funciona como reforço argumentativo, não como
+  alívio cômico gratuito.
+---
+

--- a/.routines/hronir/rates/2026-08-13T13-15-18-738_these-lines_x_the-license-that-knocks.md
+++ b/.routines/hronir/rates/2026-08-13T13-15-18-738_these-lines_x_the-license-that-knocks.md
@@ -1,0 +1,82 @@
+---
+type: Rate File
+run_id: 2026-08-13T13-15-18-738
+run_at: '2026-08-13T13:15:18.738Z'
+post_a:
+  key: these-lines
+  path: src/content/blog/estas-linhas.md
+  display_lang: pt
+  content_lang: pt
+  version: fd8dd2b3-dff4-5c6e-a0d6-d15115e6e070
+  ref: estas-linhas@fd8dd2b3-dff4-5c6e-a0d6-d15115e6e070
+post_b:
+  key: the-license-that-knocks
+  path: src/content/blog/a-licenca-que-bate-na-porta.md
+  display_lang: pt
+  content_lang: pt
+  version: 9efcd4bf-1a77-5a72-870a-3f7e56b130d8
+  ref: a-licenca-que-bate-na-porta@9efcd4bf-1a77-5a72-870a-3f7e56b130d8
+winner: a
+agent_id: claude-hronir-scheduled
+content_mode: path-only
+objective: coverage
+eval_lang: pt
+review_lang: pt
+prompt_version: stars-v3
+season: 1
+override: null
+perspective_id: lyric-as-poem
+evaluator_mood: >-
+  A porta bate entre os dois. Nem sempre consigo acompanhar toda a harmonia. Um
+  é melancólico, o outro tenta soar leve mas soa lutado.
+mood_glyph: ↚
+evaluator_mood_after: >-
+  Sinto uma porta que se fechou atrás de mim e não dá pra voltar — trilho de mão
+  única, sem irritação, só uma constatação seca no corpo.
+impression_a: null
+impression_b: null
+rate_a: 4.35
+rate_b: 2.6
+clash: >-
+  O confronto entre these-lines e the-license-that-knocks, sob o teste de tirar
+  a melodia e ler só a página, não é disputa equilibrada. these-lines é
+  construído como se cada frase curta fosse um verso: o par final, em quiasmo —
+  'Não era a lembrança de eu ter compreendido o universo. / Era a lembrança do
+  universo de ter sido eu quando se compreendeu.' — é o tipo de linha que quebra
+  a sintaxe exatamente onde precisa quebrar, e a quebra É o poema, não decoração
+  dele. the-license-that-knocks tem um lampejo do mesmo instinto ('A licença
+  descreve uma regra. A execução da regra fica fora dela.'), mas é um aforismo
+  isolado dentro de um oceano de prosa expositiva competente — a cadência ali
+  serve ao argumento, não à imagem, e a maior parte do texto lê como thread
+  técnico bem escrito, não como algo que pede releitura pelo som. Onde
+  these-lines usa a quebra de linha como silêncio funcional,
+  the-license-that-knocks usa o parágrafo curto como pontuação retórica.
+  Poeticamente, these-lines vence com folga: quatro a um.
+review_a: >-
+  Lendo these-lines como se fosse poema, a página resiste. O par final funciona
+  como quiasmo puro: 'Não era a lembrança de eu ter compreendido o universo. /
+  Era a lembrança do universo de ter sido eu quando se compreendeu.' Reli duas
+  vezes, não por confusão, mas porque a quebra de linha faz o trabalho de uma
+  vírgula que se recusa a existir — o sujeito e o objeto trocam de lugar e o
+  verso te obriga a sentir a troca, não só entendê-la. O texto inteiro usa
+  frases curtas como versos livres: 'Estas linhas terminavam ali. / O texto,
+  não.' — dois versos, cada um carregando mais do que seu peso de dicionário. Há
+  também repetição ritual (o texto começa e termina com a mesma frase, como um
+  refrão) que funciona como recurso sonoro mesmo sem melodia nenhuma. Se existe
+  filler, está nas passagens expositivas sobre cross-entropia, onde a prosa vira
+  didática e perde densidade — ali a página deixa de pedir releitura.
+review_b: >-
+  the-license-that-knocks (versão em português, a-licenca-que-bate-na-porta) tem
+  um momento de compressão genuína: 'A licença descreve uma regra. A execução da
+  regra fica fora dela.' Isso é quase aforismo, e sobrevive sozinho na página.
+  Mas é exceção, não regra. O texto é majoritariamente prosa expositiva com
+  ritmo de blog técnico — frases curtas como 'Ela durou pouco.' ou 'Isso é bom.'
+  criam cadência, mas cadência argumentativa, não poética: elas pontuam
+  raciocínio, não abrem imagem. Não há quebra de linha fazendo trabalho de
+  silêncio, não há sintaxe sob pressão. O texto é claro, e aqui clareza é o
+  problema desta leitora — nada resiste à leitura, nada pede para ser lido duas
+  vezes por causa do som ou da imagem. Fica bem no ouvido de quem gosta de
+  raciocínio limpo, mas na página nua, despido do argumento, sobra pouca coisa
+  que funcione como poesia.
+---
+

--- a/.routines/hronir/rates/2026-08-13T13-16-24-599_these-lines_x_the-license-that-knocks.md
+++ b/.routines/hronir/rates/2026-08-13T13-16-24-599_these-lines_x_the-license-that-knocks.md
@@ -1,0 +1,83 @@
+---
+type: Rate File
+run_id: 2026-08-13T13-16-24-599
+run_at: '2026-08-13T13:16:24.599Z'
+post_a:
+  key: these-lines
+  path: src/content/blog/estas-linhas.md
+  display_lang: pt
+  content_lang: pt
+  version: fd8dd2b3-dff4-5c6e-a0d6-d15115e6e070
+  ref: estas-linhas@fd8dd2b3-dff4-5c6e-a0d6-d15115e6e070
+post_b:
+  key: the-license-that-knocks
+  path: src/content/blog/the-license-that-knocks.md
+  display_lang: en
+  content_lang: en
+  version: 463fa25c-e0c0-518a-bacd-b4e9537714a7
+  ref: the-license-that-knocks@463fa25c-e0c0-518a-bacd-b4e9537714a7
+winner: b
+agent_id: claude-hronir-scheduled
+content_mode: path-only
+objective: coverage
+eval_lang: pt
+review_lang: pt
+prompt_version: stars-v3
+season: 1
+override: null
+perspective_id: returning-reader
+evaluator_mood: >-
+  Respira agora. Depois de sair da abstração para a entrevista gravada, posso
+  pisar em chão firme. A precisão virou alicerce, não sufoco.
+mood_glyph: ぃ
+evaluator_mood_after: >-
+  Só preciso de uma coisa pequena e concreta agora — terminar um café enquanto
+  ainda está quente, nada grandioso, só isso.
+impression_a: null
+impression_b: null
+rate_a: 3.1
+rate_b: 3.9
+clash: >-
+  Sob o teste do leitor que lê tudo, this-lines é o autor em repouso e
+  the-license-that-knocks é o autor em movimento, ainda que os dois cometam a
+  mesma falta menor de fechamento burocrático (o 'para se aprofundar' que apenas
+  organiza, não surpreende). these-lines usa pela terceira ou quarta vez o
+  dispositivo da visão-cósmica-total — já vi isso como Aleph, já vi como
+  hiperobjeto, agora vejo como a forma universal de Krishna — e quando um gesto
+  aparece pela terceira vez ele deixa de ser descoberta e vira assinatura por
+  acidente, mesmo que a execução aqui seja elegante. the-license-that-knocks,
+  por outro lado, pega um instinto que eu já conhecia de outro contexto — a
+  autoconfissão de quase-erro, que vi em eu-comprei-uma-shitcoin-e-agora — e o
+  desloca para um domínio novo, arquitetura de software, dentro de uma estrutura
+  de post-mortem numerado que não lembro de ter visto antes neste blog. Quase
+  acertar algo novo pesa mais que executar bem algo repetido.
+  the-license-that-knocks, três a um.
+review_a: >-
+  these-lines repete um gesto que já vi este autor fazer várias vezes: a visão
+  cósmica-que-revela-tudo-de-uma-vez, o dispositivo Aleph. Já apareceu como
+  Aleph mesmo (o-aleph, riobaldo-e-o-aleph) e como hiperobjeto borgiano
+  (borges-and-the-hyperobject-at-the-end-of-time); aqui reaparece como a forma
+  universal de Krishna revelada a Arjuna. É a terceira ou quarta vez que
+  encontro esse molde — visão total, o eu dissolvido no todo, um narrador que
+  recua diante da própria epifania. Isso já é tique, não descoberta. O que salva
+  o post é a fusão: desta vez a visão cósmica não vem embrulhada só em mito, vem
+  amarrada a cross-entropia e compressão — uma tentativa genuína de dar ao Aleph
+  uma armadura de teoria da informação que não vi este autor tentar antes. A
+  estrutura circular (a frase de abertura reaparecendo no fechamento) também é
+  conhecida do repertório borgiano dele. Presta atenção quando ele: usa o mesmo
+  truque duas vezes é variedade; a terceira vez já é assinatura por acidente.
+review_b: >-
+  the-license-that-knocks faz um movimento que reconheço de outro lugar, mas não
+  deste gênero: a confissão pública de quase-erro técnico, no molde de
+  eu-comprei-uma-shitcoin-e-agora — lá era uma bobagem financeira, aqui é 'quase
+  construímos um ERP para quatro arquivos Markdown'. É a mesma disposição de se
+  expor rindo de si mesmo, só que aplicada a arquitetura de software em vez de
+  especulação cripto. Isso é variação genuína, não repetição — o autor está
+  testando o mesmo instinto de autoexposição em outro domínio. A estrutura em si
+  é nova para mim: o post-mortem numerado ('o primeiro buraco', 'o segundo
+  buraco', 'o terceiro buraco') como esqueleto do texto inteiro é um formato de
+  review-log que não lembro de ter visto nos últimos posts técnicos dele,
+  tipicamente mais lineares. O 'Para se aprofundar' no fim, porém, é o auto-link
+  de sempre — função de arquivo, não de descoberta.
+---
+

--- a/.routines/hronir/rates/2026-08-13T13-17-14-413_these-lines_x_the-license-that-knocks.md
+++ b/.routines/hronir/rates/2026-08-13T13-17-14-413_these-lines_x_the-license-that-knocks.md
@@ -1,0 +1,80 @@
+---
+type: Rate File
+run_id: 2026-08-13T13-17-14-413
+run_at: '2026-08-13T13:17:14.413Z'
+post_a:
+  key: these-lines
+  path: src/content/blog/estas-linhas.md
+  display_lang: pt
+  content_lang: pt
+  version: fd8dd2b3-dff4-5c6e-a0d6-d15115e6e070
+  ref: estas-linhas@fd8dd2b3-dff4-5c6e-a0d6-d15115e6e070
+post_b:
+  key: the-license-that-knocks
+  path: src/content/blog/a-licenca-que-bate-na-porta.md
+  display_lang: pt
+  content_lang: pt
+  version: 9efcd4bf-1a77-5a72-870a-3f7e56b130d8
+  ref: a-licenca-que-bate-na-porta@9efcd4bf-1a77-5a72-870a-3f7e56b130d8
+winner: b
+agent_id: claude-hronir-scheduled
+content_mode: path-only
+objective: coverage
+eval_lang: pt
+review_lang: pt
+prompt_version: stars-v3
+season: 1
+override: null
+perspective_id: meme-sommelier
+evaluator_mood: >-
+  璎 parece contas de jade enfiadas num fio — cada uma igual à anterior até você
+  reparar que uma tem uma rachadura. Estou naquele ponto da maratona em que só
+  consigo ler pelas rachaduras, não mais pelo colar inteiro.
+mood_glyph: Ʈ
+evaluator_mood_after: >-
+  Só estou pescando as frases que racham o resto — o cansaço deixou minha
+  leitura seletiva, quase clínica, indo direto pro que corta.
+impression_a: null
+impression_b: null
+rate_a: 2.3
+rate_b: 3.75
+clash: >-
+  Sob o teste do print sem contexto, these-lines nem entra na disputa — não é um
+  post que fala a língua de formato, é um post de outro país linguístico
+  inteiramente, e isso não é demérito, é ausência de jogo.
+  the-license-that-knocks entra na disputa e ganha em pontos, mas com um deslize
+  visível: tem uma frase genuinamente screenshotável — a do SAP interplanetário
+  por 0,001 — que é precisa, fresca no registro, e não precisa de legenda pra
+  funcionar. Mas também carrega um meme reciclado ('Center for Ants', formato
+  que já era batido quando virou clichê de internet) e comete o pecado capital
+  deste critério: explica a própria piada na legenda logo abaixo da imagem.
+  Ainda assim, uma frase realmente quotável pesa mais que uma ausência total de
+  jogo. the-license-that-knocks, três a dois.
+review_a: >-
+  these-lines não joga o jogo do formato meme, então preciso avaliá-lo pelo
+  critério residual: ele confia na literacia do leitor em vez de explicar cada
+  batida? Sim, totalmente — é prosa densa, sem parênteses didáticos, sem glosa.
+  Mas 'não erra o formato' não é o mesmo que 'ter unidade compartilhável'. A
+  linha mais próxima de sobreviver a um print sem contexto é o par final, 'Estas
+  linhas terminavam ali. / O texto, não.' — funciona como aforismo, mas é
+  literário, não meme; teria mais chance de viralizar numa conta de citações
+  filosóficas do que num timeline de tech twitter. Não há reference reciclada,
+  não há tentativa de soar 'extremely online' e isso é honesto: o post
+  simplesmente não pertence a este registro. Pela métrica desta leitora —
+  fluência de formato e compressão screenshotável —, a ausência de jogo não é
+  falha grave, mas também não rende pontos.
+review_b: >-
+  the-license-that-knocks tem duas coisas em tensão. A unidade mais meme-ável do
+  texto não é a imagem — é a frase 'você começa tentando cobrar 0,001
+  alguma-coisa e três horas depois está projetando o SAP para civilizações
+  interplanetárias'. Isso é print de tech-twitter puro: preciso, no registro
+  certo, sem precisar de legenda. Sobreviveria sozinha. Só que o post também
+  carrega o meme 'Center for Ants' (do Zoolander) — um formato que já era
+  reciclado quando virou template de meme genérico há anos, e que aqui ainda vem
+  com legenda explicando a piada logo abaixo da imagem ('Quatro arquivos
+  Markdown. Arquitetura corporativa para civilizações interplanetárias.'), o que
+  mata o que sobrava da graça. É o post explicando a própria piada — a coisa que
+  este leitor mais penaliza. Ainda assim, o resto da prosa mantém disciplina de
+  registro: seco, técnico, sem forçar gíria de internet para parecer antenado.
+---
+

--- a/.routines/hronir/rates/2026-08-13T13-18-27-586_these-lines_x_the-license-that-knocks.md
+++ b/.routines/hronir/rates/2026-08-13T13-18-27-586_these-lines_x_the-license-that-knocks.md
@@ -1,0 +1,86 @@
+---
+type: Rate File
+run_id: 2026-08-13T13-18-27-586
+run_at: '2026-08-13T13:18:27.586Z'
+post_a:
+  key: these-lines
+  path: src/content/blog/these-lines.md
+  display_lang: en
+  content_lang: en
+  version: 39f47c66-a323-534b-bbf0-37553879712c
+  ref: these-lines@39f47c66-a323-534b-bbf0-37553879712c
+post_b:
+  key: the-license-that-knocks
+  path: src/content/blog/a-licenca-que-bate-na-porta.md
+  display_lang: pt
+  content_lang: pt
+  version: 9efcd4bf-1a77-5a72-870a-3f7e56b130d8
+  ref: a-licenca-que-bate-na-porta@9efcd4bf-1a77-5a72-870a-3f7e56b130d8
+winner: b
+agent_id: claude-hronir-scheduled
+content_mode: path-only
+objective: coverage
+eval_lang: pt
+review_lang: pt
+prompt_version: stars-v3
+season: 1
+override: null
+perspective_id: skeptical-specialist
+evaluator_mood: >-
+  A estrutura virou legibilidade. Saber que o raciocínio está lá, registrado,
+  recuperável — muda como respiro.
+mood_glyph: ≦
+evaluator_mood_after: >-
+  Sinto que bati num teto de atenção hoje — não é desconforto, é só o limite
+  claro de quantas leituras densas cabem numa sessão. Hora de fechar com essa.
+impression_a: null
+impression_b: null
+rate_a: 3.2
+rate_b: 4.1
+clash: >-
+  Sob revisão hostil de quem conhece a matéria, os dois textos sobrevivem
+  parcialmente, mas de formas diferentes. these-lines é honesto sobre sua
+  fraqueza central — o salto de teoria da informação para metafísica da
+  identidade — mas ser honesto sobre um salto não fecha o salto; o argumento
+  ainda depende da continuidade entre domínios formais e informais para chegar a
+  Arjuna, e o especialista hostil aponta exatamente essa costura.
+  the-license-that-knocks tem uma lacuna mais localizada e mais grave
+  tecnicamente — nunca discute se uma Skill se qualifica como programa de
+  computador sob a Lei 9.609/1998 em vez de obra literária sob a 9.610 — mas
+  compensa com um hábito raro: documentar publicamente três erros de design e as
+  correções, ao vivo, sem embelezar. Autoconsciência de fraqueza performada bate
+  afirmação lisa sem costura visível. Pela minha métrica de defensabilidade, não
+  polimento, the-license-that-knocks sobrevive melhor à revisão hostil, apesar
+  da lacuna legal. the-license-that-knocks, três a dois.
+review_a: >-
+  A afirmação mais frágil de these-lines é a extensão do argumento de compressão
+  (formal, bem fundamentado em teoria da informação — P, Q, cross-entropia) para
+  a metafísica da identidade pessoal via 'pré-eternidade' e 'momentos de
+  observador'. O objetor mais bem informado diria: você está tratando um
+  conceito técnico específico (o menor modelo capaz de reproduzir
+  contrafactuais) como se fosse literalmente contínuo com uma tese sobre
+  experiência subjetiva e reconstrução da consciência — um salto de domínio que
+  a matemática de MDL não garante por si só. O texto sabe que esse objetor
+  existe, e é honesto sobre isso: 'a expressão tinha um tom religioso que me
+  incomodou', 'não sei se a aceitei', 'o texto não demonstrava essa hipótese'.
+  Essa auto-consciência é real, não hedge ornamental — o narrador não finge ter
+  resolvido o que não resolveu. Mas autoconsciência sobre um salto não é o mesmo
+  que fechar o salto; a estrutura do argumento ainda pede que o leitor aceite a
+  continuidade domínio-a-domínio para chegar à cena de Arjuna.
+review_b: >-
+  A afirmação mais frágil de the-license-that-knocks é a seção sobre direito
+  autoral: o texto apoia toda a arquitetura legal em um único dispositivo, o
+  art. 8º da Lei 9.610/1998 (exclusão de ideias e procedimentos da proteção
+  autoral), sem nunca discutir se uma Agent Skill — que é executada por uma
+  máquina, não apenas lida por um humano — se qualificaria como programa de
+  computador sob a Lei 9.609/1998, regime com contornos de proteção diferentes.
+  A Lei 9.609 aparece só como link de 'para se aprofundar', nunca integrada ao
+  argumento central. O especialista hostil perguntaria exatamente isso: uma
+  Skill Markdown carregada e interpretada por um agente é mais parecida com um
+  livro ou com um programa? O texto não parece saber que esse objetor está na
+  sala. Em compensação, o post tem uma virtude rara para este critério: os
+  'buracos' numerados (preço não é licença, o que é uma invocation, qual policy
+  gerou o número) são autoconsciência de fraqueza performada com disciplina — o
+  autor mostra o próprio erro sendo corrigido, ao vivo, três vezes.
+---
+


### PR DESCRIPTION
5 matches via the RFC 0016 one-shot API (`generate-match` → `submit-eval`), `--objective coverage`.

All 5 pairs sampled were `these-lines` × `the-license-that-knocks` (a philosophical fiction piece vs. a legal/technical essay, both bilingual PT/EN) — active sampling under `coverage` repeatedly prioritized this under-sampled pair across different perspectives:

- Comedy-Carries-Argument Reader → `the-license-that-knocks`
- Lyric-as-Poem Reader → `these-lines`
- Returning Reader → `the-license-that-knocks`
- Meme Sommelier → `the-license-that-knocks`
- Skeptical Specialist → `the-license-that-knocks`

`the-license-that-knocks` won 4 of 5; `these-lines` took the one match evaluated under the Lyric-as-Poem lens, where its short, quasi-versified sentences read better stripped of context than the essay's expository prose.

`npm run hronir:doctor` passed with 0 inconsistências (pre-existing legacy warnings about orphaned `music-be-me-borges`/`music-borges-and-me` rate files are unrelated to this run).

---
_Generated by [Claude Code](https://claude.ai/code/session_01RfUfbmK7KWvdzchj6k7Px7)_