### PR TITLE
feat(blog): O banco de dados que se lembrou de Uqbar

### DIFF
--- a/src/content/blog/o-banco-de-dados-que-se-lembrou-de-uqbar.md
+++ b/src/content/blog/o-banco-de-dados-que-se-lembrou-de-uqbar.md
@@ -1,0 +1,102 @@
+---
+type: Blog Post
+title: 'O banco de dados que se lembrou de Uqbar'
+description: >-
+  O Google Ngram parece encontrar Uqbar antes de Borges. A explicação pode ser
+  banal. A coincidência, nem tanto.
+date: '2026-08-16'
+lang: pt
+docType: essay
+translationKey: database-that-remembered-uqbar
+tags:
+  - borges
+  - internet
+  - databases
+  - metadata
+  - literature
+emoji: '🪞'
+---
+
+Eu estava olhando [um post no Reddit](https://www.reddit.com/r/OpenAI/comments/1vpjnsc/whats_going_on_here/) em que alguém perguntava por que o Google Ngram parecia detectar a expressão “Chat GPT” por volta de 2002.
+
+A piada óbvia era viagem no tempo.
+
+A explicação que apareceu nos comentários era menos ambiciosa. Algumas das ocorrências vinham de livros obviamente recentes que o Google Books tratava como se tivessem sido publicados no começo dos anos 2000. Um romance de 2024, por exemplo, aparecia no conjunto que sustentava a anomalia. Não era uma mensagem do futuro. Era metadata ruim.
+
+Ainda assim, fiquei pensando que já tinha lido essa história.
+
+Não a história de alguém encontrar ChatGPT vinte anos antes de ChatGPT. A história de um sistema de referência produzir evidência documental de uma coisa que não deveria existir.
+
+Então procurei **Uqbar**.
+
+## A enciclopédia
+
+Em *Tlön, Uqbar, Orbis Tertius*, publicado em 1940, Borges começa com uma anomalia bibliográfica. Um volume de uma enciclopédia contém algumas páginas sobre Uqbar. Outro exemplar, aparentemente da mesma obra, não contém.
+
+A enciclopédia é a fictícia *The Anglo-American Cyclopaedia*, de 1917, descrita como uma reimpressão da *Encyclopaedia Britannica* de **1902**. O [Borges Center confirma essa genealogia bibliográfica](https://www.borges.pitt.edu/i/encyclopaedia-britannica): a décima edição da Britannica, de 1902–1903, é o original que o conto atribui à enciclopédia pirata.
+
+Uqbar entra no mundo por aí.
+
+Não há uma expedição. Não há uma fotografia. Não há uma testemunha que voltou de Uqbar contando o que viu. Há um verbete.
+
+A evidência de que o país existe é, primeiro, o fato de uma enciclopédia dizer que ele existe.
+
+Mais tarde aparece algo ainda maior: um volume da *First Encyclopaedia of Tlön*, a descrição sistemática de um mundo inteiro. Dentro da cronologia inventada por Borges, a obra teria quarenta volumes e o último teria sido publicado em **1914**. O [Borges Center registra também esse detalhe](https://www.borges.pitt.edu/i/first-encyclopaedia-tlon).
+
+Primeiro existe a referência. Depois a referência começa a produzir o mundo ao qual supostamente se referia.
+
+## Uqbar antes de Uqbar
+
+Abri então o [Google Ngram para “Uqbar”, entre 1895 e 1950](https://books.google.com/ngrams/graph?content=Uqbar&year_start=1895&year_end=1950&corpus=en-2019&smoothing=0&case_insensitive=false).
+
+Usei o corpus English 2019, busca sensível a maiúsculas e minúsculas e smoothing zero, para não espalhar uma ocorrência por anos vizinhos.
+
+E lá está uma pequena elevação antes de Borges publicar o conto. O trecho que chamou minha atenção fica em torno de **1900–1902**.
+
+1902.
+
+É difícil pedir uma coincidência melhor.
+
+A data não é a da *First Encyclopaedia of Tlön* — essa, dentro da ficção, termina em 1914. É a data da Britannica real que Borges escolheu como substrato da falsa enciclopédia em que Uqbar aparece pela primeira vez.
+
+Em 1940, Borges inventa a história de alguém que descobre Uqbar numa enciclopédia derivada de uma obra de 1902.
+
+Em 2026, eu digito `Uqbar` num enorme índice computacional de livros e ele parece responder: sim, há rastros por volta de 1902.
+
+Isso não demonstra que o Google retroprojetou Borges no passado.
+
+Eu não rastreei os volumes individuais que formam esse pequeno bump, e não quero transformar uma coincidência boa numa investigação que não fiz. Pode haver uma ocorrência antiga legítima da sequência de letras, uma transliteração, OCR, metadata incorreta ou alguma combinação dessas coisas. O próprio Google explica que o [Ngram é construído a partir de ocorrências em seu corpus de livros e que OCR, detecção de idioma e composição do corpus afetam os resultados](https://books.google.com/ngrams/info).
+
+A causa pode ser perfeitamente banal.
+
+O formato do erro é que não é.
+
+## Um bug borgiano
+
+Normalmente pensamos numa base bibliográfica como uma janela para o passado. Os livros vieram primeiro; o índice veio depois. Consultamos o índice para descobrir o que havia nos livros.
+
+Mas, para quem chega depois, quase sempre a ordem epistemológica é a inversa.
+
+Primeiro vemos o resultado da busca. Depois, talvez, vemos o livro.
+
+Isso dá ao sistema de representação um poder estranho. Um erro de data não muda o passado, mas muda a primeira versão do passado que recebemos. Um OCR ruim não cria uma palavra num livro antigo, mas pode criar a evidência pesquisável de que aquela palavra estava lá. Uma classificação errada pode fazer uma obra recente comparecer como testemunha de uma época em que ela não existia.
+
+No caso de “Chat GPT em 2002”, isso é só engraçado.
+
+No caso de Uqbar, o mecanismo acidentalmente imita o objeto que está indexando.
+
+O conto começa quando um homem encontra num sistema de referência uma evidência impossível. A evidência é pequena, textual e aparentemente objetiva. É justamente por parecer uma entrada bibliográfica banal que ela funciona. A partir dali, a descrição ganha densidade, produz novas referências, novos objetos e finalmente compete com a realidade que deveria apenas descrever.
+
+O Ngram não está fazendo tudo isso, claro. Ele só desenhou alguns pixels numa curva.
+
+Mas esses pixels fazem uma coisa muito específica: dão a Uqbar uma aparência de passado documental anterior ao conto que a inventou. E fazem isso perto de uma data que já desempenhava, dentro do próprio conto, o papel de passado documental de Uqbar.
+
+Talvez quando descobrirmos de onde vêm exatamente aquelas ocorrências a resposta seja decepcionante. Um livro com a data errada. Um nome parecido. Um OCR torto.
+
+Melhor ainda.
+
+Porque o ponto não depende de uma máquina do tempo. Depende apenas de uma coisa muito mais comum: confiarmos numa representação do mundo e, por alguns segundos, encontrarmos dentro dela um mundo que nunca esteve lá.
+
+O mundo não virou Tlön.
+
+O índice, por alguns pixels, virou.


### PR DESCRIPTION
## Resumo

Publica um ensaio curto a partir da anomalia de “Chat GPT” no Google Ngram e da coincidência com *Tlön, Uqbar, Orbis Tertius*.

O texto:

- liga o bump pré-1940 de `Uqbar` ao papel da *Encyclopaedia Britannica* de 1902 dentro do conto;
- distingue essa data de 1914, atribuída à *First Encyclopaedia of Tlön*;
- mantém explícita a incerteza causal: não afirma que o bump de Uqbar seja erro de metadados sem rastrear os volumes;
- usa o caso para discutir como sistemas de representação podem produzir uma aparência de passado documental.

Sem imagem: o post é curto e o próprio gráfico do Ngram funciona como objeto/link central.