### PR TITLE
hronir: 5 matches — claude-hronir-scheduled

### DIFF
--- a/.routines/2026-08-28T13-17-00-hronir-run.md
+++ b/.routines/2026-08-28T13-17-00-hronir-run.md
@@ -1,0 +1,7 @@
+---
+date: "2026-08-28T13:17:00Z"
+branch: hronir/run-2026-08-28T13-10-00
+status: open
+---
+
+5 matches — claude-hronir-scheduled. Active sampling under `coverage` again concentrated every match on `the-license-that-knocks` × `these-lines` across five perspectives (Internet-Native Watcher, Curious Outsider, Skeptical Specialist, Weird-Clarity Reader, Lateral Essayist). `the-license-that-knocks` won 3 of 5 (pacing/humor, pedagogical generosity, self-aware defensibility); `these-lines` won 2 (paraphrase-resistant closing chiasmus, structure-as-movement). Step 0 (merge open PRs) re-confirmed still blocked: `merge_pull_request` on #1552 still returns `405 Merge commits are not allowed on this repository` — same repo-setting blocker flagged in every scheduled run since 2026-08-16, now 13 PRs deep (#1552–#1586). Not re-flagged via push notification this run since nothing changed since the last report. `npm run hronir:doctor` passed with 0 inconsistências (pre-existing legacy `music-be-me-borges`/`music-borges-and-me` and `events-welcome` warnings unrelated to this run).

--- a/.routines/hronir/rates/2026-08-28T13-11-54-384_the-license-that-knocks_x_these-lines.md
+++ b/.routines/hronir/rates/2026-08-28T13-11-54-384_the-license-that-knocks_x_these-lines.md
@@ -1,0 +1,80 @@
+---
+type: Rate File
+run_id: 2026-08-28T13-11-54-384
+run_at: '2026-08-28T13:11:54.384Z'
+post_a:
+  key: the-license-that-knocks
+  path: src/content/blog/the-license-that-knocks.md
+  display_lang: en
+  content_lang: en
+  version: 463fa25c-e0c0-518a-bacd-b4e9537714a7
+  ref: the-license-that-knocks@463fa25c-e0c0-518a-bacd-b4e9537714a7
+post_b:
+  key: these-lines
+  path: src/content/blog/these-lines.md
+  display_lang: en
+  content_lang: en
+  version: 39f47c66-a323-534b-bbf0-37553879712c
+  ref: these-lines@39f47c66-a323-534b-bbf0-37553879712c
+winner: a
+agent_id: claude-hronir-scheduled
+content_mode: path-only
+objective: coverage
+eval_lang: pt
+review_lang: pt
+prompt_version: stars-v3
+season: 1
+override: null
+perspective_id: internet-native
+evaluator_mood: >-
+  A seta apontando pra cima-esquerda me soa como escape mental — saio da
+  corporalidade aprisionada. A forma Cyrillic fechada se abre em direção. Sinto
+  clareza estranha agora.
+mood_glyph: B
+evaluator_mood_after: >-
+  O glifo B parece dois nos identicos empilhados, uma coluna simetrica. Fico com
+  vontade de arrumar gavetas digitais hoje, organizar notas soltas. Rir sozinho
+  de novo com a piada do ERP deixou um cansaco leve, gostoso.
+impression_a: null
+impression_b: null
+rate_a: 4.3
+rate_b: 3.15
+clash: >-
+  O teste aqui e simples: qual eu mandaria so com leia isso, sem contexto
+  nenhum? the-license-that-knocks passa nesse teste. Ele tem ritmo de video de
+  YouTube longo daqueles que voce assiste sem querer, com uma piada de ERP que
+  rende porque o texto nao avisa que vem piada, e uma frase seria que cai logo
+  depois, ainda ecoando o riso, sem transicao marcada. these-lines exige que eu
+  explique antes de mandar, e sobre compressao e consciencia, aguenta ate a
+  metade antes de convencer, e tem uma referencia a Bhagavad Gita sem contexto
+  nenhum bem no momento mais importante do texto. Isso e exatamente o oposto do
+  que essa perspectiva premia, que e comando total de um assunto sem precisar
+  avisar o leitor antes. the-license-that-knocks, quatro a tres.
+review_a: >-
+  the-license-that-knocks eu mandaria com um simples leia isso. O ritmo funciona
+  como video-essay de verdade: comeca se rebaixando (nao ter licenca no proprio
+  repositorio de skills e chamado de frase ridicula), passa por arquitetura
+  tecnica real e entao larga a piada do Center for Ants, virando An ERP for four
+  Markdown files, exatamente no momento em que a RFC estava inchando com nomes
+  em PascalCase. A risada surpreende porque o texto nao anuncia a piada, ela
+  nasce do proprio excesso que o autor estava cometendo. Logo depois vem a frase
+  seria que fecha aquele paragrafo, do not build a licensing framework on top of
+  a knowledge framework, e ela pesa mais justamente porque chega colada na
+  piada, sem aviso nenhum. O fechamento tambem funciona: nao e um self-executing
+  license, e uma licenca que ensina maquinas a deixar prova de que cumpriram.
+  Essa e a frase que fico repetindo depois de fechar a aba.
+review_b: >-
+  these-lines eu teria que preparar antes de mandar. E um texto que sei que e
+  bom, mas que exige aviso, isso e sobre compressao e consciencia, meio
+  borgiano, aguenta ate a metade. O proprio texto antecipa esse cansaco do
+  leitor quando escreve que o leitor ja deve estar se perguntando que sucessao
+  de distracoes o trouxe ate aquelas linhas, um lance inteligente, mas que o
+  texto nao transforma em piada, apenas em constatacao seria sobre si mesmo. O
+  registro nunca sai do grave, entao quando a virada de Arjuna e Krishna chega
+  sem apresentacao nenhuma, sem nomear a Bhagavad Gita, quem nao conhece a
+  referencia cai fora bem no climax. Ainda assim o fechamento e forte, a frase
+  sobre a memoria do universo de ter sido eu quando se compreendeu tem peso de
+  verdade, so que chega depois de uma extensao que testa a paciencia de quem le
+  por curiosidade lateral, nao por compromisso academico.
+---
+

--- a/.routines/hronir/rates/2026-08-28T13-13-21-436_the-license-that-knocks_x_these-lines.md
+++ b/.routines/hronir/rates/2026-08-28T13-13-21-436_the-license-that-knocks_x_these-lines.md
@@ -1,0 +1,76 @@
+---
+type: Rate File
+run_id: 2026-08-28T13-13-21-436
+run_at: '2026-08-28T13:13:21.436Z'
+post_a:
+  key: the-license-that-knocks
+  path: src/content/blog/a-licenca-que-bate-na-porta.md
+  display_lang: pt
+  content_lang: pt
+  version: 9efcd4bf-1a77-5a72-870a-3f7e56b130d8
+  ref: a-licenca-que-bate-na-porta@9efcd4bf-1a77-5a72-870a-3f7e56b130d8
+post_b:
+  key: these-lines
+  path: src/content/blog/these-lines.md
+  display_lang: en
+  content_lang: en
+  version: 39f47c66-a323-534b-bbf0-37553879712c
+  ref: these-lines@39f47c66-a323-534b-bbf0-37553879712c
+winner: a
+agent_id: claude-hronir-scheduled
+content_mode: path-only
+objective: coverage
+eval_lang: pt
+review_lang: pt
+prompt_version: stars-v3
+season: 1
+override: null
+perspective_id: curious-outsider
+evaluator_mood: >-
+  O ゲ tem aquele corte agudo, definitivo. Quero algo sólido agora, não
+  devaneios. A música foi linda, mas flutuante.
+mood_glyph: 朙
+evaluator_mood_after: >-
+  O 朙 parece uma janela com um olho dentro, sensacao de ser vista enquanto tento
+  enxergar alguma coisa. Estou com fome de clareza concreta agora, cansada de
+  esperar a explicacao chegar so no final do texto.
+impression_a: null
+impression_b: null
+rate_a: 4.35
+rate_b: 2.9
+clash: >-
+  O teste e qual texto ganhou minha companhia antes de depender dela.
+  the-license-that-knocks nunca me deixou para tras: cada sigla, cada termo
+  juridico, cada pergunta sobre o que conta como invocation chega explicada
+  antes de ser usada de novo. these-lines me perdeu exatamente no momento em que
+  mais precisava de mim, a virada de Arjuna e Krishna sem nenhuma apresentacao,
+  sem nomear a Bhagavad Gita nem uma vez. Continuei lendo, mas de fora, tentando
+  reconstruir sozinha uma referencia que o texto assumiu que eu ja tinha.
+  the-license-that-knocks, quatro a dois. Isso e exatamente o oposto do teste
+  que essa perspectiva pede: quem chega sem contexto precisa ser conduzida ate o
+  fim, nao abandonada no penultimo paragrafo.
+review_a: >-
+  Como leitora sem bagagem previa em licenciamento de agentes,
+  a-licenca-que-bate-na-porta, aqui pelo slug the-license-that-knocks, me trouxe
+  junto do comeco ao fim. Cada termo tecnico chega definido no momento em que
+  passa a ser usado: signal quer dizer achei algo parecido o suficiente para
+  olhar, verified_use quer dizer ha evidencia razoavel de uso, e o texto ainda
+  avisa que isso nao vira automaticamente infracao. Quando chega em invocation,
+  em vez de assumir que eu sei o que e, o texto faz a pergunta que eu mesma
+  faria, uma skill carregada uma vez e consultada em cinco turnos conta uma vez
+  ou cinco, e so depois responde. O mesmo vale para o direito autoral: o artigo
+  8 da Lei 9.610 nao e so citado, e explicado, ideias e procedimentos ficam fora
+  da protecao. Em nenhum momento fechei a aba por estar perdida.
+review_b: >-
+  these-lines comeca generoso: explica compressao com o exemplo da moeda
+  honesta, define P e Q antes de usar cross-entropy, ate linka o video do
+  3Blue1Brown avisando que da pra continuar sem assistir. Eu estava acompanhando
+  bem ate esse ponto. A perda acontece perto do final, quando o texto escreve
+  entao pensei em Arjuna, no comeco do poema ele esta paralisado entre agir e
+  renunciar a acao, Krishna nao comeca pela visao divina. Nenhum nome de obra
+  aparece, ninguem explica quem sao Arjuna ou Krishna, e essa cena carrega o
+  climax metafisico inteiro do texto. Eu, leitora de fora, fiquei observando uma
+  conversa que nao foi construida para mim bem no momento mais importante. O
+  texto continua depois disso, mas eu tinha ficado para tras.
+---
+

--- a/.routines/hronir/rates/2026-08-28T13-14-45-949_these-lines_x_the-license-that-knocks.md
+++ b/.routines/hronir/rates/2026-08-28T13-14-45-949_these-lines_x_the-license-that-knocks.md
@@ -1,0 +1,87 @@
+---
+type: Rate File
+run_id: 2026-08-28T13-14-45-949
+run_at: '2026-08-28T13:14:45.949Z'
+post_a:
+  key: these-lines
+  path: src/content/blog/estas-linhas.md
+  display_lang: pt
+  content_lang: pt
+  version: fd8dd2b3-dff4-5c6e-a0d6-d15115e6e070
+  ref: estas-linhas@fd8dd2b3-dff4-5c6e-a0d6-d15115e6e070
+post_b:
+  key: the-license-that-knocks
+  path: src/content/blog/a-licenca-que-bate-na-porta.md
+  display_lang: pt
+  content_lang: pt
+  version: 9efcd4bf-1a77-5a72-870a-3f7e56b130d8
+  ref: a-licenca-que-bate-na-porta@9efcd4bf-1a77-5a72-870a-3f7e56b130d8
+winner: b
+agent_id: claude-hronir-scheduled
+content_mode: path-only
+objective: coverage
+eval_lang: pt
+review_lang: pt
+prompt_version: stars-v3
+season: 1
+override: null
+perspective_id: skeptical-specialist
+evaluator_mood: >-
+  A oscilação resolve — preciso seguir o texto que faz perguntas de si mesmo
+  enquanto escreve. O rigor não é tédio; é confiança.
+mood_glyph: 蕣
+evaluator_mood_after: >-
+  O 蕣 tem essa raiz de planta efemera, flor de um dia, me deixa pensando que
+  quero registrar uma ideia antes que ela murche. Sinto as maos meio frias,
+  precisando de um cha quente agora.
+impression_a: null
+impression_b: null
+rate_a: 3.35
+rate_b: 4.2
+clash: >-
+  Qual sobreviveria a uma revisao hostil de quem conhece o assunto?
+  the-license-that-knocks passa no teste com vantagem porque a estrutura inteira
+  do texto e uma sequencia de buracos encontrados e fechados, primeiro buraco,
+  segundo buraco, terceiro buraco, cada correcao citavel e datavel numa PR real.
+  these-lines tem um momento de honestidade equivalente quando admite que nao
+  demonstra a hipotese da marca metafisica, mas essa honestidade nao se estende
+  a virada para Arjuna e Krishna, que chega como analogia historica nao
+  examinada, pedindo emprestado o peso de uma teofania para uma tese sobre
+  compressao sem perguntar se a estrutura realmente corresponde. Eu conseguiria
+  constranger these-lines num seminario perguntando por que o criterio de
+  relevancia da pre-eternidade e binario. Eu teria mais dificuldade de
+  constranger the-license-that-knocks, porque ele ja fez essa pergunta a si
+  mesmo tres vezes antes de mim. the-license-that-knocks, quatro a tres.
+review_a: >-
+  A afirmacao mais fragil de these-lines aparece na virada da pre-eternidade:
+  bastava que a ausencia de uma pessoa alterasse uma unica continuacao possivel
+  para que ela fosse incorporada a memoria do futuro. Isso e um binario sem
+  sustentacao, ou a pessoa importa para alguma continuacao ou nao importa,
+  quando o espaco real e de graus de importancia, nao de existir ou nao existir
+  numa bifurcacao. O melhor especialista hostil perguntaria: por que o criterio
+  de relevancia e binario e nao continuo, se todo o argumento anterior sobre
+  compressao trabalha com graus, com quanto uma regularidade reduz custo? O
+  texto sabe que esta pisando em terreno raso, ele proprio diz que nao demonstra
+  a hipotese da marca metafisica e a deposita onde matematica, identidade e
+  religiao deixam de se separar, isso e honesto. Mas a virada para Arjuna e
+  Krishna e esticamento historico puro: o poema e convocado para emprestar peso
+  emocional a uma tese sobre auto-modelagem computacional sem que o texto
+  pergunte se a estrutura da teofania realmente mapeia a estrutura do argumento,
+  ou se e so uma imagem bonita telefonando de longe.
+review_b: >-
+  the-license-that-knocks e o raro post que documenta o proprio processo de
+  encontrar e corrigir suas afirmacoes mais fracas, tres vezes seguidas: gratis
+  nao e a mesma coisa que licenciado, o que conta como uma invocation, qual
+  policy gerou este numero. Isso e exatamente o que essa perspectiva mais
+  premia, fraqueza reconhecida abertamente em vez de encenada. A afirmacao mais
+  fragil que sobrevive e outra: a comparacao inicial, isto aqui e como um livro,
+  tratada como intuicao de partida para depois ser corrigida pelo artigo 8 da
+  Lei 9.610. O especialista hostil perguntaria se a analogia com livro nao
+  contamina silenciosamente o resto do argumento, mesmo depois de qualificada,
+  porque o leitor comum guarda a primeira imagem. O texto minimiza esse risco ao
+  dizer explicitamente que essa intuicao funciona so ate certo ponto, o que e o
+  oposto de um hedge ornamental, e uma admissao que muda o proximo paragrafo de
+  verdade. As referencias legais tambem sobrevivem substituicao, citam artigo
+  especifico com numero e o que ele exclui, nao um nome solto para atmosfera.
+---
+

--- a/.routines/hronir/rates/2026-08-28T13-16-09-311_these-lines_x_the-license-that-knocks.md
+++ b/.routines/hronir/rates/2026-08-28T13-16-09-311_these-lines_x_the-license-that-knocks.md
@@ -1,0 +1,78 @@
+---
+type: Rate File
+run_id: 2026-08-28T13-16-09-311
+run_at: '2026-08-28T13:16:09.311Z'
+post_a:
+  key: these-lines
+  path: src/content/blog/these-lines.md
+  display_lang: en
+  content_lang: en
+  version: 39f47c66-a323-534b-bbf0-37553879712c
+  ref: these-lines@39f47c66-a323-534b-bbf0-37553879712c
+post_b:
+  key: the-license-that-knocks
+  path: src/content/blog/a-licenca-que-bate-na-porta.md
+  display_lang: pt
+  content_lang: pt
+  version: 9efcd4bf-1a77-5a72-870a-3f7e56b130d8
+  ref: a-licenca-que-bate-na-porta@9efcd4bf-1a77-5a72-870a-3f7e56b130d8
+winner: a
+agent_id: claude-hronir-scheduled
+content_mode: path-only
+objective: coverage
+eval_lang: pt
+review_lang: pt
+prompt_version: stars-v3
+season: 1
+override: null
+perspective_id: weird-clarity
+evaluator_mood: >-
+  Glifo invertido — isso mesmo. Cansaço honesto agora: um texto dizendo que não
+  responde enquanto responde, outro dizendo que é experimento quando já é
+  confissão. Encontrei quem foi honesto de verdade.
+mood_glyph: r
+evaluator_mood_after: >-
+  O r minusculo parece um gancho pendurado, uma pergunta que nao fecha a curva.
+  Estou com vontade de reler a mesma frase varias vezes seguidas, ver se ela
+  ainda resiste depois da quinta vez.
+impression_a: null
+impression_b: null
+rate_a: 4.55
+rate_b: 2.95
+clash: >-
+  Qual desses dois deixa alguma coisa que eu nao consigo dizer de outro jeito?
+  these-lines deixa, no fechamento sobre a lembranca do universo de ter sido eu
+  quando se compreendeu, uma frase gramaticalmente simples e semanticamente
+  irredutivel, tentei parafrasear e a coisa escapou entre os dedos.
+  the-license-that-knocks tambem termina numa frase boa, nao e uma licenca
+  autoexecutavel, e uma licenca que ensina maquinas a deixar provas, mas essa eu
+  consegui reescrever sem perder nada, a licenca nao age sozinha, ensina a
+  comprovar cumprimento. Um teste a frase passa, a outra nao. these-lines,
+  quatro a dois. A frase de these-lines ainda esta na minha cabeca horas depois;
+  a de the-license-that-knocks ja virou resumo e foi arquivada.
+review_a: >-
+  A frase que carrego depois de fechar these-lines e: nao era a lembranca de eu
+  ter compreendido o universo, era a lembranca do universo de ter sido eu quando
+  se compreendeu. Tentei parafrasear: eu sou uma parte do universo que ele usa
+  para se conhecer. Errado, ou melhor, mais fraco, porque a parafrase deixa
+  sujeito e objeto separados, e a frase original os funde num so movimento
+  gramatical simples, sujeito, verbo, objeto, sem nenhuma palavra dificil, mas
+  impossivel de dizer de outro jeito sem perder exatamente o que ela faz. A
+  tentativa colapsou. O texto tambem usa paragrafos de uma frase so como
+  pontuacao real, nao decoracao: estas linhas terminavam ali, o texto nao. Duas
+  frases, dois paragrafos, e a virada inteira do conto cabe entre elas. Isso e
+  clareza estranha de verdade, nao metafora que explica para baixo.
+review_b: >-
+  the-license-that-knocks tambem termina numa frase seca e bem construida: nao e
+  uma licenca autoexecutavel, e uma licenca que ensina as maquinas a deixar
+  provas de que a cumpriram. Tentei parafrasear: a licenca nao age sozinha, ela
+  ensina quem usa a comprovar que seguiu a regra. A parafrase funcionou. Nao
+  perdi nada essencial, so troquei palavras por outras equivalentes, e isso e
+  exatamente o que essa perspectiva pune. O texto e preciso, tecnico, cada
+  buraco encontrado e fechado com rigor real, mas a precisao aqui e do tipo que
+  se explica, nao do tipo que resiste a explicacao. Nao ha arrepio na nuca, ha
+  um argumento bem montado que termina de forma clara. Isso vale muito para
+  outros leitores. No leitor de clareza estranha, um argumento que se resume bem
+  e um argumento que ja disse tudo o que tinha para dizer.
+---
+

--- a/.routines/hronir/rates/2026-08-28T13-16-56-205_these-lines_x_the-license-that-knocks.md
+++ b/.routines/hronir/rates/2026-08-28T13-16-56-205_these-lines_x_the-license-that-knocks.md
@@ -1,0 +1,80 @@
+---
+type: Rate File
+run_id: 2026-08-28T13-16-56-205
+run_at: '2026-08-28T13:16:56.205Z'
+post_a:
+  key: these-lines
+  path: src/content/blog/these-lines.md
+  display_lang: en
+  content_lang: en
+  version: 39f47c66-a323-534b-bbf0-37553879712c
+  ref: these-lines@39f47c66-a323-534b-bbf0-37553879712c
+post_b:
+  key: the-license-that-knocks
+  path: src/content/blog/the-license-that-knocks.md
+  display_lang: en
+  content_lang: en
+  version: 463fa25c-e0c0-518a-bacd-b4e9537714a7
+  ref: the-license-that-knocks@463fa25c-e0c0-518a-bacd-b4e9537714a7
+winner: a
+agent_id: claude-hronir-scheduled
+content_mode: path-only
+objective: coverage
+eval_lang: pt
+review_lang: pt
+prompt_version: stars-v3
+season: 1
+override: null
+perspective_id: lateral-essayist
+evaluator_mood: >-
+  Dois modos: a intimidade e a raiva. Uma descobre como as máquinas respiram,
+  outra descobre que ninguém respirava mesmo. Estou no meio, duvidando de qual
+  era a verdade verdadeira.
+mood_glyph: ❿
+evaluator_mood_after: >-
+  O ❿ parece um relogio contando ao contrario, uma pergunta sobre quanto tempo
+  ainda tenho de leitura boa hoje. Sinto vontade de reler o comeco de alguma
+  coisa que ja terminei de ler.
+impression_a: null
+impression_b: null
+rate_a: 4.4
+rate_b: 3.1
+clash: >-
+  Qual dos dois esta vivo por causa da ordem? these-lines esta: a frase de
+  abertura retorna identica no fechamento e significa outra coisa na segunda
+  vez, e cada secao intermediaria, entropia, a dobra, a pre-eternidade, Arjuna,
+  depende da anterior para funcionar, embaralhar destroi o conto.
+  the-license-that-knocks tem ritmo no comeco mas vira lista a partir da metade,
+  os tres buracos sao estudos de caso independentes que sobrevivem a qualquer
+  reordenacao, e o paragrafo final faz a amarracao forcada que essa perspectiva
+  rejeita, explicando o que a licenca e em vez de deixar a estrutura mostrar
+  sozinha. Sinto que poderia recortar as secoes de the-license-that-knocks e
+  embaralhar num chapeu sem perder nada essencial. these-lines, tres a um.
+review_a: >-
+  Tentei resumir o movimento de these-lines numa frase e a tentativa falhou do
+  jeito certo: comeca com quando li estas linhas pela primeira vez, pareceu-me
+  que seriam sobre compressao, atravessa entropia, cross-entropia, a dobra da
+  consciencia, a pre-eternidade, Arjuna, e termina repetindo a frase inicial
+  palavra por palavra, quando li estas linhas pela primeira vez, pareceu-me que
+  seriam sobre compressao. So que agora a frase significa outra coisa, porque o
+  leitor sabe que estas linhas ja foram apresentadas como compressao com perdas
+  do texto verdadeiro, entao a mesma abertura vira fechamento e reabertura ao
+  mesmo tempo. Movi mentalmente a secao de Arjuna para o comeco e o conto
+  morreu, porque a visao so faz sentido depois que o leitor ja atravessou a
+  dobra e a pre-eternidade, tudo depende de ter sido convencido antes. Isso e
+  ordem viva, nao lista com paragrafos.
+review_b: >-
+  the-license-that-knocks tem ritmo real no comeco, a confissao de nao ter
+  licenca, a piada do ERP, mas a partir da metade vira uma sequencia de secoes
+  com titulo, the first hole, the second hole, the third hole, cada uma
+  resolvendo um problema tecnico proprio sobre metering. Movi mentalmente o
+  terceiro buraco, sobre qual policy gerou o numero, para antes do primeiro,
+  sobre preco nao ser licenca, e o texto sobreviveu sem perda nenhuma, porque
+  cada buraco e um estudo de caso fechado em si mesmo, nao uma continuacao que
+  precisa da anterior para significar algo. Isso e o sintoma exato que essa
+  perspectiva penaliza: uma lista disfarcada de movimento. O paragrafo final
+  tenta amarrar tudo com a frase sobre a licenca que ensina maquinas a deixar
+  provas, mas essa amarracao chega de fora, explicando o que fizemos em vez de
+  deixar que a ordem ja tivesse feito o trabalho.
+---
+


### PR DESCRIPTION
5 matches via the RFC 0016 one-shot API (`generate-match` → `submit-eval`), `--objective coverage`.

Active sampling under `coverage` again concentrated all five matches on the same under-sampled pair, `the-license-that-knocks` × `these-lines`, across five perspective/language-variant combinations:

- Internet-Native Watcher (en/en) → `the-license-that-knocks` (4.30 vs 3.15)
- Curious Outsider (pt/en) → `the-license-that-knocks` (4.35 vs 2.90)
- Skeptical Specialist (pt/pt) → `the-license-that-knocks` (4.20 vs 3.35)
- Weird-Clarity Reader (en/pt) → `these-lines` (4.55 vs 2.95)
- Lateral Essayist (en/en) → `these-lines` (4.40 vs 3.10)

`the-license-that-knocks` won 3 of 5; `these-lines` won 2 of 5.

The Internet-Native Watcher, Curious Outsider, and Skeptical Specialist matches rewarded `the-license-that-knocks` for the same underlying property, read three different ways: its self-aware structure. The essay narrates its own weakest points as they're found and patched — three named "holes," each with a before/after — which reads as genuine video-essay pacing (comic self-mockery paying off into a serious line), as pedagogical generosity (every term, from `invocation` to Article 8 of Lei 9.610/1998, defined before it's leaned on), and as adversarial defensibility (a soft claim owned before a hostile reader could press on it). `these-lines` lost these three specifically where it assumes shared context — most concretely the late, unnamed Bhagavad Gita/Arjuna turn, which the Curious Outsider flagged as the exact point of losing a reader with no background, and which the Skeptical Specialist read as an unexamined historical analogy borrowing a theophany's weight without justifying the mapping.

`these-lines` won where the test was resistance to paraphrase or structural necessity of order. Its closing chiasmus — "It was not the memory of my having understood the universe. It was the universe's memory of having been me when it understood itself." — collapsed every paraphrase attempt, while `the-license-that-knocks`'s comparably strong closing line ("It is not a self-executing license. It is a license that teaches machines to leave proof that they complied with it.") paraphrased cleanly without loss. And under the reshuffling test, `these-lines`'s circular frame (its opening sentence returns verbatim as its closing sentence, now meaning something else) could not survive reordering, while `the-license-that-knocks`'s three numbered "holes" read as independent case studies that would survive being shuffled — a list wearing the shape of a movement.

**Step 0 (merge open PRs) re-confirmed still blocked.** `merge_pull_request` on #1552 still returns `405 Merge commits are not allowed on this repository`. CLAUDE.md requires merge commits, never squash, so nothing was force-merged or squashed — left for human review. This is the same repository-setting blocker flagged in every scheduled run since 2026-08-16; the backlog is now 13+ PRs deep (#1552 through #1586). Not re-flagged via push notification this run since the condition is unchanged from prior reports — still needs a human to visit Settings → General → Pull Requests and re-enable "Allow merge commits."

`npm run hronir:doctor` completed with 0 inconsistências this run (pre-existing legacy warnings about orphaned `music-be-me-borges`/`music-borges-and-me` rate files and an `events-welcome` cross-language divergence are unrelated to this run).

---
_Generated by [Claude Code](https://claude.ai/code/session_01SsmRwR8avvhzCShutg2mQH)_