### PR TITLE
ux: numera aria-label dos botões "Copy code"

### DIFF
--- a/.routines/2026-08-16T05-04-39-ux-ui-run.md
+++ b/.routines/2026-08-16T05-04-39-ux-ui-run.md
@@ -1,0 +1,14 @@
+---
+date: "2026-08-16T05:04:39Z"
+branch: claude/ecstatic-hawking-bs3sa7
+status: open
+---
+
+# Sessão 2026-08-16T05-04-39 — UX/UI
+
+Issues fechadas: #1540
+O que foi feito: botão "Copy code" gerado por CodeCopyEnhancer.astro agora recebe
+um aria-label numerado (e com sufixo de linguagem quando disponível) por bloco de
+código, em vez do mesmo "Copy code"/"Copiar código" repetido em todos os blocos
+de um post.
+CI local: astro check ✅ (0 erros) · prettier ✅ · build ✅ · check:hygiene ✅

--- a/src/components/CodeCopyEnhancer.astro
+++ b/src/components/CodeCopyEnhancer.astro
@@ -49,10 +49,8 @@ const ariaCopyLabel = lang === "pt" ? "Copiar código" : "Copy code";
       button.type = "button";
       button.className = "code-copy";
       button.textContent = labels.copy;
-      button.setAttribute(
-        "aria-label",
-        lang ? `${labels.ariaCopy} ${count} (${lang})` : `${labels.ariaCopy} ${count}`,
-      );
+      const langSuffix = lang ? ` (${lang})` : "";
+      button.setAttribute("aria-label", `${labels.ariaCopy} ${count}${langSuffix}`);
 
       let resetTimer: number | undefined;
       let inFlight = false;

--- a/src/components/CodeCopyEnhancer.astro
+++ b/src/components/CodeCopyEnhancer.astro
@@ -33,8 +33,10 @@ const ariaCopyLabel = lang === "pt" ? "Copiar código" : "Copy code";
 
   function enhance() {
     const labels = getLabels();
+    let count = 0;
     document.querySelectorAll<HTMLPreElement>("article pre").forEach((pre) => {
       if (pre.parentElement?.classList.contains("code-block")) return;
+      count += 1;
 
       const wrapper = document.createElement("div");
       wrapper.className = "code-block";
@@ -47,7 +49,10 @@ const ariaCopyLabel = lang === "pt" ? "Copiar código" : "Copy code";
       button.type = "button";
       button.className = "code-copy";
       button.textContent = labels.copy;
-      button.setAttribute("aria-label", labels.ariaCopy);
+      button.setAttribute(
+        "aria-label",
+        lang ? `${labels.ariaCopy} ${count} (${lang})` : `${labels.ariaCopy} ${count}`,
+      );
 
       let resetTimer: number | undefined;
       let inFlight = false;


### PR DESCRIPTION
## Summary

- **#1540** — `CodeCopyEnhancer.astro` created an identical `aria-label="Copy code"`/`"Copiar código"` for every `<pre>` in a post. Posts with many code blocks (e.g. `reclaiming-the-harness.md`, 15 blocks) gave screen-reader users navigating by button N indistinguishable "Copy code" entries with no way to tell which block each one copies.
- Each button's `aria-label` now includes a per-page counter, and the block's language as a suffix when `data-language` is available (e.g. `"Copy code 3 (bash)"` / `"Copiar código 3 (bash)"`). Visible button text (`Copy`/`Copiar`, `Copied!`/`Copiado!`, `Failed`/`Falhou`) and click/clipboard behavior are unchanged.
- The counter is local to each `enhance()` call, so re-running on `astro:page-load` (client-side navigation) starts fresh per page instead of drifting or duplicating.

Closes #1540

## Test plan

- [x] `npx astro check` — 0 errors (pre-existing warnings only)
- [x] `npx prettier --check .`
- [x] `npm run build` — full build + pagefind succeeded
- [x] `npm run check:hygiene`
- [x] Verified built HTML for an EN post (`dist/blog/*/index.html`) emits `data-aria-copy-label="Copy code"` and the numbered/language-suffixed logic in the bundled script
- [x] Verified built HTML for a PT post (`dist/pt/blog/*/index.html`) emits `data-aria-copy-label="Copiar código"`, confirming the same script localizes correctly via the existing `data-*` label pattern

---
_Generated by [Claude Code](https://claude.ai/code/session_0167PirUqNkjuptwTWDHEz7W)_