### PR TITLE
ux: aria-label de rating de livro inclui o título

### DIFF
--- a/.routines/2026-08-25T05-09-15-ux-ui-run.md
+++ b/.routines/2026-08-25T05-09-15-ux-ui-run.md
@@ -1,0 +1,29 @@
+---
+date: "2026-08-25T05:09:15Z"
+branch: claude/ecstatic-hawking-aw45as
+status: open
+---
+
+# Sessão 2026-08-25T05-09-15 — UX/UI
+
+Issues fechadas: #1578
+O que foi feito: `src/components/BooksPage.astro:191` — o `aria-label` do
+elemento `.rating` de cada card em `/books/` e `/pt/livros/` era
+`"${user_rating} out of 5 stars"` / `"${user_rating} de 5 estrelas"`,
+idêntico para todos os livros com a mesma nota. Prefixado com `book.title`
+(mesma fonte já usada em `data-title` no card pai), seguindo o padrão de
+separador `—` já usado em `RankingView.astro`/`posts/[key].astro`. Texto
+visível (`★★★★☆`) inalterado.
+
+Passo 0 (revisar/mesclar PRs abertos): confirmado que #1564, #1566, #1570,
+#1573, #1575 continuam com CI verde e sem conflitos, mas
+`merge_pull_request` com `merge_method: merge` retorna
+`405 Merge commits are not allowed on this repository` — mesmo bloqueio já
+sinalizado por sessões anteriores. Não fiz squash (viola a convenção do
+CLAUDE.md). Segue precisando de decisão humana sobre a configuração de merge
+do repositório.
+
+CI local: astro check ✅ (0 erros, 78 hints pré-existentes) · prettier ✅ ·
+build ✅ (3879 páginas, pagefind ok) · aria-label confirmado no HTML gerado
+em `dist/books/index.html` (EN) e `dist/pt/livros/index.html` (PT), com o
+título do livro interpolado corretamente nos dois idiomas.

--- a/src/components/BooksPage.astro
+++ b/src/components/BooksPage.astro
@@ -188,7 +188,7 @@ const booksJsonLd = {
                   {book.user_rating > 0 && (
                     <p
                       class="rating"
-                      aria-label={`${book.user_rating} ${ui.starsAria}`}
+                      aria-label={`${book.title} — ${book.user_rating} ${ui.starsAria}`}
                     >
                       {"★".repeat(book.user_rating)}
                       {"☆".repeat(5 - book.user_rating)}


### PR DESCRIPTION
## Summary

- `src/components/BooksPage.astro:191` (usado em `/books/` e `/pt/livros/`): o `aria-label` do elemento `.rating` de cada card era `"${book.user_rating} ${ui.starsAria}"` (ex. "4 out of 5 stars" / "4 de 5 estrelas"), idêntico para todo livro com a mesma nota. Como vários livros do shelf do Goodreads compartilham a mesma nota, quem navega por `aria-label` ouvia o mesmo texto repetido sem saber a qual livro se referia — mesmo padrão já corrigido em outras partes do backlog (battles, changelog, ranking).
- Prefixado com `book.title` (já disponível no `.map()`, mesma fonte usada em `data-title={book.title}` no `<article>` pai), seguindo o padrão de separador `—` já usado em `RankingView.astro`/`posts/[key].astro`.
- Texto visível (`★★★★☆`) inalterado — só o nome acessível muda.

Closes #1578

## Passo 0 da rotina (revisar/mesclar PRs abertos)

Confirmei CI verde e sem conflitos em #1564, #1566, #1570, #1573, #1575, mas `merge_pull_request` com `merge_method: merge` retorna `405 Merge commits are not allowed on this repository` — o mesmo bloqueio já sinalizado por sessões anteriores (a configuração atual do repo parece permitir só squash, o que contraria a convenção do `CLAUDE.md`, "Merge commits, not squash"). Não fiz squash para não violar a convenção; segue precisando de decisão humana sobre a configuração de merge do repositório.

## Test plan

- [x] `npx astro check` — 0 erros, 0 warnings novos (78 hints pré-existentes)
- [x] `npx prettier --check .` — passou
- [x] `npm run build` — build completo (3879 páginas, pagefind ok)
- [x] Confirmado no HTML gerado: `dist/books/index.html` tem `aria-label="A Brief History of Time — 5 out of 5 stars"`; `dist/pt/livros/index.html` tem `aria-label="A Brief History of Time — 5 de 5 estrelas"` — únicos por livro, título correto em cada idioma
- [x] `src/generated/*.json` regenerados pelo build local foram revertidos antes do commit — não fazem parte desta mudança

---
_Generated by [Claude Code](https://claude.ai/code/session_018LtBt81oBbfRdKosQyFVBB)_