### PR TITLE
docs(readme): expose the blog public surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,21 @@
 
 Personal blog and digital garden of Franklin Baldo. Built with **Astro 6** and **Pico.css v2**.
 
+**Live site:** https://franklinbaldo.github.io/
+
+## What lives here
+
+The repository powers more than a chronological blog. Its public surface currently includes:
+
+- [essays and the archive](https://franklinbaldo.github.io/archive/), with tags, search and bilingual routes;
+- curated [reading paths](https://franklinbaldo.github.io/) that connect related essays into sequences;
+- a public [projects index](https://franklinbaldo.github.io/projects/);
+- the [Hrönir ranking](https://franklinbaldo.github.io/ranking/), produced from committed pairwise evaluations used to curate and compare the writing corpus;
+- [music](https://franklinbaldo.github.io/music/) and [books](https://franklinbaldo.github.io/books/) as adjacent parts of the digital garden;
+- a public [changelog](https://franklinbaldo.github.io/changelog/) and RSS feeds for following updates.
+
+Hrönir is both repository machinery and a public-facing curation artifact: the evaluation data lives in `.routines/hronir/`, while the resulting ranking is published on the site.
+
 ## Stack
 
 - [Astro 6](https://astro.build/) with `@astrojs/mdx`


### PR DESCRIPTION
Closes #1543.

Updates the README so the GitHub entry point reflects the product that already exists: live site, archive, reading paths, projects, public Hrönir ranking, music, books, changelog and RSS. Keeps the existing developer-oriented Stack/Commands/Layout sections intact.

No product capability is invented; the links map to current public routes already present in the deployed navigation/source.