### PR TITLE
ux: smoke test e2e manual para páginas-chave (EN/PT)

### DIFF
--- a/.routines/2026-08-24T05-20-17-ux-ui-run.md
+++ b/.routines/2026-08-24T05-20-17-ux-ui-run.md
@@ -27,3 +27,17 @@ atualizar a convenção documentada). Nenhum desses PRs foi squashado.
 CI local: astro check ✅ (0 erros/warnings novos) · prettier ✅ · lint ✅ ·
 build ✅ · npm test ✅ (167/167) · depcheck ✅ · check:hygiene ✅ ·
 check:changelog ✅ · check:links ✅ · check:translations ✅ · hronir:select ✅
+
+## Pós-PR (#1575)
+
+`/code-review --fix` na própria PR encontrou 2 achados reais de robustez em
+`scripts/e2e-smoke.mjs` (órfão de `astro preview` ao matar só o wrapper
+`npx`; erro de `waitForServer` engolido sem imprimir o log do servidor) —
+corrigidos num segundo commit (spawn direto de `node_modules/.bin/astro`,
+try/catch cobrindo todo o corpo). CI verde após o fix. Tentativa de merge
+(`merge_method: merge`) bateu no mesmo `405 Merge commits are not allowed`
+já visto em #1564/#1566/#1570/#1573 — comentário deixado na PR, sem squash.
+
+Backlog abaixo de ~10 issues `routine` abertas: aberta #1576 (i18n de
+`/games/`, seção não linkada do nav — issue de decisão de escopo, no
+formato da #1083).

--- a/.routines/2026-08-24T05-20-17-ux-ui-run.md
+++ b/.routines/2026-08-24T05-20-17-ux-ui-run.md
@@ -1,0 +1,29 @@
+---
+date: "2026-08-24T05:20:17Z"
+branch: ux-ui/run-2026-08-24T05-05-45
+status: open
+---
+
+# Sessão 2026-08-24T05-20-17 — UX/UI
+
+Issue fechada: #1086
+O que foi feito: adicionado `scripts/e2e-smoke.mjs` — smoke test manual (node
+puro, sem `@playwright/test`) que sobe `astro preview` sobre um `dist/` já
+buildado e usa o `playwright` (chromium) já presente em devDependencies para
+carregar home/post/ranking em EN e PT, checando resposta HTTP ok, `<h1>`
+visível e ausência de erros de console. Novo script `npm run test:e2e`.
+Decisão explícita (documentada no PR): não entra no `check.yml` obrigatório
+por ora — fica como job manual/opcional até os 6 checks provarem estáveis ao
+longo de algumas rodadas.
+
+Passo 0 (revisar/mesclar PRs abertos): #1564, #1566, #1570, #1573 têm CI
+verde e sem conflitos, mas `mcp__github__merge_pull_request` com
+`merge_method: merge` retorna `405 Merge commits are not allowed on this
+repository` — configuração atual do repo permite só squash, o que contraria
+a convenção do CLAUDE.md. Comentário deixado nos 4 PRs sinalizando o bloqueio
+(precisa de decisão humana: ajustar a configuração de merge do repo, ou
+atualizar a convenção documentada). Nenhum desses PRs foi squashado.
+
+CI local: astro check ✅ (0 erros/warnings novos) · prettier ✅ · lint ✅ ·
+build ✅ · npm test ✅ (167/167) · depcheck ✅ · check:hygiene ✅ ·
+check:changelog ✅ · check:links ✅ · check:translations ✅ · hronir:select ✅

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
     "suno-rank:round": "node --import tsx/esm scripts/suno-rank/index.js round",
     "suno-rank:ranking": "node --import tsx/esm scripts/suno-rank/index.js ranking",
     "suno-rank:doctor": "node --import tsx/esm scripts/suno-rank/index.js doctor",
-    "test": "node --import tsx/esm --experimental-test-module-mocks --test --test-concurrency=1 \"src/**/*.test.{js,ts}\""
+    "test": "node --import tsx/esm --experimental-test-module-mocks --test --test-concurrency=1 \"src/**/*.test.{js,ts}\"",
+    "test:e2e": "node scripts/e2e-smoke.mjs"
   },
   "dependencies": {
     "@astrojs/markdown-remark": "^7.2.0",

--- a/scripts/e2e-smoke.mjs
+++ b/scripts/e2e-smoke.mjs
@@ -1,0 +1,122 @@
+// RFC-free smoke test (issue #1086): loads a handful of key pages against a
+// built `dist/` via `astro preview` and asserts each one responds OK, paints
+// an <h1>, and logs no browser console errors. Not a full regression suite —
+// just a cheap guard against a page-breaking change slipping through.
+//
+// Requires `npm run build` to have already produced `dist/` (same
+// precondition as Lighthouse CI's `staticDistDir`, see .lighthouserc.cjs).
+import { chromium } from "playwright";
+import { existsSync } from "node:fs";
+import { spawn } from "node:child_process";
+
+const PORT = 4321;
+const BASE = `http://localhost:${PORT}`;
+
+const PAGES = [
+  { id: "en-home", url: "/" },
+  { id: "en-post", url: "/blog/asymmetric-evolution/" },
+  { id: "en-ranking", url: "/ranking/" },
+  { id: "pt-home", url: "/pt/" },
+  { id: "pt-post", url: "/pt/blog/o-ovo-de-serpente/" },
+  { id: "pt-ranking", url: "/pt/ranking/" },
+];
+
+if (!existsSync("dist")) {
+  console.error(
+    "dist/ not found — run `npm run build` before `npm run test:e2e`."
+  );
+  process.exit(1);
+}
+
+function waitForServer(url, timeoutMs = 20_000) {
+  const deadline = Date.now() + timeoutMs;
+  return new Promise((resolve, reject) => {
+    const attempt = async () => {
+      try {
+        const res = await fetch(url);
+        if (res.ok || res.status === 404) return resolve();
+      } catch {
+        // server not up yet
+      }
+      if (Date.now() > deadline)
+        return reject(new Error(`timed out waiting for ${url}`));
+      setTimeout(attempt, 300);
+    };
+    attempt();
+  });
+}
+
+const preview = spawn(
+  "npx",
+  ["astro", "preview", "--port", String(PORT), "--host", "localhost"],
+  { stdio: "pipe" }
+);
+let previewOutput = "";
+preview.stdout.on("data", (d) => (previewOutput += d));
+preview.stderr.on("data", (d) => (previewOutput += d));
+
+const results = [];
+
+try {
+  await waitForServer(BASE);
+
+  const browser = await chromium.launch();
+  try {
+    for (const p of PAGES) {
+      const ctx = await browser.newContext();
+      const page = await ctx.newPage();
+      const consoleErrors = [];
+      page.on("console", (msg) => {
+        if (msg.type() === "error") consoleErrors.push(msg.text());
+      });
+      page.on("pageerror", (err) => consoleErrors.push(String(err)));
+
+      let httpOk = false;
+      let h1Visible = false;
+      let error = null;
+      try {
+        const response = await page.goto(BASE + p.url, { waitUntil: "load" });
+        httpOk = Boolean(response && response.ok());
+        h1Visible = await page.locator("h1").first().isVisible();
+      } catch (e) {
+        error = e instanceof Error ? e.message : String(e);
+      }
+
+      results.push({
+        id: p.id,
+        url: p.url,
+        pass: httpOk && h1Visible && consoleErrors.length === 0 && !error,
+        httpOk,
+        h1Visible,
+        consoleErrors,
+        error,
+      });
+      await ctx.close();
+    }
+  } finally {
+    await browser.close();
+  }
+} finally {
+  preview.kill();
+}
+
+let failed = false;
+for (const r of results) {
+  const status = r.pass ? "PASS" : "FAIL";
+  if (!r.pass) failed = true;
+  console.log(`${status}  ${r.id.padEnd(12)} ${r.url}`);
+  if (!r.pass) {
+    if (!r.httpOk) console.log(`       response not ok`);
+    if (!r.h1Visible) console.log(`       no visible <h1>`);
+    if (r.error) console.log(`       error: ${r.error}`);
+    for (const e of r.consoleErrors) console.log(`       console error: ${e}`);
+  }
+}
+
+if (failed) {
+  console.error("\ne2e smoke: FAILED");
+  console.error(previewOutput);
+  process.exit(1);
+}
+
+console.log("\ne2e smoke: all pages OK");

--- a/scripts/e2e-smoke.mjs
+++ b/scripts/e2e-smoke.mjs
@@ -46,9 +46,12 @@ function waitForServer(url, timeoutMs = 20_000) {
   });
 }
 
+// Spawned directly (not via `npx astro ...`) so `preview.kill()` below signals
+// the actual server process instead of an intermediary npx wrapper — npx can
+// leave the real astro server as an orphan on the port after the wrapper exits.
 const preview = spawn(
-  "npx",
-  ["astro", "preview", "--port", String(PORT), "--host", "localhost"],
+  "node_modules/.bin/astro",
+  ["preview", "--port", String(PORT), "--host", "localhost"],
   { stdio: "pipe" }
 );
 let previewOutput = "";
@@ -58,46 +61,54 @@ preview.stderr.on("data", (d) => (previewOutput += d));
 const results = [];
 
 try {
-  await waitForServer(BASE);
-
-  const browser = await chromium.launch();
   try {
-    for (const p of PAGES) {
-      const ctx = await browser.newContext();
-      const page = await ctx.newPage();
-      const consoleErrors = [];
-      page.on("console", (msg) => {
-        if (msg.type() === "error") consoleErrors.push(msg.text());
-      });
-      page.on("pageerror", (err) => consoleErrors.push(String(err)));
+    await waitForServer(BASE);
 
-      let httpOk = false;
-      let h1Visible = false;
-      let error = null;
-      try {
-        const response = await page.goto(BASE + p.url, { waitUntil: "load" });
-        httpOk = Boolean(response && response.ok());
-        h1Visible = await page.locator("h1").first().isVisible();
-      } catch (e) {
-        error = e instanceof Error ? e.message : String(e);
+    const browser = await chromium.launch();
+    try {
+      for (const p of PAGES) {
+        const ctx = await browser.newContext();
+        const page = await ctx.newPage();
+        const consoleErrors = [];
+        page.on("console", (msg) => {
+          if (msg.type() === "error") consoleErrors.push(msg.text());
+        });
+        page.on("pageerror", (err) => consoleErrors.push(String(err)));
+
+        let httpOk = false;
+        let h1Visible = false;
+        let error = null;
+        try {
+          const response = await page.goto(BASE + p.url, {
+            waitUntil: "load",
+          });
+          httpOk = Boolean(response && response.ok());
+          h1Visible = await page.locator("h1").first().isVisible();
+        } catch (e) {
+          error = e instanceof Error ? e.message : String(e);
+        }
+
+        results.push({
+          id: p.id,
+          url: p.url,
+          pass: httpOk && h1Visible && consoleErrors.length === 0 && !error,
+          httpOk,
+          h1Visible,
+          consoleErrors,
+          error,
+        });
+        await ctx.close();
       }
-
-      results.push({
-        id: p.id,
-        url: p.url,
-        pass: httpOk && h1Visible && consoleErrors.length === 0 && !error,
-        httpOk,
-        h1Visible,
-        consoleErrors,
-        error,
-      });
-      await ctx.close();
+    } finally {
+      await browser.close();
     }
   } finally {
-    await browser.close();
+    preview.kill();
   }
-} finally {
-  preview.kill();
+} catch (e) {
+  console.error(`e2e smoke: could not complete run — ${e.message}`);
+  console.error(previewOutput);
+  process.exit(1);
 }
 
 let failed = false;


### PR DESCRIPTION
## Summary

Closes #1086.

`playwright` já é devDependency (usado hoje só por `scripts/screenshots.mjs`)
mas não havia nenhum smoke test automatizado sobre páginas renderizadas —
só Lighthouse (categorias agregadas) e `astro check` (tipos), nenhum dos
dois pega uma página que quebra em runtime (erro de console, elemento
esperado ausente).

Adiciona `scripts/e2e-smoke.mjs`: sobe `astro preview` sobre um `dist/` já
buildado e usa o `playwright` (chromium) já instalado para carregar seis
páginas-chave — home, um post de blog e `/ranking/`, em EN e em PT — e
verificar: resposta HTTP ok, um `<h1>` visível, e ausência de erros de
console/`pageerror`. Novo script `npm run test:e2e`.

## Decisões (pedidas explicitamente pela issue)

- **Sem `@playwright/test`**: o repo já roda testes via `node:test`
  (`npm test`), e a issue pede para não introduzir dependência nova sem
  necessidade clara. `playwright` puro (a lib já presente) é suficiente para
  um smoke test — sem configurar um segundo test runner.
- **Não entra no `check.yml` obrigatório por ora**: fica como job manual
  (`npm run test:e2e`, requer `npm run build` antes). Lighthouse CI já cobre
  performance/a11y agregada; este smoke test é mais frágil (depende de
  `astro preview` subir e do Chromium do ambiente) e ainda não rodou
  repetidamente o suficiente para eu confiar em promovê-lo a bloqueante.
  Reavaliar depois de algumas rodadas estáveis.

## Passo 0 da rotina (revisar/mesclar PRs abertos)

CI verde e sem conflitos em #1564, #1566, #1570 e #1573, mas
`merge_pull_request` com `merge_method: merge` retorna `405 Merge commits
are not allowed on this repository` — a configuração atual do repo parece
permitir só squash, o que contraria a convenção do `CLAUDE.md` ("Merge
commits, not squash"). Deixei comentário nos 4 PRs sinalizando o bloqueio;
não fiz squash para não violar a convenção. Precisa de decisão humana
(ajustar as configurações de merge do repo, ou atualizar a convenção).

## Test plan

- [x] `npx astro check` — 0 erros, 0 warnings novos (78 hints pré-existentes)
- [x] `npx prettier --check .` — passou
- [x] `npm run lint` — passou, sem novos findings
- [x] `npm run build` — build completo (3879 páginas, pagefind ok)
- [x] `npm run test:e2e` (localmente, com `executablePath` apontando para o
      Chromium do ambiente de execução — não commitado, é específico deste
      sandbox) — 6/6 páginas PASS
- [x] `npm test` — 167/167
- [x] `npx depcheck` — sem findings
- [x] `npm run check:hygiene` / `check:changelog` / `check:links` /
      `check:translations` / `hronir:select` — todos verdes
- [x] `src/generated/*.json` regenerados pelo build local foram revertidos
      antes do commit — não fazem parte desta mudança

---
_Generated by [Claude Code](https://claude.ai/code/session_017tS2pRzZSrdsbXtfw1XA5K)_