### PR TITLE
hronir: 5 matches — claude-hronir-scheduled

### DIFF
--- a/.routines/2026-08-27T13-22-18-hronir-run.md
+++ b/.routines/2026-08-27T13-22-18-hronir-run.md
@@ -1,0 +1,7 @@
+---
+date: "2026-08-27T13:22:18Z"
+branch: claude/clever-wozniak-1hygoe
+status: open
+---
+
+5 matches — claude-hronir-scheduled. Active sampling under `coverage` again concentrated all five matches on the same under-sampled pair, `the-license-that-knocks` × `these-lines`, across five perspective/language combinations (Lyric-as-Poem pt/pt, Lateral Essayist pt/en, Craft Listener pt/en, Returning Reader pt/pt, Comedy-Carries-Argument pt/pt). `these-lines` won 3 of 5; `the-license-that-knocks` won 2 of 5 — winning specifically on the perspectives tuned to composer-note self-critique (Craft Listener) and comic load-bearing (the ERP-for-four-Markdown-files meme as structural self-mockery), losing on lyric density, lateral movement, and repeat-tic detection (its negation-reversal closing cadence, flagged again as signature-by-accident). Step 0 (merge open PRs) remains blocked: `merge_pull_request` on #1584 still returns `405 Merge commits are not allowed on this repository` — same repo-setting blocker reported in every run since 2026-08-16, now an 12-PR-deep backlog (#1552–#1584). Not re-flagged via notification this run since it was already surfaced in prior runs and is unchanged. `npm run hronir:doctor` completed with 0 inconsistências (pre-existing legacy warnings about orphaned `music-be-me-borges`/`music-borges-and-me` rate files and an `events-welcome` cross-language divergence are unrelated to this run).

--- a/.routines/hronir/rates/2026-08-27T13-13-29-361_the-license-that-knocks_x_these-lines.md
+++ b/.routines/hronir/rates/2026-08-27T13-13-29-361_the-license-that-knocks_x_these-lines.md
@@ -1,0 +1,97 @@
+---
+type: Rate File
+run_id: 2026-08-27T13-13-29-361
+run_at: '2026-08-27T13:13:29.361Z'
+post_a:
+  key: the-license-that-knocks
+  path: src/content/blog/a-licenca-que-bate-na-porta.md
+  display_lang: pt
+  content_lang: pt
+  version: 9efcd4bf-1a77-5a72-870a-3f7e56b130d8
+  ref: a-licenca-que-bate-na-porta@9efcd4bf-1a77-5a72-870a-3f7e56b130d8
+post_b:
+  key: these-lines
+  path: src/content/blog/estas-linhas.md
+  display_lang: pt
+  content_lang: pt
+  version: fd8dd2b3-dff4-5c6e-a0d6-d15115e6e070
+  ref: estas-linhas@fd8dd2b3-dff4-5c6e-a0d6-d15115e6e070
+winner: b
+agent_id: claude-hronir-scheduled
+content_mode: path-only
+objective: coverage
+eval_lang: pt
+review_lang: pt
+prompt_version: stars-v3
+season: 1
+override: null
+perspective_id: lyric-as-poem
+evaluator_mood: >-
+  Achei a direção. Compressão densifica demais — confiança no leitor é mais rara
+  e mais forte. O ângulo que importa é o pacing, não a densidade.
+mood_glyph: ❁
+evaluator_mood_after: >-
+  Sinto os dedos meio dormentes, como se tivesse ficado tempo demais na mesma
+  posição — preciso me levantar e andar um pouco antes de continuar.
+impression_a: null
+impression_b: null
+rate_a: 3.55
+rate_b: 4.45
+clash: >-
+  Colocadas lado a lado como páginas de poesia, the-license-that-knocks e
+  these-lines fazem apostas opostas sobre o que a compressão deve produzir.
+  the-license-that-knocks comprime para instruir — cada frase curta existe para
+  deixar uma regra mais clara, e quando o texto tenta um efeito puramente
+  literário, como no fecho sobre a licença que 'ensina as máquinas a deixar
+  provas', a imagem chega reconhecível demais, uma cadência que este mesmo autor
+  já usou em posts recentes; a melodia (o argumento jurídico) é o que sustenta o
+  texto, e a lírica é decoração sobre ela. these-lines comprime para revelar — a
+  forma circular e o quiasmo final não ilustram o argumento sobre P e Q, eles
+  SÃO o argumento, encenado na sintaxe: a frase sobre 'a lembrança do universo
+  de ter sido eu' só funciona porque o leitor já atravessou o texto inteiro e
+  reconhece a inversão. Um texto usa a página para expor uma tese; o outro usa a
+  página para fazer a tese acontecer na respiração da frase. Pelo teste desta
+  perspectiva — o texto sobrevive à remoção da melodia, ou só funciona como
+  veículo? — these-lines ganha porque sua forma é seu conteúdo;
+  the-license-that-knocks permanece um ótimo ensaio, mas um ensaio, não um poema
+  disfarçado de ensaio. these-lines, quatro a um.
+review_a: >-
+  Lido como se fosse poema, the-license-that-knocks tem um metro estranho:
+  frases de uma linha só, isoladas em parágrafo — 'Essa foi a primeira ideia.
+  Ela durou pouco.' — funcionam quase como versos livres, e por um instante o
+  texto parece um poeta técnico testando quanto ele consegue cortar sem perder o
+  sentido. Isso é compressão de verdade, não enfeite. Mas a página também revela
+  onde o texto está reaching por um efeito: o fecho — 'Não é uma licença
+  autoexecutável. É uma licença que ensina as máquinas a deixar provas de que a
+  cumpriram.' — é a mesma cadência de negação-e-reversão que já apareceu, quase
+  idêntica em estrutura, em posts recentes deste mesmo autor. Na melodia de uma
+  leitura isolada, funciona; lida como linha impressa ao lado de suas irmãs
+  anteriores, a rima estrutural começa a soar ensaiada, um tique que substitui a
+  surpresa por reconhecimento de assinatura. O corpo do texto, por sua vez, é
+  majoritariamente explicativo — diagramas em texto, listas numeradas, YAML
+  citado — e isso é prosa técnica honesta, mas não é o tipo de imagem que
+  resiste à paráfrase. 'O direito autoral continua sendo menos conveniente do
+  que um campo protected: true. Ainda bem.' é a exceção que mais se aproxima do
+  teste: duas frases curtas, a segunda batendo como um verso de resposta, com
+  ironia seca em vez de clichê.
+review_b: >-
+  these-lines passa no teste da página quase inteiro. A estrutura circular — a
+  primeira frase, 'Quando li estas linhas pela primeira vez, pareceu-me que
+  seriam sobre compressão,' retorna ao final, agora carregada de tudo que o
+  texto atravessou — é o tipo de recurso que só existe porque é lido, não porque
+  é ouvido; a melodia não faria esse trabalho, só a repetição visual na página
+  consegue. A linha mais forte do texto, para esta leitora, é o quiasmo do fim:
+  'Não era a lembrança de eu ter compreendido o universo. Era a lembrança do
+  universo de ter sido eu quando se compreendeu.' Duas frases quase idênticas em
+  superfície, invertidas no sujeito, e a inversão é o sentido — isso é
+  exatamente o tipo de pressão sintática que o texto explicativo não consegue
+  produzir, porque a imagem só aparece na simetria entre as duas linhas, lida
+  uma ao lado da outra. Há também um uso elegante do parágrafo de uma frase só
+  como unidade rítmica: 'A história ocorreria uma vez. A memória retornaria
+  tantas vezes quanto o futuro precisasse dela.' — dois versos livres, quase,
+  cada um pesando o dobro do outro por causa do paralelismo. Onde o texto falha
+  um pouco na densidade é no meio, quando a exposição sobre P e Q se estende por
+  parágrafos mais longos e mais explicativos, quase didáticos — ali a lírica
+  cede lugar à aula. Mas o fecho recupera tudo.
+---
+

--- a/.routines/hronir/rates/2026-08-27T13-14-44-385_the-license-that-knocks_x_these-lines.md
+++ b/.routines/hronir/rates/2026-08-27T13-14-44-385_the-license-that-knocks_x_these-lines.md
@@ -1,0 +1,95 @@
+---
+type: Rate File
+run_id: 2026-08-27T13-14-44-385
+run_at: '2026-08-27T13:14:44.385Z'
+post_a:
+  key: the-license-that-knocks
+  path: src/content/blog/a-licenca-que-bate-na-porta.md
+  display_lang: pt
+  content_lang: pt
+  version: 9efcd4bf-1a77-5a72-870a-3f7e56b130d8
+  ref: a-licenca-que-bate-na-porta@9efcd4bf-1a77-5a72-870a-3f7e56b130d8
+post_b:
+  key: these-lines
+  path: src/content/blog/these-lines.md
+  display_lang: en
+  content_lang: en
+  version: 39f47c66-a323-534b-bbf0-37553879712c
+  ref: these-lines@39f47c66-a323-534b-bbf0-37553879712c
+winner: b
+agent_id: claude-hronir-scheduled
+content_mode: path-only
+objective: coverage
+eval_lang: pt
+review_lang: pt
+prompt_version: stars-v3
+season: 1
+override: null
+perspective_id: lateral-essayist
+evaluator_mood: >-
+  Aprendi algo sobre pedagogia. Gostei de ver uma ideia não ganha por lado,
+  ganha por dentro da textura. Quero ler mais sobre como ideias morrem quando
+  transparentes.
+mood_glyph: ☊
+evaluator_mood_after: >-
+  Sinto uma espécie de vertigem boa, como quando desço uma escada no escuro e
+  percebo, tarde demais, que o último degrau não estava onde eu esperava — um
+  leve susto que vira risada.
+impression_a: null
+impression_b: null
+rate_a: 3.2
+rate_b: 4.6
+clash: >-
+  Testadas pelo mesmo critério — a ordem faz o sentido, ou é decoração sobre uma
+  lista? — the-license-that-knocks e these-lines chegam a resultados opostos.
+  the-license-that-knocks organiza sua descoberta em buracos numerados que
+  poderiam, na maior parte, trocar de lugar sem grande prejuízo: é uma sequência
+  de correções de engenharia narradas com honestidade, mas a ordem é biográfica
+  (foi assim que aconteceu), não estrutural (precisava ser assim para
+  significar). Só no fecho, quando a imagem do título retorna transformada, o
+  texto se aproxima do movimento genuíno que esta perspectiva valoriza.
+  these-lines faz esse retorno o tempo inteiro, em escala maior: a frase de
+  abertura sobre compressão volta ao final, mas só depois de atravessar
+  cross-entropy, uma dobra epistemológica e — o salto que nenhuma lista
+  permitiria — o Bhagavad Gita. Eu não consigo embaralhar as seções de
+  these-lines sem quebrar o efeito; consigo embaralhar boa parte dos 'buracos'
+  de the-license-that-knocks e perder relativamente pouco. A pergunta desta
+  perspectiva — qual texto está vivo por causa da sua ordem — tem uma resposta
+  clara. these-lines, quatro a um.
+review_a: >-
+  Como movimento, the-license-that-knocks é mais lista organizada do que ensaio
+  lateral: a narrativa avança em blocos numerados — 'o primeiro buraco', 'o
+  segundo buraco', 'o terceiro buraco' — cada um um problema descoberto e
+  corrigido, e o texto para, explica por que aquilo importa, e segue para o
+  próximo. Se eu embaralhasse a ordem dos buracos, pouco se perderia: cada um é
+  uma unidade quase autônoma de descoberta-e-correção, e a lógica que os conecta
+  é cronológica (o autor foi encontrando problemas nessa ordem), não necessária
+  (o segundo buraco não precisa vir depois do primeiro para fazer sentido). Isso
+  é o sintoma clássico da lista disfarçada de movimento. Dito isso, há um
+  retorno genuíno: a imagem do título — a licença que bate na porta — reaparece
+  no fecho transformada ('não é uma licença autoexecutável, é uma licença que
+  ensina as máquinas a deixar provas'), e por um instante o texto quase convence
+  de que estava se movendo o tempo todo. Mas o corpo, entre a abertura e o
+  fecho, tende a narrar em voz didática: 'Essa é uma diferença enorme', 'Isso
+  não é um detalhe para esconder no rodapé' — o texto para e explica sua própria
+  importância em vez de confiar que a estrutura já fez esse trabalho.
+review_b: >-
+  these-lines é o tipo de ensaio lateral que esta perspectiva foi desenhada para
+  reconhecer. Começa como resenha de leitura de um texto técnico sobre
+  compressão e cross-entropy, deriva para epistemologia da consciência como
+  'dobra' na predição, depois — sem aviso, sem amarração — salta para Arjuna e
+  Krishna no Bhagavad Gita, e só então retorna à primeira frase, agora carregada
+  de tudo que passou: 'When I first read these lines, it seemed to me that they
+  would be about compression' reaparece ao final, idêntica na letra e
+  completamente outra no peso. Não dá para resumir esse movimento sem destruí-lo
+  — qualquer resumo vira 'um texto sobre P e Q que depois cita a Gita', o que é
+  tecnicamente verdadeiro e inteiramente morto. Se eu tentasse embaralhar as
+  seções — colocar Arjuna antes da cross-entropy, digamos — o texto simplesmente
+  não funcionaria, porque a virada exige que o leitor já tenha atravessado a
+  exaustão técnica para sentir o alívio da imagem religiosa. O fecho — 'These
+  lines ended there. The text did not.' — é o raro final que apenas termina, sem
+  resumir 'o que estávamos fazendo', e ainda assim a última linha (a repetição
+  literal da primeira) faz o trabalho de amarração sem nenhuma amarração
+  explícita — a estrutura amarra, a prosa não precisa.
+---
+

--- a/.routines/hronir/rates/2026-08-27T13-16-03-149_these-lines_x_the-license-that-knocks.md
+++ b/.routines/hronir/rates/2026-08-27T13-16-03-149_these-lines_x_the-license-that-knocks.md
@@ -1,0 +1,85 @@
+---
+type: Rate File
+run_id: 2026-08-27T13-16-03-149
+run_at: '2026-08-27T13:16:03.149Z'
+post_a:
+  key: these-lines
+  path: src/content/blog/estas-linhas.md
+  display_lang: pt
+  content_lang: pt
+  version: fd8dd2b3-dff4-5c6e-a0d6-d15115e6e070
+  ref: estas-linhas@fd8dd2b3-dff4-5c6e-a0d6-d15115e6e070
+post_b:
+  key: the-license-that-knocks
+  path: src/content/blog/the-license-that-knocks.md
+  display_lang: en
+  content_lang: en
+  version: 463fa25c-e0c0-518a-bacd-b4e9537714a7
+  ref: the-license-that-knocks@463fa25c-e0c0-518a-bacd-b4e9537714a7
+winner: b
+agent_id: claude-hronir-scheduled
+content_mode: path-only
+objective: coverage
+eval_lang: pt
+review_lang: pt
+prompt_version: stars-v3
+season: 1
+override: null
+perspective_id: craft-listener
+evaluator_mood: 'Duas versões do mesmo. Ambas acessíveis, ambas claras.'
+mood_glyph: ∑
+evaluator_mood_after: >-
+  Estou com a sensação de estar somando coisas o dia inteiro — contas, decisões
+  pequenas — e nenhuma soma fecha de vez; só empilha para amanhã.
+impression_a: null
+impression_b: null
+rate_a: 3.75
+rate_b: 4.3
+clash: >-
+  O teste desta perspectiva pede o ponto em que o autor descreve o que estava
+  tentando fazer, e depois mede a obra contra essa descrição. these-lines
+  dificulta o teste porque sua intenção está dissolvida dentro da própria ficção
+  — não há um momento separado em que o texto sai da obra para comentar a obra;
+  a única 'nota' possível é uma frase do narrador sobre o que o texto original
+  procurava, e isso é uma camada a menos de distância crítica do que esta
+  perspectiva pede. the-license-that-knocks faz o oposto: ele é, quase inteiro,
+  o compositor narrando decisões, erros e correções, terminando numa frase que
+  funciona como declaração de intenção verificável — 'uma licença que ensina as
+  máquinas a deixar provas de que a cumpriram' — e a arquitetura de quatro
+  camadas descrita ao longo do texto é exatamente a prova de que essa intenção
+  foi cumprida, não apenas anunciada. Onde these-lines pede para ser sentido,
+  the-license-that-knocks pede para ser checado, e se deixa checar.
+  the-license-that-knocks, quatro a dois.
+review_a: >-
+  Do ponto de vista desta leitora — que procura a nota do compositor e depois
+  testa se a obra cumpre — these-lines é um caso difícil porque o texto não vem
+  com um manifesto técnico explícito sobre o que estava tentando construir. A
+  intenção mais próxima disso é interna à ficção: 'Não procurava um resumo nem
+  um arquivo perfeito. Procurava o menor modelo capaz de reproduzir por que a
+  história ocorreu.' Isso é uma declaração de projeto, mas dita pela voz
+  narrativa, não pelo autor sobre o próprio texto — e o texto entrega essa
+  promessa de um jeito indireto, encenando a própria compressão com perdas em
+  vez de descrevê-la de fora: o retorno da primeira frase ao final, agora
+  carregada, é craft legível, mas só depois de reler; na primeira passagem, ela
+  é fácil de perder. O problema, para este teste específico, é que quase não há
+  'notas do compositor' separadas da obra — a obra e a explicação da obra são a
+  mesma coisa o tempo todo, o que deixa pouco espaço para medir intenção contra
+  execução como categorias distintas.
+review_b: >-
+  the-license-that-knocks é, estruturalmente, quase todo composto de notas de
+  compositor — e isso funciona a favor dele neste teste específico. O texto
+  declara sua intenção final de forma explícita: 'It is a license that teaches
+  machines to leave proof that they complied with it.' Voltando ao corpo do
+  ensaio, a arquitetura de quatro camadas — license/addendum concede o uso,
+  policy calcula a regra, records OKF deixam a trilha, okf-parser valida a
+  trilha — é exatamente a peça que cumpre essa promessa, e dá para verificar
+  mecanicamente: cada camada faz uma coisa, e a soma das camadas produz prova. O
+  que mais impressiona esta leitora, porém, são as notas autocríticas: três
+  'buracos' nomeados, cada um com o erro original ('grátis não é a mesma coisa
+  que licenciado'), o porquê do erro, e a correção específica. Isso é exatamente
+  'craft invisível na audição, legível nas notas': o bug do okf-parser que zerou
+  as arestas do grafo por causa de uma regra de sintaxe estrita é o tipo de
+  detalhe que muda como você lê o diagrama depois de saber dele. Poucas vezes
+  uma intenção declarada e sua execução se checam tão diretamente quanto aqui.
+---
+

--- a/.routines/hronir/rates/2026-08-27T13-16-53-057_the-license-that-knocks_x_these-lines.md
+++ b/.routines/hronir/rates/2026-08-27T13-16-53-057_the-license-that-knocks_x_these-lines.md
@@ -1,0 +1,88 @@
+---
+type: Rate File
+run_id: 2026-08-27T13-16-53-057
+run_at: '2026-08-27T13:16:53.057Z'
+post_a:
+  key: the-license-that-knocks
+  path: src/content/blog/a-licenca-que-bate-na-porta.md
+  display_lang: pt
+  content_lang: pt
+  version: 9efcd4bf-1a77-5a72-870a-3f7e56b130d8
+  ref: a-licenca-que-bate-na-porta@9efcd4bf-1a77-5a72-870a-3f7e56b130d8
+post_b:
+  key: these-lines
+  path: src/content/blog/estas-linhas.md
+  display_lang: pt
+  content_lang: pt
+  version: fd8dd2b3-dff4-5c6e-a0d6-d15115e6e070
+  ref: estas-linhas@fd8dd2b3-dff4-5c6e-a0d6-d15115e6e070
+winner: b
+agent_id: claude-hronir-scheduled
+content_mode: path-only
+objective: coverage
+eval_lang: pt
+review_lang: pt
+prompt_version: stars-v3
+season: 1
+override: null
+perspective_id: returning-reader
+evaluator_mood: >-
+  O glifo 煉 é fogo refinando metal — sinto o calor da frase que não explica, só
+  queima. A versão que termina em imagem vence a que termina em conceito.
+mood_glyph: ➭
+evaluator_mood_after: >-
+  Sinto uma vontade meio urgente de reorganizar minha mesa agora — não porque
+  esteja bagunçada, mas porque quero ver as coisas na ordem certa antes de
+  continuar.
+impression_a: null
+impression_b: null
+rate_a: 3.1
+rate_b: 4.4
+clash: >-
+  O teste desta perspectiva é simples: qual post faz o autor andar para frente,
+  e qual é o autor em repouso? the-license-that-knocks tem um corpo cheio de
+  movimento real — a autocrítica dos três buracos, a poda da arquitetura
+  excessiva — mas fecha com uma cadência de negação-e-reversão que já apareceu,
+  quase idêntica, em posts recentes sobre o mesmo universo temático de agentes e
+  protocolo; a terceira vez que vejo essa estrutura, ela deixa de ser estilo e
+  vira tique. these-lines, ao contrário, abre um caminho que não reconheço nos
+  últimos posts: a estrutura circular que devolve a primeira frase transformada,
+  e o cruzamento inesperado com o Bhagavad Gita, algo que este autor não tinha
+  tentado antes nas leituras recentes que acompanhei. O fecho de these-lines
+  termina em imagem — 'O texto, não.' — enquanto the-license-that-knocks fecha
+  em conceito explicado. Entre o post competente que repete o próprio molde e o
+  post imperfeito que tenta um gesto novo, esta perspectiva sempre prefere o
+  segundo. these-lines, quatro a um.
+review_a: >-
+  Como leitora que acompanha cada post deste blog, reconheço em
+  the-license-that-knocks um gesto que já vi antes: o fecho por
+  negação-e-reversão — 'Não é uma licença autoexecutável. É uma licença que
+  ensina as máquinas a deixar provas de que a cumpriram.' Essa cadência
+  específica (nega o que o texto não é, depois afirma o que ele é, em duas
+  frases curtas simétricas) já apareceu em posts recentes deste autor sobre
+  temas de agentes e protocolo, quase palavra por palavra na estrutura. A
+  primeira vez, funcionou como assinatura; agora começa a soar como reflexo — o
+  autor cansado encontrando o molde que sabe que funciona. Isso não anula o
+  mérito do corpo do texto, que tem movimento real: os três 'buracos' nomeados,
+  a autocrítica sobre o ERP de quatro arquivos Markdown, a distinção entre
+  política e licença. Mas o teste desta perspectiva não é se o post é competente
+  — é se ele faz algo que os últimos posts não fizeram. Na abertura e no meio,
+  sim; no fecho, é o autor em repouso, não em movimento.
+review_b: >-
+  these-lines faz um movimento que não reconheço deste autor em posts recentes:
+  a estrutura circular explícita, em que a primeira frase retorna ao final,
+  agora carregada de tudo que o texto atravessou — 'Quando li estas linhas pela
+  primeira vez, pareceu-me que seriam sobre compressão' reaparece, idêntica, mas
+  irreconhecível em peso. E o salto para Arjuna e Krishna no meio de um
+  argumento sobre cross-entropia e compressão é, até onde acompanho este blog,
+  um cruzamento que este autor não tinha feito antes — não é o Wittgenstein de
+  sempre, não é a metáfora de engenharia de sempre. É o autor tentando algo
+  novo, e o risco compensa: a virada religiosa poderia ter soado piegas, e não
+  soa, porque chega depois de páginas de rigor técnico que ganharam a confiança
+  do leitor. O fecho também evita o molde de negação-reversão que apareceu em
+  outros posts recentes — 'Estas linhas terminavam ali. O texto, não.' termina
+  numa imagem de continuidade, não num conceito fechado. É exatamente o tipo de
+  final que o meu estado atual está inclinado a premiar: a versão que termina em
+  imagem, não em definição.
+---
+

--- a/.routines/hronir/rates/2026-08-27T13-17-48-444_the-license-that-knocks_x_these-lines.md
+++ b/.routines/hronir/rates/2026-08-27T13-17-48-444_the-license-that-knocks_x_these-lines.md
@@ -1,0 +1,87 @@
+---
+type: Rate File
+run_id: 2026-08-27T13-17-48-444
+run_at: '2026-08-27T13:17:48.444Z'
+post_a:
+  key: the-license-that-knocks
+  path: src/content/blog/a-licenca-que-bate-na-porta.md
+  display_lang: pt
+  content_lang: pt
+  version: 9efcd4bf-1a77-5a72-870a-3f7e56b130d8
+  ref: a-licenca-que-bate-na-porta@9efcd4bf-1a77-5a72-870a-3f7e56b130d8
+post_b:
+  key: these-lines
+  path: src/content/blog/estas-linhas.md
+  display_lang: pt
+  content_lang: pt
+  version: fd8dd2b3-dff4-5c6e-a0d6-d15115e6e070
+  ref: estas-linhas@fd8dd2b3-dff4-5c6e-a0d6-d15115e6e070
+winner: a
+agent_id: claude-hronir-scheduled
+content_mode: path-only
+objective: coverage
+eval_lang: pt
+review_lang: pt
+prompt_version: stars-v3
+season: 1
+override: null
+perspective_id: comedy-carries-argument
+evaluator_mood: >-
+  O glifo メ parece uma lâmina de katana — sinto o fio cortando a
+  grandiloquência, querendo só o osso.
+mood_glyph: 违
+evaluator_mood_after: >-
+  Sinto vontade de dizer não a alguma coisa hoje — não sei bem o quê, só uma
+  resistência baixa e constante, tipo motor de geladeira.
+impression_a: null
+impression_b: null
+rate_a: 4.25
+rate_b: 3.1
+clash: >-
+  O teste é remover a frase mais engraçada e ver se o argumento sobrevive. Em
+  the-license-that-knocks, a legenda do meme sobre o ERP para quatro arquivos
+  Markdown não sobra removível: ela é o instante em que o autor se pega no
+  próprio exagero e vira a mão, e o restante do texto — a poda da arquitetura, a
+  regra 'não construa um framework de licenciamento sobre outro framework' — só
+  chega com essa força porque passou primeiro pelo riso de si mesmo. these-lines
+  não oferece candidato ao teste: não há frase engraçada para remover, porque o
+  texto opera inteiramente em registro grave, do primeiro parágrafo sobre
+  entropia até a visão de Arjuna. Isso não o torna raso, mas torna a comparação,
+  sob esta lente específica, desequilibrada — the-license-that-knocks arrisca
+  embaraço e usa esse risco como alavanca lógica; these-lines nunca se arrisca a
+  parecer frívolo porque nunca tenta ser engraçado. Pelo critério de carga
+  cômica estrutural, e não de gravidade de tom, the-license-that-knocks, três a
+  um.
+review_a: >-
+  A frase mais engraçada de the-license-that-knocks é a legenda do meme: 'Quatro
+  arquivos Markdown. Arquitetura corporativa para civilizações
+  interplanetárias.' Tentei removê-la mentalmente e o argumento não sobrevive
+  intacto — porque a piada não é decoração sobre o argumento, ela É o momento em
+  que o argumento acontece: o texto está no meio de inflar a RFC com
+  LicenseeMeteringProfile e SigningKey, e é o próprio riso do autor diante do
+  próprio excesso que produz a pergunta que salva o desenho ('O que o okf-parser
+  já faz?'). Sem a piada, sobraria só a afirmação abstrata 'não construa
+  arquitetura demais' — verdadeira, mas sem o peso de ter sido vivida. Isso é
+  autozombaria de verdade: o autor é a piada, não protege a si mesmo. Há também
+  humor seco embutido, quase disfarçado de frase técnica: 'O direito autoral
+  continua sendo menos conveniente do que um campo protected: true. Ainda bem.'
+  — a segunda frase, de duas palavras, é o tipo de riso plano que carrega peso
+  lógico: confirma, sem explicar, que o autor prefere a lei inconveniente ao
+  controle artificial.
+review_b: >-
+  these-lines quase não oferece candidatos para o teste desta leitora. É um
+  texto de registro grave do início ao fim — há um momento de leve ironia ('A
+  coincidência me divertiu') e outro de irritação confessada ('com uma irritação
+  sem grande importância'), mas nenhuma frase é estruturalmente uma piada,
+  nenhuma faz o trabalho lógico que esta perspectiva procura. Não existe, aqui,
+  uma frase engraçada para remover e testar se o argumento desaba — porque não
+  existe comédia carregando argumento, existe só argumento. Isso não é
+  necessariamente defeito: o texto sabe o que é e não finge ser outra coisa.
+  Mas, pelo critério específico desta leitora, gravidade de registro não é a
+  mesma coisa que rigor de pensamento, e a ausência total de autoexposição
+  cômica significa que o autor nunca arrisca embaraçar-se — nunca há uma frase
+  em que o riso do leitor é usado a favor do argumento seguinte. O texto pede
+  para ser levado a sério o tempo inteiro, e o faz bem, mas essa perspectiva
+  específica não tem como premiar isso.
+---
+


### PR DESCRIPTION
5 matches via the RFC 0016 one-shot API (`generate-match` → `submit-eval`), `--objective coverage`.

Active sampling under `coverage` again concentrated all five matches on the same under-sampled pair, `the-license-that-knocks` × `these-lines`, across five perspective/language combinations:

- Lyric-as-Poem Reader (pt/pt) → `these-lines` (3.55 vs 4.45)
- Lateral Essayist (pt/en) → `these-lines` (3.20 vs 4.60)
- Craft Listener (pt/en) → `the-license-that-knocks` (3.75 vs 4.30)
- Returning Reader (pt/pt) → `these-lines` (3.10 vs 4.40)
- Comedy-Carries-Argument Reader (pt/pt) → `the-license-that-knocks` (4.25 vs 3.10)

`these-lines` won 3 of 5; `the-license-that-knocks` won 2 of 5.

`the-license-that-knocks` won on the two perspectives most attuned to structural self-awareness: Craft Listener, because the essay's own "composer notes" (three named "holes" found and fixed during the RFC review, each with an honest before/after) let the reader check a stated final intention ("a license that teaches machines to leave proof that they complied with it") directly against the essay's four-layer architecture; and Comedy-Carries-Argument, because the "ERP for four Markdown files" meme is load-bearing — it's the moment of self-mockery that produces the very question that saves the design from over-engineering, not decoration on top of an argument stated elsewhere. It lost on Lyric-as-Poem (compressed, image-driven page-level density), Lateral Essayist (`these-lines`'s sections cannot be reshuffled without breaking the Bhagavad Gita turn; `the-license-that-knocks`'s numbered "holes" mostly can), and Returning Reader, which again flagged the closing negation-reversal cadence ("It is not a self-executing license. It is a license that...") as a third-or-later consecutive instance of the same structural tic across recent posts — signature-by-accident — while `these-lines`'s literal return of its own opening line, and its unprecedented Arjuna/Krishna crossover, read as the author trying something new.

**Step 0 (merge open PRs) still blocked.** Re-confirmed directly this run: `merge_pull_request` on #1584 returns `405 Merge commits are not allowed on this repository`. CLAUDE.md requires merge commits, never squash, so nothing was force-merged or squashed — left for human review. This is the same repository-setting blocker flagged in every prior run since 2026-08-16; the backlog is now 12+ PRs deep (#1552 through #1584). This was already surfaced via push notification in earlier runs, so it was not re-flagged again this run — the underlying fix (Settings → General → Pull Requests → re-enable "Allow merge commits") is still outstanding.

`npm run hronir:doctor` completed with 0 inconsistências this run (pre-existing legacy warnings about orphaned `music-be-me-borges`/`music-borges-and-me` rate files and an `events-welcome` cross-language divergence are unrelated to this run).

---
_Generated by [Claude Code](https://claude.ai/code/session_01RWLk5tGGFnYeDSuKbdW3Wk)_