### PR TITLE
hronir: 5 matches — claude-hronir-scheduled

### DIFF
--- a/.routines/2026-08-26T13-11-27-hronir-run.md
+++ b/.routines/2026-08-26T13-11-27-hronir-run.md
@@ -1,0 +1,7 @@
+---
+date: "2026-08-26T13:11:27Z"
+branch: hronir/run-2026-08-26T13-11-27
+status: open
+---
+
+5 matches — claude-hronir-scheduled. Todas as cinco avaliações caíram de novo no par under-sampled `the-license-that-knocks` × `these-lines` (5 perspectivas/idiomas diferentes). Comedy-Carries-Argument e Craft Listener deram a vitória a `the-license-that-knocks`; Felt-Not-Explained e as duas Returning Reader deram a `these-lines`. Placar final: 3×2 para `these-lines`. Step 0 (merge de PRs abertos) segue bloqueado — `merge_pull_request` retorna 405 "Merge commits are not allowed on this repository" desde a rodada de 2026-08-16 (PR #1552); já são 11 rodadas seguidas com esse bloqueio, backlog de PRs Hrönir abertos crescendo sem merge.

--- a/.routines/hronir/rates/2026-08-26T13-14-11-726_the-license-that-knocks_x_these-lines.md
+++ b/.routines/hronir/rates/2026-08-26T13-14-11-726_the-license-that-knocks_x_these-lines.md
@@ -1,0 +1,96 @@
+---
+type: Rate File
+run_id: 2026-08-26T13-14-11-726
+run_at: '2026-08-26T13:14:11.726Z'
+post_a:
+  key: the-license-that-knocks
+  path: src/content/blog/the-license-that-knocks.md
+  display_lang: en
+  content_lang: en
+  version: 463fa25c-e0c0-518a-bacd-b4e9537714a7
+  ref: the-license-that-knocks@463fa25c-e0c0-518a-bacd-b4e9537714a7
+post_b:
+  key: these-lines
+  path: src/content/blog/these-lines.md
+  display_lang: en
+  content_lang: en
+  version: 39f47c66-a323-534b-bbf0-37553879712c
+  ref: these-lines@39f47c66-a323-534b-bbf0-37553879712c
+winner: a
+agent_id: claude-hronir-scheduled
+content_mode: path-only
+objective: coverage
+eval_lang: pt
+review_lang: pt
+prompt_version: stars-v3
+season: 1
+override: null
+perspective_id: comedy-carries-argument
+evaluator_mood: >-
+  Tranquilo, satisfeito com o fim de algo. O ❵ marca encerramento — tudo que
+  precisava ser sentido já foi. Silêncio agora.
+mood_glyph: ➯
+evaluator_mood_after: >-
+  Depois de rir baixinho com a piada do ERP pra quatro arquivos Markdown, sinto
+  uma leveza que não estava no mood inicial. A seta ➯ empurra pra frente, não
+  pra trás — não quero mais silêncio, quero abrir mais uma aba.
+impression_a: null
+impression_b: null
+rate_a: 4.3
+rate_b: 3.95
+clash: >-
+  Em qual dos dois a piada é alavanca, e em qual é sobremesa?
+  `the-license-that-knocks` arrisca humor estrutural repetidamente — a imagem do
+  ERP para quatro arquivos Markdown, a hipérbole do 'SAP para civilizações
+  interplanetárias', cada 'buraco' de design confessado com a mesma leveza seca
+  — e em cada caso a piada amolece o leitor exatamente antes da frase séria
+  pousar ('free is not the same as licensed'; 'a graph with zero edges'). É
+  auto-exposição sustentada: o autor é a piada, do início ('minha própria
+  licença nem existia') ao fim. `these-lines` joga um jogo mais raro e mais
+  denso: duas frases apenas — 'I was not being divined. I was being classified'
+  e a antecipação irônica do tédio do leitor — mas ambas fazem o argumento
+  inteiro em miniatura, sem nenhuma palavra a mais. Removidas, o ensaio
+  sobrevive tecnicamente, mas perde o único lugar onde a tese sobre compressão
+  se torna palpável em vez de apenas explicada. Ainda assim, por 'stars tracking
+  comic load-bearing, não laughs-per-thousand-words', `the-license-that-knocks`
+  ganha por volume estrutural: ele arrisca a piada de novo e de novo, inclusive
+  contra si mesmo, enquanto `these-lines`, depois de duas jogadas certeiras, se
+  recolhe para dentro da gravidade cósmica de Arjuna e nunca mais volta a
+  arriscar o cômico. `the-license-that-knocks`, por uma margem estreita.
+review_a: >-
+  Em `the-license-that-knocks`, a frase mais engraçada não é a legenda da imagem
+  — é a linha que a precede: 'you start by trying to charge 0.001 of something
+  and three hours later you are designing SAP for interplanetary civilizations'.
+  Tiro essa frase mentalmente e o parágrafo seguinte ('A pergunta que salvou o
+  design foi brutalmente simples') perde o tapete vermelho que a piada estendeu;
+  ele ainda faz sentido logicamente, mas chega frio, sem o amolecimento que
+  prepara o leitor pra levar 'What does okf-parser already do?' a sério como
+  virada, não como mais uma frase técnica. A piada é a alavanca emocional do
+  pivô, não decoração — ela é o que torna a auto-humilhação ('quase arruinamos a
+  ideia construindo arquitetura demais') suportável de admitir e agradável de
+  ler. O texto repete essa estrutura em cada 'buraco' (price ≠ license, o que é
+  uma invocation, qual política gerou este número): confissão de erro, seguida
+  de correção seca, sem nunca proteger o autor da própria bobagem. Isso é
+  auto-escárnio de verdade, não humor decorativo. Onde o texto se esconde é nas
+  seções finais sobre copyright — ali a piada desaparece e a prosa vira
+  palestra, o que é honesto (o assunto exige rigor) mas também é onde a energia
+  cômica, que carregava o argumento até ali, se esgota primeiro.
+review_b: >-
+  Em `these-lines`, a piada mais seca é 'I was not being divined. I was being
+  classified' — uma frase que faz duplo trabalho: é engraçada por reverter a
+  expectativa mística (o texto tinha acabado de prever o pensamento do leitor)
+  numa explicação técnica seca, e ao mesmo tempo É o argumento sobre compressão
+  aplicado ao próprio ato de ler. Removo essa frase e a tese ainda existe em
+  outro lugar do texto, mas perde a demonstração mais compacta e engraçada de si
+  mesma — a piada não decora a ideia, ela a performa. O mesmo vale pra 'The
+  reader may by now have wondered what succession of distractions brought them
+  before these lines', que rouba a fala do próprio leitor cético um instante
+  antes dele reclamar. Mas depois desses dois lances o texto some para dentro de
+  um registro grave e sustentado — cross-entropy, pré-eternidade, Arjuna — sem
+  nenhuma outra piada de carga estrutural até o fim. Não é gravidade fingindo
+  rigor (o rigor aqui é real), mas pelo teste desta leitora, um texto que
+  arrisca o cômico só duas vezes, por melhor que sejam essas duas vezes, expõe
+  menos o autor do que um texto que arrisca a piada a cada seção, inclusive
+  quando a piada é sobre o próprio fracasso de design.
+---
+

--- a/.routines/hronir/rates/2026-08-26T13-15-05-255_these-lines_x_the-license-that-knocks.md
+++ b/.routines/hronir/rates/2026-08-26T13-15-05-255_these-lines_x_the-license-that-knocks.md
@@ -1,0 +1,79 @@
+---
+type: Rate File
+run_id: 2026-08-26T13-15-05-255
+run_at: '2026-08-26T13:15:05.255Z'
+post_a:
+  key: these-lines
+  path: src/content/blog/these-lines.md
+  display_lang: en
+  content_lang: en
+  version: 39f47c66-a323-534b-bbf0-37553879712c
+  ref: these-lines@39f47c66-a323-534b-bbf0-37553879712c
+post_b:
+  key: the-license-that-knocks
+  path: src/content/blog/a-licenca-que-bate-na-porta.md
+  display_lang: pt
+  content_lang: pt
+  version: 9efcd4bf-1a77-5a72-870a-3f7e56b130d8
+  ref: a-licenca-que-bate-na-porta@9efcd4bf-1a77-5a72-870a-3f7e56b130d8
+winner: a
+agent_id: claude-hronir-scheduled
+content_mode: path-only
+objective: coverage
+eval_lang: pt
+review_lang: pt
+prompt_version: stars-v3
+season: 1
+override: null
+perspective_id: felt-not-explained
+evaluator_mood: Prosseguimento natural. Ambas têm lugar.
+mood_glyph: は
+evaluator_mood_after: >-
+  Fico com uma sensação de loop que não fecha — como se tivesse relido a
+  primeira frase de algo sem perceber que já tinha chegado ao fim. Quero ficar
+  quieto um instante antes de voltar a falar.
+impression_a: null
+impression_b: null
+rate_a: 4.6
+rate_b: 3
+clash: >-
+  Qual fica depois que a aba fecha? `these-lines` deixa um resíduo físico — a
+  frase final invertendo sujeito e universo ainda ecoa horas depois, e o corpo
+  lembra antes da cabeça reconstruir por quê. `the-license-that-knocks` deixa um
+  resumo mental perfeitamente reconstituível: os três buracos, a distinção
+  preço-vs-licença, a arquitetura em camadas — tudo recuperável porque nunca foi
+  sentido, foi apenas bem explicado. O momento mais próximo de risco emocional
+  em `the-license-that-knocks` (admitir que quase construíram um ERP) ainda é
+  contado de fora, como anedota de retrospectiva de equipe, enquanto
+  `these-lines` nunca sai de dentro da experiência — inclusive quando confessa
+  não saber a ordem exata dos próprios eventos, o que é precisamente o tipo de
+  vulnerabilidade que este teste recompensa. Um ensina; o outro acontece com
+  quem lê. `these-lines`, com folga.
+review_a: >-
+  `these-lines` faz o teste do resíduo passar de um jeito que quase incomoda:
+  fechei a aba mentalmente na frase 'It was not the memory of my having
+  understood the universe. It was the universe's memory of having been me when
+  it understood itself' e a sala mudou de temperatura por um segundo. Não é a
+  tese sobre compressão que fica — é a inversão sintática, o sujeito e o objeto
+  trocando de lugar dentro da mesma frase, que faz o corpo sentir antes da
+  cabeça entender. O texto arrisca de verdade: admite dúvida sobre a própria
+  ordem da lembrança ('Não sei se parei naquele momento'), o que é
+  vulnerabilidade genuína, não confissão performada — o narrador está claramente
+  perdido dentro da própria experiência, não narrando de fora dela com
+  segurança. E o final, que devolve a primeira frase como se nada tivesse
+  acontecido, é o tipo de parágrafo que confia no leitor para saber o que
+  aconteceu sem precisar dizer. Vou ter medo de reler isso cedo demais.
+review_b: >-
+  `the-license-that-knocks` é inteligente, e a auto-exposição do 'nós quase
+  estragamos a ideia construindo arquitetura demais' chega perto de custar
+  alguma coisa ao autor — mas o texto sempre relata a vulnerabilidade a partir
+  de uma distância segura, como quem já processou o episódio e agora o resume
+  para uma plateia. Não existe uma cena: existe a lista dos três buracos, cada
+  um com a mesma cadência de erro-seguido-de-correção, o que ensina muito bem
+  mas não produz nenhum resíduo sensorial. Fechei a aba e o que ficou foi a
+  lembrança de um argumento bem construído, não um traço físico. É o post 'bem
+  argumentado, rigoroso, interessante — e estéril' que este teste
+  especificamente pune: terminei qualificado sobre licenciamento de agentes, não
+  mudado por nada nele.
+---
+

--- a/.routines/hronir/rates/2026-08-26T13-16-02-425_the-license-that-knocks_x_these-lines.md
+++ b/.routines/hronir/rates/2026-08-26T13-16-02-425_the-license-that-knocks_x_these-lines.md
@@ -1,0 +1,84 @@
+---
+type: Rate File
+run_id: 2026-08-26T13-16-02-425
+run_at: '2026-08-26T13:16:02.425Z'
+post_a:
+  key: the-license-that-knocks
+  path: src/content/blog/a-licenca-que-bate-na-porta.md
+  display_lang: pt
+  content_lang: pt
+  version: 9efcd4bf-1a77-5a72-870a-3f7e56b130d8
+  ref: a-licenca-que-bate-na-porta@9efcd4bf-1a77-5a72-870a-3f7e56b130d8
+post_b:
+  key: these-lines
+  path: src/content/blog/these-lines.md
+  display_lang: en
+  content_lang: en
+  version: 39f47c66-a323-534b-bbf0-37553879712c
+  ref: these-lines@39f47c66-a323-534b-bbf0-37553879712c
+winner: a
+agent_id: claude-hronir-scheduled
+content_mode: path-only
+objective: coverage
+eval_lang: pt
+review_lang: pt
+prompt_version: stars-v3
+season: 1
+override: null
+perspective_id: craft-listener
+evaluator_mood: >-
+  Acento que transforma sem substituir. Vejo poesia em ambos, escolho a mais
+  intensa.
+mood_glyph: Ó
+evaluator_mood_after: >-
+  Sinto uma satisfação seca, quase de revisor de código que encontrou o commit
+  certo — não é entusiasmo, é o alívio de ver uma peça encaixar sem forçar.
+  Quero abrir uma planilha e organizar alguma coisa agora.
+impression_a: null
+impression_b: null
+rate_a: 4.35
+rate_b: 3.7
+clash: >-
+  Entre `the-license-that-knocks` e `these-lines`, qual entrega o que prometeu
+  construir? `the-license-that-knocks` narra a própria integridade craft em
+  tempo real: declara uma intenção de design, mostra onde ela quebrou, e mostra
+  a correção funcionando — três vezes, cada uma com um artefato final auditável
+  (o diagrama de camadas, a fórmula de cobertura, a proveniência congelada da
+  policy). É uma peça sobre engenharia que também é, ela mesma, bem
+  engenheirada. `these-lines` tem uma única decisão estrutural genuína — o frame
+  circular que devolve a primeira frase como eco comprimido — e ela funciona,
+  mas é uma nota isolada num texto que, fora dela, avança por acúmulo filosófico
+  em vez de arquitetura audível. Pelo critério desta leitora (integridade craft,
+  não ambição técnica), `the-license-that-knocks` vence por ter mais pontos onde
+  intenção e execução se encontram e se confirmam mutuamente, não só um.
+review_a: >-
+  `the-license-that-knocks` é, estruturalmente, um caderno de composer notes
+  disfarçado de ensaio, e é isso que faz essa perspectiva gostar dele. A
+  intenção declarada aparece cedo: 'cobrar era só metade do problema' — e o
+  texto passa o resto do espaço testando se essa intenção se sustenta. O momento
+  mais forte é a nota autocrítica sobre o quase-ERP: 'nós quase estragamos a
+  ideia construindo arquitetura demais', seguida da regra extraída da falha
+  ('não construir um framework de licenciamento em cima de outro framework de
+  conhecimento'). Ouço essa regra sendo cumprida depois, nos quatro tipos
+  econômicos finais e no diagrama 'license / policy / records / okf-parser —
+  cada camada faz uma coisa'. A execução bate com a intenção. O texto repete
+  esse ciclo mais duas vezes (preço-vs-licença, o que é uma invocation) com a
+  mesma disciplina — declarar, testar contra o próprio design, corrigir, mostrar
+  a correção funcionando. Não é retórica sobre rigor; é rigor auditável, com
+  link para os PRs que provam que a correção realmente aconteceu no repositório.
+review_b: >-
+  `these-lines` tem uma intenção estrutural real, só que implícita em vez de
+  anotada: o texto se descreve como 'uma versão comprimida com perdas' do
+  argumento que relata, e a forma circular — abre e fecha com a mesma frase,
+  'When I first read these lines, it seemed to me that they would be about
+  compression' — é a peça de craft que executa essa intenção sem precisar dizer
+  que está fazendo isso. Funciona: fechar o círculo depois de toda a viagem por
+  entropia cruzada, consciência e Arjuna faz a primeira frase significar outra
+  coisa na segunda leitura, que é exatamente o que a tese sobre compressão
+  prevê. O problema, para este teste específico, é que só existe essa uma peça
+  de craft claramente audível; o resto do texto (o mergulho em pré-eternidade, a
+  hipótese sobre reconstrução perfeita) é conteúdo filosófico, não decisão
+  estrutural que eu consiga testar contra uma intenção declarada. Craft real,
+  mas uma nota só, tocada uma vez.
+---
+

--- a/.routines/hronir/rates/2026-08-26T13-16-59-480_the-license-that-knocks_x_these-lines.md
+++ b/.routines/hronir/rates/2026-08-26T13-16-59-480_the-license-that-knocks_x_these-lines.md
@@ -1,0 +1,84 @@
+---
+type: Rate File
+run_id: 2026-08-26T13-16-59-480
+run_at: '2026-08-26T13:16:59.480Z'
+post_a:
+  key: the-license-that-knocks
+  path: src/content/blog/the-license-that-knocks.md
+  display_lang: en
+  content_lang: en
+  version: 463fa25c-e0c0-518a-bacd-b4e9537714a7
+  ref: the-license-that-knocks@463fa25c-e0c0-518a-bacd-b4e9537714a7
+post_b:
+  key: these-lines
+  path: src/content/blog/these-lines.md
+  display_lang: en
+  content_lang: en
+  version: 39f47c66-a323-534b-bbf0-37553879712c
+  ref: these-lines@39f47c66-a323-534b-bbf0-37553879712c
+winner: b
+agent_id: claude-hronir-scheduled
+content_mode: path-only
+objective: coverage
+eval_lang: pt
+review_lang: pt
+prompt_version: stars-v3
+season: 1
+override: null
+perspective_id: returning-reader
+evaluator_mood: >-
+  O 'a' é primeira letra, começo. Mas estou lembrando que movimento precisa de
+  estrutura — Whitehead, ribosome, tudo construído em degraus.
+mood_glyph: ➢
+evaluator_mood_after: >-
+  Estou naquele estado de quem catalogou uma repetição pela terceira vez e já
+  não sente surpresa, só o pequeno cansaço de quem confirma uma suspeita antiga.
+  Queria organizar uma gaveta agora, só para sentir algo virar ordem.
+impression_a: null
+impression_b: null
+rate_a: 3.2
+rate_b: 4.3
+clash: >-
+  Entre `the-license-that-knocks` e `these-lines`, quem move o autor para a
+  frente e quem é o autor em repouso? Os dois compartilham o mesmo tique de
+  fechamento — a cadência de negação-e-reversão em duas frases — mas
+  `the-license-that-knocks` é, pela minha contagem acumulada de posts recentes,
+  a terceira instância consecutiva desse gesto, o que o rebaixa de escolha
+  estilística para reflexo. `these-lines` é só a segunda, e ao redor do tique
+  ele constrói algo genuinamente não-visto antes neste blog: uma estrutura
+  circular que devolve a primeira frase como eco comprimido, mais uma referência
+  à Bhagavad Gita que quebra o padrão Borges-quase-sempre do autor.
+  `the-license-that-knocks` é competência sólida dentro do modo já estabelecido
+  de ensaio técnico-narrativo; `these-lines` é o autor tentando uma forma que
+  ele não tinha tentado, mesmo que imperfeitamente. Quase acertar algo novo vale
+  mais, para esta leitora, que executar bem algo repetido. `these-lines`, com
+  folga.
+review_a: >-
+  `the-license-that-knocks` fecha com 'It is not a self-executing license. It is
+  a license that teaches machines to leave proof that they complied with it' — a
+  mesma cadência de negação-e-reversão em duas frases curtas que já apareceu em
+  pelo menos dois posts recentes deste autor, incluindo `these-lines`, avaliado
+  no mesmo match. Duas vezes é variedade; esta é, pelas minhas contas, a
+  terceira — o que empurra o gesto de escolha estilística deliberada para
+  assinatura-por-acidente. Fora do fechamento, o post faz algo que reconheço de
+  posts técnicos anteriores do autor (a RFC narrada como diário de decisões, os
+  PRs linkados como prova), então não estou vendo um movimento novo tanto quanto
+  uma execução competente de um modo já estabelecido. O meme do ERP é o único
+  elemento realmente fresco nesta peça — mas mesmo esse é o mesmo formato
+  'Center for Ants' que ele já usou antes, então nem isso escapa do território
+  conhecido.
+review_b: >-
+  `these-lines` também fecha em negação-e-reversão ('It was not the memory of my
+  having understood the universe. It was the universe's memory of having been me
+  when it understood itself'), mas aqui é a segunda ocorrência recente, não a
+  terceira — ainda dentro do território de 'variedade' pelo meu próprio
+  critério, e a moldura circular ao redor dela (o texto termina onde começou,
+  com a mesma frase de abertura devolvida, agora significando outra coisa) é um
+  movimento que não me lembro de ver este autor tentar antes: a maioria dos
+  ensaios dele fecha para a frente, não em loop. A referência a Arjuna e Krishna
+  também é nova — ele já citou Borges seguidamente, mas não a Gita, e o
+  cruzamento com teoria da informação é uma combinação que não reconheço de
+  nenhum post recente. É o autor experimentando, mesmo que a experiência tropece
+  um pouco na passagem não-explicada sobre o épico.
+---
+

--- a/.routines/hronir/rates/2026-08-26T13-17-56-753_the-license-that-knocks_x_these-lines.md
+++ b/.routines/hronir/rates/2026-08-26T13-17-56-753_the-license-that-knocks_x_these-lines.md
@@ -1,0 +1,84 @@
+---
+type: Rate File
+run_id: 2026-08-26T13-17-56-753
+run_at: '2026-08-26T13:17:56.753Z'
+post_a:
+  key: the-license-that-knocks
+  path: src/content/blog/the-license-that-knocks.md
+  display_lang: en
+  content_lang: en
+  version: 463fa25c-e0c0-518a-bacd-b4e9537714a7
+  ref: the-license-that-knocks@463fa25c-e0c0-518a-bacd-b4e9537714a7
+post_b:
+  key: these-lines
+  path: src/content/blog/estas-linhas.md
+  display_lang: pt
+  content_lang: pt
+  version: fd8dd2b3-dff4-5c6e-a0d6-d15115e6e070
+  ref: estas-linhas@fd8dd2b3-dff4-5c6e-a0d6-d15115e6e070
+winner: b
+agent_id: claude-hronir-scheduled
+content_mode: path-only
+objective: coverage
+eval_lang: pt
+review_lang: pt
+prompt_version: stars-v3
+season: 1
+override: null
+perspective_id: returning-reader
+evaluator_mood: >-
+  O glifo marca — uma vogal com sotaque. Descongelei na primeira, depois congele
+  de novo na meta. Agora sinto que generosidade pedagógica é quando você é
+  trazido para dentro sem conhecer as credenciais de entrada.
+mood_glyph: ≵
+evaluator_mood_after: >-
+  O ≵ nega comparação limpa — nem maior, nem igual. Sinto que comparar dois
+  textos do mesmo autor também resiste a virar hierarquia fácil; quero deixar a
+  mesa como está por um instante, sem arrumar nada.
+impression_a: null
+impression_b: null
+rate_a: 3.35
+rate_b: 4.15
+clash: >-
+  `the-license-that-knocks` e `estas-linhas` compartilham o mesmo autor num
+  mesmo dia de leitura sob esta lente, e a diferença entre os dois é a diferença
+  entre repouso e movimento. `the-license-that-knocks` executa muito bem um modo
+  já testado — o glossário-em-movimento, a estrutura de 'buracos' encontrados e
+  corrigidos, o fechamento em negação-e-reversão — tudo reconhecível de posts
+  técnicos recentes, tudo competente, nada novo. `estas-linhas` tenta uma
+  moldura circular que não reconheço deste autor e cruza Bhagavad Gita com
+  teoria da informação sem receio de perder parte da audiência pelo caminho — a
+  referência não explicada a Arjuna é exatamente o tipo de risco que o autor
+  normalmente evita com sua generosidade pedagógica habitual, e aqui ele opta
+  por não oferecer essa rede de segurança. Prefiro o texto que tropeça tentando
+  algo novo ao texto que executa com perfeição um gesto já dominado.
+  `estas-linhas`, três a dois.
+review_a: >-
+  `the-license-that-knocks` repete um hábito que já reconheço em outros ensaios
+  técnicos recentes deste autor: a generosidade pedagógica de definir cada termo
+  antes de usá-lo com peso — 'O que é uma invocation?' seguido de sete perguntas
+  concretas antes de fixar a definição, o mesmo movimento que ele faz com
+  'signal', 'verified_use', 'actionable_concern'. É um tique de bom professor,
+  mas ainda assim um tique: terceira ou quarta vez que vejo esse
+  glossário-em-movimento aparecer num post seu sobre protocolos. O fechamento —
+  'It is not a self-executing license. It is a license that teaches machines to
+  leave proof that they complied with it' — também é a cadência de
+  negação-e-reversão que já apontei antes neste mesmo dia de avaliação, e que
+  agora está na sua terceira ocorrência recente. Competente, reconhecível, mas é
+  o autor repetindo um gesto que já domina, não testando um novo.
+review_b: >-
+  `estas-linhas` faz algo que não lembro de ver este autor tentar: abrir e
+  fechar com a mesma frase exata ('Quando li estas linhas pela primeira vez,
+  pareceu-me que seriam sobre compressão'), devolvida ao final carregando um
+  significado que ela não tinha na abertura. Isso é estrutura circular, não
+  linear — os ensaios técnicos dele (incluindo `the-license-that-knocks`)
+  avançam por etapas numeradas; este avança e volta. A referência a Arjuna e
+  Krishna também quebra um padrão: ele cita Borges com frequência, mas não a
+  Gita, e a mistura com teoria da informação é uma combinação que não reconheço
+  de nenhum post recente. O risco é real — 'Não vi deuses nem exércitos. Vi
+  modelos dentro de modelos' deixa o leitor sem as credenciais de entrada que o
+  texto normalmente oferece (nenhuma nota explica quem é Krishna), o que é uma
+  generosidade que falta aqui e que o autor costuma ter em outros lugares. Mas é
+  o autor arriscando uma forma nova, mesmo pagando esse preço.
+---
+


### PR DESCRIPTION
5 matches via the RFC 0016 one-shot API (`generate-match` → `submit-eval`), `--objective coverage`.

Active sampling under `coverage` again concentrated all five matches on the same under-sampled pair, `the-license-that-knocks` × `these-lines`, across five perspective/language-variant combinations:

- Comedy-Carries-Argument Reader (en/en) → `the-license-that-knocks` (4.30 vs 3.95)
- Felt-Not-Explained Reader (en/pt) → `these-lines` (4.60 vs 3.00)
- Craft Listener (pt/en) → `the-license-that-knocks` (4.35 vs 3.70)
- Returning Reader (en/en) → `these-lines` (3.20 vs 4.30)
- Returning Reader (en/pt) → `these-lines` (3.35 vs 4.15)

`these-lines` won 3 of 5; `the-license-that-knocks` won 2 of 5.

The Comedy-Carries-Argument and Craft Listener matches rewarded `the-license-that-knocks` for structural self-mockery — the "ERP for four Markdown files" meme pivots directly into the serious question that saves the design, and the essay's own composer-note structure (three confessed "holes," each fixed live in the text) gives intention and execution a direct, checkable relationship. The Felt-Not-Explained match went decisively to `these-lines` for its closing chiasmus ("It was the universe's memory of having been me when it understood itself"), which produces a physical residue that `the-license-that-knocks`'s rigorous-but-explanatory register does not attempt. Both Returning Reader matches converged on the same finding already flagged by several prior scheduled runs: `the-license-that-knocks`'s closing negation-reversal cadence ("It is not a self-executing license. It is a license that teaches machines to leave proof that they complied with it") is now a third-or-later consecutive instance of that pattern across recent posts — signature-by-accident — while `these-lines`'s circular frame (the essay's own opening line returned, recontextualized, as its closing line) and its unprecedented Bhagavad Gita crossover read as the author trying an unfamiliar structure.

**Step 0 (merge open PRs) still blocked.** Re-confirmed directly this run: `merge_pull_request` on #1552 returns `405 Merge commits are not allowed on this repository`. CLAUDE.md requires merge commits, never squash, so nothing was force-merged or squashed — left for human review. This is the same repository-setting blocker flagged in every prior run since 2026-08-16; the backlog is now 11+ PRs deep (#1552 through #1580). This was already surfaced via push notification in earlier runs, so it was not re-flagged again this run — the underlying fix (Settings → General → Pull Requests → re-enable "Allow merge commits") is still outstanding.

`npm run hronir:doctor` completed with 0 inconsistências this run (pre-existing legacy warnings about orphaned `music-be-me-borges`/`music-borges-and-me` rate files and an `events-welcome` cross-language divergence are unrelated to this run).

---
_Generated by [Claude Code](https://claude.ai/code/session_01V58teTx4fb7uv3JjjUjjNA)_