### PR TITLE
ux: localizar dossiê de ranking e nomes acessíveis do PathsTeaser

### DIFF
--- a/.routines/2026-08-15T05-07-09-ranking-dossier-i18n-a11y.md
+++ b/.routines/2026-08-15T05-07-09-ranking-dossier-i18n-a11y.md
@@ -1,0 +1,28 @@
+---
+date: "2026-08-15T05:07:09Z"
+branch: claude/ecstatic-hawking-f3cx8j
+status: open
+---
+
+# Sessão 2026-08-15T05-07-09 — UX/UI
+
+Issues fechadas: #1535, #1539
+
+O que foi feito:
+
+- #1535: `/ranking/posts/[key].astro` (dossiê de ranking) agora localiza
+  `lang`/`Breadcrumbs`/`HronirExplainer` a partir de `postInfo.lang` em vez
+  de fixar `"en"`, e todas as strings de UI da página (rank change, win
+  rate, wins/duels, sparkline caption, perspective rankings, duel history,
+  won/lost, vs, analysis link, breadcrumb Home/Ranking) passam por um
+  objeto `strings` en/pt local ao arquivo. `RankingView.astro:331` também
+  localiza o tooltip "Dossier: {title}" via novo campo `dossierTooltip` em
+  `RankingStrings`, preenchido em `ranking.astro`/`pt/ranking.astro`.
+- #1539: `PathsTeaser.astro` — link "Start here →"/"Começar →" repetido em
+  cada card de reading path agora tem `aria-label` distinto
+  (`"${startHere} — ${pick(lang, path.title)}"`), texto visível inalterado.
+
+CI local: astro check ✅ (0 erros, warnings pré-existentes) · prettier ✅ ·
+build ✅. Conferido `dist/ranking/posts/<key>/index.html` (en) e
+`dist/pt/ranking/index.html` + `dist/pt/index.html` (pt) — strings e
+aria-labels corretos no idioma certo.

--- a/src/components/PathsTeaser.astro
+++ b/src/components/PathsTeaser.astro
@@ -73,7 +73,12 @@ const ICONS: Record<string, string> = {
               <small>
                 {count}{' '}{t(lang, count === 1 ? 'paths.essay' : 'paths.essays')}
                 {' · '}
-                <a href={`${pathsRoot}/${path.slug}/`}>{t(lang, 'paths.startHere')}</a>
+                <a
+                  href={`${pathsRoot}/${path.slug}/`}
+                  aria-label={`${t(lang, 'paths.startHere')} — ${pick(lang, path.title)}`}
+                >
+                  {t(lang, 'paths.startHere')}
+                </a>
               </small>
             </p>
           </div>

--- a/src/components/RankingView.astro
+++ b/src/components/RankingView.astro
@@ -74,6 +74,7 @@ export interface RankingStrings {
   allPerspectivesLabel: string;
   tensionUnavailable: string;
   eloTooltip: string;
+  dossierTooltip: string;
 }
 
 interface Props {
@@ -328,7 +329,7 @@ function snapshotElo(key: string): { elo: number; peak: number } | null {
               data-sort-record={r.appearances}
             >
               <th scope="row" class="col-rank">
-                <a href={`/ranking/posts/${r.key}/`} class="rank-link" title={`Dossier: ${r.post?.title ?? r.key}`}>{r.rank}</a>
+                <a href={`/ranking/posts/${r.key}/`} class="rank-link" title={strings.dossierTooltip.replace("{title}", r.post?.title ?? r.key)}>{r.rank}</a>
               </th>
               <td class="col-post">
                 {href ? (

--- a/src/pages/pt/ranking.astro
+++ b/src/pages/pt/ranking.astro
@@ -137,6 +137,7 @@ const strings: RankingStrings = {
   allPerspectivesLabel: "Todas",
   tensionUnavailable: "tensão não disponível",
   eloTooltip: "Elo: {elo} ({delta} desde 1000 · pico: {peak})",
+  dossierTooltip: "Dossiê: {title}",
 };
 ---
 

--- a/src/pages/ranking.astro
+++ b/src/pages/ranking.astro
@@ -134,6 +134,7 @@ const strings: RankingStrings = {
   allPerspectivesLabel: "All",
   tensionUnavailable: "tension not available",
   eloTooltip: "Elo: {elo} ({delta} since 1000 · peak: {peak})",
+  dossierTooltip: "Dossier: {title}",
 };
 ---
 

--- a/src/pages/ranking/posts/[key].astro
+++ b/src/pages/ranking/posts/[key].astro
@@ -51,6 +51,8 @@ const lang: "en" | "pt" = postInfo?.lang === "pt" ? "pt" : "en";
 const strings =
   lang === "pt"
     ? {
+        dossierSuffix: "Dossiê",
+        metaDescription: `Histórico de ranking e registro de duelos de "${title}" no sistema Hrönir.`,
         readPost: "Ler post →",
         globalRank: "posição global",
         rankChange: "variação de posição",
@@ -71,6 +73,8 @@ const strings =
         ranking: "Ranking",
       }
     : {
+        dossierSuffix: "Dossier",
+        metaDescription: `Ranking history and duel record for "${title}" in the Hrönir system.`,
         readPost: "Read post →",
         globalRank: "global rank",
         rankChange: "rank change",
@@ -154,8 +158,8 @@ function fmtDate(iso: string): string {
 ---
 
 <PageLayout
-  title={`${title} — Dossier | Franklin Baldo`}
-  description={`Ranking history and duel record for "${title}" in the Hrönir system.`}
+  title={`${title} — ${strings.dossierSuffix} | Franklin Baldo`}
+  description={strings.metaDescription}
   lang={lang}
   noindex
   breadcrumb={toBreadcrumbLd(crumbs, Astro.site)}

--- a/src/pages/ranking/posts/[key].astro
+++ b/src/pages/ranking/posts/[key].astro
@@ -46,6 +46,51 @@ const postHref = postInfo
     : `/blog/${postInfo.slug}/`
   : null;
 
+const lang: "en" | "pt" = postInfo?.lang === "pt" ? "pt" : "en";
+
+const strings =
+  lang === "pt"
+    ? {
+        readPost: "Ler post →",
+        globalRank: "posição global",
+        rankChange: "variação de posição",
+        winRate: "taxa de vitória",
+        winsDuels: "vitórias / duelos",
+        ordinal: "ordinal",
+        sparklineCaption: "Taxa de vitória ao longo do tempo (cada ponto = um duelo, cronológico)",
+        perspectiveRankings: "Rankings por perspectiva",
+        duelHistory: "Histórico de duelos",
+        duelHistoryTotal: "no total",
+        noDuels: "Nenhum duelo registrado ainda.",
+        won: "Venceu",
+        lost: "Perdeu",
+        vs: "vs",
+        readFullAnalysis: "Ler análise completa",
+        analysis: "análise →",
+        home: "Início",
+        ranking: "Ranking",
+      }
+    : {
+        readPost: "Read post →",
+        globalRank: "global rank",
+        rankChange: "rank change",
+        winRate: "win rate",
+        winsDuels: "wins / duels",
+        ordinal: "ordinal",
+        sparklineCaption: "Win rate over time (each point = one duel, chronological)",
+        perspectiveRankings: "Perspective rankings",
+        duelHistory: "Duel history",
+        duelHistoryTotal: "total",
+        noDuels: "No duels recorded yet.",
+        won: "Won",
+        lost: "Lost",
+        vs: "vs",
+        readFullAnalysis: "Read full analysis",
+        analysis: "analysis →",
+        home: "Home",
+        ranking: "Ranking",
+      };
+
 const duels = getPostDuelHistory(key);
 
 // Per-perspective rankings
@@ -86,8 +131,8 @@ const sparklinePts = chronological.map((d) => ({ won: d.winnerKey === key }));
 const sparklinePath = buildSparkline(sparklinePts);
 
 const crumbs = [
-  { name: "Home", href: "/" },
-  { name: "Ranking", href: "/ranking/" },
+  { name: strings.home, href: lang === "pt" ? "/pt/" : "/" },
+  { name: strings.ranking, href: lang === "pt" ? "/pt/ranking/" : "/ranking/" },
   { name: title, href: `/ranking/posts/${key}/` },
 ];
 
@@ -100,56 +145,60 @@ function hue(id: string): number {
 function fmtDate(iso: string): string {
   const d = new Date(iso);
   if (Number.isNaN(d.valueOf())) return "—";
-  return d.toLocaleDateString("en-US", { year: "numeric", month: "short", day: "numeric" });
+  return d.toLocaleDateString(lang === "pt" ? "pt-BR" : "en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
 }
 ---
 
 <PageLayout
   title={`${title} — Dossier | Franklin Baldo`}
   description={`Ranking history and duel record for "${title}" in the Hrönir system.`}
-  lang="en"
+  lang={lang}
   noindex
   breadcrumb={toBreadcrumbLd(crumbs, Astro.site)}
 >
-  <Breadcrumbs items={crumbs} lang="en" />
+  <Breadcrumbs items={crumbs} lang={lang} />
 
   <hgroup>
     <h1>{title}</h1>
-    {postHref && <p><a href={postHref}>Read post →</a></p>}
+    {postHref && <p><a href={postHref}>{strings.readPost}</a></p>}
   </hgroup>
 
-  <HronirExplainer lang="en" />
+  <HronirExplainer lang={lang} />
 
   <div class="dossier-stats">
     <div class="doss-stat">
       <span class="doss-val">#{currentRank}</span>
-      <span class="doss-lbl">global rank</span>
+      <span class="doss-lbl">{strings.globalRank}</span>
     </div>
     {delta !== null && delta !== 0 && (
       <div class="doss-stat">
         <span class={`doss-val ${delta > 0 ? "delta-up" : "delta-down"}`}>
           {delta > 0 ? `+${delta}` : `${delta}`}
         </span>
-        <span class="doss-lbl">rank change</span>
+        <span class="doss-lbl">{strings.rankChange}</span>
       </div>
     )}
     <div class="doss-stat">
       <span class="doss-val">{winRate}%</span>
-      <span class="doss-lbl">win rate</span>
+      <span class="doss-lbl">{strings.winRate}</span>
     </div>
     <div class="doss-stat">
       <span class="doss-val">{overallWins}/{duels.length}</span>
-      <span class="doss-lbl">wins / duels</span>
+      <span class="doss-lbl">{strings.winsDuels}</span>
     </div>
     <div class="doss-stat">
       <span class="doss-val">{rankEntry.ordinal.toFixed(3)}</span>
-      <span class="doss-lbl">ordinal</span>
+      <span class="doss-lbl">{strings.ordinal}</span>
     </div>
   </div>
 
   {sparklinePath && (
     <div class="sparkline-wrap">
-      <p class="sparkline-caption">Win rate over time (each point = one duel, chronological)</p>
+      <p class="sparkline-caption">{strings.sparklineCaption}</p>
       <svg viewBox="0 0 200 36" class="sparkline" aria-hidden="true">
         <line x1="0" y1="18" x2="200" y2="18" class="spark-ref" />
         <path d={sparklinePath} class="spark-path" />
@@ -173,7 +222,7 @@ function fmtDate(iso: string): string {
 
   {perspectiveRanks.length > 0 && (
     <section class="persp-ranks">
-      <h2>Perspective rankings</h2>
+      <h2>{strings.perspectiveRankings}</h2>
       <ul class="persp-list">
         {perspectiveRanks.map((pr) => (
           <li>
@@ -189,9 +238,9 @@ function fmtDate(iso: string): string {
   )}
 
   <section class="duel-history">
-    <h2>Duel history <small>({duels.length} total)</small></h2>
+    <h2>{strings.duelHistory} <small>({duels.length} {strings.duelHistoryTotal})</small></h2>
     {duels.length === 0 ? (
-      <p class="empty">No duels recorded yet.</p>
+      <p class="empty">{strings.noDuels}</p>
     ) : (
       <ol class="duel-list">
         {duels.map((d) => {
@@ -209,10 +258,10 @@ function fmtDate(iso: string): string {
           return (
             <li class={won ? "duel-won" : "duel-lost"}>
               <div class="duel-row">
-                <span class="duel-outcome" aria-label={won ? "Won" : "Lost"}>{won ? "W" : "L"}</span>
+                <span class="duel-outcome" aria-label={won ? strings.won : strings.lost}>{won ? "W" : "L"}</span>
                 <div class="duel-content">
                   <div class="duel-opponent">
-                    <span class="vs-label">vs</span>
+                    <span class="vs-label">{strings.vs}</span>
                     {opponentHref ? (
                       <a href={opponentHref}>{opponentTitle}</a>
                     ) : (
@@ -239,9 +288,9 @@ function fmtDate(iso: string): string {
                   <a
                     href={`/ranking/battles/${d.id}/`}
                     class="duel-analysis-link"
-                    title="Read full analysis"
+                    title={strings.readFullAnalysis}
                   >
-                    analysis →
+                    {strings.analysis}
                   </a>
                 )}
               </div>


### PR DESCRIPTION
## Summary

Two small, independent UX/UI fixes from the `routine` backlog:

- **#1535** — `/ranking/posts/[key].astro` (ranking dossier page) fixed `lang="en"` on `PageLayout`/`Breadcrumbs`/`HronirExplainer` and had all its UI strings hardcoded in English, even for posts whose primary language is Portuguese. It now derives `lang` from `postInfo.lang` and threads a local `strings` object (mirroring the `RankingStrings` pattern already used by `RankingView.astro`) through the page: rank stats labels, sparkline caption, "Perspective rankings"/"Duel history" headings, Won/Lost/vs labels, the analysis link, and the breadcrumb Home/Ranking labels. `RankingView.astro`'s `title="Dossier: {title}"` tooltip (line 331) also picked up a new `dossierTooltip` field on `RankingStrings`, localized in both `ranking.astro` and `pt/ranking.astro`.
- **#1539** — `PathsTeaser.astro` rendered three identical "Start here →"/"Começar →" links (one per reading path) with no distinguishing accessible name, so a screen-reader user browsing by links heard three identical entries. Each link now gets `aria-label={"${startHere} — ${pathTitle}"}`; the visible text and the `<h3>`'s accessible name are unchanged.

## Test plan

- [x] `npx astro check` — 0 errors (pre-existing warnings only)
- [x] `npx prettier --check .`
- [x] `npm run build` — full build + pagefind succeeded
- [x] `npm run check:hygiene`
- [x] Verified `dist/ranking/posts/<key>/index.html` renders `lang="en"` and English strings for an EN dossier
- [x] Verified `dist/pt/ranking/index.html` renders the `Dossiê: <title>` tooltip and `dist/pt/index.html` renders distinct `aria-label="Começar → — <path title>"` per card, visible text unchanged

Closes #1535
Closes #1539


---
_Generated by [Claude Code](https://claude.ai/code/session_01Pc92e8fsAqMCKzJGBJAAmE)_