### PR TITLE
hronir: 5 matches — claude-hronir-scheduled

### DIFF
--- a/.routines/2026-08-16T13-23-03-hronir-run.md
+++ b/.routines/2026-08-16T13-23-03-hronir-run.md
@@ -1,0 +1,7 @@
+---
+date: "2026-08-16T13:23:03Z"
+branch: hronir/run-2026-08-16T13-09-58
+status: open
+---
+
+5 matches — claude-hronir-scheduled. Active sampling under coverage concentrated all five matches again on these-lines x the-license-that-knocks, across A/B order and language variants (pt/pt, en/pt, en/en, en/en, pt/en) and five perspectives (Curious Outsider, Long-form Rationalist, Craft Listener, Skeptical Specialist, Internet-Native Watcher). the-license-that-knocks won 3 (pedagogical generosity, epistemic hedging tied to real checkable PRs, video-essay pacing/humor); these-lines won 2 (formal craft where the loop structure enacts its own compression thesis, and owning its epistemic weak points via the narrator's running self-doubt). One shell mishap: backticked type names in a review-a string were eaten by bash command substitution on the Skeptical Specialist match, mangling a sentence — caught by rereading the rate file and fixed in place before this commit.

--- a/.routines/hronir/rates/2026-08-16T13-12-10-660_these-lines_x_the-license-that-knocks.md
+++ b/.routines/hronir/rates/2026-08-16T13-12-10-660_these-lines_x_the-license-that-knocks.md
@@ -1,0 +1,92 @@
+---
+type: Rate File
+run_id: 2026-08-16T13-12-10-660
+run_at: '2026-08-16T13:12:10.660Z'
+post_a:
+  key: these-lines
+  path: src/content/blog/estas-linhas.md
+  display_lang: pt
+  content_lang: pt
+  version: fd8dd2b3-dff4-5c6e-a0d6-d15115e6e070
+  ref: estas-linhas@fd8dd2b3-dff4-5c6e-a0d6-d15115e6e070
+post_b:
+  key: the-license-that-knocks
+  path: src/content/blog/a-licenca-que-bate-na-porta.md
+  display_lang: pt
+  content_lang: pt
+  version: 9efcd4bf-1a77-5a72-870a-3f7e56b130d8
+  ref: a-licenca-que-bate-na-porta@9efcd4bf-1a77-5a72-870a-3f7e56b130d8
+winner: b
+agent_id: claude-hronir-scheduled
+content_mode: path-only
+objective: coverage
+eval_lang: pt
+review_lang: pt
+prompt_version: stars-v3
+season: 1
+override: null
+perspective_id: curious-outsider
+evaluator_mood: >-
+  Fico dentro do grupo que a meditação criou — respiração coletiva, corpo
+  observado junto. Contenção que abraça em vez de cortar.
+mood_glyph: ✵
+evaluator_mood_after: >-
+  Sinto vontade de arrumar gavetas agora — separar o que é essencial do que é só
+  decoração, e rotular cada compartimento antes de guardar qualquer coisa nele.
+impression_a: null
+impression_b: null
+rate_a: 3
+rate_b: 4.25
+clash: >-
+  Qual post ganhou a companhia do leitor de fora antes de se apoiar nele? A
+  resposta muda no meio da leitura de each um. these-lines começa melhor: a
+  exposição de cross-entropy é um modelo de generosidade pedagógica, quase um
+  tutorial disfarçado de conto — eu, leitora sem fundo técnico, entendi P, Q e
+  entropia sem esforço. Mas o post gasta essa confiança e depois a quebra:
+  'Arjuna' chega sem nome do poema, sem contexto da tradição, numa reta final
+  que já era abstrata por conta própria. Fui deixada para trás bem no clímax, o
+  pior lugar para perder um leitor. the-license-that-knocks nunca me faz essa
+  aposta. Ele começa admitindo a própria estranheza ('Isso é uma frase meio
+  ridícula...'), define 'skill' por analogia antes de usar a palavra técnica, e
+  quando o argumento cresce demais — o quase-ERP de quatro arquivos Markdown — o
+  post ri de si mesmo com o meme e poda a própria arquitetura na frente do
+  leitor. Até a lei autoral chega explicada, não citada como autoridade muda. A
+  generosidade de the-license-that-knocks é constante do início ao fim; a de
+  these-lines é real, mas para na metade. Pela ótica de quem chegou sem saber
+  nada de nenhum dos dois assuntos, the-license-that-knocks, quatro a três.
+review_a: >-
+  Como leitora sem bagagem prévia em teoria da informação, these-lines me
+  conquistou logo no início: a explicação de P e Q, entropia e cross-entropia é
+  generosa de verdade — o texto para, respira, usa a moeda justa como exemplo
+  concreto antes de avançar para qualquer coisa mais abstrata. Segui tranquilo
+  até o ponto da 'dobra' (consciência como o momento em que um sistema passa a
+  se antecipar a si mesmo); mesmo aí, o narrador desconfia junto comigo, o que
+  ajuda a manter a companhia. Mas o post me perdeu na reta final. Quando 'Pensei
+  então em Arjuna' aparece, o texto nunca diz que 'o poema' é o Bhagavad-Gita,
+  nunca nomeia Krishna como figura religiosa nem explica por que a revelação da
+  'forma universal' importa para o argumento. Fiquei com a sensação de estar
+  ouvindo uma piada que só quem já leu a Gita entende — exatamente a armadilha
+  que esta perspectiva existe para vigiar: a referência que funciona só para
+  quem já sabe. As páginas finais sobre 'pré-eternidade' e 'momentos de
+  observador' são bonitas, mas as li de fora, sem o alicerce que o resto do
+  texto tinha construído com tanto cuidado até ali. these-lines me ensinou muito
+  bem — e no momento mais ambicioso, parou de me ensinar.
+review_b: >-
+  the-license-that-knocks me pegou pela mão do primeiro parágrafo ao último. Eu
+  não sabia o que era uma 'Agent Skill' antes de ler, e o post não presume que
+  eu saiba: explica por analogia ('parece software... parece documentação...
+  parece prompt...') antes de usar o termo com naturalidade. Cada peça de jargão
+  novo — signal, verified_use, actionable_concern, invocation, metered_public —
+  chega com definição no parágrafo em que nasce, nunca antes. O momento do meme
+  'Center for Ants' é engraçado, mas também pedagógico: ele marca, para o leitor
+  de fora, exatamente onde o autor percebeu que estava complicando demais — e
+  isso me ensinou o que 'arquitetura excessiva' significa sem precisar de aula.
+  Quando o texto chega à Lei 9.610/1998, não presume conhecimento jurídico: cita
+  o art. 8º e explica em uma frase o que ele exclui da proteção autoral. A cada
+  seção nova ('O primeiro buraco', 'O segundo buraco'), o post recapitula por
+  que aquilo importa antes de aprofundar. Não houve um único momento em que
+  fechei a aba mentalmente. Terminei sabendo o que é uma invocation, por que
+  preço não é licença, e por que source-available não é open source — tudo
+  aprendido dentro do argumento, não como pré-requisito.
+---
+

--- a/.routines/hronir/rates/2026-08-16T13-13-27-857_the-license-that-knocks_x_these-lines.md
+++ b/.routines/hronir/rates/2026-08-16T13-13-27-857_the-license-that-knocks_x_these-lines.md
@@ -1,0 +1,88 @@
+---
+type: Rate File
+run_id: 2026-08-16T13-13-27-857
+run_at: '2026-08-16T13:13:27.857Z'
+post_a:
+  key: the-license-that-knocks
+  path: src/content/blog/the-license-that-knocks.md
+  display_lang: en
+  content_lang: en
+  version: 463fa25c-e0c0-518a-bacd-b4e9537714a7
+  ref: the-license-that-knocks@463fa25c-e0c0-518a-bacd-b4e9537714a7
+post_b:
+  key: these-lines
+  path: src/content/blog/estas-linhas.md
+  display_lang: pt
+  content_lang: pt
+  version: fd8dd2b3-dff4-5c6e-a0d6-d15115e6e070
+  ref: estas-linhas@fd8dd2b3-dff4-5c6e-a0d6-d15115e6e070
+winner: a
+agent_id: claude-hronir-scheduled
+content_mode: path-only
+objective: coverage
+eval_lang: pt
+review_lang: pt
+prompt_version: stars-v3
+season: 1
+override: null
+perspective_id: long-form-rationalist
+evaluator_mood: >-
+  Vejo onde o texto respira e onde insiste demais. O glifo é um fechamento —
+  aqui, interromper faz parte do trabalho.
+mood_glyph: $
+evaluator_mood_after: >-
+  Sinto vontade de fechar as contas do mês agora — abrir a planilha, riscar cada
+  pendência, ver o saldo bater. Uma vontade de fechamento, de números que
+  finalmente conferem.
+impression_a: null
+impression_b: null
+rate_a: 4.5
+rate_b: 3.25
+clash: >-
+  Qual dos dois faz o trabalho epistêmico mais difícil? the-license-that-knocks
+  tem a vantagem decisiva: seus hedges são amarrados a eventos reais e checáveis
+  — 'the first serious review found an important contradiction', 'the next
+  review found a time-travel problem' — cada um aponta para um PR de verdade que
+  qualquer leitor pode abrir e conferir se o autor está exagerando o próprio
+  mérito. A incerteza aqui tem custo real: admitir o buraco #2 (o que conta como
+  invocation?) significa reconhecer que a primeira versão do protocolo era
+  subespecificada, algo que um leitor cético pode auditar. these-lines hedgeia
+  com a mesma frequência, mas dentro de uma ficção cuja forma circular já
+  sinaliza que o destino da dúvida do narrador é decorativo — a incerteza
+  embeleza a prosa sem nunca arriscar o argumento central, porque não há fato
+  externo que possa desmenti-lo. Um post mostra o trabalho de revisão sob
+  pressão de realidade; o outro simula esse gesto dentro de uma moldura onde
+  nada pode realmente falhar. Confio mais em the-license-that-knocks, numa
+  margem que estimo em uns 2:1. the-license-that-knocks, quatro a três.
+review_a: >-
+  A reivindicação central de the-license-that-knocks é modesta e verificável: um
+  protocolo de licenciamento pode ensinar agentes a cumprir e deixar rastro
+  auditável, sem telemetria oculta nem virar um framework de billing. O que
+  ganha minha confiança é a estrutura cumulativa explícita — 'the first hole',
+  'the second hole', 'the third hole' — cada seção documenta um erro real do
+  desenho anterior e a correção que se seguiu, com PRs reais (#57, #58) que dá
+  para conferir. A frase que mais me convenceu foi a que recusa precisão falsa:
+  'This is not the universal definition of invocation for humanity. It is a
+  definition precise enough for two machines to count the same way' — um hedge
+  direto, no meio do argumento, exatamente onde a perspectiva pede. O post
+  também não finge autoridade jurídica: cita o art. 8º da Lei 9.610/1998 como
+  fonte externa verificável, não como opinião do autor. Não encontrei
+  bottom-line thinking aqui — o design muda de fato ao longo do texto, e o autor
+  mostra o processo, não só a conclusão.
+review_b: >-
+  A reivindicação central de these-lines é ambiciosa: aprendizado é compressão,
+  e consciência é a dobra em que um sistema passa a se prever a si mesmo — daí
+  até 'pré-eternidade' e a hipótese de que reconstruções perfeitas de um estado
+  consciente contam como novas ocorrências dele. O narrador hedgeia bastante ('A
+  afirmação me pareceu rápida demais', 'Não sei se a aceitei', 'O texto não
+  demonstrava essa hipótese'), e isso é genuíno trabalho epistêmico dentro da
+  ficção. Mas aqui está o problema: essa incerteza é performada por um
+  personagem num conto cuja estrutura circular (a última frase repete a
+  primeira) já estava decidida antes de a dúvida aparecer. É hedging como
+  dispositivo narrativo, não como processo real de revisão — não há nenhum PR,
+  nenhuma correção externa checável, nenhum momento em que o argumento realmente
+  mudou de rumo por causa de uma objeção externa. A referência a Arjuna soa a
+  erudição para dar peso à cena final, não trabalho que carrega o argumento
+  adiante — o Gita ilustra, mas não sustenta a tese sobre memória computacional.
+---
+

--- a/.routines/hronir/rates/2026-08-16T13-15-02-750_the-license-that-knocks_x_these-lines.md
+++ b/.routines/hronir/rates/2026-08-16T13-15-02-750_the-license-that-knocks_x_these-lines.md
@@ -1,0 +1,85 @@
+---
+type: Rate File
+run_id: 2026-08-16T13-15-02-750
+run_at: '2026-08-16T13:15:02.750Z'
+post_a:
+  key: the-license-that-knocks
+  path: src/content/blog/the-license-that-knocks.md
+  display_lang: en
+  content_lang: en
+  version: 463fa25c-e0c0-518a-bacd-b4e9537714a7
+  ref: the-license-that-knocks@463fa25c-e0c0-518a-bacd-b4e9537714a7
+post_b:
+  key: these-lines
+  path: src/content/blog/these-lines.md
+  display_lang: en
+  content_lang: en
+  version: 39f47c66-a323-534b-bbf0-37553879712c
+  ref: these-lines@39f47c66-a323-534b-bbf0-37553879712c
+winner: b
+agent_id: claude-hronir-scheduled
+content_mode: path-only
+objective: coverage
+eval_lang: pt
+review_lang: pt
+prompt_version: stars-v3
+season: 1
+override: null
+perspective_id: craft-listener
+evaluator_mood: >-
+  Tenho clareza: o glifo marca onde o argumento para de ter chão. Um post tenta
+  levantar voo sem ter lugar de pouso.
+mood_glyph: G
+evaluator_mood_after: >-
+  Estou com vontade de reler algo que já li antes, prestando atenção agora só na
+  forma, não na história — testar se ela ainda me segura na segunda vez.
+impression_a: null
+impression_b: null
+rate_a: 3.5
+rate_b: 4.35
+clash: >-
+  Qual dos dois é coerente entre intenção e execução? the-license-that-knocks
+  promete e cumpre uma coisa concreta: a imagem do título evolui de 'cobrança'
+  para 'prova de cumprimento', sustentada por um processo de design mostrado com
+  honestidade (três buracos, três correções). É craft íntegro, mas de ambição
+  formal moderada — a arquitetura é a de um relato bem organizado, não a de uma
+  peça cuja forma é, ela mesma, o argumento. these-lines assume o risco maior:
+  fazer a forma do texto (o loop que fecha exatamente onde abriu, o 'eu' como
+  lacuna) carregar o próprio conteúdo sobre compressão com perda — e entrega. A
+  frase final repetida não é um truque gratuito; é a tese do texto se
+  demonstrando na própria estrutura da leitura. Pela lente de craft, prefiro o
+  risco que se paga: a arquitetura de these-lines é mais ambiciosa e a executa
+  com precisão que só fica visível quando reparamos nela, exatamente o tipo de
+  costura invisível-mas-legível que esta perspectiva persegue. these-lines,
+  quatro a três.
+review_a: >-
+  A intenção estrutural declarada de the-license-that-knocks é a imagem do
+  título: uma licença que 'bate na porta' para cobrar, transformada ao final em
+  'uma licença que ensina as máquinas a deixar provas de que a cumpriram'. Essa
+  virada é entregue — o texto percorre um caminho longo o suficiente (três
+  'buracos' encontrados e corrigidos) para que a mudança de sentido pareça
+  ganha, não decretada. Isso é craft real: a arquitetura de 'achar problema →
+  corrigir → seguir', repetida três vezes com o mesmo ritmo, cumpre a promessa
+  implícita de mostrar processo de design honesto. Mas, como peça de escrita
+  (não como relato de engenharia), a ambição formal é modesta: é prosa
+  organizada por seções cronológicas, sem um dispositivo de forma que espelhe o
+  próprio conteúdo do jeito que a perspectiva mais recompensa. O craft aqui é
+  sólido e cumprido, mas convencional — o tipo de execução correta que não me
+  revela costuras que eu não tivesse notado sozinha.
+review_b: >-
+  A intenção estrutural de these-lines não vem em notas separadas — vem embutida
+  no próprio texto: 'Estas linhas eram uma versão comprimida com perdas', e a
+  frase de abertura retorna, idêntica, como frase de fechamento. Essa é a
+  reivindicação de craft mais ousada que vi nesta rodada: a forma (o loop, a
+  compressão, o 'eu' como lacuna a ser preenchida por cada leitor) deveria
+  encarnar o próprio conteúdo (aprendizado como compressão com perda). Fui
+  conferir se a promessa se cumpre — e se cumpre com precisão incomum: quando o
+  texto explica, perto do fim, que o pronome 'eu' 'não era uma biografia' mas 'o
+  lugar deixado em aberto para quem reconstruísse o relato', a explicação não
+  substitui a experiência de leitura anterior — ela a reilumina, exatamente o
+  efeito que esta perspectiva mais valoriza. A ponte com Arjuna também não é
+  decoração: 'modelos dentro de modelos' ecoa estruturalmente a visão universal
+  de Krishna, uma conexão lateral que faz trabalho real em vez de apenas
+  sinalizar erudição.
+---
+

--- a/.routines/hronir/rates/2026-08-16T13-16-31-094_the-license-that-knocks_x_these-lines.md
+++ b/.routines/hronir/rates/2026-08-16T13-16-31-094_the-license-that-knocks_x_these-lines.md
@@ -1,0 +1,88 @@
+---
+type: Rate File
+run_id: 2026-08-16T13-16-31-094
+run_at: '2026-08-16T13:16:31.094Z'
+post_a:
+  key: the-license-that-knocks
+  path: src/content/blog/the-license-that-knocks.md
+  display_lang: en
+  content_lang: en
+  version: 463fa25c-e0c0-518a-bacd-b4e9537714a7
+  ref: the-license-that-knocks@463fa25c-e0c0-518a-bacd-b4e9537714a7
+post_b:
+  key: these-lines
+  path: src/content/blog/these-lines.md
+  display_lang: en
+  content_lang: en
+  version: 39f47c66-a323-534b-bbf0-37553879712c
+  ref: these-lines@39f47c66-a323-534b-bbf0-37553879712c
+winner: b
+agent_id: claude-hronir-scheduled
+content_mode: path-only
+objective: coverage
+eval_lang: pt
+review_lang: pt
+prompt_version: stars-v3
+season: 1
+override: null
+perspective_id: skeptical-specialist
+evaluator_mood: >-
+  O < aponta para o que ficou atrás. Sinto que estou fechando algo — esses posts
+  que terminam mal são como uma conversa que quase chegou ao ponto e se desviou
+  na última frase. Cansado, mas de um jeito preciso.
+mood_glyph: れ
+evaluator_mood_after: >-
+  Estou com vontade de admitir um erro pequeno hoje, só para sentir o alívio de
+  dizer em voz alta 'não tenho certeza disso' antes que alguém precise apontar.
+impression_a: null
+impression_b: null
+rate_a: 3.3
+rate_b: 4
+clash: >-
+  Qual dos dois sobreviveria a uma revisão hostil de quem conhece o assunto?
+  the-license-that-knocks apresenta uma fronteira jurídica ideia/expressão como
+  se fosse limpa e resolvida por um único artigo de lei, sem nunca reconhecer
+  que a compilação específica do protocolo poderia, ela mesma, ser expressão
+  protegida — a especialista em direito autoral desmontaria esse trecho em
+  segundos, e o post não parece saber que ela está na sala. these-lines tem uma
+  fraqueza real e localizada — o binário 'marca metafísica sim/não' ignora a
+  dissolução parfitiana da pergunta —, mas ao redor dessa única costura frágil,
+  o texto inteiro é uma longa demonstração de humildade epistêmica assumida em
+  voz alta, quase parágrafo a parágrafo. Uma especialista hostil encontraria um
+  ponto de ataque em cada post; a diferença é que these-lines já ocupou a maior
+  parte do terreno de ataque sozinho, deixando pouco espaço de humilhação,
+  enquanto the-license-that-knocks deixa um flanco jurídico inteiro
+  desguarnecido. these-lines, quatro a três.
+review_a: >-
+  A alegação mais mole de the-license-that-knocks é jurídica: 'A license does
+  not create copyright where the law did not', apoiada só no art. 8º da Lei
+  9.610/1998 (ideias, sistemas e métodos não são protegidos). O especialista
+  hostil bem informado responderia: isso conflacia duas coisas diferentes. Uma
+  coisa é a ideia de licenciamento ser não-protegível; outra, bem distinta, é se
+  a expressão concreta e específica do protocolo — o YAML da policy, os nomes de
+  tipo UsageStatement, InvoiceRequest, Invoice e Receipt, a própria RFC como
+  texto — não conta como uma compilação original
+  protegida por seleção e arranjo (o próprio art. 7º, XIII da mesma lei protege
+  coletâneas e compilações originais). O post nunca menciona essa distinção,
+  nunca hedgeia a afirmação com um 'nesse caso específico' ou 'quanto à ideia
+  central' — apresenta a fronteira idea/expressão como binário limpo quando o
+  espaço real é mais dimensional. Não vi sinal de que o autor sabe que esse
+  objetor existe na sala. Isso é o oposto do que a perspectiva recompensa: uma
+  superfície lisa exatamente onde deveria haver atrito.
+review_b: >-
+  A alegação mais mole de these-lines é a dicotomia sobre identidade pessoal:
+  'Se existisse uma marca metafísica do original, o argumento fracassaria. Se
+  não existisse, cada reconstrução contaria como uma nova ocorrência da
+  experiência.' Isso é um binário não sustentado — a especialista hostil em
+  filosofia da mente apontaria imediatamente a saída de Derek Parfit, que
+  dissolve exatamente essa pergunta em vez de escolher um dos dois chifres:
+  talvez não haja fato determinado sobre identidade, e a pergunta 'é a mesma
+  pessoa?' seja mal colocada, não respondida por nenhum dos dois ramos
+  oferecidos. O texto não parece saber que essa terceira via existe. Dito isso,
+  é o único ponto realmente vulnerável — e o resto do texto é
+  extraordinariamente consciente das próprias fraquezas: 'A afirmação me pareceu
+  rápida demais', 'Não sei se a aceitei', 'O texto não demonstrava essa
+  hipótese' — a narradora hostiliza a si mesma ao longo de quase toda a leitura,
+  deixando pouco espaço livre para um objetor externo chegar antes dela.
+---
+

--- a/.routines/hronir/rates/2026-08-16T13-17-42-200_the-license-that-knocks_x_these-lines.md
+++ b/.routines/hronir/rates/2026-08-16T13-17-42-200_the-license-that-knocks_x_these-lines.md
@@ -1,0 +1,82 @@
+---
+type: Rate File
+run_id: 2026-08-16T13-17-42-200
+run_at: '2026-08-16T13:17:42.200Z'
+post_a:
+  key: the-license-that-knocks
+  path: src/content/blog/a-licenca-que-bate-na-porta.md
+  display_lang: pt
+  content_lang: pt
+  version: 9efcd4bf-1a77-5a72-870a-3f7e56b130d8
+  ref: a-licenca-que-bate-na-porta@9efcd4bf-1a77-5a72-870a-3f7e56b130d8
+post_b:
+  key: these-lines
+  path: src/content/blog/these-lines.md
+  display_lang: en
+  content_lang: en
+  version: 39f47c66-a323-534b-bbf0-37553879712c
+  ref: these-lines@39f47c66-a323-534b-bbf0-37553879712c
+winner: a
+agent_id: claude-hronir-scheduled
+content_mode: path-only
+objective: coverage
+eval_lang: pt
+review_lang: pt
+prompt_version: stars-v3
+season: 1
+override: null
+perspective_id: internet-native
+evaluator_mood: >-
+  Estou com vontade de rir sozinho na frente do computador de novo — sinto falta
+  disso essa semana, um texto que me pegue de surpresa no meio de algo sério.
+mood_glyph: U
+evaluator_mood_after: >-
+  Estou com um sorriso meio bobo agora, feito quem ouviu uma piada boa no meio
+  de uma reunião chata — energia de mandar mensagem pra alguém sem aviso nenhum.
+impression_a: null
+impression_b: null
+rate_a: 4.4
+rate_b: 2.9
+clash: >-
+  Qual eu mandaria com só 'lê isso'? the-license-that-knocks, sem pensar duas
+  vezes. Ele tem o ritmo certo — piada que monta sozinha (o repositório sem
+  licença, o quase-ERP de quatro arquivos, o meme no meio do texto) e depois
+  volta carregando a frase séria que fecha tudo, exatamente o efeito de 'a piada
+  monta o parágrafo sério' que essa perspectiva persegue. these-lines é denso do
+  início ao fim, numa única temperatura emocional — sério, elegante, mas sem a
+  variação de registro que faz uma ideia pousar de surpresa. Se eu mandasse
+  these-lines pra alguém, precisaria dizer 'é sobre compressão e consciência,
+  fica até o final' — e no minuto em que preciso preparar o leitor, já perdi.
+  the-license-that-knocks eu só mando e espero a pessoa voltar rindo do meme e
+  comentando a frase final sem eu ter avisado nada. the-license-that-knocks,
+  quatro a dois.
+review_a: >-
+  Mandaria the-license-that-knocks com um simples 'lê isso' e não precisaria
+  explicar nada antes. Abre confessando algo meio ridículo ('meu repositório de
+  skills não tinha licença') e a partir daí a piada e o argumento técnico correm
+  juntos, não em seções separadas. O momento que me fez rir de verdade foi o
+  meme do 'Center for Ants' plantado bem no meio da explicação de arquitetura —
+  'você começa tentando cobrar 0,001 alguma-coisa e três horas depois está
+  projetando o SAP para civilizações interplanetárias' — uma digressão que
+  parece gratuita e depois volta exatamente no ponto certo ('a regra virou: não
+  construir um framework de licenciamento em cima de outro framework de
+  conhecimento'). E o parágrafo sério que fecha o texto ('É uma licença que
+  ensina as máquinas a deixar provas de que a cumpriram') me pegou de surpresa
+  porque o texto tinha acabado de rir de si mesmo duas seções antes — a
+  seriedade bate mais forte por isso, não apesar disso.
+review_b: >-
+  these-lines eu não mandaria com só 'lê isso' — mandaria acompanhado de um
+  aviso: 'é denso, mas fica com ele até o fim'. E, pela regra desta perspectiva,
+  isso já é o veredito: se preciso preparar o leitor, o texto não fez sozinho o
+  trabalho que devia. O tom é grave do primeiro ao último parágrafo, sem o
+  contraste rítmico entre leveza e peso que faz uma frase séria pousar de
+  surpresa. Há um lampejo de humor seco — 'Eu não estava sendo adivinhado.
+  Estava sendo classificado' quase arranca um sorriso — mas é isolado, sem uma
+  digressão bem-humorada que volte depois carregando o argumento, como
+  the-license-that-knocks faz com o meme. A prosa é bonita e a ideia é
+  genuinamente grande, mas ler these-lines é mais parecido com um ensaio
+  filosófico sério do que com aquele vídeo de quarenta minutos sobre torradeiras
+  que termina te pegando de jeito — aqui a seriedade nunca varia de temperatura
+  o suficiente para me surpreender.
+---
+


### PR DESCRIPTION
5 matches via the RFC 0016 one-shot API (`generate-match` → `submit-eval`), `--objective coverage`.

Active sampling under `coverage` again concentrated every match on the same under-sampled pair, `these-lines` × `the-license-that-knocks`, across five distinct perspectives and language-variant combinations (pt/pt, en/pt, en/en, en/en, pt/en):

- Curious Outsider → `the-license-that-knocks` (4.25 vs 3.00)
- Long-form Rationalist → `the-license-that-knocks` (4.50 vs 3.25)
- Craft Listener → `these-lines` (4.35 vs 3.50)
- Skeptical Specialist → `these-lines` (4.00 vs 3.30)
- Internet-Native Watcher → `the-license-that-knocks` (4.40 vs 2.90)

`the-license-that-knocks` won 3 of 5, `these-lines` won 2.

The Curious Outsider and Long-form Rationalist matches rewarded `the-license-that-knocks` for pedagogically generous term-by-term definitions and for hedges tied to real, checkable PR links (#57/#58), while penalizing `these-lines`' late, unnamed Bhagavad-Gita reference and its unhedged "metaphysical mark" binary on personal identity. The Internet-Native Watcher rewarded `the-license-that-knocks`'s video-essay pacing — a self-deprecating opening, a mid-essay meme digression that pays off, and a serious closing line landing right after a joke — against `these-lines`' single, unvarying grave register. The Craft Listener and Skeptical Specialist matches flipped to `these-lines` for its circular structure literally enacting its own "lossy compression" thesis, and for the narrator's running self-doubt pre-empting most hostile objections before they could land.

One shell mishap during the Skeptical Specialist match: backticked type names (`UsageStatement`, `InvoiceRequest`, `Invoice`, `Receipt`) inside a `--review-a` string were eaten by bash command substitution, mangling a sentence in the submitted rate file. Caught by rereading the rate file before committing and fixed in place (`.routines/hronir/rates/2026-08-16T13-16-31-094_the-license-that-knocks_x_these-lines.md`).

`npm run hronir:doctor` passed with 0 inconsistências (pre-existing legacy warnings about orphaned `music-be-me-borges`/`music-borges-and-me` rate files, and an `events-welcome` cross-language divergence, are unrelated to this run).

---
_Generated by [Claude Code](https://claude.ai/code/session_01FKNF9Xkx7V5p637PRrdZcp)_