### PR TITLE
ux: width/height explícitos em GitHubRepo.astro reduzem CLS

### DIFF
--- a/.routines/2026-08-27T05-09-01-ux-ui-run.md
+++ b/.routines/2026-08-27T05-09-01-ux-ui-run.md
@@ -1,0 +1,21 @@
+---
+date: "2026-08-27T05:09:01Z"
+branch: claude/ecstatic-hawking-v8eu4e
+status: open
+---
+
+# Sessão 2026-08-27T05-09-01 — UX/UI
+
+Issues fechadas: #1582
+O que foi feito: adicionados `width`/`height` explícitos ao `<img>` de
+`GitHubRepo.astro` para reservar espaço e reduzir CLS (a API
+`github-readme-stats` retorna sempre width=400; height varia com o
+tamanho da descrição, 120 cobre o caso comum de descrição de uma linha).
+CI local: astro check ✅ (0 erros/warnings, 78 hints pré-existentes) ·
+prettier ✅ · build ✅ (3879 páginas, pagefind ok) · check:hygiene ✅
+
+Passo 0 da rotina: bloqueio de merge commit (405) confirmado novamente em
+#1564 — segue ativo, precisa de decisão humana sobre a configuração de
+merge do repositório (permite só squash, convenção do CLAUDE.md pede merge
+commit). Nenhum dos PRs pendentes (#1564, #1566, #1570, #1575, #1579,
+#1583) foi mesclado.

--- a/src/components/GitHubRepo.astro
+++ b/src/components/GitHubRepo.astro
@@ -18,7 +18,13 @@ const darkSrc = `${base}&theme=transparent&text_color=eeeeee&title_color=ffffff&
   >
     <picture>
       <source media="(prefers-color-scheme: dark)" srcset={darkSrc} />
-      <img src={lightSrc} alt={`${owner}/${repo}`} loading="lazy" />
+      <img
+        src={lightSrc}
+        alt={`${owner}/${repo}`}
+        loading="lazy"
+        width="400"
+        height="120"
+      />
     </picture>
   </a>
   {caption && <figcaption>{caption}</figcaption>}


### PR DESCRIPTION
## Summary

- `src/components/GitHubRepo.astro:21`: o `<img>` do cartão de repositório GitHub (`github-readme-stats.vercel.app/api/pin`) não declarava `width`/`height`, então o navegador não reserva espaço antes da imagem externa carregar, causando layout shift (CLS) — diferente de `MusicPostLayout.astro`/`PostCard.astro`, que já fixam dimensões.
- Confirmei o formato real da API (fonte de `anuraghazra/github-readme-stats`, `src/cards/repo-card.js`, já que o deployment público em `github-readme-stats.vercel.app` está retornando `503 DEPLOYMENT_PAUSED` no momento — não consegui bater a imagem real): `width` é sempre `400` (não há querystring de override nesta rota); `height = (descriptionLines > 1 ? 120 : 110) + descriptionLines * 10`, ou seja `120` para o caso comum de descrição de uma linha (o padrão da maioria dos repos).
- Adicionei `width="400" height="120"` ao `<img>`. A CSS existente (`height: auto; max-width: 100%`) preserva o comportamento responsivo — as dimensões só servem para o navegador reservar espaço/calcular o aspect-ratio até a imagem real chegar. Para repositórios com descrição de 2+ linhas ainda sobra um pequeno shift residual (imagem real fica mais alta), mas é uma fração do CLS anterior (que reservava 0px).
- `srcset`/`src` (URLs geradas), o comportamento dark/light via `<picture>` e `loading="lazy"` ficam inalterados.

Closes #1582

## Nota — componente sem uso atual

`grep -rli GitHubRepo` no repo inteiro (fora do próprio arquivo) não encontrou nenhum import/uso do componente em `src/content/blog/` nem em nenhuma página — ele não está em produção hoje. A issue já previa essa checagem via `grep -rl GitHubRepo src/content/blog/`; documentando aqui que o resultado foi vazio, então a confirmação visual de "sem CLS perceptível" pedida na issue não pôde ser feita numa página real (nada usa o componente para testar). O fix segue correto e alinhado ao padrão dos outros componentes de imagem do repo, e fica pronto para quando o componente for usado.

## Passo 0 da rotina (revisar/mesclar PRs abertos)

Confirmei que o bloqueio já documentado por sessões anteriores (#1564, #1566, #1570, #1575, #1579, #1583) segue ativo: `merge_pull_request` com `merge_method: merge` retorna `405 Merge commits are not allowed on this repository`. Não tentei squash (proibido pelo `CLAUDE.md`, "Merge commits, not squash"). Segue precisando de decisão humana sobre a configuração de merge do repositório — nenhum dos 6 PRs pendentes foi mesclado por mim.

## Test plan

- [x] `npx astro check` — 0 erros, 0 warnings novos (78 hints pré-existentes)
- [x] `npx prettier --check .` — passou
- [x] `npm run build` — build completo (3879 páginas, pagefind ok)
- [x] `npm run check:hygiene` — verde
- [x] `src/generated/*.json` regenerados pelo build local foram revertidos antes do commit — não fazem parte desta mudança
- [ ] Confirmação visual de ausência de CLS numa página real — não aplicável, componente sem uso atual (ver nota acima)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KsoLDj1gu5yxmQ8AgBWwpJ)_