### PR TITLE
ux: fecha #1576, documenta bloqueio de merge da rotina UX/UI

### DIFF
--- a/.routines/2026-08-29T05-03-45-ux-ui-run.md
+++ b/.routines/2026-08-29T05-03-45-ux-ui-run.md
@@ -1,0 +1,72 @@
+---
+date: "2026-08-29T05:03:45Z"
+branch: claude/ecstatic-hawking-v73q54
+status: open
+---
+
+# Sessão 2026-08-29T05-03-45 — UX/UI
+
+## Passo 0 — revisar/mesclar PRs abertos
+
+Confirmado que o bloqueio já documentado por 6+ sessões anteriores (#1564,
+#1566, #1570, #1573, #1575, #1579, #1583, #1585, #1587) segue ativo:
+`merge_pull_request` com `merge_method: merge` retorna
+`405 Merge commits are not allowed on this repository`; sessões anteriores
+já confirmaram que `merge_method: rebase` recebe o mesmo 405. Squash é
+proibido pela convenção do `CLAUDE.md` ("Merge commits, not squash"), então
+nenhum dos 9 PRs pendentes desta rotina foi mesclado.
+
+Reconfirmei tentando mesclar #1564 (CI verde, `mergeable_state: clean`) —
+mesmo 405. Não tentei os outros 8 individualmente para não gastar chamadas
+repetindo um erro já bem documentado.
+
+**Isso não é mais um blip isolado**: são 9 PRs desta rotina (mais antigo,
+#1564, aberto em 19/08 — 10 dias parado) acumulados só porque a rotina não
+consegue completar seu próprio ciclo de merge. Precisa de decisão humana:
+habilitar "Allow merge commits" em Settings → General → Pull Requests, ou
+mudar a convenção do `CLAUDE.md` para squash (nota: commits recentes em
+`main`, ex. `da23870`/`2d7e8e8`, têm formato de mensagem de squash-merge do
+GitHub, sugerindo que merges manuais do Franklin pela UI já estão usando
+squash na prática — a convenção documentada pode já estar desatualizada
+frente ao uso real).
+
+## Passo 1 — escolher item de trabalho
+
+Fiz um novo sweep manual (grep por `aria-label` estático em `.map()`, `<img>`
+sem `width`/`height`) em `src/components/` e `src/pages/` inteiros. Toda
+ocorrência problemática encontrada já tem um PR pendente que a corrige (só
+não mesclado por causa do bloqueio acima):
+
+- `RankingView.astro` (pódio, tension) → #1587, #1570
+- `posts/[key].astro` (badge W/L, link de análise) → #1570, #1583
+- `battles/index.astro`/`page/[n].astro` (tension) → #1564
+- `changelog/index.astro` (tags) → #1564
+- `BooksPage.astro` (rating) → #1579
+- `GitHubRepo.astro` (CLS) → #1585
+- `Header.astro` (breakpoint pt) → #1566
+
+Não encontrei nenhum item novo, pequeno e verificável fora desse conjunto já
+coberto. As únicas issues abertas sem PR pendente são #1083 e #1576 — ambas
+explicitamente enquadradas como issues de **decisão de escopo**, não bugs
+pontuais (a própria #1576 pede "decidir" como primeiro passo).
+
+## Decisão tomada nesta sessão
+
+Fechei **#1576** (`i18n: seção /games/ é 100% inglês`) como `not_planned`:
+`/games/` não está linkado do `Header.astro` nem de nenhum nav principal —
+é um easter egg, não conteúdo bilíngue de primeira classe. Mesmo precedente
+já documentado no `CLAUDE.md` para `changelog/` (EN-only deliberado).
+Justificativa completa no comentário da issue.
+
+Não mexi em **#1083** (i18n do subsistema `/ranking/` do Hrönir) — é uma
+decisão arquitetural maior (mirror `/pt/ranking/...` vs. chrome en-only para
+conteúdo estruturalmente multi-idioma), já discutida em #1573, e não é
+"pequena" o suficiente para uma sessão desta rotina.
+
+## Resultado
+
+Sem mudança de código nesta rodada — não há PR de fix novo. O trabalho de
+código-fonte da rotina está saturado: os 9 PRs pendentes já cobrem todo o
+backlog acionável de bugs pontuais, e o que resta como issue aberta é
+decisão arquitetural. O item mais urgente para o dono do repo é o bloqueio
+de merge, não uma nova issue de UX.


### PR DESCRIPTION
## Summary

- Fechei #1576 (`i18n: seção /games/ é 100% inglês`) como `not_planned`: a seção não está linkada do `Header.astro` nem de nenhum nav principal — é um easter egg, não conteúdo bilíngue de primeira classe. Mesmo precedente já documentado no `CLAUDE.md` para `changelog/` (EN-only deliberado). Justificativa completa no [comentário da issue](https://github.com/franklinbaldo/franklinbaldo.github.io/issues/1576#issuecomment-5460472353).
- Journal desta sessão (`.routines/2026-08-29T05-03-45-ux-ui-run.md`) documenta o resultado do passo 1 da rotina: um novo sweep manual (grep por `aria-label` estático em loops, `<img>` sem `width`/`height`) não encontrou nenhum item novo — todo bug pontual localizado já tem um PR pendente que o corrige (#1564, #1566, #1570, #1573, #1575, #1579, #1583, #1585, #1587). As únicas issues abertas restantes (#1083, #1576) são de decisão de escopo, não bugs pequenos e verificáveis.

## Passo 0 da rotina (revisar/mesclar PRs abertos)

Reconfirmei o bloqueio já documentado por 6+ sessões anteriores: `merge_pull_request` com `merge_method: merge` continua retornando `405 Merge commits are not allowed on this repository` (testado em #1564, CI verde, `mergeable_state: clean`). Sessões anteriores já confirmaram que `merge_method: rebase` recebe o mesmo 405. Squash é proibido pela convenção do `CLAUDE.md` ("Merge commits, not squash"), então não mesclei nenhum PR pendente.

São agora **9 PRs desta rotina** acumulados desde 19/08 (10 dias) só por esse bloqueio — não é mais um blip isolado, é um problema sistêmico que impede a rotina de completar seu próprio ciclo. Precisa de decisão humana: habilitar "Allow merge commits" em Settings → General → Pull Requests, ou atualizar a convenção do `CLAUDE.md` para squash. Nota: commits recentes em `main` (`da23870`, `2d7e8e8`) têm formato de mensagem de squash-merge do GitHub, sugerindo que merges manuais do Franklin pela UI já usam squash na prática — a convenção documentada pode estar desatualizada frente ao uso real.

## Test plan

- [x] `npx prettier --check .` — passou
- [x] `npm run check:hygiene` — verde (nome do journal validado)
- [x] Sem mudança de código nesta rodada — só issue e journal

---
_Generated by [Claude Code](https://claude.ai/code/session_015L2ongtHoUzdhZrvweo5hB)_