### PR TITLE
ux: aria-label distinto no link "Continuar lendo" do PostCard

### DIFF
--- a/.routines/2026-08-14T05-05-52-ux-ui-run.md
+++ b/.routines/2026-08-14T05-05-52-ux-ui-run.md
@@ -1,0 +1,15 @@
+---
+date: "2026-08-14T05:05:52Z"
+branch: claude/ecstatic-hawking-idjsxa
+status: open
+---
+
+# Sessão 2026-08-14T05-05-52 — UX/UI
+
+Issues fechadas: #1534
+O que foi feito: adiciona `aria-label` distinto ("Continue reading → — <título>" /
+"Continuar lendo → — <título>") ao link "Continuar lendo" em `PostCard.astro`,
+para que leitores de tela distingam links repetidos em listas (arquivo, tags,
+rail de posts relacionados). Texto visível inalterado.
+CI local: astro check ✅ (0 errors) · prettier ✅ · build ✅ (aria-label
+verificado no HTML gerado em EN e PT via grep em dist/tags/**).

--- a/src/components/FeaturedRail.astro
+++ b/src/components/FeaturedRail.astro
@@ -44,7 +44,7 @@ const dateOpts = { year: 'numeric', month: 'long', day: 'numeric' } as const;
             </a>
           )}
           <p class="cta">
-            <a href={href}>{t(lang, 'post.continueReading')}</a>
+            <a href={href} aria-label={`${t(lang, 'post.continueReading')} — ${title}`}>{t(lang, 'post.continueReading')}</a>
           </p>
         </article>
       );

--- a/src/components/PostCard.astro
+++ b/src/components/PostCard.astro
@@ -73,7 +73,7 @@ const overflowCount = allTags.length - visibleTags.length;
         {overflowCount > 0 && <span class="card-tag-overflow">+{overflowCount}</span>}
       </p>
     )}
-    <a href={href}>{t(postLang, 'post.continueReading')}</a>
+    <a href={href} aria-label={`${t(postLang, 'post.continueReading')} — ${title}`}>{t(postLang, 'post.continueReading')}</a>
   </footer>
 </article>
 


### PR DESCRIPTION
Closes #1534

## O que foi feito

`PostCard.astro` é usado em listas (arquivo, tags, rail de posts
relacionados), então um leitor de tela navegando por links ouvia N links
idênticos "Continue reading →" / "Continuar lendo →" sem saber para qual
post cada um leva.

Adiciona `aria-label` distinto ao link, combinando o rótulo traduzido com o
título do post (`"Continue reading → — <título>"` /
`"Continuar lendo → — <título>"`), mantendo o texto visível inalterado.

## Validação

- `astro check`: 0 erros novos (só hints/warnings pré-existentes)
- `prettier --check .`: ✅
- `npm run build`: ✅ completo, incl. prebuild/pregen e pagefind
- Confirmado no HTML gerado que o `aria-label` correto aparece tanto em
  páginas EN (`dist/tags/**`) quanto PT (`dist/pt/tags/**`)

## Invariantes respeitados

- Texto visível/layout inalterados
- `aria-hidden`/`tabindex="-1"` no link da imagem hero permanecem intocados
- Funciona nos builds `en` e `pt`
- Strings de tradução `post.continueReading` não alteradas

---
_Generated by [Claude Code](https://claude.ai/code/session_01TpYJSNuhSvEQLptNeDgFKh)_