### PR TITLE
ux: aria-lang em títulos de post fora do idioma padrão da página

### DIFF
--- a/.routines/2026-08-23T05-17-56-ux-ui-run.md
+++ b/.routines/2026-08-23T05-17-56-ux-ui-run.md
@@ -1,0 +1,24 @@
+---
+date: "2026-08-23T05:17:56Z"
+branch: claude/ecstatic-hawking-796uzi
+status: open
+---
+
+# Sessão 2026-08-23T05-17-56 — UX/UI
+
+Issues fechadas: nenhuma (achado de auditoria, não uma issue pré-existente do backlog)
+O que foi feito: título de post em idioma diferente do idioma-padrão da página
+(inglês, ou o idioma do post corrente em posts/[key].astro), renderizado
+inline em /ranking/battles/, /ranking/battles/[id]/, /ranking/perspectives/
+e no histórico de duelos de /ranking/posts/[key]/, não tinha atributo lang
+— seguindo o mesmo padrão já usado nos blockquotes de evaluatorMood
+(lang="pt-BR") em battles/[id].astro. Adicionado lang={info.lang === "pt" ?
+"pt" : undefined} de forma consistente nos 6 arquivos afetados, sempre a
+partir do mesmo objeto que já fornece o título exibido (garante que lang e
+texto nunca dessincronizem).
+Nota: com o dataset atual, todo translationKey com pt tem também uma versão
+en, e o mapa de deduplicação (byKey) sempre prefere "en" quando ambas
+existem — então a marcação lang="pt" não aparece no HTML gerado hoje
+(confirmado via grep no dist/ após build). A lógica é exercida no dia em que
+existir um post publicado só em pt (sem par en) para o mesmo translationKey.
+CI local: astro check ✅ (0 erros, hints pré-existentes) · prettier ✅ · build ✅

--- a/src/pages/ranking/battles/[id].astro
+++ b/src/pages/ranking/battles/[id].astro
@@ -149,8 +149,8 @@ const crumbs = [
         <div class="versus-label">Winner 🏆</div>
         <div class="versus-title">
           {winnerHref
-            ? <a href={winnerHref}>{winnerTitle}</a>
-            : <span>{winnerTitle}</span>}
+            ? <a href={winnerHref} lang={winnerInfo?.lang === "pt" ? "pt" : undefined}>{winnerTitle}</a>
+            : <span lang={winnerInfo?.lang === "pt" ? "pt" : undefined}>{winnerTitle}</span>}
         </div>
         {hasRates && <div class="versus-rate">{rateWinner!.toFixed(2)}</div>}
         {winnerRank && (
@@ -168,8 +168,8 @@ const crumbs = [
         <div class="versus-label">Challenger</div>
         <div class="versus-title">
           {loserHref
-            ? <a href={loserHref}>{loserTitle}</a>
-            : <span>{loserTitle}</span>}
+            ? <a href={loserHref} lang={loserInfo?.lang === "pt" ? "pt" : undefined}>{loserTitle}</a>
+            : <span lang={loserInfo?.lang === "pt" ? "pt" : undefined}>{loserTitle}</span>}
         </div>
         {hasRates && <div class="versus-rate loser-rate">{rateLoser!.toFixed(2)}</div>}
         {loserRank && (
@@ -201,13 +201,13 @@ const crumbs = [
     <div class="analyses-grid">
       {duel.parsedContent.postAAnalysis && (
         <section class="content-section">
-          <h3>Analysis — {postAInfo?.title ?? duel.postAKey}</h3>
+          <h3>Analysis — <span lang={postAInfo?.lang === "pt" ? "pt" : undefined}>{postAInfo?.title ?? duel.postAKey}</span></h3>
           <div class="prose" set:html={marked.parse(duel.parsedContent.postAAnalysis)} />
         </section>
       )}
       {duel.parsedContent.postBAnalysis && (
         <section class="content-section">
-          <h3>Analysis — {postBInfo?.title ?? duel.postBKey}</h3>
+          <h3>Analysis — <span lang={postBInfo?.lang === "pt" ? "pt" : undefined}>{postBInfo?.title ?? duel.postBKey}</span></h3>
           <div class="prose" set:html={marked.parse(duel.parsedContent.postBAnalysis)} />
         </section>
       )}

--- a/src/pages/ranking/battles/index.astro
+++ b/src/pages/ranking/battles/index.astro
@@ -26,6 +26,9 @@ const duels = allDuels.slice(0, PER_PAGE);
 function postLabel(key: string) {
   return byKey.get(key)?.title ?? key;
 }
+function postLangAttr(key: string) {
+  return byKey.get(key)?.lang === "pt" ? "pt" : undefined;
+}
 function postHref(key: string) {
   const p = byKey.get(key);
   if (!p) return null;
@@ -150,13 +153,13 @@ const crumbs = [
             </div>
             <div class="battle-versus">
               <div class="side winner">
-                <span class="post-name">{winnerName}</span>
+                <span class="post-name" lang={postLangAttr(d.winnerKey)}>{winnerName}</span>
                 <span class="medal" aria-hidden="true">🏆</span>
                 {hasRates && <span class="rate">{rateWinner!.toFixed(1)}</span>}
               </div>
               <div class="divider"><span class="vs">VS</span></div>
               <div class="side loser">
-                <span class="post-name">{loserName}</span>
+                <span class="post-name" lang={postLangAttr(d.loserKey)}>{loserName}</span>
                 {hasRates && <span class="rate loser-rate">{rateLoser!.toFixed(1)}</span>}
               </div>
             </div>

--- a/src/pages/ranking/battles/page/[n].astro
+++ b/src/pages/ranking/battles/page/[n].astro
@@ -41,6 +41,9 @@ for (const p of allPosts) {
 function postLabel(key: string) {
   return byKey.get(key)?.title ?? key;
 }
+function postLangAttr(key: string) {
+  return byKey.get(key)?.lang === "pt" ? "pt" : undefined;
+}
 
 function fmtDate(iso: string) {
   return new Date(iso).toLocaleDateString("en-US", { year: "numeric", month: "short", day: "numeric" });
@@ -161,13 +164,13 @@ const crumbs = [
             </div>
             <div class="battle-versus">
               <div class="side winner">
-                <span class="post-name">{winnerName}</span>
+                <span class="post-name" lang={postLangAttr(d.winnerKey)}>{winnerName}</span>
                 <span class="medal" aria-hidden="true">🏆</span>
                 {hasRates && <span class="rate">{rateWinner!.toFixed(1)}</span>}
               </div>
               <div class="divider"><span class="vs">VS</span></div>
               <div class="side loser">
-                <span class="post-name">{loserName}</span>
+                <span class="post-name" lang={postLangAttr(d.loserKey)}>{loserName}</span>
                 {hasRates && <span class="rate loser-rate">{rateLoser!.toFixed(1)}</span>}
               </div>
             </div>

--- a/src/pages/ranking/perspectives/[id].astro
+++ b/src/pages/ranking/perspectives/[id].astro
@@ -105,7 +105,10 @@ const crumbs = [
             <td class="col-rank">{r.rank}</td>
             <td>
               {r.post ? (
-                <a href={r.post.lang === "pt" ? `/pt/blog/${r.post.slug}/` : `/blog/${r.post.slug}/`}>
+                <a
+                  href={r.post.lang === "pt" ? `/pt/blog/${r.post.slug}/` : `/blog/${r.post.slug}/`}
+                  lang={r.post.lang === "pt" ? "pt" : undefined}
+                >
                   {r.post.title}
                 </a>
               ) : (

--- a/src/pages/ranking/perspectives/index.astro
+++ b/src/pages/ranking/perspectives/index.astro
@@ -42,6 +42,7 @@ const enriched = perspectives.map((p) => {
     hue: hue(p.id),
     duelCount: rows.reduce((sum, r) => sum + r.appearances, 0) / 2,
     leaderTitle: leader?.title ?? null,
+    leaderLang: leader?.lang === "pt" ? "pt" : undefined,
     leaderHref,
     postsRanked: rows.length,
   };
@@ -78,7 +79,7 @@ const crumbs = [
         {p.leaderTitle && (
           <div class="persp-leader">
             <span class="persp-leader-label">Leader</span>
-            <span class="persp-leader-title">{p.leaderTitle}</span>
+            <span class="persp-leader-title" lang={p.leaderLang}>{p.leaderTitle}</span>
           </div>
         )}
       </a>

--- a/src/pages/ranking/posts/[key].astro
+++ b/src/pages/ranking/posts/[key].astro
@@ -267,7 +267,9 @@ function fmtDate(iso: string): string {
                   <div class="duel-opponent">
                     <span class="vs-label">{strings.vs}</span>
                     {opponentHref ? (
-                      <a href={opponentHref}>{opponentTitle}</a>
+                      <a href={opponentHref} lang={opponent && opponent.lang !== lang ? opponent.lang : undefined}>
+                        {opponentTitle}
+                      </a>
                     ) : (
                       <code>{opponentKey}</code>
                     )}


### PR DESCRIPTION
## Summary

Auditoria manual do subsistema `/ranking/` (relacionado à issue #1083, i18n do
ranking Hrönir) encontrou um gap de acessibilidade menor e bem localizado:
título de post renderizado inline, quando em idioma diferente do
idioma-padrão da página, não tinha atributo `lang` — violando WCAG 3.1.2
(Language of Parts). O mesmo componente já resolve isso corretamente em
outro lugar: os blockquotes de `evaluatorMood` em `battles/[id].astro` já
usam `lang="pt-BR"` porque o mood é sempre em português (RFC 0012 §6). Este
PR estende o mesmo padrão aos títulos de post.

Arquivos e pontos afetados:

- `src/pages/ranking/battles/index.astro` e `battles/page/[n].astro`: nome
  do post vencedor/perdedor em cada card (`.post-name`).
- `src/pages/ranking/battles/[id].astro`: título do vencedor/desafiante na
  seção versus, e o título nos headings "Analysis — {title}".
- `src/pages/ranking/perspectives/index.astro`: título do post líder em
  cada card de perspectiva.
- `src/pages/ranking/perspectives/[id].astro`: título do post em cada linha
  da tabela de ranking por perspectiva.
- `src/pages/ranking/posts/[key].astro`: título do oponente no histórico de
  duelos (marcado só quando difere do idioma da página corrente, que já
  segue o idioma do post — RFC 0016).

Em todos os casos o `lang` é derivado do **mesmo objeto** que já fornece o
texto exibido (nunca uma fonte separada), então título e atributo nunca
dessincronizam.

## Nota sobre escopo (issue #1083)

Não fecha #1083. Essa issue pede localização completa de chrome de página
(breadcrumbs, `<html lang>`, formatação de data) para o subárvore
`/ranking/`. Investigando o código, esse chrome é deliberadamente en-only
hoje porque o conteúdo dessas páginas é estruturalmente multi-idioma — um
duelo, por exemplo, pode comparar uma versão en com uma pt do mesmo
`translationKey` (RFC 0012 §6: "Content can differ per side in a work
duel"), e um ranking por perspectiva mistura posts en/pt na mesma tabela.
Não há um "idioma da página" único para esses casos, então a opção mais
barata sugerida pela issue #1 ("detectar e usar o idioma do post/perspectiva
relevante") não se aplica de forma limpa. A correção aqui é um passo
concreto e de baixo risco dentro desse escopo maior — deixo #1083 aberta
para a decisão arquitetural completa (mirror `/pt/ranking/...` vs. manter
chrome en-only, ver item 2 da issue).

## Nota sobre o dataset atual

Com o corpus publicado hoje, todo `translationKey` que tem uma versão `pt`
também tem uma versão `en`, e o mapa de deduplicação usado nessas páginas
(`byKey`) sempre prefere a versão `en` quando ambas existem. Por isso
`lang="pt"` não aparece no HTML gerado neste build (confirmado via `grep` em
`dist/` após `npm run build`) — a lógica passa a ser exercida no dia em que
existir um post publicado só em `pt` (sem par `en`) para o mesmo
`translationKey`. Cheguei a tentar usar `duel.postAContentLang` /
`postBContentLang` (RFC 0012 §6, gravado por lado do duelo) como sinal
alternativo, mas descobri que ele descreve o idioma do conteúdo avaliado no
momento do duelo, não necessariamente o idioma do **título exibido hoje**
(ex.: um duelo com `postAContentLang: "pt"` cujo título atual, vindo de
`byKey`, é o inglês "Veil of Infinity" — a marcação ficaria errada). Por
isso mantive a fonte `byKey`/`postInfo.lang`, que é sempre a mesma usada
para o texto exibido.

## Test plan

- [x] `npx astro check` — 0 erros, 0 warnings novos (hints pré-existentes,
      incluindo o `postHref` não utilizado em `battles/index.astro`, que já
      existia antes deste PR)
- [x] `npx prettier --check .` — passou
- [x] `npm run build` — build completo (3879 páginas, pagefind ok)
- [x] Confirmado por leitura + build que nenhum `lang="pt"` incorreto é
      emitido (ex.: o duelo que envolve "Veil of Infinity" continua sem
      `lang`, corretamente, pois o título exibido é inglês)
- [x] `src/generated/*.json` regenerados pelo build local foram revertidos
      antes do commit — não fazem parte desta mudança


---
_Generated by [Claude Code](https://claude.ai/code/session_019USbqB8mMa1V8VzSKTRqzr)_