### PR TITLE
ux: aria-label do link de análise no histórico de duelos identifica o adversário

### DIFF
--- a/.routines/2026-08-26T05-09-14-ux-ui-run.md
+++ b/.routines/2026-08-26T05-09-14-ux-ui-run.md
@@ -1,0 +1,18 @@
+---
+date: "2026-08-26T05:09:14Z"
+branch: claude/ecstatic-hawking-emd4t8
+status: open
+---
+
+# Sessão 2026-08-26T05-09-14 — UX/UI
+
+Issues fechadas: nenhuma (achado via auditoria manual, sem issue prévia)
+O que foi feito: link "análise →" do histórico de duelos em
+`/ranking/posts/[key]/` tinha `aria-label` estático
+(`strings.readFullAnalysis`, ex. "Read full analysis") repetido em toda
+linha do `.map()` sobre `duels` — leitor de tela ouvia o mesmo nome
+acessível para cada duelo, sem saber contra qual adversário. Interpolado
+`opponentTitle` (já em escopo) no `aria-label`, seguindo o mesmo padrão
+já usado nas issues #1559/#1560/#1567/#1568/#1578. Texto visível e `title`
+(tooltip) inalterados.
+CI local: astro check ✅ (0 erros, 78 hints pré-existentes) · prettier ✅ · build ✅

--- a/src/pages/ranking/posts/[key].astro
+++ b/src/pages/ranking/posts/[key].astro
@@ -293,6 +293,7 @@ function fmtDate(iso: string): string {
                     href={`/ranking/battles/${d.id}/`}
                     class="duel-analysis-link"
                     title={strings.readFullAnalysis}
+                    aria-label={`${strings.readFullAnalysis} — ${strings.vs} ${opponentTitle}`}
                   >
                     {strings.analysis}
                   </a>


### PR DESCRIPTION
## Summary

- `src/pages/ranking/posts/[key].astro:291-299`: o link "análise →" de cada linha do histórico de duelos (`.duel-analysis-link`) tinha `title={strings.readFullAnalysis}` como único atributo de nome/dica, e o texto visível (`{strings.analysis}`) é idêntico em toda linha do `.map()` sobre `duels`. Como o cálculo de nome acessível de um `<a>` prioriza o conteúdo de texto sobre `title` quando ambos existem, um leitor de tela navegando pelos links dessa lista ouvia "analysis →" repetido, sem saber a qual duelo/adversário cada link se referia.
- Adicionado `aria-label={`${strings.readFullAnalysis} — ${strings.vs} ${opponentTitle}`}`, interpolando `opponentTitle` (já calculado algumas linhas acima, mesma fonte usada no link do oponente logo ao lado). Mesma categoria de fix já aplicada em outras partes do backlog (issues #1559/#1560/#1567/#1568/#1578) — encontrado via auditoria manual desta rodada, sem issue prévia.
- Texto visível (`análise →`/`analysis →`) e `title` (tooltip) inalterados — só o `aria-label` muda.

## Passo 0 da rotina (revisar/mesclar PRs abertos)

Confirmei que o bloqueio já documentado por sessões anteriores (#1564, #1566, #1570, #1573, #1575, #1579) segue ativo: `merge_pull_request` com `merge_method: merge` retorna `405 Merge commits are not allowed on this repository`. Não tentei squash (proibido pelo `CLAUDE.md`, "Merge commits, not squash"). Segue precisando de decisão humana sobre a configuração de merge do repositório — nenhum dos 6 PRs pendentes foi mesclado por mim.

## Passo 6 da rotina (reabastecer backlog)

Backlog tinha 9 issues abertas com label `routine` (abaixo do limiar de ~10). Abri duas novas a partir de auditoria manual desta rodada:
- #1581 — linha de pódio em `RankingView.astro` não identifica o post no `aria-label`.
- #1582 — imagem de `GitHubRepo.astro` sem `width`/`height` causa CLS.

## Test plan

- [x] `npx astro check` — 0 erros, 0 warnings novos (78 hints pré-existentes)
- [x] `npx prettier --check .` — passou
- [x] `npm run build` — build completo (3879 páginas, pagefind ok)
- [x] Confirmado no HTML gerado (`dist/ranking/posts/agent-no-verbs/index.html`): `aria-label="Read full analysis — vs The Ruliad Is Laughing"` etc — único por linha
- [x] Ramo `lang === "pt"` do arquivo revisado por leitura (mesma estrutura `strings`, ambos os campos existem nos dois idiomas) — não exercitado no build atual porque nenhum `translationKey` publicado hoje resolve para uma dossiê-page só-pt (mesma situação documentada em #1573)
- [x] `npm run check:hygiene` — verde
- [x] `src/generated/*.json` regenerados pelo build local foram revertidos antes do commit — não fazem parte desta mudança


---
_Generated by [Claude Code](https://claude.ai/code/session_01G6m4bAsssyY4Q3o5mdM5sb)_