### PR TITLE
ux: aria-label de pódio em RankingView.astro identifica o post

### DIFF
--- a/.routines/2026-08-28T05-05-28-ux-ui-run.md
+++ b/.routines/2026-08-28T05-05-28-ux-ui-run.md
@@ -1,0 +1,11 @@
+---
+date: "2026-08-28T05:05:28Z"
+branch: claude/ecstatic-hawking-52wv6p
+status: open
+---
+
+# Sessão 2026-08-28T05-05-28 — UX/UI
+
+Issues fechadas: #1581
+O que foi feito: aria-label da linha de pódio (1º/2º/3º) em RankingView.astro agora inclui o título do post, não só a posição — antes um leitor de tela ouvia só "1st place" sem saber qual post.
+CI local: astro check ✅ (0 erros, 0 warnings, 78 hints pré-existentes) · prettier ✅ · build ✅ · check:hygiene ✅

--- a/src/components/RankingView.astro
+++ b/src/components/RankingView.astro
@@ -318,11 +318,12 @@ function snapshotElo(key: string): { elo: number; peak: number } | null {
             : "";
           const podiumClass = r.rank === 1 ? "row-gold" : r.rank === 2 ? "row-silver" : r.rank === 3 ? "row-bronze" : "";
           const podiumLabel = r.rank === 1 ? strings.podiumGold : r.rank === 2 ? strings.podiumSilver : r.rank === 3 ? strings.podiumBronze : undefined;
+          const podiumRowLabel = podiumLabel ? `${podiumLabel} — ${r.post?.title ?? r.key}` : undefined;
           const eloVal = snapshotElo(r.key)?.elo ?? 0;
           return (
             <tr
               class={podiumClass || undefined}
-              aria-label={podiumLabel}
+              aria-label={podiumRowLabel}
               data-sort-winrate={winRatePct}
               data-sort-delta={delta ?? 0}
               data-sort-elo={eloVal}


### PR DESCRIPTION
## Summary

- `src/components/RankingView.astro:319-325` (usado em `/ranking/` e `/pt/ranking/`): o `aria-label` das três primeiras linhas da tabela de ranking (`podiumLabel`) era só `"1st place"`/`"2nd place"`/`"3rd place"`, aplicado à `<tr>` inteira. Como o `aria-label` sobrescreve o conteúdo acessível de toda a linha (incluindo o link do post em `.col-post`), um leitor de tela navegando até essa linha ouvia só a posição, sem saber qual post está no pódio.
- Interpolado `r.post?.title ?? r.key` no `aria-label`, seguindo o mesmo padrão `${label} — ${title}` já usado em outras partes do backlog (battles, changelog, histórico de duelos).
- Texto visível e classes CSS (`row-gold`/`row-silver`/`row-bronze`) inalterados — só o `aria-label` muda. Linhas fora do pódio continuam sem `aria-label`.

Closes #1581

## Passo 0 da rotina (revisar/mesclar PRs abertos)

Reconfirmei o bloqueio já documentado por várias sessões anteriores (#1564, #1566, #1570, #1573, #1575, #1579, #1583, #1585): `merge_pull_request` com `merge_method: merge` continua retornando `405 Merge commits are not allowed on this repository`. Não tentei squash (proíbido pelo `CLAUDE.md`, "Merge commits, not squash"). São agora 8 PRs desta rotina acumulados desde 19/08 sem poder ser mesclados — segue precisando de decisão humana sobre a configuração de merge do repositório (Settings → General → Pull Requests → permitir merge commit).

## Test plan

- [x] `npx astro check` — 0 erros, 0 warnings novos (78 hints pré-existentes)
- [x] `npx prettier --check .` — passou
- [x] `npm run build` — build completo (3879 páginas, pagefind ok)
- [x] Confirmado no HTML gerado: `dist/ranking/index.html` tem `aria-label="1st place — The Third Half and the Fourth Wall"` etc.; `dist/pt/ranking/index.html` tem `aria-label="1º lugar — A Terceira Metade e a Quarta Parede"` etc. — únicos por linha, título correto em cada idioma
- [x] `npm run check:hygiene` — verde
- [x] `src/generated/*.json` regenerados pelo build local foram revertidos antes do commit — não fazem parte desta mudança


---
_Generated by [Claude Code](https://claude.ai/code/session_01GYiCufcGQBi9vqyd16NG6P)_