### PR TITLE
fix(music): show keyboard focus on playback thumbnails (#1541)

### DIFF
--- a/src/styles/music-focus.css
+++ b/src/styles/music-focus.css
@@ -1,0 +1,8 @@
+/* Keyboard focus for image-backed playback controls in Favorites/Recent.
+ * These images become role="button" + tabindex=0 at runtime, so they need
+ * the same explicit focus treatment as the catalogue's native cover links. */
+main:has(#songs-grid) .mini-card img:focus-visible,
+main:has(#songs-grid) .history-item img:focus-visible {
+  outline: 2px solid var(--pico-primary);
+  outline-offset: 2px;
+}

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -1,4 +1,5 @@
 @import "./music.css";
+@import "./music-focus.css";
 
 /*
  * Design tokens — warm paper aesthetic.


### PR DESCRIPTION
Closes #1541.

## O que muda

- adiciona foco visível explícito aos thumbnails interativos de Favoritos e Recentes;
- usa `outline` + `outline-offset`, portanto não altera o box/layout;
- reutiliza `var(--pico-primary)`, coerente com o foco já desenhado para as capas do grid principal;
- vale para `/music/` e `/pt/musicas/` porque ambos usam os mesmos seletores/classes e o mesmo stylesheet global.

## Fronteira

Não altera `bindPlayTrigger()`, Enter/Espaço, hover, playback nem estrutura HTML. É uma correção local de acessibilidade, não adoção de componente Cobogó.

## Verificação

- Prettier/CI completo do repositório;
- Astro check/build;
- após merge, conferir deploy de Pages e a presença do CSS publicado.
