### PR TITLE
ux: aria-labels de tension/tags únicos por linha em battles e changelog

### DIFF
--- a/.routines/2026-08-19T05-06-37-ux-ui-run.md
+++ b/.routines/2026-08-19T05-06-37-ux-ui-run.md
@@ -1,0 +1,17 @@
+---
+date: "2026-08-19T05:06:37Z"
+branch: ux-ui/run-2026-08-19T05-00-15
+status: open
+---
+
+# Sessão 2026-08-19T05-06-37 — UX/UI
+
+Issues fechadas: #1559, #1560
+O que foi feito: aria-label de "tension ausente" em /ranking/battles/ (index e
+page/[n]) agora inclui os nomes das obras do duelo em vez de texto estático
+repetido; aria-label da lista de tags de release em /changelog/ agora inclui
+a versão. battles/[id].astro:189 confirmado como instância única por página
+(fora de loop) — sem alteração necessária ali, conforme a própria issue #1559
+previa. Sem página PT irmã de /changelog/ — nada a replicar lá.
+CI local: astro check ✅ (0 errors/warnings) · prettier ✅ · build ✅ (3879
+páginas, pagefind ok)

--- a/src/pages/changelog/index.astro
+++ b/src/pages/changelog/index.astro
@@ -68,7 +68,7 @@ const repositoryUrl = "https://github.com/franklinbaldo/franklinbaldo.github.io"
             <p class="release-summary">{entry.data.description}</p>
 
             {entry.data.tags && entry.data.tags.length > 0 && (
-              <ul class="changelog-tags" aria-label="Release tags">
+              <ul class="changelog-tags" aria-label={`Tags for v${entry.data.version}`}>
                 {entry.data.tags.map((tag) => (
                   <li>#{tag}</li>
                 ))}

--- a/src/pages/ranking/battles/index.astro
+++ b/src/pages/ranking/battles/index.astro
@@ -166,7 +166,7 @@ const crumbs = [
                 <div class="tf loser-fill" style={`width:${100 - tensionPct}%`}></div>
               </div>
             ) : (
-              <div class="tension-absent" aria-label="Rates not available">—</div>
+              <div class="tension-absent" aria-label={`${winnerName} vs ${loserName} — rates not available`}>—</div>
             )}
             <div class="read-cta">Read analysis →</div>
           </a>

--- a/src/pages/ranking/battles/page/[n].astro
+++ b/src/pages/ranking/battles/page/[n].astro
@@ -177,7 +177,7 @@ const crumbs = [
                 <div class="tf loser-fill" style={`width:${100 - tensionPct}%`}></div>
               </div>
             ) : (
-              <div class="tension-absent" aria-label="Rates not available">—</div>
+              <div class="tension-absent" aria-label={`${winnerName} vs ${loserName} — rates not available`}>—</div>
             )}
             <div class="read-cta">Read analysis →</div>
           </a>


### PR DESCRIPTION
## Summary

- `src/pages/ranking/battles/index.astro` e `battles/page/[n].astro`: o placeholder de tensão ausente (`.tension-absent`) tinha o mesmo `aria-label="Rates not available"` em toda linha do `.map()` sobre os duelos. Agora inclui os nomes das obras (`${winnerName} vs ${loserName} — rates not available`), igual ao padrão já usado no link `.battle-link` da mesma linha.
- `src/pages/changelog/index.astro`: a lista de tags de cada release tinha `aria-label="Release tags"` idêntico em toda entrada. Agora inclui a versão (`Tags for v${entry.data.version}`), seguindo a mesma convenção já usada no link de âncora da entry.
- `battles/[id].astro:189` (issue #1559, item 2) foi conferido: o placeholder ali aparece uma única vez por página de detalhe, fora de qualquer loop — sem necessidade de mudança, conforme a própria issue previa.
- `/changelog/` não tem página PT irmã — nada a replicar (issue #1560, item 2).

Closes #1559
Closes #1560

## Test plan

- [x] `npx astro check` — 0 errors, 0 warnings
- [x] `npx prettier --check .` — passou
- [x] `npm run build` — build completo (3879 páginas, pagefind ok)
- [x] Confirmado no HTML gerado: `dist/changelog/index.html` contém `aria-label="Tags for v0.1.0"`
- [x] Nenhum duelo do dataset atual está sem rates, então o branch `.tension-absent` não é exercitado no build atual — a lógica foi revisada por leitura e segue exatamente o padrão já usado (e testado) em `.battle-link` na mesma linha.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AvRcXVWNuMwdbDKG6ADUex)_