### PR TITLE
ux: nomes acessíveis únicos para badges PT/EN e link de site

### DIFF
--- a/.routines/2026-08-18T05-06-43-ux-ui-run.md
+++ b/.routines/2026-08-18T05-06-43-ux-ui-run.md
@@ -1,0 +1,13 @@
+---
+date: "2026-08-18T05:06:43Z"
+branch: claude/ecstatic-hawking-8ja40c
+status: open
+---
+
+# Sessão 2026-08-18T05-06-43 — UX/UI
+
+Issues fechadas: #1550, #1551
+O que foi feito: aria-label dos badges PT/EN de /archive/ (e paginação) e do
+link "↗ site" de /projects/ agora incluem o título do post / nome do repo,
+desambiguando o nome acessível por linha para leitores de tela.
+CI local: astro check ✅ · prettier ✅ · build ✅

--- a/src/pages/archive/index.astro
+++ b/src/pages/archive/index.astro
@@ -139,7 +139,7 @@ const archiveLd = {
                 </td>
                 <td class="col-pt">
                   {ptId && (
-                    <a class="pt-badge" href={`/pt/blog/${ptId}/`} aria-label="Portuguese version available" title="Ler em Português">PT</a>
+                    <a class="pt-badge" href={`/pt/blog/${ptId}/`} aria-label={`${post.data.title} — Portuguese version available`} title="Ler em Português">PT</a>
                   )}
                 </td>
               </tr>

--- a/src/pages/archive/page/[n].astro
+++ b/src/pages/archive/page/[n].astro
@@ -157,7 +157,7 @@ const archiveLd = {
                 </td>
                 <td class="col-pt">
                   {ptId && (
-                    <a class="pt-badge" href={`/pt/blog/${ptId}/`} aria-label="Portuguese version available" title="Ler em Português">PT</a>
+                    <a class="pt-badge" href={`/pt/blog/${ptId}/`} aria-label={`${post.data.title} — Portuguese version available`} title="Ler em Português">PT</a>
                   )}
                 </td>
               </tr>

--- a/src/pages/projects.astro
+++ b/src/pages/projects.astro
@@ -88,7 +88,7 @@ const fmt = new Intl.DateTimeFormat("en-US", { year: "numeric", month: "short", 
           {repo.language && <><kbd>{repo.language}</kbd> · </>}
           {repo.forks_count > 0 && <>⑂ {repo.forks_count} · </>}
           updated <time datetime={repo.pushed_at}>{fmt.format(new Date(repo.pushed_at))}</time>
-          {repo.homepage && <> · <a href={repo.homepage}>↗ site</a></>}
+          {repo.homepage && <> · <a href={repo.homepage} aria-label={`${repo.name} site`}>↗ site</a></>}
         </small>
       </footer>
     </article>

--- a/src/pages/pt/archive/index.astro
+++ b/src/pages/pt/archive/index.astro
@@ -145,7 +145,7 @@ const years = [...byYear.keys()].sort((a, b) => b - a);
                 </td>
                 <td class="col-en">
                   {enId && (
-                    <a class="en-badge" href={`/blog/${enId}/`} aria-label="Versão em inglês disponível" title="Read in English">EN</a>
+                    <a class="en-badge" href={`/blog/${enId}/`} aria-label={`${post.data.title} — Versão em inglês disponível`} title="Read in English">EN</a>
                   )}
                 </td>
               </tr>

--- a/src/pages/pt/archive/page/[n].astro
+++ b/src/pages/pt/archive/page/[n].astro
@@ -163,7 +163,7 @@ const years = [...byYear.keys()].sort((a, b) => b - a);
                 </td>
                 <td class="col-en">
                   {enId && (
-                    <a class="en-badge" href={`/blog/${enId}/`} aria-label="Versão em inglês disponível" title="Read in English">EN</a>
+                    <a class="en-badge" href={`/blog/${enId}/`} aria-label={`${post.data.title} — Versão em inglês disponível`} title="Read in English">EN</a>
                   )}
                 </td>
               </tr>

--- a/src/pages/pt/projects.astro
+++ b/src/pages/pt/projects.astro
@@ -88,7 +88,7 @@ const fmt = new Intl.DateTimeFormat("pt-BR", { year: "numeric", month: "short", 
           {repo.language && <><kbd>{repo.language}</kbd> · </>}
           {repo.forks_count > 0 && <>⑂ {repo.forks_count} · </>}
           atualizado <time datetime={repo.pushed_at}>{fmt.format(new Date(repo.pushed_at))}</time>
-          {repo.homepage && <> · <a href={repo.homepage}>↗ site</a></>}
+          {repo.homepage && <> · <a href={repo.homepage} aria-label={`Site de ${repo.name}`}>↗ site</a></>}
         </small>
       </footer>
     </article>


### PR DESCRIPTION
## Summary

- `/archive/` (e `/archive/page/[n]/`, EN e PT): o `aria-label` dos badges "PT"/"EN" por linha da tabela agora inclui o título do post, em vez de um `aria-label` estático idêntico repetido em toda linha.
- `/projects/` (e `/pt/projects/`): o link "↗ site" de cada repositório agora tem `aria-label` que inclui o nome do repositório.
- Texto visível, `title` (tooltip) e destino (`href`) de todos os links permanecem inalterados — só o nome acessível (usado por leitores de tela ao navegar por lista de links) foi desambiguado.

Closes #1550, Closes #1551

## Test plan

- [x] `npx astro check` — 0 erros (warnings pré-existentes não relacionados)
- [x] `npx prettier --check .`
- [x] `npm run build` — build completo
- [x] Inspecionado o HTML gerado em `dist/archive/index.html` e `dist/pt/archive/index.html`: cada badge PT/EN agora tem `aria-label` único por post (ex. `"The license that knocks — Portuguese version available"`)
- [x] `src/pages/projects.astro` / `pt/projects.astro`: fetch da API do GitHub não está disponível no ambiente de build do sandbox (lista de repos vem vazia), então não foi possível inspecionar o HTML gerado; a sintaxe segue o mesmo padrão já verificado no fix de `/archive/` e passou por `astro check`/`prettier` sem erros

---
_Generated by [Claude Code](https://claude.ai/code/session_01U1TnZT7LFxsFAXzY7C3CqQ)_