### PR TITLE
docs: kickstart da fábrica multi-work de audiolivros em OKF

### DIFF
--- a/docs/okf/audiobook/github-actions-execution.md
+++ b/docs/okf/audiobook/github-actions-execution.md
@@ -1,26 +1,30 @@
 ---
 type: Architecture Contract
-title: Audiobook — GitHub Actions control plane
-description: Contrato para usar GitHub Actions como ponto único de operação da pipeline de audiolivro e despachar compute remoto por CLI.
-tags: [audiobook, github-actions, kaggle, colab, cli, tts, internet-archive]
+title: Audiobook Factory — GitHub Actions control plane
+description: Contrato para usar GitHub Actions como ponto único de operação da pipeline multi-work de audiolivros e despachar compute remoto por CLI.
+tags: [audiobook, github-actions, kaggle, colab, cli, tts, internet-archive, multi-work]
 timestamp: 2026-08-30T18:20:00Z
 ---
 
-# GitHub Actions como plano de controle do audiolivro
+# GitHub Actions como plano de controle da fábrica de audiolivros
 
 ## 1. Decisão
 
 A operação normal da pipeline deve acontecer por **GitHub Actions**.
 
-O operador não precisa abrir Kaggle, Colab nem notebook. O workflow recebe os parâmetros da execução, lê credenciais de GitHub Secrets, valida e planeja o trabalho, despacha compute remoto, acompanha o job, recupera os resultados, valida os artefatos, monta o capítulo e publica os outputs selecionados.
+O operador não precisa abrir Kaggle, Colab, Internet Archive nem notebook. O workflow recebe `work_id` e os demais parâmetros da execução, lê credenciais de GitHub Secrets, valida e planeja o trabalho, despacha compute remoto, acompanha o job, recupera os resultados, valida os artefatos, monta a unidade e publica os outputs selecionados.
 
 GitHub Actions é o **plano de controle**; GPU, TTS e storage são planos de execução substituíveis.
+
+Não existe workflow por livro. Existe uma pipeline genérica cuja primeira dimensão é `work_id`.
 
 ```text
 workflow_dispatch / future automation
                   |
                   v
            GitHub Actions
+                  |
+        resolve work_id
                   |
         validate + plan
                   |
@@ -39,10 +43,28 @@ workflow_dispatch / future automation
        +----------+----------+
        |                     |
  Internet Archive       blog / feed RSS
- (media when enabled)   (canonical identity)
+ (per-work media)       (per-work identity)
 ```
 
-## 2. Segurança e autenticação
+## 2. Descoberta de obras
+
+O workflow deve descobrir obras a partir de `data/audiobooks/*/work.md` ou de um índice derivado desses manifests.
+
+A lista de obras não deve ser duplicada em YAML do workflow.
+
+Resolver `work_id` significa carregar, no mínimo:
+
+- diretório canônico da obra;
+- idiomas e metadata básicos;
+- configuração de vozes;
+- configuração de publicação;
+- namespace de cache/artifacts;
+- podcast/feed da obra;
+- identifier remoto de storage quando já configurado.
+
+Uma obra desconhecida falha antes de qualquer compute ou chamada externa.
+
+## 3. Segurança e autenticação
 
 Nenhum segredo é versionado.
 
@@ -58,53 +80,74 @@ Exemplos de famílias de credenciais:
 
 Os nomes finais dos secrets são definidos pela implementação dos respectivos adapters. O contrato é que cada adapter documente explicitamente quais secrets consome e falhe cedo quando estiverem ausentes.
 
-## 3. Runners remotos
+Secrets são infraestrutura compartilhada; configuração editorial e escolha de backend/modelo podem variar por obra sem criar novos secrets necessariamente.
 
-### 3.1. Kaggle
+## 4. Runners remotos
 
-O workflow instala o Kaggle CLI, injeta a credencial por ambiente, monta um staging directory, envia um **script kernel** privado com GPU e acompanha o estado até sucesso/falha.
+### 4.1. Kaggle
 
-O job remoto executa o mesmo `worker.py` usado localmente.
+O workflow instala o Kaggle CLI, injeta a credencial por ambiente, monta um staging directory namespaced por `work_id`, envia um **script kernel** privado com GPU e acompanha o estado até sucesso/falha.
+
+O job remoto executa o mesmo `worker.py` usado localmente e recebe `--work <work_id>`.
 
 O workflow então baixa os outputs do kernel e os valida antes da montagem/publicação.
 
-### 3.2. Colab
+### 4.2. Colab
 
 O workflow instala o CLI oficial do Colab e usa somente operações não interativas.
 
-O caminho preferido deve ser `colab run` ou `colab exec`, mantendo o mesmo worker Python e transmitindo configuração por argumentos/arquivos e environment variables suportadas pelo CLI.
+O caminho preferido deve ser `colab run` ou `colab exec`, mantendo o mesmo worker Python e transmitindo `work_id`, configuração e inputs por argumentos/arquivos/environment variables suportadas pelo CLI.
 
 A autenticação headless e, principalmente, o acesso efetivo à GPU gratuita a partir da identidade usada no GitHub Actions devem ser provados por um smoke test real antes de o runner Colab ser declarado suportado para produção.
 
-Falha de quota/provisionamento é erro do runner, não do backend TTS.
+Falha de quota/provisionamento é erro do runner, não do backend TTS nem da obra.
 
-### 3.3. API
+### 4.3. API
 
-Backends HTTP podem pular a etapa de GPU remota, mas continuam obedecendo ao mesmo plano de segmentos, manifests, cache e validações.
+Backends HTTP podem pular a etapa de GPU remota, mas continuam obedecendo ao mesmo plano de segmentos, manifests, cache e validações, inclusive `work_id`.
 
-## 4. Publicação e Internet Archive
+## 5. Namespacing e isolamento
+
+Todo estado derivado precisa ser isolado por obra.
+
+Exemplos:
+
+```text
+cache/audiobook/hpmor/...
+cache/audiobook/bhagavad-gita/...
+
+artifacts/audiobook/hpmor/001/...
+artifacts/audiobook/bhagavad-gita/001/...
+```
+
+Concurrency também deve considerar `work_id` e unidade para impedir duas publicações concorrentes de alterarem o mesmo feed/item remoto sem necessidade de serializar obras diferentes.
+
+Uma execução de HPMOR não pode invalidar, apagar ou sobrescrever resultados do Bhagavad Gita.
+
+## 6. Publicação e Internet Archive
 
 GitHub Actions também é o ponto único de operação da publicação.
 
-Quando `publish` estiver habilitado para o Internet Archive, o workflow deve:
+Quando `publish` estiver habilitado para o Internet Archive, o workflow resolve o **item estável daquela obra** e deve:
 
 1. instalar o cliente/adapter de upload (`ia`/`internetarchive` ou equivalente suportado);
 2. carregar as credenciais exclusivamente de GitHub Secrets;
-3. fazer upload do áudio final e demais arquivos selecionados para o item estável da obra;
-4. aguardar o arquivo ficar disponível publicamente;
-5. verificar a URL final conforme o contrato de podcast (`HEAD`, range request, MIME e bytes);
-6. só então atualizar o feed RSS e publicar o blog.
+3. obter o `archive_identifier` da configuração de `work_id`;
+4. fazer upload do áudio final e demais arquivos selecionados para esse item;
+5. aguardar o arquivo ficar disponível publicamente;
+6. verificar a URL final conforme o contrato de podcast (`HEAD`, range request, MIME e bytes);
+7. só então atualizar **o feed RSS daquela obra** e publicar o blog.
 
 A ordem impede que o feed anuncie um episódio cujo enclosure ainda não possa ser reproduzido.
 
 O Internet Archive é um backend de publicação, não uma fonte canônica: Git continua guardando corpus, configuração, hashes e proveniência. Se o Archive estiver temporariamente indisponível, o áudio montado continua recuperável como artifact de build e a publicação pode ser retomada sem regerar o TTS.
 
-## 5. Workflow de produção
+## 7. Workflow de produção
 
 O workflow inicial deve usar `workflow_dispatch` e aceitar parâmetros como:
 
-- obra;
-- capítulo/intervalo;
+- `work_id`;
+- capítulo/unidade ou intervalo;
 - backend/modelo;
 - runner (`kaggle`, `colab`, `api` e, para debug, `local`);
 - `dry_run`;
@@ -117,6 +160,7 @@ Fluxo de referência:
 ```text
 checkout
   -> setup
+  -> resolve work
   -> validate
   -> plan
   -> dry-run gate
@@ -126,42 +170,67 @@ checkout
   -> validate output manifest
   -> assemble
   -> encode final media
-  -> optional publish media (Internet Archive preferred)
+  -> optional publish media to work storage
   -> verify public enclosure
-  -> generate feed/site metadata
-  -> deploy site
+  -> generate work feed/site metadata
+  -> deploy site/catalog
 ```
 
-## 6. Idempotência e retomada
+O mesmo workflow deve funcionar conceitualmente assim:
+
+```text
+work=hpmor
+```
+
+ou:
+
+```text
+work=bhagavad-gita
+```
+
+sem alterar o código do workflow.
+
+## 8. Idempotência e retomada
 
 O workflow não pressupõe que uma execução longa termina em uma única tentativa.
 
 Cada fase deve poder ser retomada a partir de estado verificável:
 
-- cache keys determinam segmentos já válidos;
+- cache keys incluem `work_id` e determinam segmentos já válidos;
 - outputs remotos são validados por digest;
-- capítulo montado é regenerável sem ressintetizar segmentos válidos;
-- upload de publicação usa identifier/nome de arquivo estáveis;
+- unidade montada é regenerável sem ressintetizar segmentos válidos;
+- upload de publicação usa identifier/nome de arquivo estáveis por obra;
 - feed só muda após confirmação do arquivo público.
 
 Uma falha depois da síntese não deve obrigar a gastar GPU novamente.
 
-## 7. Dry-run e proteção de custo
+## 9. Dry-run e proteção de custo
 
-`dry_run` não envia job pago nem chama API cobrada. Ele mostra exatamente o que seria produzido e quais credenciais/runners seriam necessários.
+`dry_run` não envia job pago nem chama API cobrada. Ele mostra exatamente:
+
+- obra resolvida;
+- unidade(s) selecionada(s);
+- segmentos pendentes;
+- runner/backend/modelo;
+- cache aproveitado;
+- credenciais necessárias;
+- destino de publicação quando aplicável.
 
 Qualquer backend capaz de gerar cobrança deve permanecer opt-in na primeira versão.
 
 Compute gratuito de Kaggle/Colab também deve respeitar planejamento e cache para não desperdiçar quota.
 
-## 8. Critérios de aceite
+## 10. Critérios de aceite
 
 O control plane está implementado quando:
 
-1. um workflow manual consegue validar e planejar um capítulo sem segredo externo;
-2. um runner remoto consegue executar o worker e devolver output validável;
-3. secrets nunca aparecem em corpus, commit ou artifact;
-4. falha de runner é distinguida de falha de modelo;
-5. uma execução interrompida pode ser retomada sem regenerar segmentos válidos;
-6. a mesma interface de workflow pode trocar Kaggle/Colab/API sem alterar o corpus;
-7. quando a publicação no Internet Archive for ativada, upload, verificação e atualização do feed podem ocorrer integralmente dentro do GitHub Actions.
+1. um workflow manual consegue resolver duas fixtures/obras diferentes por `work_id`;
+2. uma obra inválida falha antes de compute;
+3. um runner remoto consegue executar o worker e devolver output validável;
+4. secrets nunca aparecem em corpus, commit ou artifact;
+5. falha de runner é distinguida de falha de modelo;
+6. uma execução interrompida pode ser retomada sem regenerar segmentos válidos;
+7. a mesma interface de workflow pode trocar Kaggle/Colab/API sem alterar o corpus;
+8. cache, artifacts, manifests, storage e feed são isolados por obra;
+9. nenhuma obra exige workflow próprio;
+10. quando a publicação no Internet Archive for ativada, upload, verificação e atualização do feed da obra podem ocorrer integralmente dentro do GitHub Actions.

--- a/docs/okf/audiobook/github-actions-execution.md
+++ b/docs/okf/audiobook/github-actions-execution.md
@@ -74,6 +74,8 @@ O runner deve usar autenticação não interativa suportada pelo Kaggle CLI, pre
 
 O token não pode ser copiado para o staging enviado ao kernel.
 
+Referência: [Kaggle CLI](https://github.com/Kaggle/kaggle-cli).
+
 ### 3.2. Colab
 
 O runner deve usar o mecanismo headless oficialmente suportado pelo Colab CLI. A primeira implementação deve provar em CI que a identidade usada pelo workflow consegue provisionar o acelerador esperado.
@@ -81,6 +83,8 @@ O runner deve usar o mecanismo headless oficialmente suportado pelo Colab CLI. A
 A disponibilidade de GPU gratuita da conta é uma propriedade operacional do runner, não do modelo TTS. Falta de quota/alocação deve produzir status `runner_unavailable`, não reprovar o backend de TTS.
 
 Segredos necessários pelo worker remoto devem ser injetados no runtime pelo mecanismo de environment variables do CLI, sem `.env` versionado ou notebook intermediário.
+
+Referência: [Google Colab CLI](https://github.com/googlecolab/google-colab-cli).
 
 ## 4. Worker comum
 

--- a/docs/okf/audiobook/github-actions-execution.md
+++ b/docs/okf/audiobook/github-actions-execution.md
@@ -1,0 +1,183 @@
+---
+type: Architecture Contract
+title: Audiobook — GitHub Actions control plane
+description: Contrato para usar GitHub Actions como ponto único de operação da pipeline de audiolivro e despachar compute remoto por CLI.
+tags: [audiobook, github-actions, kaggle, colab, cli, tts]
+timestamp: 2026-08-30T18:20:00Z
+---
+
+# GitHub Actions como plano de controle do audiolivro
+
+## 1. Decisão
+
+A operação normal da pipeline deve acontecer por **GitHub Actions**.
+
+O operador não precisa abrir Kaggle, Colab nem notebook. O workflow recebe os parâmetros da execução, lê credenciais de GitHub Secrets, valida e planeja o trabalho, despacha compute remoto, acompanha o job, recupera os resultados, valida os artefatos, monta o capítulo e publica os outputs selecionados.
+
+GitHub Actions é o **plano de controle**; GPU e TTS são planos de execução substituíveis.
+
+```text
+workflow_dispatch / future automation
+              |
+              v
+        GitHub Actions
+              |
+     +--------+--------+----------------+
+     |                 |                |
+   Kaggle            Colab            API TTS
+     |                 |                |
+     +--------+--------+----------------+
+              |
+              v
+       segmentos de áudio
+              |
+              v
+      validate + assemble
+              |
+              v
+       publish + artifact
+```
+
+## 2. Interface do workflow
+
+O workflow de produção deve aceitar, no mínimo:
+
+- `work`;
+- `chapter` ou intervalo;
+- `backend`/modelo TTS;
+- `runner`: `kaggle`, `colab`, `api` ou `local` para testes;
+- `dry_run`;
+- `force` para invalidar cache deliberadamente;
+- opcionalmente `publish` para separar geração de publicação.
+
+O workflow deve ser acionável manualmente por `workflow_dispatch` na primeira versão. Geração automática por eventos pode ser adicionada somente depois que cache, custo e publicação estiverem estáveis.
+
+## 3. Segredos
+
+Credenciais nunca entram em Markdown, manifests públicos, arquivos de staging ou argumentos impressos em logs.
+
+Nomes canônicos iniciais:
+
+```text
+KAGGLE_API_TOKEN
+COLAB_ADC_JSON          # ou outro mecanismo headless comprovado pelo CLI
+HF_TOKEN                # quando um modelo no Hugging Face exigir autenticação
+HIGGS_API_KEY           # se usado
+FISH_API_KEY            # se usado
+```
+
+Outros backends podem adicionar seus próprios secrets sem alterar o contrato do corpus.
+
+### 3.1. Kaggle
+
+O runner deve usar autenticação não interativa suportada pelo Kaggle CLI, preferencialmente `KAGGLE_API_TOKEN` exposto apenas como variável de ambiente do step.
+
+O token não pode ser copiado para o staging enviado ao kernel.
+
+### 3.2. Colab
+
+O runner deve usar o mecanismo headless oficialmente suportado pelo Colab CLI. A primeira implementação deve provar em CI que a identidade usada pelo workflow consegue provisionar o acelerador esperado.
+
+A disponibilidade de GPU gratuita da conta é uma propriedade operacional do runner, não do modelo TTS. Falta de quota/alocação deve produzir status `runner_unavailable`, não reprovar o backend de TTS.
+
+Segredos necessários pelo worker remoto devem ser injetados no runtime pelo mecanismo de environment variables do CLI, sem `.env` versionado ou notebook intermediário.
+
+## 4. Worker comum
+
+O GitHub Actions nunca deve conter a lógica principal do modelo.
+
+O mesmo `scripts/audiobook/worker.py` é executado localmente ou no runner remoto. O workflow apenas:
+
+1. produz `plan.json`;
+2. prepara staging mínimo;
+3. despacha o worker;
+4. aguarda conclusão;
+5. baixa outputs;
+6. valida o manifesto;
+7. chama `assemble`;
+8. publica quando solicitado.
+
+Isso impede divergência entre implementação local, Kaggle e Colab.
+
+## 5. Kaggle em CI
+
+Fluxo conceitual:
+
+```bash
+kaggle kernels push -p "$STAGING"
+# poll até complete/error
+kaggle kernels status "$KERNEL_REF"
+kaggle kernels output "$KERNEL_REF" -p "$OUTPUT"
+```
+
+O job remoto deve ser `kernel_type: script`, privado e com GPU habilitada.
+
+O nome do kernel deve incorporar identidade suficiente para evitar colisão entre execuções concorrentes ou o workflow deve serializar explicitamente o runner.
+
+## 6. Colab em CI
+
+O runner pode usar uma execução efêmera para jobs simples ou uma VM persistente durante um batch quando o custo de carregar o modelo repetidamente for relevante.
+
+Fluxo conceitual efêmero:
+
+```bash
+colab run --gpu <preferencia> scripts/audiobook/worker.py -- <args>
+```
+
+Fluxo conceitual persistente:
+
+```text
+colab new -> install/sync -> exec N vezes -> download -> stop
+```
+
+O wrapper deve garantir teardown em `finally`/step `always()` quando uma VM persistente tiver sido criada.
+
+## 7. Estado e retomada
+
+Uma execução remota pode terminar por quota, timeout ou falha transitória. Por isso:
+
+- cada segmento é independente;
+- cada output possui cache key determinística;
+- o worker escreve progresso incremental;
+- rerun não deve refazer segmentos válidos já persistidos;
+- o manifesto distingue `generated`, `reused`, `failed` e `pending`;
+- o workflow pode retomar um capítulo sem começar do zero.
+
+## 8. Artefatos do workflow
+
+Cada execução de síntese deve produzir, no mínimo:
+
+```text
+plan.json
+run-manifest.json
+segments/
+chapter/                 # quando assemble tiver sido executado
+benchmark/               # quando for rodada comparativa
+```
+
+Os outputs de áudio podem ser temporariamente publicados como GitHub Actions artifacts durante desenvolvimento. Isso não define o storage de distribuição final.
+
+## 9. Segurança e logs
+
+- usar `set -euo pipefail` nos wrappers shell;
+- nunca usar `set -x` em steps que manipulam secrets;
+- não imprimir environment completo;
+- não serializar tokens no `plan.json` ou manifesto;
+- marcar valores derivados sensíveis com masking quando necessário;
+- workflows de PR vindos de forks não recebem secrets e, portanto, não podem sintetizar remotamente;
+- a síntese real deve exigir evento/contexto autorizado.
+
+## 10. Critério de aceite do runner automático
+
+Um runner só pode ser declarado suportado em GitHub Actions depois de um teste end-to-end que prove:
+
+1. autenticação headless;
+2. provisionamento do compute;
+3. envio do worker e input;
+4. execução sem UI;
+5. recuperação dos outputs;
+6. teardown/encerramento;
+7. ausência de secret nos logs e artefatos;
+8. rerun idempotente com cache.
+
+Até esse teste, o runner pode existir como experimental sem bloquear os demais.

--- a/docs/okf/audiobook/github-actions-execution.md
+++ b/docs/okf/audiobook/github-actions-execution.md
@@ -2,7 +2,7 @@
 type: Architecture Contract
 title: Audiobook — GitHub Actions control plane
 description: Contrato para usar GitHub Actions como ponto único de operação da pipeline de audiolivro e despachar compute remoto por CLI.
-tags: [audiobook, github-actions, kaggle, colab, cli, tts]
+tags: [audiobook, github-actions, kaggle, colab, cli, tts, internet-archive]
 timestamp: 2026-08-30T18:20:00Z
 ---
 
@@ -14,174 +14,154 @@ A operação normal da pipeline deve acontecer por **GitHub Actions**.
 
 O operador não precisa abrir Kaggle, Colab nem notebook. O workflow recebe os parâmetros da execução, lê credenciais de GitHub Secrets, valida e planeja o trabalho, despacha compute remoto, acompanha o job, recupera os resultados, valida os artefatos, monta o capítulo e publica os outputs selecionados.
 
-GitHub Actions é o **plano de controle**; GPU e TTS são planos de execução substituíveis.
+GitHub Actions é o **plano de controle**; GPU, TTS e storage são planos de execução substituíveis.
 
 ```text
 workflow_dispatch / future automation
-              |
-              v
-        GitHub Actions
-              |
-     +--------+--------+----------------+
-     |                 |                |
-   Kaggle            Colab            API TTS
-     |                 |                |
-     +--------+--------+----------------+
-              |
-              v
-       segmentos de áudio
-              |
-              v
-      validate + assemble
-              |
-              v
-       publish + artifact
+                  |
+                  v
+           GitHub Actions
+                  |
+        validate + plan
+                  |
+       +----------+----------+
+       |          |          |
+     Colab      Kaggle      API
+       |          |          |
+       +----------+----------+
+                  |
+             collect
+                  |
+             assemble
+                  |
+             publish
+                  |
+       +----------+----------+
+       |                     |
+ Internet Archive       blog / feed RSS
+ (media when enabled)   (canonical identity)
 ```
 
-## 2. Interface do workflow
+## 2. Segurança e autenticação
 
-O workflow de produção deve aceitar, no mínimo:
+Nenhum segredo é versionado.
 
-- `work`;
-- `chapter` ou intervalo;
-- `backend`/modelo TTS;
-- `runner`: `kaggle`, `colab`, `api` ou `local` para testes;
-- `dry_run`;
-- `force` para invalidar cache deliberadamente;
-- opcionalmente `publish` para separar geração de publicação.
+Credenciais externas são mantidas em GitHub Actions Secrets e expostas somente ao step que precisa delas. O workflow deve evitar ecoar segredos em logs e não deve gravá-los em artifacts.
 
-O workflow deve ser acionável manualmente por `workflow_dispatch` na primeira versão. Geração automática por eventos pode ser adicionada somente depois que cache, custo e publicação estiverem estáveis.
+Exemplos de famílias de credenciais:
 
-## 3. Segredos
+- Kaggle API token;
+- credenciais headless aceitas pelo Colab CLI;
+- tokens de Hugging Face quando necessários para modelos gated;
+- chaves de APIs TTS;
+- credenciais de upload do Internet Archive quando o backend de publicação estiver habilitado.
 
-Credenciais nunca entram em Markdown, manifests públicos, arquivos de staging ou argumentos impressos em logs.
+Os nomes finais dos secrets são definidos pela implementação dos respectivos adapters. O contrato é que cada adapter documente explicitamente quais secrets consome e falhe cedo quando estiverem ausentes.
 
-Nomes canônicos iniciais:
-
-```text
-KAGGLE_API_TOKEN
-COLAB_ADC_JSON          # ou outro mecanismo headless comprovado pelo CLI
-HF_TOKEN                # quando um modelo no Hugging Face exigir autenticação
-HIGGS_API_KEY           # se usado
-FISH_API_KEY            # se usado
-```
-
-Outros backends podem adicionar seus próprios secrets sem alterar o contrato do corpus.
+## 3. Runners remotos
 
 ### 3.1. Kaggle
 
-O runner deve usar autenticação não interativa suportada pelo Kaggle CLI, preferencialmente `KAGGLE_API_TOKEN` exposto apenas como variável de ambiente do step.
+O workflow instala o Kaggle CLI, injeta a credencial por ambiente, monta um staging directory, envia um **script kernel** privado com GPU e acompanha o estado até sucesso/falha.
 
-O token não pode ser copiado para o staging enviado ao kernel.
+O job remoto executa o mesmo `worker.py` usado localmente.
 
-Referência: [Kaggle CLI](https://github.com/Kaggle/kaggle-cli).
+O workflow então baixa os outputs do kernel e os valida antes da montagem/publicação.
 
 ### 3.2. Colab
 
-O runner deve usar o mecanismo headless oficialmente suportado pelo Colab CLI. A primeira implementação deve provar em CI que a identidade usada pelo workflow consegue provisionar o acelerador esperado.
+O workflow instala o CLI oficial do Colab e usa somente operações não interativas.
 
-A disponibilidade de GPU gratuita da conta é uma propriedade operacional do runner, não do modelo TTS. Falta de quota/alocação deve produzir status `runner_unavailable`, não reprovar o backend de TTS.
+O caminho preferido deve ser `colab run` ou `colab exec`, mantendo o mesmo worker Python e transmitindo configuração por argumentos/arquivos e environment variables suportadas pelo CLI.
 
-Segredos necessários pelo worker remoto devem ser injetados no runtime pelo mecanismo de environment variables do CLI, sem `.env` versionado ou notebook intermediário.
+A autenticação headless e, principalmente, o acesso efetivo à GPU gratuita a partir da identidade usada no GitHub Actions devem ser provados por um smoke test real antes de o runner Colab ser declarado suportado para produção.
 
-Referência: [Google Colab CLI](https://github.com/googlecolab/google-colab-cli).
+Falha de quota/provisionamento é erro do runner, não do backend TTS.
 
-## 4. Worker comum
+### 3.3. API
 
-O GitHub Actions nunca deve conter a lógica principal do modelo.
+Backends HTTP podem pular a etapa de GPU remota, mas continuam obedecendo ao mesmo plano de segmentos, manifests, cache e validações.
 
-O mesmo `scripts/audiobook/worker.py` é executado localmente ou no runner remoto. O workflow apenas:
+## 4. Publicação e Internet Archive
 
-1. produz `plan.json`;
-2. prepara staging mínimo;
-3. despacha o worker;
-4. aguarda conclusão;
-5. baixa outputs;
-6. valida o manifesto;
-7. chama `assemble`;
-8. publica quando solicitado.
+GitHub Actions também é o ponto único de operação da publicação.
 
-Isso impede divergência entre implementação local, Kaggle e Colab.
+Quando `publish` estiver habilitado para o Internet Archive, o workflow deve:
 
-## 5. Kaggle em CI
+1. instalar o cliente/adapter de upload (`ia`/`internetarchive` ou equivalente suportado);
+2. carregar as credenciais exclusivamente de GitHub Secrets;
+3. fazer upload do áudio final e demais arquivos selecionados para o item estável da obra;
+4. aguardar o arquivo ficar disponível publicamente;
+5. verificar a URL final conforme o contrato de podcast (`HEAD`, range request, MIME e bytes);
+6. só então atualizar o feed RSS e publicar o blog.
 
-Fluxo conceitual:
+A ordem impede que o feed anuncie um episódio cujo enclosure ainda não possa ser reproduzido.
 
-```bash
-kaggle kernels push -p "$STAGING"
-# poll até complete/error
-kaggle kernels status "$KERNEL_REF"
-kaggle kernels output "$KERNEL_REF" -p "$OUTPUT"
-```
+O Internet Archive é um backend de publicação, não uma fonte canônica: Git continua guardando corpus, configuração, hashes e proveniência. Se o Archive estiver temporariamente indisponível, o áudio montado continua recuperável como artifact de build e a publicação pode ser retomada sem regerar o TTS.
 
-O job remoto deve ser `kernel_type: script`, privado e com GPU habilitada.
+## 5. Workflow de produção
 
-O nome do kernel deve incorporar identidade suficiente para evitar colisão entre execuções concorrentes ou o workflow deve serializar explicitamente o runner.
+O workflow inicial deve usar `workflow_dispatch` e aceitar parâmetros como:
 
-## 6. Colab em CI
+- obra;
+- capítulo/intervalo;
+- backend/modelo;
+- runner (`kaggle`, `colab`, `api` e, para debug, `local`);
+- `dry_run`;
+- `force`;
+- `publish`;
+- backend de storage/publicação quando houver mais de um.
 
-O runner pode usar uma execução efêmera para jobs simples ou uma VM persistente durante um batch quando o custo de carregar o modelo repetidamente for relevante.
-
-Fluxo conceitual efêmero:
-
-```bash
-colab run --gpu <preferencia> scripts/audiobook/worker.py -- <args>
-```
-
-Fluxo conceitual persistente:
+Fluxo de referência:
 
 ```text
-colab new -> install/sync -> exec N vezes -> download -> stop
+checkout
+  -> setup
+  -> validate
+  -> plan
+  -> dry-run gate
+  -> dispatch remote compute
+  -> wait/poll
+  -> download results
+  -> validate output manifest
+  -> assemble
+  -> encode final media
+  -> optional publish media (Internet Archive preferred)
+  -> verify public enclosure
+  -> generate feed/site metadata
+  -> deploy site
 ```
 
-O wrapper deve garantir teardown em `finally`/step `always()` quando uma VM persistente tiver sido criada.
+## 6. Idempotência e retomada
 
-## 7. Estado e retomada
+O workflow não pressupõe que uma execução longa termina em uma única tentativa.
 
-Uma execução remota pode terminar por quota, timeout ou falha transitória. Por isso:
+Cada fase deve poder ser retomada a partir de estado verificável:
 
-- cada segmento é independente;
-- cada output possui cache key determinística;
-- o worker escreve progresso incremental;
-- rerun não deve refazer segmentos válidos já persistidos;
-- o manifesto distingue `generated`, `reused`, `failed` e `pending`;
-- o workflow pode retomar um capítulo sem começar do zero.
+- cache keys determinam segmentos já válidos;
+- outputs remotos são validados por digest;
+- capítulo montado é regenerável sem ressintetizar segmentos válidos;
+- upload de publicação usa identifier/nome de arquivo estáveis;
+- feed só muda após confirmação do arquivo público.
 
-## 8. Artefatos do workflow
+Uma falha depois da síntese não deve obrigar a gastar GPU novamente.
 
-Cada execução de síntese deve produzir, no mínimo:
+## 7. Dry-run e proteção de custo
 
-```text
-plan.json
-run-manifest.json
-segments/
-chapter/                 # quando assemble tiver sido executado
-benchmark/               # quando for rodada comparativa
-```
+`dry_run` não envia job pago nem chama API cobrada. Ele mostra exatamente o que seria produzido e quais credenciais/runners seriam necessários.
 
-Os outputs de áudio podem ser temporariamente publicados como GitHub Actions artifacts durante desenvolvimento. Isso não define o storage de distribuição final.
+Qualquer backend capaz de gerar cobrança deve permanecer opt-in na primeira versão.
 
-## 9. Segurança e logs
+Compute gratuito de Kaggle/Colab também deve respeitar planejamento e cache para não desperdiçar quota.
 
-- usar `set -euo pipefail` nos wrappers shell;
-- nunca usar `set -x` em steps que manipulam secrets;
-- não imprimir environment completo;
-- não serializar tokens no `plan.json` ou manifesto;
-- marcar valores derivados sensíveis com masking quando necessário;
-- workflows de PR vindos de forks não recebem secrets e, portanto, não podem sintetizar remotamente;
-- a síntese real deve exigir evento/contexto autorizado.
+## 8. Critérios de aceite
 
-## 10. Critério de aceite do runner automático
+O control plane está implementado quando:
 
-Um runner só pode ser declarado suportado em GitHub Actions depois de um teste end-to-end que prove:
-
-1. autenticação headless;
-2. provisionamento do compute;
-3. envio do worker e input;
-4. execução sem UI;
-5. recuperação dos outputs;
-6. teardown/encerramento;
-7. ausência de secret nos logs e artefatos;
-8. rerun idempotente com cache.
-
-Até esse teste, o runner pode existir como experimental sem bloquear os demais.
+1. um workflow manual consegue validar e planejar um capítulo sem segredo externo;
+2. um runner remoto consegue executar o worker e devolver output validável;
+3. secrets nunca aparecem em corpus, commit ou artifact;
+4. falha de runner é distinguida de falha de modelo;
+5. uma execução interrompida pode ser retomada sem regenerar segmentos válidos;
+6. a mesma interface de workflow pode trocar Kaggle/Colab/API sem alterar o corpus;
+7. quando a publicação no Internet Archive for ativada, upload, verificação e atualização do feed podem ocorrer integralmente dentro do GitHub Actions.

--- a/docs/okf/audiobook/index.md
+++ b/docs/okf/audiobook/index.md
@@ -1,0 +1,57 @@
+---
+type: Index
+title: Audiobook Factory
+description: Índice do sistema multi-work que transforma obras textuais em audiolivros e podcasts reproduzíveis.
+tags: [audiobook, okf, multi-work, tts, podcast, github-actions]
+timestamp: 2026-08-30T18:45:00Z
+---
+
+# Audiobook Factory
+
+Este diretório documenta a **fábrica de audiolivros** do blog: uma pipeline genérica para transformar obras textuais em edições narradas, publicá-las como podcasts independentes e manter toda a produção rastreável e reproduzível.
+
+O produto é a pipeline; cada livro é uma instância.
+
+```text
+book/work
+  -> original OKF
+  -> translation OKF
+  -> narration OKF
+  -> TTS
+  -> audio
+  -> durable media storage
+  -> per-work podcast RSS
+  -> blog/player
+```
+
+## Documentos
+
+- [`prd.md`](./prd.md) — PRD e plano de implementação inicial, usando HPMOR como primeira obra end-to-end.
+- [`multi-work-architecture.md`](./multi-work-architecture.md) — contrato que garante uma única pipeline para HPMOR, Bhagavad Gita e futuras obras, com `work_id`, configuração e podcast independentes.
+- [`github-actions-execution.md`](./github-actions-execution.md) — GitHub Actions como plano de controle; Colab/Kaggle/API como runners substituíveis e execução totalmente headless.
+- [`podcast-publication.md`](./podcast-publication.md) — contrato de RSS, episódio, enclosure, transcript, storage e publicação; Internet Archive é o destino durável preferencial da mídia quando habilitado.
+
+## Casos de referência
+
+### HPMOR
+
+Primeira obra a ser implementada. Valida tradução, múltiplas vozes, diálogo, interpretação dramática, geração incremental e publicação de um corpus longo.
+
+### Bhagavad Gita
+
+Segundo caso de referência arquitetural. Não precisa ser implementado na primeira fase; existe desde já para impedir acoplamento acidental do motor a HPMOR, inglês, ficção ou múltiplos personagens.
+
+## Invariante de produto
+
+Adicionar uma obra normal deve significar essencialmente:
+
+```text
+create data/audiobooks/<work_id>/work.md
+add original/translation/narration
+configure voices + publication
+run the same GitHub Actions workflow
+```
+
+Não deve significar criar novos workers, novos runners, novo publisher ou workflow específico para aquela obra.
+
+Cada obra publicada possui sua própria página e seu próprio feed RSS em namespace derivado de `work_id`, enquanto `/audiobooks/` funciona como catálogo agregado no blog.

--- a/docs/okf/audiobook/multi-work-architecture.md
+++ b/docs/okf/audiobook/multi-work-architecture.md
@@ -1,0 +1,422 @@
+---
+type: Product Architecture
+title: Audiobook factory — multi-work architecture
+description: Contrato para transformar múltiplas obras em audiolivros e podcasts independentes usando a mesma pipeline, runners e infraestrutura de publicação.
+tags: [audiobook, okf, multi-work, podcast, rss, github-actions, internet-archive]
+timestamp: 2026-08-30T18:40:00Z
+---
+
+# Fábrica de audiolivros — arquitetura multi-work
+
+## 1. Decisão
+
+O produto não é "o audiolivro do HPMOR". O produto é uma **pipeline genérica de livro -> audiolivro -> podcast** hospedada no repositório do blog.
+
+Cada obra é uma instância independente dessa pipeline.
+
+_Harry Potter and the Methods of Rationality_ é a primeira obra de referência. _Bhagavad Gita_ é o segundo caso de referência para garantir desde o início que a arquitetura não dependa de personagens, inglês como idioma-fonte, estrutura narrativa de romance ou qualquer propriedade específica do HPMOR.
+
+Adicionar uma nova obra deve ser principalmente uma operação de **dados/configuração**, não uma alteração do motor.
+
+```text
+                       audiobook engine
+                              |
+          +-------------------+-------------------+
+          |                   |                   |
+        hpmor          bhagavad-gita          work-N
+          |                   |                   |
+  original/translation/  original/translation/   ...
+      narration             narration
+          |                   |
+          v                   v
+       podcast A           podcast B
+```
+
+## 2. Unidade de produto: Work
+
+A unidade de primeiro nível é `work`.
+
+Cada obra recebe um `work_id` estável, legível e independente do título exibido.
+
+Exemplos:
+
+```yaml
+work_id: hpmor
+```
+
+```yaml
+work_id: bhagavad-gita
+```
+
+O `work_id` é usado para:
+
+- localizar o corpus;
+- namespacing de `chapter_id` e `segment_id`;
+- selecionar a obra na CLI e no GitHub Actions;
+- construir URLs públicas;
+- construir o identificador lógico do podcast;
+- namespacing de cache, manifests e artifacts;
+- localizar configuração de vozes e publicação;
+- impedir colisões entre obras.
+
+Depois da primeira publicação pública, `work_id` deve ser considerado identidade estável.
+
+## 3. Estrutura de dados
+
+A estrutura canônica é genérica:
+
+```text
+data/audiobooks/
+  hpmor/
+    work.md
+    original/
+      001.md
+      ...
+    translation/
+      001.md
+      ...
+    narration/
+      001.md
+      ...
+    voices.yaml
+
+  bhagavad-gita/
+    work.md
+    original/
+      001.md
+      ...
+    translation/
+      001.md
+      ...
+    narration/
+      001.md
+      ...
+    voices.yaml
+
+scripts/audiobook/
+  # código compartilhado por TODAS as obras
+  validate.py
+  plan.py
+  worker.py
+  assemble.py
+  publish.py
+  runners/
+    colab.sh
+    kaggle.sh
+  storage/
+    internet_archive.py
+```
+
+Nunca deve surgir `scripts/hpmor/` ou implementação equivalente por obra para funções já pertencentes ao motor.
+
+Código específico de uma obra só é aceitável quando representar uma peculiaridade real e inevitável de ingestão/formato da fonte; mesmo nesse caso deve entrar como adapter configurável, não como fork da pipeline.
+
+## 4. Manifesto da obra
+
+Cada obra possui `work.md`, também em Markdown/OKF, como raiz semântica daquele bundle.
+
+Exemplo conceitual para HPMOR:
+
+```markdown
+---
+type: Audiobook Work
+work_id: hpmor
+title: Harry Potter and the Methods of Rationality
+author: Eliezer Yudkowsky
+source_lang: en
+target_lang: pt-BR
+publication_slug: hpmor
+---
+
+# Harry Potter and the Methods of Rationality
+
+Primeira obra de referência da fábrica de audiolivros.
+```
+
+Exemplo conceitual para Bhagavad Gita:
+
+```markdown
+---
+type: Audiobook Work
+work_id: bhagavad-gita
+title: Bhagavad Gita
+source_lang: sa
+target_lang: pt-BR
+publication_slug: bhagavad-gita
+---
+
+# Bhagavad Gita
+
+Obra independente processada pela mesma pipeline.
+```
+
+O schema definitivo pode crescer, mas deve permitir pelo menos:
+
+- `work_id`;
+- título;
+- autoria/atribuição quando aplicável;
+- idioma(s) de origem;
+- idioma da edição narrada;
+- informação de proveniência da fonte;
+- configuração editorial/publicação;
+- política ou nota sobre direitos/proveniência quando relevante;
+- slug público estável.
+
+Direitos autorais não devem ser inferidos automaticamente a partir da idade da obra. O manifesto apenas registra a base/proveniência escolhida para aquela edição; a pipeline técnica não decide por conta própria se um texto pode ser publicado.
+
+## 5. Capítulos e divisões estruturais
+
+`chapter` é o nome operacional inicial da unidade publicável, mas o motor não deve pressupor que toda obra seja um romance moderno.
+
+Uma obra pode mapear sua estrutura natural para essa unidade:
+
+- capítulo de romance;
+- capítulo/adhyaya de texto religioso ou filosófico;
+- canto;
+- livro interno;
+- conto;
+- ensaio;
+- outra divisão editorial apropriada.
+
+A UI pode exibir o nome editorial correto enquanto o contrato interno continua usando uma identidade genérica de unidade, inicialmente `chapter_id` por simplicidade.
+
+Exemplos:
+
+```text
+hpmor-001
+bhagavad-gita-001
+```
+
+Nada no worker TTS deve depender de o conteúdo ser ficção, possuir diálogo ou ter personagens.
+
+## 6. Três camadas por obra
+
+Cada obra mantém o mesmo contrato:
+
+```text
+original OKF
+    -> translation OKF
+        -> narration OKF
+            -> audio
+```
+
+### 6.1. Original
+
+Representa a fonte escolhida para aquela edição e preserva proveniência.
+
+O idioma de origem não é fixo em inglês. Para Bhagavad Gita pode ser sânscrito, ou outra edição-fonte explicitamente escolhida e documentada.
+
+### 6.2. Translation
+
+Representa a edição textual em `target_lang` usada como tradução canônica para leitura humana.
+
+A pipeline deve permitir obras em que a tradução tenha origem direta na fonte ou em uma edição intermediária, desde que `derived_from` e proveniência tornem essa cadeia explícita.
+
+Se futuramente houver uma obra que já esteja no idioma-alvo e não exija tradução, o motor deve poder representar uma camada equivalente sem duplicação semântica desnecessária; isso é uma extensão do schema, não motivo para duplicar a pipeline.
+
+### 6.3. Narration
+
+É a adaptação oral da edição canônica. Continua provider-neutral e pode introduzir direção de voz, pronúncia, expansão oral, pausas e outras informações necessárias para TTS.
+
+Em HPMOR, `voices.yaml` provavelmente terá vários personagens. Em Bhagavad Gita, a estratégia pode ser narrador único, narrador + vozes distintas, ou outra direção editorial. Isso é configuração da obra, não decisão global do motor.
+
+## 7. Uma CLI, muitas obras
+
+Todos os comandos recebem `--work`.
+
+Exemplos conceituais:
+
+```bash
+uv run scripts/audiobook/validate.py --work hpmor
+uv run scripts/audiobook/plan.py --work hpmor --chapter 1
+uv run scripts/audiobook/worker.py --work hpmor --chapter 1 --backend breeze
+```
+
+E, sem mudar o código:
+
+```bash
+uv run scripts/audiobook/validate.py --work bhagavad-gita
+uv run scripts/audiobook/plan.py --work bhagavad-gita --chapter 1
+uv run scripts/audiobook/worker.py --work bhagavad-gita --chapter 1 --backend breeze
+```
+
+Não haverá um workflow GitHub Actions por livro. O workflow é genérico e recebe `work_id` como input.
+
+## 8. GitHub Actions multi-work
+
+O ponto único de operação continua sendo GitHub Actions.
+
+O workflow pode expor seleção de obra:
+
+```text
+work: hpmor | bhagavad-gita | <outro work_id>
+chapter: ...
+backend: ...
+runner: ...
+publish: ...
+```
+
+Idealmente a lista de obras é descoberta do conteúdo de `data/audiobooks/*/work.md`, não codificada manualmente no workflow.
+
+Cache, artifacts e concurrency devem ser namespaced por `work_id`.
+
+Exemplo:
+
+```text
+audiobook:hpmor:chapter-001
+audiobook:bhagavad-gita:chapter-001
+```
+
+Uma execução de uma obra nunca invalida ou sobrescreve artifacts de outra.
+
+## 9. Um podcast por obra
+
+Cada obra publicável recebe **seu próprio feed RSS**.
+
+Estrutura pública conceitual:
+
+```text
+/audiobooks/
+  index.html
+
+/audiobooks/hpmor/
+  index.html
+  feed.xml
+  001/
+  002/
+
+/audiobooks/bhagavad-gita/
+  index.html
+  feed.xml
+  001/
+  002/
+```
+
+Isso produz experiências independentes:
+
+```text
+HPMOR -> podcast HPMOR
+Bhagavad Gita -> podcast Bhagavad Gita
+Work N -> podcast Work N
+```
+
+O usuário pode assinar apenas as obras que quiser.
+
+O blog também mantém uma página agregadora `/audiobooks/` listando as obras disponíveis e oferecendo player/assinatura para cada uma.
+
+Não deve existir um único feed global misturando capítulos de todas as obras como única forma de consumo. Um feed agregado futuro pode existir como conveniência, mas nunca substitui os feeds por obra.
+
+## 10. Identidade de podcast e episódio
+
+Cada obra possui `podcast_id` derivado de `work_id` ou declarado no manifesto.
+
+Exemplo:
+
+```text
+podcast_id: audiobook:hpmor
+podcast_id: audiobook:bhagavad-gita
+```
+
+Cada unidade publicada possui GUID independente do arquivo de mídia:
+
+```text
+audiobook:hpmor:hpmor-001
+audiobook:bhagavad-gita:bhagavad-gita-001
+```
+
+Regenerar mídia, trocar TTS, runner ou storage nunca muda o GUID.
+
+## 11. Internet Archive multi-work
+
+O Internet Archive é o destino durável preferencial para mídia publicada, quando ativado.
+
+A unidade padrão de publicação deve ser **um item do Archive por obra**, não um item global contendo todos os audiolivros.
+
+Exemplo conceitual:
+
+```text
+franklinbaldo-hpmor-ptbr-audiobook
+franklinbaldo-bhagavad-gita-ptbr-audiobook
+```
+
+Cada item pode conter:
+
+```text
+001.mp3
+002.mp3
+...
+cover.jpg
+manifest.json
+```
+
+A associação entre `work_id` e identifier remoto é configuração persistida da obra. O workflow nunca deve inventar um novo item a cada execução.
+
+Isso mantém publicação, proveniência, metadata e eventual manutenção independentes por livro.
+
+## 12. Site como catálogo de audiolivros
+
+A seção de audiolivros do blog deve ser data-driven.
+
+Ao adicionar um novo `data/audiobooks/<work_id>/work.md`, o site deve conseguir, após implementação das etapas necessárias:
+
+1. descobrir a obra;
+2. gerar sua página de catálogo;
+3. listar unidades/capítulos disponíveis;
+4. expor o feed RSS próprio;
+5. mostrar o player dos episódios publicados;
+6. fornecer links para original/tradução/narração conforme a política editorial daquela obra;
+7. mostrar status de produção/publicação quando útil.
+
+Adicionar Bhagavad Gita não deve exigir criar uma nova página Astro manualmente se a página genérica de obra já existir.
+
+## 13. Benchmark e configuração podem variar por obra
+
+O benchmark inicial de modelos usa HPMOR e um corpus pt-BR controlado, mas o modelo vencedor não precisa ser global e permanente.
+
+A melhor configuração pode variar por obra:
+
+- HPMOR pode privilegiar interpretação dramática e múltiplas vozes;
+- Bhagavad Gita pode privilegiar cadência, clareza, estabilidade e uma direção vocal diferente;
+- outra obra pode exigir outro modelo, voz ou ritmo.
+
+Por isso backend/modelo são configuração de produção e entram no manifesto do áudio, não na identidade semântica da obra.
+
+## 14. Critérios de aceite da arquitetura multi-work
+
+A arquitetura está corretamente generalizada quando:
+
+1. existe um único conjunto de scripts compartilhados;
+2. todos os comandos selecionam a obra por `work_id`;
+3. nenhuma regra do motor contém `if work == "hpmor"` para comportamento genérico;
+4. HPMOR e uma segunda fixture de obra podem validar usando o mesmo código;
+5. cada obra possui corpus, vozes, cache, manifests e publicação isolados;
+6. cada obra recebe página e feed RSS próprios;
+7. o GitHub Actions despacha qualquer obra sem workflow específico;
+8. Internet Archive, quando usado, recebe item estável por obra;
+9. adicionar uma nova obra normal não exige alterar worker, runners ou publisher;
+10. o site descobre obras a partir dos manifests em vez de uma lista duplicada em código.
+
+## 15. Casos de referência
+
+### HPMOR
+
+Primeira implementação end-to-end. Estressa:
+
+- tradução inglês -> pt-BR;
+- diálogo;
+- múltiplos personagens;
+- vozes consistentes;
+- interpretação dramática;
+- corpus longo.
+
+### Bhagavad Gita
+
+Segundo caso de referência arquitetural. Estressa:
+
+- idioma-fonte diferente de inglês, conforme a edição escolhida;
+- estrutura editorial que não deve ser forçada ao modelo de romance;
+- possibilidade de direção vocal/narração distinta;
+- proveniência e escolha de edição-fonte;
+- reutilização completa da mesma infraestrutura sem código específico.
+
+Nenhum conteúdo do Bhagavad Gita precisa entrar na Fase 1 do HPMOR. Sua função agora é servir como **teste de generalidade do design**.

--- a/docs/okf/audiobook/podcast-publication.md
+++ b/docs/okf/audiobook/podcast-publication.md
@@ -54,6 +54,8 @@ Cada episódio deve incluir, no mínimo:
 
 O feed deve ser validável por ferramentas de podcast antes de publicação.
 
+Referência de interoperabilidade: [Apple Podcasts — RSS feed requirements](https://podcasters.apple.com/support/823-podcast-requirements).
+
 ## 4. Áudio do episódio
 
 O formato de distribuição inicial preferido é MP3 ou AAC, mantendo WAV/FLAC apenas como intermediário/master quando necessário.
@@ -69,11 +71,15 @@ A URL usada no `<enclosure>` precisa:
 - não depender de cookie ou sessão;
 - permanecer acessível depois que o workflow de Actions terminar.
 
+Referência de áudio: [Apple Podcasts — audio requirements](https://podcasters.apple.com/support/893-audio-requirements).
+
 ## 5. Feed no blog; mídia fora do Pages quando necessário
 
 O feed, páginas HTML, artwork, transcript e manifests pequenos podem ser publicados pelo próprio site.
 
-O áudio integral **não deve depender de caber no deploy do GitHub Pages**. Um audiolivro longo pode ultrapassar os limites de tamanho do Pages mesmo com compressão eficiente.
+O áudio integral **não deve depender de caber no deploy do GitHub Pages**. Um audiolivro longo pode ultrapassar os limites de tamanho do Pages mesmo com compressão eficiente. O GitHub atualmente recomenda até 1 GB para o repositório-fonte, limita o site publicado a 1 GB e aplica limite de banda mensal soft de 100 GB.
+
+Referência: [GitHub Pages limits](https://docs.github.com/en/pages/getting-started-with-github-pages/github-pages-limits).
 
 A arquitetura portanto separa:
 
@@ -150,11 +156,18 @@ Cada episódio pode expor:
 
 O transcript é derivado da camada de narração + timestamps efetivamente produzidos pelo áudio, não da tradução isoladamente.
 
+Referências:
+
+- [Podcasting 2.0 — transcript tag](https://podcasting2.org/docs/podcast-namespace/tags/transcript)
+- [Podcasting 2.0 — transcript formats](https://podcasting2.org/docs/podcast-namespace/examples/transcripts/transcripts)
+
 ### 8.2. Chapters
 
 A pipeline pode gerar um arquivo JSON de capítulos/marcadores e referenciá-lo com `<podcast:chapters>`.
 
 Mesmo que cada episódio já corresponda a um capítulo do livro, os chapters internos podem representar cenas, seções ou outros marcos úteis dentro de episódios longos.
+
+Referência: [Podcasting 2.0 — chapters](https://podcasting2.org/docs/podcast-namespace/tags/chapters).
 
 ## 9. Relação com as três camadas OKF
 

--- a/docs/okf/audiobook/podcast-publication.md
+++ b/docs/okf/audiobook/podcast-publication.md
@@ -1,46 +1,67 @@
 ---
 type: Product Architecture
-title: Audiobook — podcast publication contract
-description: Contrato para publicar capítulos de audiolivro como episódios de um podcast RSS hospedado pelo blog.
-tags: [audiobook, podcast, rss, podcasting-2.0, astro, publishing, internet-archive]
+title: Audiobook — per-work podcast publication contract
+description: Contrato para publicar cada obra da fábrica de audiolivros como um podcast RSS independente hospedado pelo blog.
+tags: [audiobook, podcast, rss, podcasting-2.0, astro, publishing, internet-archive, multi-work]
 timestamp: 2026-08-30T18:25:00Z
 ---
 
-# Publicação do audiolivro como podcast
+# Publicação de cada obra como podcast
 
 ## 1. Objetivo
 
-Todo capítulo de audiolivro marcado como publicável deve poder virar automaticamente um episódio de podcast.
+Toda obra publicável da fábrica de audiolivros recebe seu próprio podcast RSS.
 
-O usuário assina uma única URL RSS no tocador de sua preferência. Depois disso, novos capítulos publicados pela pipeline aparecem no player sem qualquer ação adicional.
+Todo capítulo/unidade da obra marcado como publicável deve poder virar automaticamente um episódio desse podcast.
 
-O blog é a identidade pública e canônica do podcast.
+O usuário assina uma única URL RSS para aquela obra no tocador de sua preferência. Depois disso, novos capítulos publicados pela pipeline aparecem no player sem qualquer ação adicional.
+
+O blog é a identidade pública e canônica dos podcasts; o storage da mídia é infraestrutura substituível.
+
+Exemplos conceituais:
+
+```text
+HPMOR
+  -> https://franklinbaldo.com/audiobooks/hpmor/feed.xml
+
+Bhagavad Gita
+  -> https://franklinbaldo.com/audiobooks/bhagavad-gita/feed.xml
+```
+
+Não existe dependência arquitetural de HPMOR neste contrato.
 
 ## 2. Identidade estável
 
-Cada obra recebe uma URL estável de feed, por exemplo:
+Cada obra recebe uma URL estável de feed derivada do `publication_slug`/`work_id`, por exemplo:
 
 ```text
 https://franklinbaldo.com/audiobooks/hpmor/feed.xml
+https://franklinbaldo.com/audiobooks/bhagavad-gita/feed.xml
 ```
 
 A URL exata será definida pela estrutura pública do site, mas depois de publicada deve ser considerada parte do contrato externo.
 
-Cada capítulo corresponde a um `<item>` RSS com GUID estável derivado da identidade canônica do capítulo, nunca do arquivo de áudio.
+Cada unidade publicada corresponde a um `<item>` RSS com GUID estável derivado da identidade canônica da obra + unidade, nunca do arquivo de áudio.
 
 Exemplo conceitual:
 
 ```text
-podcast_id: audiobook-hpmor
+podcast_id: audiobook:hpmor
 chapter_id: hpmor-001
-episode_guid: audiobook-hpmor:hpmor-001
+episode_guid: audiobook:hpmor:hpmor-001
 ```
 
-Regenerar o áudio, mudar backend TTS ou corrigir metadados **não cria novo episódio**. O GUID permanece o mesmo.
+```text
+podcast_id: audiobook:bhagavad-gita
+chapter_id: bhagavad-gita-001
+episode_guid: audiobook:bhagavad-gita:bhagavad-gita-001
+```
+
+Regenerar o áudio, mudar backend TTS, runner, codec ou storage **não cria novo episódio**. O GUID permanece o mesmo.
 
 ## 3. RSS
 
-O feed deve seguir RSS 2.0 e incluir o namespace `itunes` para compatibilidade ampla. Deve ser público e não exigir autenticação.
+Cada feed deve seguir RSS 2.0 e incluir o namespace `itunes` para compatibilidade ampla. Deve ser público e não exigir autenticação.
 
 Cada episódio deve incluir, no mínimo:
 
@@ -50,7 +71,7 @@ Cada episódio deve incluir, no mínimo:
 - descrição;
 - `<enclosure>` com URL HTTPS, tamanho em bytes e MIME type;
 - duração quando disponível;
-- link para a página do capítulo no blog.
+- link para a página da unidade/capítulo no blog.
 
 O feed deve ser validável por ferramentas de podcast antes de publicação.
 
@@ -73,29 +94,28 @@ A URL usada no `<enclosure>` precisa:
 
 Referência de áudio: [Apple Podcasts — audio requirements](https://podcasters.apple.com/support/893-audio-requirements).
 
-## 5. Feed no blog; mídia fora do Pages quando necessário
+## 5. Feed no blog; mídia fora do Pages
 
 O feed, páginas HTML, artwork, transcript e manifests pequenos podem ser publicados pelo próprio site.
 
-O áudio integral **não deve depender de caber no deploy do GitHub Pages**. Um audiolivro longo pode ultrapassar os limites de tamanho do Pages mesmo com compressão eficiente. O GitHub atualmente recomenda até 1 GB para o repositório-fonte, limita o site publicado a 1 GB e aplica limite de banda mensal soft de 100 GB.
+O áudio integral **não deve depender de caber no deploy do GitHub Pages**. Um acervo com vários audiolivros torna essa separação ainda mais importante.
 
 Referência: [GitHub Pages limits](https://docs.github.com/en/pages/getting-started-with-github-pages/github-pages-limits).
 
-A arquitetura portanto separa:
+A arquitetura separa:
 
 ```text
 Blog / GitHub Pages
-  - feed.xml
-  - página da obra
-  - página do capítulo
-  - artwork
-  - transcript / chapters metadata
+  /audiobooks/
+  /audiobooks/<work_id>/
+  /audiobooks/<work_id>/feed.xml
+  transcript / chapters / artwork / páginas
              |
              | enclosure URL
              v
-Media storage
-  - chapter-001.mp3
-  - chapter-002.mp3
+Media storage por obra
+  - 001.mp3
+  - 002.mp3
   - ...
 ```
 
@@ -103,38 +123,49 @@ O backend de mídia é substituível. A identidade do podcast não muda quando o
 
 ### 5.1. Internet Archive como destino durável preferencial
 
-O **Internet Archive** é o destino durável preferencial para os arquivos finais publicados do audiolivro, sem ser requisito para o primeiro protótipo.
+O **Internet Archive** é o destino durável preferencial para os arquivos finais publicados, sem ser requisito para o primeiro protótipo.
 
-A motivação é separar três funções diferentes:
+A unidade padrão de storage deve ser **um item do Internet Archive por obra**, evitando misturar múltiplos audiolivros em um único item global.
 
-- GitHub mantém código, corpus, configuração, manifestos e proveniência;
-- GitHub Pages mantém a identidade pública, páginas e feed RSS;
-- Internet Archive mantém os binários finais de mídia destinados à distribuição durável.
-
-O fluxo de produção pode começar usando artifacts temporários de GitHub Actions ou outro storage experimental. A promoção para Internet Archive entra quando a pipeline de publicação estiver estável.
-
-O upload deve ser totalmente headless e acionável pelo mesmo GitHub Actions, preferencialmente através do cliente de linha de comando `ia`/biblioteca `internetarchive` ou API equivalente, com credenciais mantidas exclusivamente em GitHub Secrets. O projeto não depende de interação manual no site do Archive.
-
-O upload para Internet Archive deve ser **idempotente**: a obra recebe um identifier estável, e cada capítulo final usa um nome de arquivo determinístico. Um desenho inicial possível é:
+Exemplos conceituais:
 
 ```text
-Internet Archive item: franklinbaldo-hpmor-ptbr-audiobook
-
-files:
-  hpmor-001.mp3
-  hpmor-002.mp3
-  hpmor-003.mp3
-  ...
-  cover.jpg
-  manifest.json
+work_id: hpmor
+archive_identifier: franklinbaldo-hpmor-ptbr-audiobook
 ```
 
-A identidade do item e os nomes exatos ainda podem mudar antes da primeira publicação, mas, depois de expostos no feed, devem ser tratados como contratos externos.
+```text
+work_id: bhagavad-gita
+archive_identifier: franklinbaldo-bhagavad-gita-ptbr-audiobook
+```
 
-Antes de inserir uma URL do Archive em `<enclosure>`, o estágio `publish` deve verificar empiricamente que a URL final do arquivo satisfaz o contrato de podcast desta especificação (`HEAD`, range requests, MIME e estabilidade). O Internet Archive é o destino preferencial, não uma exceção às validações de interoperabilidade.
+Cada item pode conter:
 
-A pipeline deve registrar no manifesto de publicação:
+```text
+001.mp3
+002.mp3
+...
+cover.jpg
+manifest.json
+```
 
+A associação `work_id -> archive_identifier` é persistida na configuração da obra. O workflow não inventa um item novo a cada execução.
+
+A motivação é separar três funções:
+
+- Git mantém código, corpus, configuração, manifests e proveniência;
+- GitHub Pages mantém catálogo, identidade pública, páginas e feeds RSS;
+- Internet Archive mantém mídia final destinada à distribuição durável.
+
+O fluxo pode começar usando artifacts temporários de GitHub Actions ou outro storage experimental. A promoção para Internet Archive entra quando a publicação estiver estável.
+
+O upload deve ser totalmente headless e acionável pelo mesmo GitHub Actions, preferencialmente através do cliente `ia`/biblioteca `internetarchive` ou API equivalente, com credenciais mantidas exclusivamente em GitHub Secrets.
+
+Antes de inserir uma URL do Archive em `<enclosure>`, `publish` deve verificar empiricamente que a URL final satisfaz o contrato HTTP desta especificação (`HEAD`, range requests, MIME e estabilidade).
+
+O manifesto de publicação registra:
+
+- `work_id`;
 - identifier do item no Internet Archive;
 - nome do arquivo remoto;
 - URL pública final usada no `<enclosure>`;
@@ -142,34 +173,35 @@ A pipeline deve registrar no manifesto de publicação:
 - momento do upload;
 - resultado da verificação HTTP pós-upload.
 
-A substituição de um áudio regenerado não altera o `episode_guid`. O feed pode atualizar o `<enclosure>` para a versão final do mesmo capítulo mantendo a identidade lógica do episódio.
-
-Referência operacional: o projeto oficial `internetarchive` fornece biblioteca Python e a ferramenta de linha de comando `ia`, incluindo upload de arquivos para itens do Archive.
+A substituição de um áudio regenerado não altera o `episode_guid`.
 
 ## 6. Publicação pela mesma pipeline
 
-O estágio `publish` recebe um capítulo já montado e validado.
+O estágio `publish` recebe uma unidade já montada e validada e conhece seu `work_id`.
 
 Fluxo:
 
 1. validar áudio final;
 2. calcular digest, bytes, duração e MIME;
-3. enviar o arquivo para media storage — preferencialmente Internet Archive quando esse backend estiver habilitado;
-4. verificar `HEAD` e range request na URL pública;
-5. gerar/atualizar metadata do episódio;
-6. gerar transcript/timestamps derivados quando disponíveis;
-7. reconstruir o feed RSS;
-8. executar validação do feed;
-9. publicar o site;
-10. registrar no manifesto a URL do enclosure e a versão publicada.
+3. resolver configuração de publicação da obra;
+4. enviar o arquivo para media storage — preferencialmente o item do Internet Archive daquela obra quando habilitado;
+5. verificar `HEAD` e range request na URL pública;
+6. gerar/atualizar metadata do episódio;
+7. gerar transcript/timestamps derivados quando disponíveis;
+8. reconstruir **somente o feed da obra afetada** e, quando necessário, o catálogo agregado;
+9. executar validação do feed;
+10. publicar o site;
+11. registrar no manifesto a URL do enclosure e a versão publicada.
 
-A ordem é importante: o feed nunca deve apontar para um enclosure que ainda não esteja publicamente acessível.
+A ordem é importante: o feed nunca aponta para um enclosure que ainda não esteja publicamente acessível.
+
+Uma publicação de HPMOR não deve reescrever semanticamente o estado de publicação do Bhagavad Gita, e vice-versa.
 
 ## 7. Estado de publicação
 
 O corpus textual não deve ser publicado como episódio apenas porque existe áudio.
 
-Cada capítulo tem lifecycle explícito, por exemplo:
+Cada unidade tem lifecycle explícito, por exemplo:
 
 ```yaml
 publication:
@@ -179,11 +211,11 @@ publication:
 
 Somente `ready` pode ser promovido por um workflow autorizado para `published`.
 
-O status editorial pertence à obra/capítulo; não ao runner de compute.
+O status editorial pertence à obra/unidade; não ao runner de compute.
 
 ## 8. Podcasting 2.0
 
-O feed deve poder usar o namespace Podcasting 2.0 sem tornar isso requisito para players tradicionais.
+Cada feed deve poder usar o namespace Podcasting 2.0 sem tornar isso requisito para players tradicionais.
 
 ### 8.1. Transcript
 
@@ -210,7 +242,7 @@ Referências:
 
 A pipeline pode gerar um arquivo JSON de capítulos/marcadores e referenciá-lo com `<podcast:chapters>`.
 
-Mesmo que cada episódio já corresponda a um capítulo do livro, os chapters internos podem representar cenas, seções ou outros marcos úteis dentro de episódios longos.
+Mesmo que cada episódio corresponda a uma divisão da obra, os chapters internos podem representar cenas, seções, versos/blocos ou outros marcos úteis dentro de episódios longos.
 
 Referência: [Podcasting 2.0 — chapters](https://podcasting2.org/docs/podcast-namespace/tags/chapters).
 
@@ -219,47 +251,62 @@ Referência: [Podcasting 2.0 — chapters](https://podcasting2.org/docs/podcast-
 O podcast não cria uma quarta fonte textual.
 
 ```text
-original OKF
-    -> translation OKF
-        -> narration OKF
-            -> audio
-                -> podcast episode
+work
+  -> original OKF
+      -> translation OKF
+          -> narration OKF
+              -> audio
+                  -> podcast episode
 ```
 
 A descrição pública e o transcript podem ser gerados a partir das fontes canônicas, mas não substituem nenhuma delas.
 
-## 10. Página do episódio no blog
+## 10. Página da obra e episódio no blog
 
-Cada episódio deve ter página própria, com pelo menos:
+Cada obra deve ter página própria e cada episódio/unidade, página reproduzível por template genérico.
 
-- título/capítulo;
+A página da obra oferece:
+
+- título/atribuição;
+- capa/artwork;
+- descrição;
+- índice de episódios/unidades;
+- player quando aplicável;
+- URL/ação de assinatura do feed daquela obra.
+
+A página de episódio pode oferecer:
+
+- título/unidade;
 - player HTML;
 - duração;
 - data de publicação;
-- link do feed/ação de assinatura;
-- texto em português quando a política de publicação permitir;
+- texto em português quando a política da obra permitir;
 - opcionalmente original e comparação lado a lado;
-- informação de modelo/produção em seção técnica discreta, se desejado.
+- informação técnica de produção, se desejado.
 
 O player web e o player de podcast consomem o mesmo arquivo de mídia final.
 
-## 11. Assinatura
+## 11. Catálogo e assinatura
 
-A página da obra deve oferecer claramente a URL do feed e links de assinatura compatíveis com os destinos que forem configurados.
+`/audiobooks/` é o catálogo agregado do blog, não um substituto dos feeds individuais.
+
+Ele lista as obras disponíveis e oferece claramente a assinatura de cada podcast.
 
 A primeira versão não depende de cadastro em diretórios: qualquer player que aceite URL RSS diretamente deve funcionar.
 
-Submissão futura a Apple Podcasts, Podcast Index ou outros diretórios é uma etapa de distribuição separada e não muda o feed canônico do blog.
+Submissão futura a Apple Podcasts, Podcast Index ou outros diretórios é etapa de distribuição separada por obra e não muda os feeds canônicos do blog.
 
 ## 12. Critério de aceite
 
-A publicação como podcast está funcional quando:
+A publicação multi-work como podcast está funcional quando:
 
-1. um capítulo `ready` é publicado por GitHub Actions;
-2. o áudio fica disponível em URL estável com streaming/seek;
-3. o feed RSS é atualizado automaticamente;
-4. o episódio mantém GUID estável entre regenerações;
-5. o feed pode ser adicionado manualmente a um player de podcast;
-6. após publicar um segundo capítulo, o player o recebe como novo episódio sem nova assinatura;
-7. transcript e chapters opcionais não quebram compatibilidade RSS tradicional;
-8. quando o backend Internet Archive estiver ativado, o upload e a verificação pós-upload são feitos integralmente pelo workflow, sem etapa manual.
+1. uma obra pode ter seu feed gerado sem código exclusivo;
+2. um capítulo/unidade `ready` é publicado por GitHub Actions;
+3. o áudio fica disponível em URL estável com streaming/seek;
+4. o feed correto da obra é atualizado automaticamente;
+5. o episódio mantém GUID estável entre regenerações;
+6. os feeds de HPMOR e de uma segunda fixture/obra podem coexistir sem colisão;
+7. um feed pode ser adicionado manualmente a um player de podcast;
+8. após publicar um segundo capítulo, o player o recebe como novo episódio sem nova assinatura;
+9. transcript e chapters opcionais não quebram compatibilidade RSS tradicional;
+10. quando Internet Archive estiver ativado, upload e verificação pós-upload são feitos integralmente pelo workflow e no item correspondente àquela obra.

--- a/docs/okf/audiobook/podcast-publication.md
+++ b/docs/okf/audiobook/podcast-publication.md
@@ -2,7 +2,7 @@
 type: Product Architecture
 title: Audiobook — podcast publication contract
 description: Contrato para publicar capítulos de audiolivro como episódios de um podcast RSS hospedado pelo blog.
-tags: [audiobook, podcast, rss, podcasting-2.0, astro, publishing]
+tags: [audiobook, podcast, rss, podcasting-2.0, astro, publishing, internet-archive]
 timestamp: 2026-08-30T18:25:00Z
 ---
 
@@ -99,7 +99,52 @@ Media storage
   - ...
 ```
 
-O backend de mídia é substituível. Pode começar com uma opção gratuita/experimental, desde que satisfaça o contrato HTTP acima. A identidade do podcast não muda quando o storage muda.
+O backend de mídia é substituível. A identidade do podcast não muda quando o storage muda.
+
+### 5.1. Internet Archive como destino durável preferencial
+
+O **Internet Archive** é o destino durável preferencial para os arquivos finais publicados do audiolivro, sem ser requisito para o primeiro protótipo.
+
+A motivação é separar três funções diferentes:
+
+- GitHub mantém código, corpus, configuração, manifestos e proveniência;
+- GitHub Pages mantém a identidade pública, páginas e feed RSS;
+- Internet Archive mantém os binários finais de mídia destinados à distribuição durável.
+
+O fluxo de produção pode começar usando artifacts temporários de GitHub Actions ou outro storage experimental. A promoção para Internet Archive entra quando a pipeline de publicação estiver estável.
+
+O upload deve ser totalmente headless e acionável pelo mesmo GitHub Actions, preferencialmente através do cliente de linha de comando `ia`/biblioteca `internetarchive` ou API equivalente, com credenciais mantidas exclusivamente em GitHub Secrets. O projeto não depende de interação manual no site do Archive.
+
+O upload para Internet Archive deve ser **idempotente**: a obra recebe um identifier estável, e cada capítulo final usa um nome de arquivo determinístico. Um desenho inicial possível é:
+
+```text
+Internet Archive item: franklinbaldo-hpmor-ptbr-audiobook
+
+files:
+  hpmor-001.mp3
+  hpmor-002.mp3
+  hpmor-003.mp3
+  ...
+  cover.jpg
+  manifest.json
+```
+
+A identidade do item e os nomes exatos ainda podem mudar antes da primeira publicação, mas, depois de expostos no feed, devem ser tratados como contratos externos.
+
+Antes de inserir uma URL do Archive em `<enclosure>`, o estágio `publish` deve verificar empiricamente que a URL final do arquivo satisfaz o contrato de podcast desta especificação (`HEAD`, range requests, MIME e estabilidade). O Internet Archive é o destino preferencial, não uma exceção às validações de interoperabilidade.
+
+A pipeline deve registrar no manifesto de publicação:
+
+- identifier do item no Internet Archive;
+- nome do arquivo remoto;
+- URL pública final usada no `<enclosure>`;
+- digest local e, quando disponível, digest reportado pelo storage;
+- momento do upload;
+- resultado da verificação HTTP pós-upload.
+
+A substituição de um áudio regenerado não altera o `episode_guid`. O feed pode atualizar o `<enclosure>` para a versão final do mesmo capítulo mantendo a identidade lógica do episódio.
+
+Referência operacional: o projeto oficial `internetarchive` fornece biblioteca Python e a ferramenta de linha de comando `ia`, incluindo upload de arquivos para itens do Archive.
 
 ## 6. Publicação pela mesma pipeline
 
@@ -109,7 +154,7 @@ Fluxo:
 
 1. validar áudio final;
 2. calcular digest, bytes, duração e MIME;
-3. enviar o arquivo para media storage;
+3. enviar o arquivo para media storage — preferencialmente Internet Archive quando esse backend estiver habilitado;
 4. verificar `HEAD` e range request na URL pública;
 5. gerar/atualizar metadata do episódio;
 6. gerar transcript/timestamps derivados quando disponíveis;
@@ -216,4 +261,5 @@ A publicação como podcast está funcional quando:
 4. o episódio mantém GUID estável entre regenerações;
 5. o feed pode ser adicionado manualmente a um player de podcast;
 6. após publicar um segundo capítulo, o player o recebe como novo episódio sem nova assinatura;
-7. transcript e chapters opcionais não quebram compatibilidade RSS tradicional.
+7. transcript e chapters opcionais não quebram compatibilidade RSS tradicional;
+8. quando o backend Internet Archive estiver ativado, o upload e a verificação pós-upload são feitos integralmente pelo workflow, sem etapa manual.

--- a/docs/okf/audiobook/podcast-publication.md
+++ b/docs/okf/audiobook/podcast-publication.md
@@ -1,0 +1,206 @@
+---
+type: Product Architecture
+title: Audiobook — podcast publication contract
+description: Contrato para publicar capítulos de audiolivro como episódios de um podcast RSS hospedado pelo blog.
+tags: [audiobook, podcast, rss, podcasting-2.0, astro, publishing]
+timestamp: 2026-08-30T18:25:00Z
+---
+
+# Publicação do audiolivro como podcast
+
+## 1. Objetivo
+
+Todo capítulo de audiolivro marcado como publicável deve poder virar automaticamente um episódio de podcast.
+
+O usuário assina uma única URL RSS no tocador de sua preferência. Depois disso, novos capítulos publicados pela pipeline aparecem no player sem qualquer ação adicional.
+
+O blog é a identidade pública e canônica do podcast.
+
+## 2. Identidade estável
+
+Cada obra recebe uma URL estável de feed, por exemplo:
+
+```text
+https://franklinbaldo.com/audiobooks/hpmor/feed.xml
+```
+
+A URL exata será definida pela estrutura pública do site, mas depois de publicada deve ser considerada parte do contrato externo.
+
+Cada capítulo corresponde a um `<item>` RSS com GUID estável derivado da identidade canônica do capítulo, nunca do arquivo de áudio.
+
+Exemplo conceitual:
+
+```text
+podcast_id: audiobook-hpmor
+chapter_id: hpmor-001
+episode_guid: audiobook-hpmor:hpmor-001
+```
+
+Regenerar o áudio, mudar backend TTS ou corrigir metadados **não cria novo episódio**. O GUID permanece o mesmo.
+
+## 3. RSS
+
+O feed deve seguir RSS 2.0 e incluir o namespace `itunes` para compatibilidade ampla. Deve ser público e não exigir autenticação.
+
+Cada episódio deve incluir, no mínimo:
+
+- `title`;
+- `guid` estável;
+- `pubDate`;
+- descrição;
+- `<enclosure>` com URL HTTPS, tamanho em bytes e MIME type;
+- duração quando disponível;
+- link para a página do capítulo no blog.
+
+O feed deve ser validável por ferramentas de podcast antes de publicação.
+
+## 4. Áudio do episódio
+
+O formato de distribuição inicial preferido é MP3 ou AAC, mantendo WAV/FLAC apenas como intermediário/master quando necessário.
+
+Para narrativa predominantemente mono, MP3 mono em faixa adequada a voz é suficiente como baseline; encoding final fica separado da geração TTS para poder ser alterado sem regenerar a fala.
+
+A URL usada no `<enclosure>` precisa:
+
+- ser pública e estável;
+- aceitar `HEAD`;
+- aceitar byte-range/range requests para streaming e seek;
+- devolver Content-Type correto;
+- não depender de cookie ou sessão;
+- permanecer acessível depois que o workflow de Actions terminar.
+
+## 5. Feed no blog; mídia fora do Pages quando necessário
+
+O feed, páginas HTML, artwork, transcript e manifests pequenos podem ser publicados pelo próprio site.
+
+O áudio integral **não deve depender de caber no deploy do GitHub Pages**. Um audiolivro longo pode ultrapassar os limites de tamanho do Pages mesmo com compressão eficiente.
+
+A arquitetura portanto separa:
+
+```text
+Blog / GitHub Pages
+  - feed.xml
+  - página da obra
+  - página do capítulo
+  - artwork
+  - transcript / chapters metadata
+             |
+             | enclosure URL
+             v
+Media storage
+  - chapter-001.mp3
+  - chapter-002.mp3
+  - ...
+```
+
+O backend de mídia é substituível. Pode começar com uma opção gratuita/experimental, desde que satisfaça o contrato HTTP acima. A identidade do podcast não muda quando o storage muda.
+
+## 6. Publicação pela mesma pipeline
+
+O estágio `publish` recebe um capítulo já montado e validado.
+
+Fluxo:
+
+1. validar áudio final;
+2. calcular digest, bytes, duração e MIME;
+3. enviar o arquivo para media storage;
+4. verificar `HEAD` e range request na URL pública;
+5. gerar/atualizar metadata do episódio;
+6. gerar transcript/timestamps derivados quando disponíveis;
+7. reconstruir o feed RSS;
+8. executar validação do feed;
+9. publicar o site;
+10. registrar no manifesto a URL do enclosure e a versão publicada.
+
+A ordem é importante: o feed nunca deve apontar para um enclosure que ainda não esteja publicamente acessível.
+
+## 7. Estado de publicação
+
+O corpus textual não deve ser publicado como episódio apenas porque existe áudio.
+
+Cada capítulo tem lifecycle explícito, por exemplo:
+
+```yaml
+publication:
+  status: draft # draft | ready | published
+  published_at: null
+```
+
+Somente `ready` pode ser promovido por um workflow autorizado para `published`.
+
+O status editorial pertence à obra/capítulo; não ao runner de compute.
+
+## 8. Podcasting 2.0
+
+O feed deve poder usar o namespace Podcasting 2.0 sem tornar isso requisito para players tradicionais.
+
+### 8.1. Transcript
+
+Como a pipeline já conhece texto, speakers e limites temporais dos segmentos, ela pode gerar WebVTT de alta qualidade sem transcrever novamente o áudio.
+
+Cada episódio pode expor:
+
+```xml
+<podcast:transcript
+  url="https://.../001.vtt"
+  type="text/vtt"
+  language="pt-BR"
+  rel="captions" />
+```
+
+O transcript é derivado da camada de narração + timestamps efetivamente produzidos pelo áudio, não da tradução isoladamente.
+
+### 8.2. Chapters
+
+A pipeline pode gerar um arquivo JSON de capítulos/marcadores e referenciá-lo com `<podcast:chapters>`.
+
+Mesmo que cada episódio já corresponda a um capítulo do livro, os chapters internos podem representar cenas, seções ou outros marcos úteis dentro de episódios longos.
+
+## 9. Relação com as três camadas OKF
+
+O podcast não cria uma quarta fonte textual.
+
+```text
+original OKF
+    -> translation OKF
+        -> narration OKF
+            -> audio
+                -> podcast episode
+```
+
+A descrição pública e o transcript podem ser gerados a partir das fontes canônicas, mas não substituem nenhuma delas.
+
+## 10. Página do episódio no blog
+
+Cada episódio deve ter página própria, com pelo menos:
+
+- título/capítulo;
+- player HTML;
+- duração;
+- data de publicação;
+- link do feed/ação de assinatura;
+- texto em português quando a política de publicação permitir;
+- opcionalmente original e comparação lado a lado;
+- informação de modelo/produção em seção técnica discreta, se desejado.
+
+O player web e o player de podcast consomem o mesmo arquivo de mídia final.
+
+## 11. Assinatura
+
+A página da obra deve oferecer claramente a URL do feed e links de assinatura compatíveis com os destinos que forem configurados.
+
+A primeira versão não depende de cadastro em diretórios: qualquer player que aceite URL RSS diretamente deve funcionar.
+
+Submissão futura a Apple Podcasts, Podcast Index ou outros diretórios é uma etapa de distribuição separada e não muda o feed canônico do blog.
+
+## 12. Critério de aceite
+
+A publicação como podcast está funcional quando:
+
+1. um capítulo `ready` é publicado por GitHub Actions;
+2. o áudio fica disponível em URL estável com streaming/seek;
+3. o feed RSS é atualizado automaticamente;
+4. o episódio mantém GUID estável entre regenerações;
+5. o feed pode ser adicionado manualmente a um player de podcast;
+6. após publicar um segundo capítulo, o player o recebe como novo episódio sem nova assinatura;
+7. transcript e chapters opcionais não quebram compatibilidade RSS tradicional.

--- a/docs/okf/audiobook/prd.md
+++ b/docs/okf/audiobook/prd.md
@@ -1,30 +1,34 @@
 ---
 type: Product Requirements Document
-title: Audiolivro HPMOR em português — pipeline OKF, TTS e compute CLI-first
-description: PRD para uma pipeline reproduzível de original, tradução, adaptação de narração, benchmark de TTS e geração incremental de audiolivro com runners remotos acionados por linha de comando.
-tags: [audiobook, hpmor, okf, translation, tts, github-actions, kaggle, colab, cli, podcast]
+title: Audiobook Factory — PRD inicial com HPMOR como primeira obra
+description: PRD para uma pipeline multi-work reproduzível de original, tradução, adaptação de narração, benchmark de TTS, geração incremental e publicação como podcast.
+tags: [audiobook, hpmor, bhagavad-gita, okf, translation, tts, github-actions, kaggle, colab, cli, podcast, multi-work]
 timestamp: 2026-08-30T16:37:00Z
 ---
 
-# Audiolivro HPMOR em português
+# Audiobook Factory — PRD inicial
 
 ## 1. Resumo
 
-Este projeto cria uma pipeline reproduzível para produzir uma edição em áudio, em português do Brasil, de _Harry Potter and the Methods of Rationality_ (HPMOR), de Eliezer Yudkowsky.
+Este projeto cria uma **fábrica genérica de audiolivros** no repositório do blog. Uma mesma pipeline transforma diferentes obras em edições narradas em português do Brasil e as publica como podcasts independentes.
 
-O princípio central é separar rigorosamente três representações textuais do mesmo capítulo:
+_Harry Potter and the Methods of Rationality_ (HPMOR), de Eliezer Yudkowsky, é a primeira obra end-to-end e o corpus de referência da implementação inicial. _Bhagavad Gita_ é o segundo caso de referência arquitetural e existe desde já para garantir que o desenho não dependa de HPMOR, de inglês como idioma-fonte, de ficção, de diálogo ou de múltiplos personagens.
 
-1. **original** — o texto-fonte em inglês, preservado como referência;
-2. **tradução** — uma tradução fiel para português brasileiro, adequada para leitura humana e comparação com o original;
+O contrato multi-work completo está em [`multi-work-architecture.md`](./multi-work-architecture.md). O índice do produto está em [`index.md`](./index.md).
+
+Para cada obra, o princípio central é separar rigorosamente três representações textuais de cada unidade/capítulo:
+
+1. **original** — o texto-fonte escolhido, preservado como referência e com proveniência;
+2. **tradução** — uma tradução canônica para português brasileiro, adequada para leitura humana e comparação com o original;
 3. **narração** — uma adaptação da tradução destinada especificamente à síntese de voz, podendo ajustar pontuação, pronúncia, pausas, expansão de símbolos, divisão de falas e instruções de interpretação necessárias para que o TTS produza o resultado esperado.
 
-As três camadas são Markdown em formato OKF e compartilham a mesma identidade de obra e capítulo. O áudio é derivado da camada de narração; nunca é a fonte canônica do texto.
+As três camadas são Markdown em formato OKF e compartilham a mesma identidade de obra e unidade. O áudio é derivado da camada de narração; nunca é a fonte canônica do texto.
 
 A computação de GPU deve ser **CLI-first**. O projeto não usa notebooks como interface operacional nem como fonte executável canônica. Toda lógica de produção vive em scripts versionados; Kaggle, Colab e futuros provedores são apenas runners remotos desses scripts.
 
 GitHub Actions é o ponto único de operação da pipeline: valida, planeja, despacha compute remoto usando credenciais em GitHub Secrets, recupera outputs, monta o capítulo e publica os artefatos. O contrato detalhado está em [`github-actions-execution.md`](./github-actions-execution.md).
 
-Capítulos publicados também devem ser distribuídos como episódios de um podcast RSS hospedado pelo blog. O usuário assina o feed uma vez no tocador de sua preferência e recebe automaticamente os capítulos seguintes. O contrato de publicação está em [`podcast-publication.md`](./podcast-publication.md).
+Cada obra publicada recebe seu **próprio podcast RSS** hospedado pelo blog. O usuário assina uma obra uma vez no tocador de sua preferência e recebe automaticamente os capítulos seguintes daquela obra. O contrato de publicação está em [`podcast-publication.md`](./podcast-publication.md).
 
 ## 2. Problema
 
@@ -37,46 +41,49 @@ Um fluxo ingênuo de `texto -> TTS -> arquivo de áudio` perde informação e mi
 - trocar de modelo ou provedor de TTS exige refazer a arquitetura;
 - notebooks manuais tornam a execução difícil de automatizar, revisar e reproduzir;
 - artefatos derivados podem se tornar impossíveis de reproduzir depois;
-- publicar áudio sem feed estável obriga o ouvinte a acompanhar manualmente o site em vez de usar um tocador de podcast.
+- publicar áudio sem feed estável obriga o ouvinte a acompanhar manualmente o site em vez de usar um tocador de podcast;
+- uma implementação centrada em uma única obra tende a duplicar código, workflows e páginas quando novos livros forem adicionados.
 
-O projeto deve transformar o audiolivro em um sistema de conteúdo versionado, auditável, regenerável e assinável.
+O projeto deve transformar livros em um sistema multi-work de conteúdo versionado, auditável, regenerável e assinável.
 
 ## 3. Objetivo do produto
 
-Entregar uma pipeline capaz de executar, para cada capítulo:
+Entregar uma pipeline única capaz de executar, para qualquer `work_id`:
 
 ```text
-original OKF
-    |
-    v
-tradução OKF
-    |
-    v
-narração OKF
-    |
-    v
-planner
-    |
-    v
-worker TTS (.py)
-    |
-    +--> local
-    +--> Colab CLI
-    +--> Kaggle CLI
-    +--> API TTS
-    |
-    v
-segmentos de áudio
-    |
-    v
-áudio do capítulo
-    |
-    +--> página/player no blog
-    +--> episódio no feed RSS
-    +--> artefatos de distribuição futuros
+work.md
+   |
+   +--> original OKF
+   |       |
+   |       v
+   +--> tradução OKF
+   |       |
+   |       v
+   +--> narração OKF
+           |
+           v
+        planner
+           |
+           v
+     worker TTS (.py)
+           |
+           +--> local
+           +--> Colab CLI
+           +--> Kaggle CLI
+           +--> API TTS
+           |
+           v
+    segmentos de áudio
+           |
+           v
+      áudio da unidade
+           |
+           +--> storage durável
+           +--> página/player da obra
+           +--> episódio no feed RSS da obra
 ```
 
-O HPMOR é o primeiro corpus e o caso de uso de referência. A arquitetura não deve depender semanticamente de HPMOR e deve poder ser reutilizada para outras obras.
+O código do motor deve ser compartilhado. HPMOR, Bhagavad Gita e futuras obras diferem por corpus/configuração, não por uma pipeline paralela.
 
 ## 4. Princípios
 
@@ -88,9 +95,9 @@ Original, tradução e narração são fontes versionadas. MP3, M4A, M4B, wavefo
 
 A tradução deve permanecer linguisticamente fiel e legível. Ajustes feitos apenas para satisfazer o comportamento de um sintetizador pertencem à camada de narração.
 
-### 4.3. Identidade compartilhada
+### 4.3. Identidade compartilhada e namespaced por obra
 
-Toda representação equivalente do mesmo capítulo deve carregar o mesmo `work_id` e `chapter_id`.
+Toda representação equivalente da mesma unidade deve carregar o mesmo `work_id` e `chapter_id`.
 
 ```yaml
 work_id: hpmor
@@ -98,13 +105,23 @@ chapter_id: hpmor-001
 chapter_number: 1
 ```
 
-A tradução e a narração apontam explicitamente para a camada da qual derivam.
+Para outra obra:
+
+```yaml
+work_id: bhagavad-gita
+chapter_id: bhagavad-gita-001
+chapter_number: 1
+```
+
+A tradução e a narração apontam explicitamente para a camada da qual derivam. IDs de unidade e segmento são namespaced por `work_id` para evitar colisões.
 
 ### 4.4. Unidades menores que o capítulo
 
-A geração de áudio opera sobre segmentos estáveis menores que um capítulo. Um segmento pode ser uma fala, um parágrafo narrativo ou outra unidade suficientemente pequena para regeneração isolada.
+A geração de áudio opera sobre segmentos estáveis menores que uma unidade publicável. Um segmento pode ser uma fala, um parágrafo narrativo ou outra unidade suficientemente pequena para regeneração isolada.
 
 Cada segmento possui `segment_id` estável. O mesmo ID é preservado enquanto a unidade correspondente continua semanticamente sendo a mesma.
+
+O termo operacional inicial continua sendo `chapter`, mas a UI não deve presumir romance moderno: uma obra pode expor capítulo, adhyaya, canto, ensaio, conto ou outra divisão editorial apropriada.
 
 ### 4.5. TTS é implementação, não contrato
 
@@ -124,6 +141,7 @@ Nenhum fine-tune deve ser presumido antes de testar zero-shot.
 
 Um segmento de áudio é identificado por uma chave derivada, no mínimo, de:
 
+- `work_id` e `segment_id`;
 - texto de narração;
 - identidade/configuração da voz;
 - backend e modelo TTS;
@@ -136,7 +154,9 @@ Se a chave não mudar e o artefato existir, a pipeline reutiliza o áudio.
 
 ### 4.8. Git guarda estado; áudio pesado não precisa morar no Git
 
-O repositório guarda corpus, manifestos, configuração, proveniência e hashes. Arquivos pesados podem ser mantidos como artifacts ou em um destino de publicação definido posteriormente.
+O repositório guarda corpus, manifests, configuração, proveniência e hashes. Arquivos pesados podem ser mantidos como artifacts temporários e/ou em storage de mídia separado.
+
+O Internet Archive é o destino durável preferencial para áudio final publicado quando esse backend estiver habilitado. A preferência não é requisito para o primeiro protótipo e não muda o fato de o storage ser substituível.
 
 ### 4.9. CLI-first; notebooks não são fonte executável
 
@@ -157,11 +177,20 @@ A operação suportada do produto parte do GitHub Actions. Kaggle, Colab e APIs 
 
 Secrets permanecem no GitHub e são expostos somente ao step/runtime que deles precisar. Um runner remoto é considerado suportado apenas depois de autenticação headless e execução end-to-end comprovadas.
 
-### 4.11. Podcast é saída de primeira classe
+Não existe workflow por livro. Um único workflow recebe `work_id`.
 
-O capítulo não termina tecnicamente em um arquivo de áudio. Quando marcado como publicável, ele deve poder virar um episódio de um feed RSS estável mantido pelo blog.
+### 4.11. Podcast é saída de primeira classe e existe por obra
 
-O `chapter_id` determina um GUID de episódio estável. Regenerar o áudio com outro TTS não deve criar episódio duplicado.
+Uma unidade não termina tecnicamente em um arquivo de áudio. Quando marcada como publicável, ela deve poder virar um episódio do feed RSS estável daquela obra.
+
+Cada obra possui um feed próprio, conceitualmente:
+
+```text
+/audiobooks/hpmor/feed.xml
+/audiobooks/bhagavad-gita/feed.xml
+```
+
+O `chapter_id` determina um GUID de episódio estável. Regenerar o áudio com outro TTS ou mover o enclosure para outro storage não deve criar episódio duplicado.
 
 ## 5. Modelo de conteúdo
 
@@ -170,6 +199,7 @@ O `chapter_id` determina um GUID de episódio estável. Regenerar o áudio com o
 ```text
 data/audiobooks/
   hpmor/
+    work.md
     original/
       001.md
       002.md
@@ -183,9 +213,19 @@ data/audiobooks/
       002.md
       ...
     voices.yaml
-    manifest.json
+
+  bhagavad-gita/
+    work.md
+    original/
+      ...
+    translation/
+      ...
+    narration/
+      ...
+    voices.yaml
 
 scripts/audiobook/
+  # compartilhados entre todas as obras
   worker.py
   plan.py
   validate.py
@@ -194,9 +234,15 @@ scripts/audiobook/
   runners/
     colab.sh
     kaggle.sh
+  storage/
+    internet_archive.py
 ```
 
-O corpus fica fora de `src/content/blog/**`: ele não é um post do Hrönir e não deve entrar acidentalmente em ranking, versionamento ou seleção de posts.
+O corpus fica fora de `src/content/blog/**`: livros não são posts do Hrönir e não devem entrar acidentalmente em ranking, versionamento ou seleção de posts.
+
+`work.md` é a raiz OKF de cada obra e carrega `work_id`, título, idiomas, atribuição/proveniência, slug público e configuração editorial relevante.
+
+Adicionar uma obra normal deve significar adicionar `data/audiobooks/<work_id>/...`, e não criar novo worker, novo publisher ou novo workflow.
 
 ### 5.2. Original
 
@@ -222,7 +268,8 @@ Requisitos:
 - preservar a proveniência;
 - registrar digest do conteúdo importado;
 - não conter adaptação para português ou TTS;
-- manter IDs de segmentos estáveis após a primeira segmentação.
+- manter IDs de segmentos estáveis após a primeira segmentação;
+- não pressupor inglês como idioma de origem.
 
 ### 5.3. Tradução
 
@@ -244,11 +291,12 @@ Texto traduzido...
 
 Requisitos:
 
-- mesmo `chapter_id` do original;
+- mesmo `work_id` e `chapter_id` do original;
 - alinhamento por `segment_id`;
 - tradução adequada para leitura humana;
 - nenhum truque específico de sintetizador;
-- comparação automática original <-> tradução por capítulo e segmento.
+- comparação automática original <-> tradução por unidade e segmento;
+- cadeia de derivação/proveniência explícita quando a edição usar fonte intermediária.
 
 ### 5.4. Narração
 
@@ -289,7 +337,9 @@ Casos típicos:
 
 ## 6. Vozes
 
-`voices.yaml` define identidades lógicas, não IDs rígidos de um fornecedor.
+`voices.yaml` pertence à obra e define identidades lógicas, não IDs rígidos de um fornecedor.
+
+Para HPMOR pode haver narrador e vários personagens:
 
 ```yaml
 narrator:
@@ -305,9 +355,9 @@ mcgonagall:
   locale: pt-BR
 ```
 
-Cada backend mantém separadamente o mapeamento da identidade lógica para referência, prompt, voice clone ou configuração concreta.
+Outra obra pode usar uma estratégia completamente diferente sem mudar o motor. Bhagavad Gita pode, por exemplo, começar com narrador único ou outra direção editorial definida no próprio corpus.
 
-Isso permite trocar modelo sem reescrever o corpus e comparar backends mantendo a mesma intenção de voz.
+Cada backend mantém separadamente o mapeamento da identidade lógica para referência, prompt, voice clone ou configuração concreta.
 
 ## 7. Benchmark de TTS
 
@@ -326,9 +376,11 @@ O projeto mantém um corpus pequeno de benchmark pt-BR com segmentos que cubram:
 - frases longas;
 - números, siglas e abreviações;
 - fonemas e encontros relevantes do português brasileiro;
-- nomes ingleses dentro de frase portuguesa;
-- alternância pt-BR/inglês;
+- nomes estrangeiros dentro de frase portuguesa;
+- alternância pt-BR/outro idioma;
 - passagens mais longas para testar estabilidade.
+
+O benchmark inicial pode privilegiar HPMOR, mas a configuração vencedora não precisa ser universal. Obras diferentes podem escolher modelo/voz/direção diferentes.
 
 ### 7.2. Candidatos iniciais
 
@@ -377,15 +429,28 @@ python scripts/audiobook/worker.py \
   --output-dir <dir>
 ```
 
+O mesmo código deve aceitar:
+
+```text
+python scripts/audiobook/worker.py \
+  --work bhagavad-gita \
+  --chapter 1 \
+  --backend breeze \
+  --model <modelo> \
+  --input-plan <plan.json> \
+  --output-dir <dir>
+```
+
 O worker:
 
 1. lê um plano de segmentos já validado;
-2. instala/carrega apenas o backend selecionado;
-3. gera cada segmento de forma independente;
-4. escreve áudio + metadata de execução;
-5. não altera original, tradução ou narração;
-6. pode retomar execução parcial;
-7. encerra com código diferente de zero em falhas não recuperáveis.
+2. lê configuração da obra por `work_id`;
+3. instala/carrega apenas o backend selecionado;
+4. gera cada segmento de forma independente;
+5. escreve áudio + metadata de execução;
+6. não altera original, tradução ou narração;
+7. pode retomar execução parcial;
+8. encerra com código diferente de zero em falhas não recuperáveis.
 
 O script deve ser capaz de detectar a GPU disponível e registrar hardware, versões e parâmetros no manifesto da execução.
 
@@ -395,7 +460,7 @@ Dependências Python devem ser declaradas de forma autocontida sempre que viáve
 
 ### 9.1. Princípio
 
-Colab e Kaggle não recebem implementações distintas do TTS. Eles recebem o mesmo worker.
+Colab e Kaggle não recebem implementações distintas do TTS nem por modelo nem por obra. Eles recebem o mesmo worker.
 
 O adapter de runner resolve apenas:
 
@@ -468,17 +533,17 @@ O runner local também é a implementação de referência para o contrato de en
 
 ## 10. Pipeline
 
-A pipeline expõe estágios independentes:
+A pipeline expõe estágios independentes e sempre recebe `work_id`:
 
 1. `import` — obtém/normaliza o original e calcula proveniência/digest;
 2. `translate` — cria ou atualiza a tradução;
 3. `prepare-narration` — cria ou atualiza a camada de narração;
-4. `validate` — verifica IDs, alinhamento, links e schema;
+4. `validate` — verifica obra, IDs, alinhamento, links e schema;
 5. `plan` — calcula segmentos, cache keys e trabalho pendente;
 6. `benchmark` — opcionalmente gera as mesmas amostras em múltiplos backends;
 7. `synthesize` — despacha o worker para runner local/Colab/Kaggle/API;
-8. `assemble` — concatena segmentos em capítulo;
-9. `publish` — envia a mídia, atualiza o episódio/feed e publica os artefatos.
+8. `assemble` — concatena segmentos em uma unidade/capítulo;
+9. `publish` — envia a mídia, atualiza o episódio/feed da obra e publica os artefatos.
 
 Cada estágio pode ser executado sem obrigatoriamente executar os posteriores.
 
@@ -486,7 +551,8 @@ Cada estágio pode ser executado sem obrigatoriamente executar os posteriores.
 
 Antes de síntese, `plan` deve mostrar:
 
-- capítulos selecionados;
+- obra selecionada;
+- unidades/capítulos selecionados;
 - segmentos a gerar;
 - backend/modelo/voz;
 - runner escolhido;
@@ -502,29 +568,32 @@ GitHub Actions é **orquestrador e ponto único de operação**, não requisito 
 
 O workflow de produção deve poder:
 
-1. validar o corpus;
-2. gerar o plano;
-3. escolher runner;
-4. invocar `colab` ou `kaggle` CLI, ou usar um backend HTTP;
-5. acompanhar a execução;
-6. recuperar outputs;
-7. validar manifestos;
-8. montar o capítulo;
-9. publicar mídia/feed quando autorizado.
+1. descobrir/validar `work_id`;
+2. validar o corpus;
+3. gerar o plano;
+4. escolher runner;
+5. invocar `colab` ou `kaggle` CLI, ou usar um backend HTTP;
+6. acompanhar a execução;
+7. recuperar outputs;
+8. validar manifests;
+9. montar a unidade;
+10. publicar mídia/feed da obra quando autorizado.
 
 O primeiro workflow usa `workflow_dispatch` e aceita, no mínimo:
 
-- obra;
-- capítulo ou intervalo;
+- `work_id`;
+- capítulo/unidade ou intervalo;
 - backend/modelo;
 - runner (`local`, `colab`, `kaggle`, `api` quando houver);
 - `dry_run`;
 - `force` para ignorar cache;
 - `publish`.
 
+A lista de obras deve preferencialmente ser descoberta de `data/audiobooks/*/work.md`, não duplicada em código.
+
 Credenciais externas entram somente por GitHub Secrets e nunca no corpus, logs ou artefatos públicos.
 
-Detalhes de autenticação headless, staging, retomada e segurança ficam no contrato [`github-actions-execution.md`](./github-actions-execution.md).
+Detalhes de autenticação headless, staging, retomada, publicação no Internet Archive e segurança ficam no contrato [`github-actions-execution.md`](./github-actions-execution.md).
 
 ## 12. Manifesto derivado
 
@@ -553,57 +622,73 @@ A pipeline produz manifesto suficiente para reproduzir e auditar o resultado.
 
 O manifesto é derivado e não substitui os três bundles textuais.
 
-Depois de publicação, pode registrar também `episode_guid`, `enclosure_url`, digest do arquivo distribuído e timestamp de publicação.
+Depois de publicação, pode registrar também `episode_guid`, `enclosure_url`, storage/identifier remoto, digest do arquivo distribuído e timestamp de publicação.
 
 ## 13. Validação
 
 Validações mínimas:
 
+- todo diretório de obra possui `work.md` válido;
+- `work_id` é único e coincide com o namespace esperado;
 - todos os documentos possuem `type` OKF;
-- todo capítulo possui `work_id`, `chapter_id`, `chapter_number` e `lang`;
+- toda unidade possui `work_id`, `chapter_id`, número/ordem e `lang`;
 - original, tradução e narração concordam em identidade;
 - `derived_from` resolve;
 - `segment_id` não se repete dentro da obra;
 - ordem dos segmentos é determinística;
 - descendentes não referenciam silenciosamente segmentos inexistentes;
-- manifestos nunca são tratados como fonte canônica;
+- manifests nunca são tratados como fonte canônica;
 - nenhum segredo aparece versionado;
 - runner não modifica corpus canônico;
 - outputs declarados pelo worker correspondem ao plano recebido;
 - episódio publicado tem GUID estável;
-- enclosure está publicamente acessível antes de entrar no feed.
+- enclosure está publicamente acessível antes de entrar no feed;
+- uma obra não sobrescreve cache, manifest ou publicação de outra.
 
-## 14. Site e podcast
+## 14. Site e podcasts
 
-O próprio `franklinbaldo.github.io` deve ser o frontend e a identidade RSS do audiolivro.
+O próprio `franklinbaldo.github.io` deve ser o frontend e a identidade RSS da fábrica de audiolivros.
 
-A experiência inclui:
+A estrutura pública é data-driven:
+
+```text
+/audiobooks/                         # catálogo de obras
+/audiobooks/hpmor/                   # página da obra
+/audiobooks/hpmor/feed.xml           # podcast HPMOR
+/audiobooks/bhagavad-gita/           # página da obra
+/audiobooks/bhagavad-gita/feed.xml   # podcast Bhagavad Gita
+```
+
+Cada obra pode oferecer:
 
 - página da obra;
-- índice de capítulos;
-- página/player por capítulo;
+- índice de unidades/capítulos;
+- página/player por unidade;
 - indicação do trecho corrente quando disponível;
 - texto traduzido sincronizado;
 - comparação original/tradução quando desejada;
-- feed RSS de podcast;
+- feed RSS próprio;
 - ação clara para copiar/adicionar o feed ao tocador;
 - M4B e outros formatos futuramente.
 
-O feed fica no blog; a mídia pesada pode usar storage separado. Essa separação evita acoplar o podcast aos limites de armazenamento do GitHub Pages.
+O feed fica no blog; a mídia pesada pode usar storage separado, preferencialmente Internet Archive quando habilitado. Essa separação evita acoplar os podcasts aos limites de armazenamento do GitHub Pages.
 
 O contrato completo de RSS, enclosure, GUID, transcript e Podcasting 2.0 está em [`podcast-publication.md`](./podcast-publication.md).
 
 ## 15. Escopo autoral e publicação
 
-O projeto nasce como experimento pessoal, aberto e não comercial. Questões de autorização, política de distribuição ou eventual mudança de alcance não são gate para o kickstart técnico.
+Cada obra deve registrar sua própria proveniência e base editorial/publicação em `work.md` ou configuração associada.
 
-Se o projeto adquirir distribuição material, monetização ou relevância que altere seu perfil de risco, a publicação deve receber revisão própria antes de ser ampliada.
+O motor não presume que toda obra está em domínio público nem que toda obra requer a mesma autorização. Obras podem entrar por domínio público, licença, permissão ou outra base adequada ao caso concreto.
+
+Questões de autorização não devem contaminar o código compartilhado do motor; são metadata/política da obra e gates de publicação quando relevantes.
 
 ## 16. Não-objetivos iniciais
 
 Não fazem parte do kickstart:
 
-- gerar todos os capítulos imediatamente;
+- gerar todos os capítulos do HPMOR imediatamente;
+- implementar já o conteúdo do Bhagavad Gita;
 - escolher um vencedor TTS sem benchmark próprio;
 - adaptar/fine-tunar modelo antes de testar zero-shot;
 - criar vozes clonadas de atores ou pessoas reais;
@@ -612,7 +697,8 @@ Não fazem parte do kickstart:
 - automatizar gasto em todo `push`;
 - contaminar tradução com comandos de sintetizador;
 - manter notebooks operacionais ou uma pipeline paralela em `.ipynb`;
-- depender de um diretório comercial de podcasts para que a assinatura funcione.
+- depender de um diretório comercial de podcasts para que a assinatura funcione;
+- criar código, workflow ou página manual específica para cada novo livro.
 
 ## 17. Fases
 
@@ -620,39 +706,42 @@ Não fazem parte do kickstart:
 
 Esta PR.
 
-Critério de aceite: o documento fixa arquitetura de corpus, benchmark, worker, compute CLI-first, controle via GitHub Actions e publicação como podcast.
+Critério de aceite: os documentos fixam arquitetura multi-work, corpus, benchmark, worker, compute CLI-first, controle via GitHub Actions e publicação de um podcast independente por obra.
 
-### Fase 1 — corpus mínimo e validação
+### Fase 1 — motor mínimo + HPMOR como primeira obra
 
 Entregáveis:
 
+- estrutura genérica `data/audiobooks/<work_id>/`;
+- `data/audiobooks/hpmor/work.md`;
 - `data/audiobooks/hpmor/{original,translation,narration}`;
-- capítulo 1 nas três camadas;
+- capítulo 1 do HPMOR nas três camadas;
 - `voices.yaml` mínimo;
-- validador de IDs, derivação e segmentos;
+- validador genérico de obra, IDs, derivação e segmentos;
+- uma segunda fixture mínima fictícia ou estrutural para provar que o validador não depende de HPMOR;
 - fixtures/testes;
 - nenhuma chamada paga.
 
-Critério de aceite: um agente percorre deterministicamente `original -> translation -> narration` do capítulo 1 e mapeia os segmentos correspondentes.
+Critério de aceite: o mesmo validador percorre deterministicamente uma obra por `work_id`; HPMOR é apenas a primeira instância real.
 
-### Fase 2 — planner, worker e runners
+### Fase 2 — planner, worker e runners genéricos
 
 Entregáveis:
 
 - parser da narração;
 - representação interna de requests TTS;
 - interface de backend;
-- cache key;
+- cache key namespaced por obra;
 - `plan`/dry-run;
 - backend fake;
 - `scripts/audiobook/worker.py`;
 - runner local;
 - wrappers CLI para Colab e Kaggle;
 - Kaggle configurado como `kernel_type: script`;
-- workflow GitHub Actions capaz de despachar runner fake/headless;
+- workflow GitHub Actions genérico com `work_id` capaz de despachar runner fake/headless;
 - nenhum notebook requerido.
 
-Critério de aceite: o mesmo worker executa um job fake localmente e pode ser despachado por Actions pelos CLIs remotos sem divergência de contrato.
+Critério de aceite: o mesmo worker executa jobs de duas fixtures/obras sem alteração de código e pode ser despachado por Actions pelos CLIs remotos.
 
 ### Fase 3 — benchmark real
 
@@ -661,47 +750,56 @@ Entregáveis:
 - adapters dos candidatos selecionados;
 - corpus benchmark pt-BR;
 - execução comparável em pelo menos um runner gratuito disponível;
-- amostras e manifestos comparáveis;
+- amostras e manifests comparáveis;
 - relatório de qualidade/estabilidade/desempenho.
 
-Critério de aceite: existe evidência própria suficiente para escolher ou ordenar os modelos para o capítulo 1.
+Critério de aceite: existe evidência própria suficiente para escolher ou ordenar os modelos para a primeira obra, sem transformar essa escolha em default obrigatório de todas as obras futuras.
 
-### Fase 4 — primeiro capítulo em áudio e feed
+### Fase 4 — primeiro HPMOR em áudio e feed
 
 Entregáveis:
 
-- backend/modelo selecionado;
+- backend/modelo selecionado para HPMOR;
 - geração incremental;
 - montagem do capítulo;
 - manifesto completo;
 - storage de mídia compatível com podcast;
-- feed RSS inicial;
+- feed RSS HPMOR inicial;
 - episódio do capítulo 1;
 - artifact com áudio resultante.
 
-Critério de aceite: capítulo 1 reproduzível a partir do commit/configuração e assinável em um player de podcast usando o feed do blog.
+Critério de aceite: capítulo 1 reproduzível a partir do commit/configuração e assinável em um player de podcast usando o feed HPMOR do blog.
 
-### Fase 5 — experiência no blog
+### Fase 5 — experiência multi-work no blog
 
 Entregáveis:
 
-- loader dedicado;
-- página da obra;
-- página/player de capítulo;
+- loader genérico de obras;
+- `/audiobooks/` como catálogo;
+- página genérica por `work_id`;
+- página/player genérico por unidade;
 - metadados de navegação;
-- ação de assinatura/copiar feed;
-- transcript/timestamps derivados quando disponíveis.
+- ação de assinatura/copiar feed por obra;
+- transcript/timestamps derivados quando disponíveis;
+- nenhuma página Astro exclusiva de HPMOR necessária para comportamento genérico.
 
-### Fase 6 — escala
+### Fase 6 — Internet Archive e escala
 
-Somente após o capítulo 1 estar satisfatório:
+Após o primeiro capítulo estar satisfatório:
 
-- capítulos seguintes;
+- backend de publicação Internet Archive;
+- item/identifier estável por obra;
+- capítulos seguintes do HPMOR;
 - consistência de personagens/pronúncia;
 - geração batch incremental;
-- armazenamento/publicação durável;
 - formatos adicionais;
 - submissão opcional a diretórios de podcasts.
+
+### Fase 7 — segunda obra real
+
+Adicionar Bhagavad Gita ou outra obra elegível usando a mesma infraestrutura.
+
+Critério de aceite: a nova obra cria corpus/configuração/feed próprios sem alteração necessária no worker, runners, planner ou publisher para o caso normal.
 
 ## 18. Métricas de sucesso
 
@@ -710,39 +808,46 @@ O projeto é bem-sucedido quando:
 - qualquer tradução é rastreável ao original;
 - qualquer narração é rastreável à tradução;
 - qualquer áudio é rastreável ao texto/configuração/modelo/runner;
-- corrigir uma fala não força regenerar o capítulo inteiro;
+- corrigir uma fala não força regenerar a unidade inteira;
 - trocar backend não exige reescrever o corpus;
 - o mesmo worker roda localmente e em compute remoto;
 - nenhum notebook manual é necessário;
 - GitHub Actions consegue executar a pipeline sem interação com UI externa;
-- o capítulo 1 pode ser reproduzido por comandos documentados;
-- o feed pode ser adicionado a um tocador de podcast;
+- o feed de uma obra pode ser adicionado a um tocador de podcast;
 - novos capítulos publicados aparecem como novos episódios sem reassinar;
+- múltiplas obras coexistem sem colisão de IDs/cache/publicação;
+- adicionar uma nova obra normal não exige alterar o motor;
+- cada obra possui página e feed próprios;
 - o corpus continua compreensível como Markdown sem ferramenta de TTS.
 
 ## 19. Decisões já tomadas
 
-1. haverá três camadas: original, tradução e narração;
-2. todas serão Markdown compatível com OKF;
-3. as camadas correspondentes compartilham `chapter_id` e IDs menores;
-4. narração adapta a forma para TTS sem substituir a tradução;
-5. TTS é pluggable e provider-neutral;
-6. idioma não listado no model card não elimina candidato;
-7. zero-shot é testado antes de qualquer adaptação;
-8. escolha de modelo passa por benchmark pt-BR próprio;
-9. código de produção é CLI-first e script-first;
-10. `.ipynb` não é fonte operacional do projeto;
-11. Colab e Kaggle são runners do mesmo worker;
-12. Kaggle usa `kernel_type: script`;
-13. GitHub Actions é o plano de controle e ponto único de operação;
-14. credenciais remotas ficam em GitHub Secrets;
-15. chamadas pagas começam manuais/dry-run;
-16. binários de áudio são derivados;
-17. capítulos publicáveis viram episódios com GUID estável;
-18. o feed RSS canônico é hospedado pelo blog;
-19. mídia pesada pode usar storage separado do GitHub Pages;
-20. HPMOR é o corpus inicial, não uma dependência arquitetural.
+1. o produto é uma fábrica de audiolivros multi-work; HPMOR é a primeira obra, não o motor;
+2. haverá três camadas por obra: original, tradução e narração;
+3. todas serão Markdown compatível com OKF;
+4. cada obra possui `work_id` estável e `work.md` como raiz do bundle;
+5. as camadas correspondentes compartilham `chapter_id` e IDs menores namespaced por obra;
+6. narração adapta a forma para TTS sem substituir a tradução;
+7. TTS é pluggable e provider-neutral;
+8. idioma não listado no model card não elimina candidato;
+9. zero-shot é testado antes de qualquer adaptação;
+10. escolha de modelo passa por benchmark pt-BR próprio e pode variar por obra;
+11. código de produção é CLI-first e script-first;
+12. `.ipynb` não é fonte operacional do projeto;
+13. Colab e Kaggle são runners do mesmo worker;
+14. Kaggle usa `kernel_type: script`;
+15. GitHub Actions é o plano de controle e ponto único de operação;
+16. credenciais remotas ficam em GitHub Secrets;
+17. chamadas pagas começam manuais/dry-run;
+18. binários de áudio são derivados;
+19. cada obra publicável recebe um podcast/feed RSS próprio;
+20. GUID de episódio é estável e independente de TTS/storage;
+21. o feed RSS canônico é hospedado pelo blog;
+22. mídia pesada usa storage separado do GitHub Pages quando necessário;
+23. Internet Archive é o destino durável preferencial quando habilitado;
+24. o blog terá catálogo `/audiobooks/` e páginas data-driven por obra;
+25. Bhagavad Gita é o segundo caso de referência de generalidade, sem conteúdo exigido no kickstart.
 
 ## 20. Primeira próxima ação
 
-A próxima PR após este PRD deve implementar a **Fase 1**. Em paralelo, a implementação da Fase 2 já deve preservar o contrato de que o worker será um script Python comum executável por GitHub Actions e despachável por CLI, sem notebook como camada intermediária.
+A próxima PR após este PRD deve implementar a **Fase 1** como motor genérico + HPMOR como primeira instância. A estrutura e os testes já devem tornar impossível acoplar silenciosamente o código a `hpmor`, preservando desde o início o caminho para Bhagavad Gita e futuras obras.

--- a/docs/okf/audiobook/prd.md
+++ b/docs/okf/audiobook/prd.md
@@ -1,8 +1,8 @@
 ---
 type: Product Requirements Document
-title: Audiolivro HPMOR em português — pipeline OKF e TTS
-description: PRD para uma pipeline reproduzível de original, tradução, adaptação de narração e geração incremental de audiolivro.
-tags: [audiobook, hpmor, okf, translation, tts, github-actions]
+title: Audiolivro HPMOR em português — pipeline OKF, TTS e compute CLI-first
+description: PRD para uma pipeline reproduzível de original, tradução, adaptação de narração, benchmark de TTS e geração incremental de audiolivro com runners remotos acionados por linha de comando.
+tags: [audiobook, hpmor, okf, translation, tts, github-actions, kaggle, colab, cli]
 timestamp: 2026-08-30T16:37:00Z
 ---
 
@@ -16,11 +16,11 @@ O princípio central é separar rigorosamente três representações textuais do
 
 1. **original** — o texto-fonte em inglês, preservado como referência;
 2. **tradução** — uma tradução fiel para português brasileiro, adequada para leitura humana e comparação com o original;
-3. **narração** — uma adaptação da tradução destinada especificamente à síntese de voz, podendo ajustar pontuação, pronúncia, pausas, expansão de símbolos, divisão de falas e outras instruções necessárias para que o TTS produza o resultado esperado.
+3. **narração** — uma adaptação da tradução destinada especificamente à síntese de voz, podendo ajustar pontuação, pronúncia, pausas, expansão de símbolos, divisão de falas e instruções de interpretação necessárias para que o TTS produza o resultado esperado.
 
-As três camadas são Markdown em formato OKF e compartilham a mesma identidade de obra e de capítulo. O áudio é derivado da camada de narração; nunca é a fonte canônica do texto.
+As três camadas são Markdown em formato OKF e compartilham a mesma identidade de obra e capítulo. O áudio é derivado da camada de narração; nunca é a fonte canônica do texto.
 
-A computação pesada deve ser executável por GitHub Actions. A pipeline deve ser incremental: uma alteração pequena em texto, voz ou configuração não deve obrigar a regenerar o livro inteiro.
+A computação de GPU deve ser **CLI-first**. O projeto não usa notebooks como interface operacional nem como fonte executável canônica. Toda lógica de produção vive em scripts versionados; Kaggle, Colab e futuros provedores são apenas runners remotos desses scripts.
 
 ## 2. Problema
 
@@ -30,14 +30,15 @@ Um fluxo ingênuo de `texto -> TTS -> arquivo de áudio` perde informação e mi
 - correções de pronúncia ou ritmo acabam contaminando a tradução canônica;
 - não existe uma ligação determinística entre original, tradução e trecho de áudio;
 - regenerar um capítulo inteiro por causa de uma fala é caro e lento;
-- trocar de provedor de TTS exige refazer a arquitetura;
+- trocar de modelo ou provedor de TTS exige refazer a arquitetura;
+- notebooks manuais tornam a execução difícil de automatizar, revisar e reproduzir;
 - artefatos derivados podem se tornar impossíveis de reproduzir depois.
 
 O projeto deve transformar o audiolivro em um sistema de conteúdo versionado, auditável e regenerável.
 
 ## 3. Objetivo do produto
 
-Entregar uma pipeline capaz de, para cada capítulo:
+Entregar uma pipeline capaz de executar, para cada capítulo:
 
 ```text
 original OKF
@@ -49,7 +50,17 @@ tradução OKF
 narração OKF
     |
     v
-segmentos TTS
+planner
+    |
+    v
+worker TTS (.py)
+    |
+    +--> local
+    +--> Colab CLI
+    +--> Kaggle CLI
+    |
+    v
+segmentos de áudio
     |
     v
 áudio do capítulo
@@ -58,7 +69,7 @@ segmentos TTS
     +--> artefatos de distribuição futuros
 ```
 
-O HPMOR é o primeiro corpus e o caso de uso de referência. A arquitetura, porém, não deve depender semanticamente de HPMOR e deve poder ser reutilizada para outras obras no futuro.
+O HPMOR é o primeiro corpus e o caso de uso de referência. A arquitetura não deve depender semanticamente de HPMOR e deve poder ser reutilizada para outras obras.
 
 ## 4. Princípios
 
@@ -74,51 +85,68 @@ A tradução deve permanecer linguisticamente fiel e legível. Ajustes feitos ap
 
 Toda representação equivalente do mesmo capítulo deve carregar o mesmo `work_id` e `chapter_id`.
 
-Exemplo:
-
 ```yaml
 work_id: hpmor
 chapter_id: hpmor-001
 chapter_number: 1
 ```
 
-A tradução e a narração devem apontar explicitamente para a camada da qual derivam.
+A tradução e a narração apontam explicitamente para a camada da qual derivam.
 
 ### 4.4. Unidades menores que o capítulo
 
-A geração de áudio deve operar sobre segmentos estáveis menores que um capítulo. Um segmento pode ser uma fala, um parágrafo narrativo ou outra unidade suficientemente pequena para regeneração isolada.
+A geração de áudio opera sobre segmentos estáveis menores que um capítulo. Um segmento pode ser uma fala, um parágrafo narrativo ou outra unidade suficientemente pequena para regeneração isolada.
 
-Cada segmento deve possuir um `segment_id` estável dentro do capítulo. O mesmo ID deve ser preservado sempre que a unidade correspondente continua semanticamente sendo a mesma.
+Cada segmento possui `segment_id` estável. O mesmo ID é preservado enquanto a unidade correspondente continua semanticamente sendo a mesma.
 
-### 4.5. Provedor de TTS é implementação, não contrato
+### 4.5. TTS é implementação, não contrato
 
-A camada canônica de narração não deve depender de OpenAI, ElevenLabs, Google, modelo local ou qualquer outro fornecedor específico.
+A camada canônica de narração não depende de Breeze, Higgs, Chatterbox, Qwen, Fish, OpenAI, Google ou qualquer outro fornecedor específico.
 
-Um adaptador transforma o formato canônico de narração no request particular de cada backend.
+Um adapter transforma a representação canônica de narração no formato esperado pelo backend selecionado.
 
-### 4.6. Reprodutibilidade por hash
+### 4.6. Idioma declarado pelo modelo não é gate
+
+A ausência de `pt-BR` ou `Portuguese` no model card não elimina um modelo do benchmark.
+
+Modelos generativos podem produzir português adequadamente mesmo quando o idioma não é oficialmente suportado ou avaliado. O critério do projeto é empírico: o modelo permanece candidato enquanto produzir resultado aceitável no corpus de benchmark em português brasileiro.
+
+Nenhum fine-tune deve ser presumido antes de testar zero-shot.
+
+### 4.7. Reprodutibilidade por hash
 
 Um segmento de áudio é identificado por uma chave derivada, no mínimo, de:
 
-- texto de narração do segmento;
+- texto de narração;
 - identidade/configuração da voz;
-- backend e modelo de TTS;
-- parâmetros relevantes do backend;
-- versão do schema/adaptador de narração.
+- backend e modelo TTS;
+- parâmetros relevantes;
+- seed, quando aplicável;
+- versão do adapter;
+- versão do schema de narração.
 
-Se essa chave não mudar e o artefato existir, a pipeline deve reutilizá-lo.
+Se a chave não mudar e o artefato existir, a pipeline reutiliza o áudio.
 
-### 4.7. Git guarda estado; áudio pesado não precisa morar no Git
+### 4.8. Git guarda estado; áudio pesado não precisa morar no Git
 
-O repositório deve guardar corpus, manifestos, configuração, proveniência e hashes. Arquivos de áudio pesados podem ser produzidos por Actions e armazenados como artifacts ou em um destino de publicação definido posteriormente.
+O repositório guarda corpus, manifestos, configuração, proveniência e hashes. Arquivos pesados podem ser mantidos como artifacts ou em um destino de publicação definido posteriormente.
 
-Não é requisito inicial versionar binários de áudio no histórico Git.
+### 4.9. CLI-first; notebooks não são fonte executável
+
+A fonte operacional do projeto é composta por scripts versionados (`.py`, `.sh` e, quando útil, ferramentas Node já existentes no repo).
+
+Regras:
+
+- nenhuma etapa exige abrir uma UI de notebook;
+- `.ipynb` não é formato canônico de código do projeto;
+- um runner pode internamente usar infraestrutura Jupyter, mas isso é detalhe do provedor;
+- o mesmo worker Python deve ser executável localmente, no Colab e no Kaggle com o mínimo possível de diferenças;
+- toda execução remota deve poder ser iniciada, observada e ter seus resultados recuperados por linha de comando;
+- comandos usados manualmente devem ser automatizáveis posteriormente por GitHub Actions.
 
 ## 5. Modelo de conteúdo
 
 ### 5.1. Estrutura-alvo
-
-A estrutura inicial proposta é:
 
 ```text
 data/audiobooks/
@@ -137,13 +165,20 @@ data/audiobooks/
       ...
     voices.yaml
     manifest.json
+
+scripts/audiobook/
+  worker.py
+  plan.py
+  validate.py
+  assemble.py
+  runners/
+    colab.sh
+    kaggle.sh
 ```
 
-O corpus fica fora de `src/content/blog/**`: ele não é um post do Hrönir e não deve entrar acidentalmente em ranking, versionamento ou seleção de posts. O site poderá consumi-lo posteriormente por um loader dedicado, seguindo o princípio já usado em outras fontes derivadas do blog.
+O corpus fica fora de `src/content/blog/**`: ele não é um post do Hrönir e não deve entrar acidentalmente em ranking, versionamento ou seleção de posts.
 
 ### 5.2. Original
-
-Exemplo mínimo:
 
 ```markdown
 ---
@@ -164,14 +199,12 @@ Texto original...
 
 Requisitos:
 
-- preservar a proveniência do texto;
+- preservar a proveniência;
 - registrar digest do conteúdo importado;
-- não incluir adaptações feitas para português ou TTS;
-- manter IDs de segmentos estáveis após a primeira segmentação, salvo quando a própria segmentação precisar mudar.
+- não conter adaptação para português ou TTS;
+- manter IDs de segmentos estáveis após a primeira segmentação.
 
 ### 5.3. Tradução
-
-Exemplo mínimo:
 
 ```markdown
 ---
@@ -191,15 +224,13 @@ Texto traduzido...
 
 Requisitos:
 
-- usar o mesmo `chapter_id` do original;
-- conservar o alinhamento por `segment_id` sempre que possível;
-- ser adequada como tradução para leitura humana;
-- não conter truques específicos de TTS apenas para alterar a pronúncia do sintetizador;
-- permitir comparação automática original <-> tradução por capítulo e segmento.
+- mesmo `chapter_id` do original;
+- alinhamento por `segment_id`;
+- tradução adequada para leitura humana;
+- nenhum truque específico de sintetizador;
+- comparação automática original <-> tradução por capítulo e segmento.
 
 ### 5.4. Narração
-
-Exemplo mínimo:
 
 ```markdown
 ---
@@ -218,29 +249,27 @@ narration_schema: 1
 Texto preparado especificamente para ser narrado...
 ```
 
-A sintaxe exata das diretivas poderá evoluir na primeira implementação, mas o contrato é fixo:
+O contrato da camada:
 
-- Markdown continua legível sem um renderer especial;
+- Markdown continua legível sem renderer especial;
 - cada trecho enviado ao TTS possui identidade estável;
-- `speaker` e demais instruções são provider-neutral;
-- instruções específicas de um fornecedor não entram no corpus canônico;
-- a adaptação pode divergir superficialmente da tradução quando isso melhora a realização oral sem mudar o sentido pretendido.
+- `speaker`, emoção, ritmo, pausa e demais instruções são provider-neutral;
+- tags proprietárias de um modelo não entram no corpus canônico;
+- a adaptação pode divergir superficialmente da tradução para melhorar a realização oral sem mudar o sentido.
 
-Casos típicos da camada de narração:
+Casos típicos:
 
-- escrever por extenso uma sigla ou expressão que o TTS pronuncia incorretamente;
-- introduzir ou retirar pontuação para obter a pausa correta;
-- marcar alternância entre narrador e personagens;
-- estabelecer pronúncia canônica de nomes;
-- dividir uma frase longa em dois requests;
-- controlar pausas e ênfases;
-- eliminar artefatos tipográficos que não devem ser verbalizados.
+- escrever uma sigla por extenso;
+- ajustar pontuação para obter pausas;
+- marcar narrador/personagem;
+- definir pronúncia de nomes;
+- dividir frases longas;
+- controlar ritmo, ênfase e emoção;
+- eliminar artefatos tipográficos não verbalizados.
 
 ## 6. Vozes
 
-`voices.yaml` define identidades lógicas de voz, não IDs rígidos de um único fornecedor.
-
-Exemplo conceitual:
+`voices.yaml` define identidades lógicas, não IDs rígidos de um fornecedor.
 
 ```yaml
 narrator:
@@ -256,70 +285,238 @@ mcgonagall:
   locale: pt-BR
 ```
 
-Cada backend mantém separadamente o mapeamento de identidade lógica para voz/modelo concreto.
+Cada backend mantém separadamente o mapeamento da identidade lógica para referência, prompt, voice clone ou configuração concreta.
 
-Isso permite:
+Isso permite trocar modelo sem reescrever o corpus e comparar backends mantendo a mesma intenção de voz.
 
-- trocar o fornecedor sem reescrever o corpus;
-- comparar vozes de diferentes backends;
-- manter a identidade de um personagem ao longo de todos os capítulos;
-- alterar uma voz e invalidar somente os segmentos afetados.
+## 7. Benchmark de TTS
 
-## 7. Pipeline
+### 7.1. Escolha empírica
 
-### 7.1. Estágios
+Nenhum modelo é escolhido definitivamente por leaderboard ou model card.
 
-A pipeline deve expor estágios independentes:
+O projeto mantém um corpus pequeno de benchmark pt-BR com segmentos que cubram:
+
+- narração neutra;
+- diálogo coloquial;
+- perguntas/exclamações;
+- ironia;
+- medo, raiva e outras emoções;
+- fala baixa/sussurro quando suportado;
+- frases longas;
+- números, siglas e abreviações;
+- fonemas e encontros relevantes do português brasileiro;
+- nomes ingleses dentro de frase portuguesa;
+- alternância pt-BR/inglês;
+- passagens mais longas para testar estabilidade.
+
+### 7.2. Candidatos iniciais
+
+A primeira rodada deve permitir pelo menos:
+
+- Breeze TTS 2;
+- Higgs TTS 3;
+- Chatterbox V3 / pt-BR;
+- Qwen3-TTS;
+- Fish S2.x, enquanto acessível.
+
+A lista é expansível sem alterar o contrato do corpus.
+
+### 7.3. Métricas
+
+Registrar, quando aplicável:
+
+- preferência cega humana;
+- naturalidade em pt-BR;
+- inteligibilidade/pronúncia;
+- expressividade e aderência à direção narrativa;
+- estabilidade da identidade da voz;
+- repetições, omissões e alucinações;
+- duração produzida;
+- real-time factor;
+- VRAM observada;
+- falhas de execução;
+- custo monetário;
+- quantidade de intervenção manual necessária.
+
+A escolha para produção deve privilegiar qualidade de audiobook e estabilidade, não apenas WER.
+
+## 8. Worker TTS único
+
+A unidade executável de geração deve ser um script Python, inicialmente `scripts/audiobook/worker.py`.
+
+Contrato conceitual:
+
+```text
+python scripts/audiobook/worker.py \
+  --work hpmor \
+  --chapter 1 \
+  --backend breeze \
+  --model <modelo> \
+  --input-plan <plan.json> \
+  --output-dir <dir>
+```
+
+O worker:
+
+1. lê um plano de segmentos já validado;
+2. instala/carrega apenas o backend selecionado;
+3. gera cada segmento de forma independente;
+4. escreve áudio + metadata de execução;
+5. não altera original, tradução ou narração;
+6. pode retomar execução parcial;
+7. encerra com código diferente de zero em falhas não recuperáveis.
+
+O script deve ser capaz de detectar a GPU disponível e registrar hardware, versões e parâmetros no manifesto da execução.
+
+Dependências Python devem ser declaradas de forma autocontida sempre que viável, preferencialmente com PEP 723/`uv run`, evitando manter ambientes manuais diferentes por runner.
+
+## 9. Runners de compute
+
+### 9.1. Princípio
+
+Colab e Kaggle não recebem implementações distintas do TTS. Eles recebem o mesmo worker.
+
+O adapter de runner resolve apenas:
+
+- provisionamento/acelerador;
+- envio do script e inputs;
+- autenticação;
+- acompanhamento do job;
+- recuperação dos outputs;
+- teardown quando aplicável.
+
+### 9.2. Colab CLI
+
+O caminho preferido é o CLI oficial do Google Colab, executando diretamente o arquivo Python local.
+
+Forma conceitual:
+
+```bash
+colab run --gpu T4 scripts/audiobook/worker.py -- \
+  --work hpmor \
+  --chapter 1 \
+  --backend breeze \
+  --input-plan plan.json \
+  --output-dir output
+```
+
+Quando for útil reutilizar uma VM durante vários testes, o runner pode usar `colab new`, `colab install`, `colab exec`, `colab download` e `colab stop` em vez do job efêmero.
+
+O projeto não presume que um tipo específico de GPU estará sempre disponível. Falha de quota ou alocação deve ser tratada como indisponibilidade do runner, não como falha do modelo TTS.
+
+### 9.3. Kaggle CLI
+
+Kaggle deve ser usado como **script kernel**, não notebook.
+
+O staging do job contém:
+
+```text
+.kaggle-job/
+  worker.py
+  plan.json
+  kernel-metadata.json
+```
+
+`kernel-metadata.json` usa:
+
+```json
+{
+  "code_file": "worker.py",
+  "language": "python",
+  "kernel_type": "script",
+  "is_private": true,
+  "enable_gpu": true
+}
+```
+
+Fluxo conceitual:
+
+```bash
+kaggle kernels push -p .kaggle-job --accelerator NvidiaTeslaT4
+kaggle kernels status <user>/<job>
+kaggle kernels output <user>/<job> -p output
+```
+
+O wrapper deve gerar o staging automaticamente; nenhum `.ipynb` precisa existir no repositório.
+
+### 9.4. Local
+
+O mesmo worker deve continuar executável localmente para CPU/GPU disponível, testes e depuração.
+
+O runner local também é a implementação de referência para o contrato de entrada/saída.
+
+## 10. Pipeline
+
+A pipeline expõe estágios independentes:
 
 1. `import` — obtém/normaliza o original e calcula proveniência/digest;
-2. `translate` — cria ou atualiza a camada de tradução;
-3. `prepare-narration` — cria ou atualiza a camada orientada ao TTS;
-4. `validate` — verifica IDs, alinhamento, links de derivação e schema;
-5. `plan` — calcula quais segmentos precisam ser sintetizados e quanto trabalho será executado;
-6. `synthesize` — gera apenas segmentos ausentes ou invalidados;
-7. `assemble` — concatena segmentos em capítulo, preservando ordem e metadados;
-8. `publish` — disponibiliza artefatos no destino configurado.
+2. `translate` — cria ou atualiza a tradução;
+3. `prepare-narration` — cria ou atualiza a camada de narração;
+4. `validate` — verifica IDs, alinhamento, links e schema;
+5. `plan` — calcula segmentos, cache keys e trabalho pendente;
+6. `benchmark` — opcionalmente gera as mesmas amostras em múltiplos backends;
+7. `synthesize` — despacha o worker para runner local/Colab/Kaggle;
+8. `assemble` — concatena segmentos em capítulo;
+9. `publish` — disponibiliza artefatos.
 
-Cada estágio deve poder ser executado sem obrigatoriamente executar os posteriores.
+Cada estágio pode ser executado sem obrigatoriamente executar os posteriores.
 
-### 7.2. Dry-run obrigatório
+### 10.1. Dry-run obrigatório
 
-Qualquer workflow capaz de chamar um serviço pago deve possuir modo `dry-run` que mostre:
+Antes de síntese, `plan` deve mostrar:
 
-- capítulo(s) selecionado(s);
-- número de segmentos a gerar;
-- backend/modelo/voz resolvidos;
-- segmentos reutilizados do cache;
+- capítulos selecionados;
+- segmentos a gerar;
+- backend/modelo/voz;
+- runner escolhido;
+- segmentos reutilizados;
 - segmentos invalidados;
-- estimativa de caracteres ou outra unidade de cobrança disponível.
+- estimativa de caracteres/duração/custo quando disponível.
 
-Nenhum evento de `push` comum deve, na primeira versão, disparar automaticamente uma despesa de TTS.
+Nenhum `push` comum dispara automaticamente despesa de API.
 
-### 7.3. GitHub Actions
+## 11. GitHub Actions
 
-O primeiro workflow de produção deve usar `workflow_dispatch` e aceitar, no mínimo:
+GitHub Actions é **orquestrador**, não requisito de GPU.
+
+O workflow de produção deve poder:
+
+1. validar o corpus;
+2. gerar o plano;
+3. escolher runner;
+4. invocar `colab` ou `kaggle` CLI, ou usar um backend HTTP quando configurado;
+5. acompanhar a execução;
+6. recuperar outputs;
+7. validar manifestos;
+8. montar/publicar artefatos.
+
+O primeiro workflow usa `workflow_dispatch` e aceita, no mínimo:
 
 - obra;
-- capítulo ou intervalo de capítulos;
-- backend;
+- capítulo ou intervalo;
+- backend/modelo;
+- runner (`local`, `colab`, `kaggle`, `api` quando houver);
 - `dry_run`;
-- `force` para ignorar cache, quando necessário.
+- `force` para ignorar cache.
 
-Credenciais de serviços externos entram somente por GitHub Actions secrets e nunca são escritas no corpus, logs ou artefatos.
+Credenciais externas entram somente por secrets/configuração segura e nunca no corpus, logs ou artefatos públicos.
 
-## 8. Manifesto derivado
+A autenticação headless de cada CLI deve ser validada antes de torná-la runner automático de Actions. Um runner pode inicialmente ser acionado manualmente por CLI sem impedir que o resto da pipeline seja automatizado.
 
-A pipeline deve produzir um manifesto por build, contendo informação suficiente para reproduzir e auditar o resultado.
+## 12. Manifesto derivado
 
-Exemplo conceitual:
+A pipeline produz manifesto suficiente para reproduzir e auditar o resultado.
 
 ```json
 {
   "work_id": "hpmor",
   "chapter_id": "hpmor-001",
   "narration_digest": "sha256:...",
-  "backend": "example",
-  "model": "example-model",
+  "runner": "kaggle",
+  "hardware": "NvidiaTeslaT4",
+  "backend": "breeze",
+  "model": "...",
   "segments": [
     {
       "segment_id": "hpmor-001-s0001",
@@ -332,165 +529,176 @@ Exemplo conceitual:
 }
 ```
 
-O manifesto é derivado e pode ser regenerado. Ele não substitui os três bundles textuais.
+O manifesto é derivado e não substitui os três bundles textuais.
 
-## 9. Validação
-
-O projeto deve falhar cedo quando houver inconsistência estrutural.
+## 13. Validação
 
 Validações mínimas:
 
-- todos os arquivos possuem `type` OKF;
-- todo capítulo possui `work_id`, `chapter_id`, `chapter_number` e `lang` válidos;
-- original, tradução e narração de um capítulo concordam em `work_id` e `chapter_id`;
-- `derived_from` resolve para arquivo existente;
-- `segment_id` não se repete dentro de uma obra;
-- a ordem dos segmentos é determinística;
-- um segmento de tradução/narração não referencia silenciosamente um segmento inexistente no ancestral;
+- todos os documentos possuem `type` OKF;
+- todo capítulo possui `work_id`, `chapter_id`, `chapter_number` e `lang`;
+- original, tradução e narração concordam em identidade;
+- `derived_from` resolve;
+- `segment_id` não se repete dentro da obra;
+- ordem dos segmentos é determinística;
+- descendentes não referenciam silenciosamente segmentos inexistentes;
 - manifestos nunca são tratados como fonte canônica;
-- nenhum segredo aparece em arquivos versionados.
+- nenhum segredo aparece versionado;
+- runner não modifica corpus canônico;
+- outputs declarados pelo worker correspondem ao plano recebido.
 
-A implementação deve preferir validação por ferramenta existente do ecossistema OKF quando ela já cobre o requisito, complementando somente o que é específico do domínio de audiolivro.
+## 14. Site
 
-## 10. Site
+A primeira entrega não exige uma experiência pública completa, mas a arquitetura deve permitir que `franklinbaldo.github.io` seja o frontend do audiolivro.
 
-A primeira entrega não exige uma experiência pública completa, mas a arquitetura deve permitir que o próprio `franklinbaldo.github.io` se torne o frontend do audiolivro.
-
-Uma fase posterior pode oferecer:
+Fases posteriores podem oferecer:
 
 - página da obra;
 - índice de capítulos;
-- player por capítulo;
+- player;
 - indicação do trecho corrente;
 - texto traduzido sincronizado;
-- comparação opcional original/tradução;
-- feed RSS/podcast;
-- M4B ou outros formatos de distribuição.
+- comparação original/tradução;
+- RSS/podcast;
+- M4B e outros formatos.
 
-A interface web consome artefatos da pipeline; não redefine o corpus canônico.
+A interface consome artefatos; não redefine o corpus canônico.
 
-## 11. Escopo autoral e de publicação
+## 15. Escopo autoral e publicação
 
 O projeto nasce como experimento pessoal, aberto e não comercial. Questões de autorização, política de distribuição ou eventual mudança de alcance não são gate para o kickstart técnico.
 
-Se o projeto adquirir distribuição material, monetização ou outra relevância que altere seu perfil de risco, essa etapa deve receber revisão própria antes de ampliar a publicação. Essa revisão é uma decisão de distribuição, não um requisito para modelar o corpus e construir a pipeline.
+Se o projeto adquirir distribuição material, monetização ou relevância que altere seu perfil de risco, a publicação deve receber revisão própria antes de ser ampliada.
 
-## 12. Não-objetivos iniciais
+## 16. Não-objetivos iniciais
 
 Não fazem parte do kickstart:
 
-- gerar imediatamente todos os capítulos;
-- escolher definitivamente um fornecedor de TTS;
+- gerar todos os capítulos imediatamente;
+- escolher um vencedor TTS sem benchmark próprio;
+- adaptar/fine-tunar modelo antes de testar zero-shot;
 - criar vozes clonadas de atores ou pessoas reais;
-- produzir uma dramatização com efeitos sonoros e trilha;
-- otimizar o site antes de existir um capítulo end-to-end;
-- armazenar grandes binários de áudio no histórico Git;
-- automatizar gasto de API em todo `push`;
-- transformar a camada de tradução em texto cheio de instruções de sintetizador.
+- dramatização com efeitos/trilha;
+- armazenar grandes binários no Git;
+- automatizar gasto em todo `push`;
+- contaminar tradução com comandos de sintetizador;
+- manter notebooks operacionais ou uma pipeline paralela em `.ipynb`.
 
-## 13. Fases
+## 17. Fases
 
 ### Fase 0 — contrato
 
 Esta PR.
 
-Entregáveis:
-
-- PRD OKF;
-- decisão explícita das três camadas;
-- identidade compartilhada entre as camadas;
-- contrato de pipeline incremental e provider-neutral.
-
-Critério de aceite: o documento é suficiente para implementar a Fase 1 sem precisar decidir novamente a arquitetura fundamental.
+Critério de aceite: o documento fixa arquitetura de corpus, benchmark, worker e compute CLI-first.
 
 ### Fase 1 — corpus mínimo e validação
 
 Entregáveis:
 
-- criar `data/audiobooks/hpmor/{original,translation,narration}`;
-- adicionar o capítulo 1 nas três camadas;
-- definir `voices.yaml` mínimo;
-- implementar validador de IDs, `derived_from` e segmentos;
-- adicionar testes/fixtures;
-- nenhuma chamada de rede paga.
+- `data/audiobooks/hpmor/{original,translation,narration}`;
+- capítulo 1 nas três camadas;
+- `voices.yaml` mínimo;
+- validador de IDs, derivação e segmentos;
+- fixtures/testes;
+- nenhuma chamada paga.
 
-Critério de aceite: um agente consegue percorrer deterministicamente `original -> translation -> narration` do capítulo 1 e mapear cada segmento correspondente.
+Critério de aceite: um agente percorre deterministicamente `original -> translation -> narration` do capítulo 1 e mapeia os segmentos correspondentes.
 
-### Fase 2 — planner e backend abstrato
+### Fase 2 — planner, worker e runners
 
 Entregáveis:
 
-- parser da camada de narração;
+- parser da narração;
 - representação interna de requests TTS;
 - interface de backend;
-- cálculo de cache key;
-- comando `plan`/dry-run;
-- backend fake para testes.
+- cache key;
+- `plan`/dry-run;
+- backend fake;
+- `scripts/audiobook/worker.py`;
+- runner local;
+- wrappers CLI para Colab e Kaggle;
+- Kaggle configurado como `kernel_type: script`;
+- nenhum notebook requerido.
 
-Critério de aceite: o sistema informa exatamente quais segmentos seriam gerados sem chamar um serviço externo.
+Critério de aceite: o mesmo worker executa um job fake localmente e pode ser despachado pelos dois CLIs remotos sem divergência de contrato.
 
-### Fase 3 — primeiro capítulo em áudio
+### Fase 3 — benchmark real
 
 Entregáveis:
 
-- um backend real de TTS;
-- workflow manual em GitHub Actions;
-- geração incremental dos segmentos;
+- adapters dos candidatos selecionados;
+- corpus benchmark pt-BR;
+- execução comparável em pelo menos um runner gratuito disponível;
+- amostras e manifestos comparáveis;
+- relatório de qualidade/estabilidade/desempenho.
+
+Critério de aceite: existe evidência própria suficiente para escolher ou ordenar os modelos para o capítulo 1.
+
+### Fase 4 — primeiro capítulo em áudio
+
+Entregáveis:
+
+- backend/modelo selecionado;
+- geração incremental;
 - montagem do capítulo;
-- manifesto com digests e duração;
-- artifact de Actions com o áudio resultante.
+- manifesto completo;
+- artifact com áudio resultante.
 
-Critério de aceite: o capítulo 1 é reproduzível a partir do commit do corpus e da configuração declarada.
+Critério de aceite: capítulo 1 reproduzível a partir do commit, configuração e runner declarado.
 
-### Fase 4 — experiência no blog
+### Fase 5 — experiência no blog
 
 Entregáveis:
 
-- loader/coleção dedicada;
+- loader dedicado;
 - página da obra;
 - página/player de capítulo;
-- metadados suficientes para navegação.
+- metadados de navegação.
 
-Critério de aceite: o capítulo produzido pela Fase 3 pode ser ouvido no frontend sem duplicar manualmente conteúdo ou metadados.
-
-### Fase 5 — escala
+### Fase 6 — escala
 
 Somente após o capítulo 1 estar satisfatório:
 
-- tradução/adaptação dos capítulos seguintes;
-- revisão de consistência de personagens e pronúncia;
+- capítulos seguintes;
+- consistência de personagens/pronúncia;
 - geração batch incremental;
-- estratégia de armazenamento/publicação durável;
-- formatos de distribuição adicionais.
+- armazenamento/publicação durável;
+- formatos adicionais.
 
-## 14. Métricas de sucesso
+## 18. Métricas de sucesso
 
 O projeto é bem-sucedido quando:
 
-- qualquer trecho traduzido pode ser rastreado ao original correspondente;
-- qualquer trecho narrado pode ser rastreado à tradução correspondente;
-- qualquer segmento de áudio pode ser rastreado ao texto/configuração que o gerou;
-- corrigir uma única fala não força a regeneração do capítulo inteiro;
-- trocar de backend não exige reescrever o corpus de narração;
-- o capítulo 1 pode ser regenerado deterministicamente por GitHub Actions;
-- o corpus continua compreensível como Markdown sem depender da ferramenta de TTS.
+- qualquer tradução é rastreável ao original;
+- qualquer narração é rastreável à tradução;
+- qualquer áudio é rastreável ao texto/configuração/modelo/runner;
+- corrigir uma fala não força regenerar o capítulo inteiro;
+- trocar backend não exige reescrever o corpus;
+- o mesmo worker roda localmente e em compute remoto;
+- nenhum notebook manual é necessário;
+- o capítulo 1 pode ser reproduzido por comandos documentados;
+- o corpus continua compreensível como Markdown sem ferramenta de TTS.
 
-## 15. Decisões já tomadas
+## 19. Decisões já tomadas
 
-Estas decisões são parte do contrato do produto e não devem ser reabertas durante a Fase 1 sem evidência concreta de inviabilidade:
-
-1. haverá três camadas textuais: original, tradução e narração;
+1. haverá três camadas: original, tradução e narração;
 2. todas serão Markdown compatível com OKF;
-3. original e tradução são separados por capítulo;
-4. as camadas correspondentes compartilham o mesmo `chapter_id`;
-5. o alinhamento deve chegar a unidades menores que o capítulo para permitir rastreabilidade e geração incremental;
-6. a narração pode adaptar a forma do texto para TTS, mas não substitui a tradução canônica;
-7. TTS é pluggable e provider-neutral no contrato canônico;
-8. GitHub Actions será um ambiente suportado para a computação de produção;
-9. chamadas pagas começam manuais e com dry-run;
-10. binários de áudio são derivados e não precisam ser commitados no Git;
-11. o HPMOR é o corpus inicial, não uma dependência arquitetural do motor.
+3. as camadas correspondentes compartilham `chapter_id` e IDs menores;
+4. narração adapta a forma para TTS sem substituir a tradução;
+5. TTS é pluggable e provider-neutral;
+6. idioma não listado no model card não elimina candidato;
+7. zero-shot é testado antes de qualquer adaptação;
+8. escolha de modelo passa por benchmark pt-BR próprio;
+9. código de produção é CLI-first e script-first;
+10. `.ipynb` não é fonte operacional do projeto;
+11. Colab e Kaggle são runners do mesmo worker;
+12. Kaggle usa `kernel_type: script`;
+13. GitHub Actions atua como orquestrador e não precisa fornecer GPU;
+14. chamadas pagas começam manuais/dry-run;
+15. binários de áudio são derivados;
+16. HPMOR é o corpus inicial, não uma dependência arquitetural.
 
-## 16. Primeira próxima ação
+## 20. Primeira próxima ação
 
-A próxima PR após este PRD deve implementar exclusivamente a **Fase 1**: estrutura do corpus, capítulo 1 nas três camadas, identidade/alinhamento e validação local, sem integrar ainda um fornecedor real de TTS.
+A próxima PR após este PRD deve implementar a **Fase 1**. Em paralelo, a implementação da Fase 2 já deve preservar o contrato de que o worker será um script Python comum executável por CLI, sem notebook como camada intermediária.

--- a/docs/okf/audiobook/prd.md
+++ b/docs/okf/audiobook/prd.md
@@ -2,7 +2,7 @@
 type: Product Requirements Document
 title: Audiolivro HPMOR em português — pipeline OKF, TTS e compute CLI-first
 description: PRD para uma pipeline reproduzível de original, tradução, adaptação de narração, benchmark de TTS e geração incremental de audiolivro com runners remotos acionados por linha de comando.
-tags: [audiobook, hpmor, okf, translation, tts, github-actions, kaggle, colab, cli]
+tags: [audiobook, hpmor, okf, translation, tts, github-actions, kaggle, colab, cli, podcast]
 timestamp: 2026-08-30T16:37:00Z
 ---
 
@@ -22,6 +22,10 @@ As três camadas são Markdown em formato OKF e compartilham a mesma identidade 
 
 A computação de GPU deve ser **CLI-first**. O projeto não usa notebooks como interface operacional nem como fonte executável canônica. Toda lógica de produção vive em scripts versionados; Kaggle, Colab e futuros provedores são apenas runners remotos desses scripts.
 
+GitHub Actions é o ponto único de operação da pipeline: valida, planeja, despacha compute remoto usando credenciais em GitHub Secrets, recupera outputs, monta o capítulo e publica os artefatos. O contrato detalhado está em [`github-actions-execution.md`](./github-actions-execution.md).
+
+Capítulos publicados também devem ser distribuídos como episódios de um podcast RSS hospedado pelo blog. O usuário assina o feed uma vez e recebe os capítulos seguintes automaticamente no tocador de podcast. O contrato de publicação está em [`podcast-publication.md`](./podcast-publication.md).
+
 ## 2. Problema
 
 Um fluxo ingênuo de `texto -> TTS -> arquivo de áudio` perde informação e mistura responsabilidades:
@@ -32,9 +36,10 @@ Um fluxo ingênuo de `texto -> TTS -> arquivo de áudio` perde informação e mi
 - regenerar um capítulo inteiro por causa de uma fala é caro e lento;
 - trocar de modelo ou provedor de TTS exige refazer a arquitetura;
 - notebooks manuais tornam a execução difícil de automatizar, revisar e reproduzir;
-- artefatos derivados podem se tornar impossíveis de reproduzir depois.
+- artefatos derivados podem se tornar impossíveis de reproduzir depois;
+- publicar áudio sem feed estável obriga o ouvinte a acompanhar manualmente o site em vez de usar um tocador de podcast.
 
-O projeto deve transformar o audiolivro em um sistema de conteúdo versionado, auditável e regenerável.
+O projeto deve transformar o audiolivro em um sistema de conteúdo versionado, auditável, regenerável e assinável.
 
 ## 3. Objetivo do produto
 
@@ -58,6 +63,7 @@ worker TTS (.py)
     +--> local
     +--> Colab CLI
     +--> Kaggle CLI
+    +--> API TTS
     |
     v
 segmentos de áudio
@@ -65,7 +71,8 @@ segmentos de áudio
     v
 áudio do capítulo
     |
-    +--> publicação web / player
+    +--> página/player no blog
+    +--> episódio no feed RSS
     +--> artefatos de distribuição futuros
 ```
 
@@ -144,6 +151,18 @@ Regras:
 - toda execução remota deve poder ser iniciada, observada e ter seus resultados recuperados por linha de comando;
 - comandos usados manualmente devem ser automatizáveis posteriormente por GitHub Actions.
 
+### 4.10. GitHub Actions é o plano de controle
+
+A operação suportada do produto parte do GitHub Actions. Kaggle, Colab e APIs TTS são recursos remotos acionados pela pipeline, não interfaces que o operador precise visitar manualmente.
+
+Secrets permanecem no GitHub e são expostos somente ao step/runtime que deles precisar. Um runner remoto é considerado suportado apenas depois de autenticação headless e execução end-to-end comprovadas.
+
+### 4.11. Podcast é saída de primeira classe
+
+O capítulo não termina tecnicamente em um arquivo de áudio. Quando marcado como publicável, ele deve poder virar um episódio de um feed RSS estável mantido pelo blog.
+
+O `chapter_id` determina um GUID de episódio estável. Regenerar o áudio com outro TTS não deve criar episódio duplicado.
+
 ## 5. Modelo de conteúdo
 
 ### 5.1. Estrutura-alvo
@@ -171,6 +190,7 @@ scripts/audiobook/
   plan.py
   validate.py
   assemble.py
+  publish.py
   runners/
     colab.sh
     kaggle.sh
@@ -456,9 +476,9 @@ A pipeline expõe estágios independentes:
 4. `validate` — verifica IDs, alinhamento, links e schema;
 5. `plan` — calcula segmentos, cache keys e trabalho pendente;
 6. `benchmark` — opcionalmente gera as mesmas amostras em múltiplos backends;
-7. `synthesize` — despacha o worker para runner local/Colab/Kaggle;
+7. `synthesize` — despacha o worker para runner local/Colab/Kaggle/API;
 8. `assemble` — concatena segmentos em capítulo;
-9. `publish` — disponibiliza artefatos.
+9. `publish` — envia a mídia, atualiza o episódio/feed e publica os artefatos.
 
 Cada estágio pode ser executado sem obrigatoriamente executar os posteriores.
 
@@ -478,18 +498,19 @@ Nenhum `push` comum dispara automaticamente despesa de API.
 
 ## 11. GitHub Actions
 
-GitHub Actions é **orquestrador**, não requisito de GPU.
+GitHub Actions é **orquestrador e ponto único de operação**, não requisito de GPU.
 
 O workflow de produção deve poder:
 
 1. validar o corpus;
 2. gerar o plano;
 3. escolher runner;
-4. invocar `colab` ou `kaggle` CLI, ou usar um backend HTTP quando configurado;
+4. invocar `colab` ou `kaggle` CLI, ou usar um backend HTTP;
 5. acompanhar a execução;
 6. recuperar outputs;
 7. validar manifestos;
-8. montar/publicar artefatos.
+8. montar o capítulo;
+9. publicar mídia/feed quando autorizado.
 
 O primeiro workflow usa `workflow_dispatch` e aceita, no mínimo:
 
@@ -498,11 +519,12 @@ O primeiro workflow usa `workflow_dispatch` e aceita, no mínimo:
 - backend/modelo;
 - runner (`local`, `colab`, `kaggle`, `api` quando houver);
 - `dry_run`;
-- `force` para ignorar cache.
+- `force` para ignorar cache;
+- `publish`.
 
-Credenciais externas entram somente por secrets/configuração segura e nunca no corpus, logs ou artefatos públicos.
+Credenciais externas entram somente por GitHub Secrets e nunca no corpus, logs ou artefatos públicos.
 
-A autenticação headless de cada CLI deve ser validada antes de torná-la runner automático de Actions. Um runner pode inicialmente ser acionado manualmente por CLI sem impedir que o resto da pipeline seja automatizado.
+Detalhes de autenticação headless, staging, retomada e segurança ficam no contrato [`github-actions-execution.md`](./github-actions-execution.md).
 
 ## 12. Manifesto derivado
 
@@ -531,6 +553,8 @@ A pipeline produz manifesto suficiente para reproduzir e auditar o resultado.
 
 O manifesto é derivado e não substitui os três bundles textuais.
 
+Depois de publicação, pode registrar também `episode_guid`, `enclosure_url`, digest do arquivo distribuído e timestamp de publicação.
+
 ## 13. Validação
 
 Validações mínimas:
@@ -545,24 +569,29 @@ Validações mínimas:
 - manifestos nunca são tratados como fonte canônica;
 - nenhum segredo aparece versionado;
 - runner não modifica corpus canônico;
-- outputs declarados pelo worker correspondem ao plano recebido.
+- outputs declarados pelo worker correspondem ao plano recebido;
+- episódio publicado tem GUID estável;
+- enclosure está publicamente acessível antes de entrar no feed.
 
-## 14. Site
+## 14. Site e podcast
 
-A primeira entrega não exige uma experiência pública completa, mas a arquitetura deve permitir que `franklinbaldo.github.io` seja o frontend do audiolivro.
+O próprio `franklinbaldo.github.io` deve ser o frontend e a identidade RSS do audiolivro.
 
-Fases posteriores podem oferecer:
+A experiência inclui:
 
 - página da obra;
 - índice de capítulos;
-- player;
-- indicação do trecho corrente;
+- página/player por capítulo;
+- indicação do trecho corrente quando disponível;
 - texto traduzido sincronizado;
-- comparação original/tradução;
-- RSS/podcast;
-- M4B e outros formatos.
+- comparação original/tradução quando desejada;
+- feed RSS de podcast;
+- ação clara para copiar/adicionar o feed ao tocador;
+- M4B e outros formatos futuramente.
 
-A interface consome artefatos; não redefine o corpus canônico.
+O feed fica no blog; a mídia pesada pode usar storage separado. Essa separação evita acoplar o podcast aos limites de armazenamento do GitHub Pages.
+
+O contrato completo de RSS, enclosure, GUID, transcript e Podcasting 2.0 está em [`podcast-publication.md`](./podcast-publication.md).
 
 ## 15. Escopo autoral e publicação
 
@@ -582,7 +611,8 @@ Não fazem parte do kickstart:
 - armazenar grandes binários no Git;
 - automatizar gasto em todo `push`;
 - contaminar tradução com comandos de sintetizador;
-- manter notebooks operacionais ou uma pipeline paralela em `.ipynb`.
+- manter notebooks operacionais ou uma pipeline paralela em `.ipynb`;
+- depender de um diretório comercial de podcasts para que a assinatura funcione.
 
 ## 17. Fases
 
@@ -590,7 +620,7 @@ Não fazem parte do kickstart:
 
 Esta PR.
 
-Critério de aceite: o documento fixa arquitetura de corpus, benchmark, worker e compute CLI-first.
+Critério de aceite: o documento fixa arquitetura de corpus, benchmark, worker, compute CLI-first, controle via GitHub Actions e publicação como podcast.
 
 ### Fase 1 — corpus mínimo e validação
 
@@ -619,9 +649,10 @@ Entregáveis:
 - runner local;
 - wrappers CLI para Colab e Kaggle;
 - Kaggle configurado como `kernel_type: script`;
+- workflow GitHub Actions capaz de despachar runner fake/headless;
 - nenhum notebook requerido.
 
-Critério de aceite: o mesmo worker executa um job fake localmente e pode ser despachado pelos dois CLIs remotos sem divergência de contrato.
+Critério de aceite: o mesmo worker executa um job fake localmente e pode ser despachado por Actions pelos CLIs remotos sem divergência de contrato.
 
 ### Fase 3 — benchmark real
 
@@ -635,7 +666,7 @@ Entregáveis:
 
 Critério de aceite: existe evidência própria suficiente para escolher ou ordenar os modelos para o capítulo 1.
 
-### Fase 4 — primeiro capítulo em áudio
+### Fase 4 — primeiro capítulo em áudio e feed
 
 Entregáveis:
 
@@ -643,9 +674,12 @@ Entregáveis:
 - geração incremental;
 - montagem do capítulo;
 - manifesto completo;
+- storage de mídia compatível com podcast;
+- feed RSS inicial;
+- episódio do capítulo 1;
 - artifact com áudio resultante.
 
-Critério de aceite: capítulo 1 reproduzível a partir do commit, configuração e runner declarado.
+Critério de aceite: capítulo 1 reproduzível a partir do commit/configuração e assinável em um player de podcast usando o feed do blog.
 
 ### Fase 5 — experiência no blog
 
@@ -654,7 +688,9 @@ Entregáveis:
 - loader dedicado;
 - página da obra;
 - página/player de capítulo;
-- metadados de navegação.
+- metadados de navegação;
+- ação de assinatura/copiar feed;
+- transcript/timestamps derivados quando disponíveis.
 
 ### Fase 6 — escala
 
@@ -664,7 +700,8 @@ Somente após o capítulo 1 estar satisfatório:
 - consistência de personagens/pronúncia;
 - geração batch incremental;
 - armazenamento/publicação durável;
-- formatos adicionais.
+- formatos adicionais;
+- submissão opcional a diretórios de podcasts.
 
 ## 18. Métricas de sucesso
 
@@ -677,7 +714,10 @@ O projeto é bem-sucedido quando:
 - trocar backend não exige reescrever o corpus;
 - o mesmo worker roda localmente e em compute remoto;
 - nenhum notebook manual é necessário;
+- GitHub Actions consegue executar a pipeline sem interação com UI externa;
 - o capítulo 1 pode ser reproduzido por comandos documentados;
+- o feed pode ser adicionado a um tocador de podcast;
+- novos capítulos publicados aparecem como novos episódios sem reassinar;
 - o corpus continua compreensível como Markdown sem ferramenta de TTS.
 
 ## 19. Decisões já tomadas
@@ -694,11 +734,15 @@ O projeto é bem-sucedido quando:
 10. `.ipynb` não é fonte operacional do projeto;
 11. Colab e Kaggle são runners do mesmo worker;
 12. Kaggle usa `kernel_type: script`;
-13. GitHub Actions atua como orquestrador e não precisa fornecer GPU;
-14. chamadas pagas começam manuais/dry-run;
-15. binários de áudio são derivados;
-16. HPMOR é o corpus inicial, não uma dependência arquitetural.
+13. GitHub Actions é o plano de controle e ponto único de operação;
+14. credenciais remotas ficam em GitHub Secrets;
+15. chamadas pagas começam manuais/dry-run;
+16. binários de áudio são derivados;
+17. capítulos publicáveis viram episódios com GUID estável;
+18. o feed RSS canônico é hospedado pelo blog;
+19. mídia pesada pode usar storage separado do GitHub Pages;
+20. HPMOR é o corpus inicial, não uma dependência arquitetural.
 
 ## 20. Primeira próxima ação
 
-A próxima PR após este PRD deve implementar a **Fase 1**. Em paralelo, a implementação da Fase 2 já deve preservar o contrato de que o worker será um script Python comum executável por CLI, sem notebook como camada intermediária.
+A próxima PR após este PRD deve implementar a **Fase 1**. Em paralelo, a implementação da Fase 2 já deve preservar o contrato de que o worker será um script Python comum executável por GitHub Actions e despachável por CLI, sem notebook como camada intermediária.

--- a/docs/okf/audiobook/prd.md
+++ b/docs/okf/audiobook/prd.md
@@ -24,7 +24,7 @@ A computação de GPU deve ser **CLI-first**. O projeto não usa notebooks como 
 
 GitHub Actions é o ponto único de operação da pipeline: valida, planeja, despacha compute remoto usando credenciais em GitHub Secrets, recupera outputs, monta o capítulo e publica os artefatos. O contrato detalhado está em [`github-actions-execution.md`](./github-actions-execution.md).
 
-Capítulos publicados também devem ser distribuídos como episódios de um podcast RSS hospedado pelo blog. O usuário assina o feed uma vez e recebe os capítulos seguintes automaticamente no tocador de podcast. O contrato de publicação está em [`podcast-publication.md`](./podcast-publication.md).
+Capítulos publicados também devem ser distribuídos como episódios de um podcast RSS hospedado pelo blog. O usuário assina o feed uma vez no tocador de sua preferência e recebe automaticamente os capítulos seguintes. O contrato de publicação está em [`podcast-publication.md`](./podcast-publication.md).
 
 ## 2. Problema
 

--- a/docs/okf/audiobook/prd.md
+++ b/docs/okf/audiobook/prd.md
@@ -1,0 +1,496 @@
+---
+type: Product Requirements Document
+title: Audiolivro HPMOR em português — pipeline OKF e TTS
+description: PRD para uma pipeline reproduzível de original, tradução, adaptação de narração e geração incremental de audiolivro.
+tags: [audiobook, hpmor, okf, translation, tts, github-actions]
+timestamp: 2026-08-30T16:37:00Z
+---
+
+# Audiolivro HPMOR em português
+
+## 1. Resumo
+
+Este projeto cria uma pipeline reproduzível para produzir uma edição em áudio, em português do Brasil, de _Harry Potter and the Methods of Rationality_ (HPMOR), de Eliezer Yudkowsky.
+
+O princípio central é separar rigorosamente três representações textuais do mesmo capítulo:
+
+1. **original** — o texto-fonte em inglês, preservado como referência;
+2. **tradução** — uma tradução fiel para português brasileiro, adequada para leitura humana e comparação com o original;
+3. **narração** — uma adaptação da tradução destinada especificamente à síntese de voz, podendo ajustar pontuação, pronúncia, pausas, expansão de símbolos, divisão de falas e outras instruções necessárias para que o TTS produza o resultado esperado.
+
+As três camadas são Markdown em formato OKF e compartilham a mesma identidade de obra e de capítulo. O áudio é derivado da camada de narração; nunca é a fonte canônica do texto.
+
+A computação pesada deve ser executável por GitHub Actions. A pipeline deve ser incremental: uma alteração pequena em texto, voz ou configuração não deve obrigar a regenerar o livro inteiro.
+
+## 2. Problema
+
+Um fluxo ingênuo de `texto -> TTS -> arquivo de áudio` perde informação e mistura responsabilidades:
+
+- uma tradução boa para leitura silenciosa nem sempre soa natural quando narrada;
+- correções de pronúncia ou ritmo acabam contaminando a tradução canônica;
+- não existe uma ligação determinística entre original, tradução e trecho de áudio;
+- regenerar um capítulo inteiro por causa de uma fala é caro e lento;
+- trocar de provedor de TTS exige refazer a arquitetura;
+- artefatos derivados podem se tornar impossíveis de reproduzir depois.
+
+O projeto deve transformar o audiolivro em um sistema de conteúdo versionado, auditável e regenerável.
+
+## 3. Objetivo do produto
+
+Entregar uma pipeline capaz de, para cada capítulo:
+
+```text
+original OKF
+    |
+    v
+tradução OKF
+    |
+    v
+narração OKF
+    |
+    v
+segmentos TTS
+    |
+    v
+áudio do capítulo
+    |
+    +--> publicação web / player
+    +--> artefatos de distribuição futuros
+```
+
+O HPMOR é o primeiro corpus e o caso de uso de referência. A arquitetura, porém, não deve depender semanticamente de HPMOR e deve poder ser reutilizada para outras obras no futuro.
+
+## 4. Princípios
+
+### 4.1. Texto antes de áudio
+
+Original, tradução e narração são fontes versionadas. MP3, M4A, M4B, waveform, timestamps e demais arquivos de áudio são artefatos derivados.
+
+### 4.2. Tradução não é narração
+
+A tradução deve permanecer linguisticamente fiel e legível. Ajustes feitos apenas para satisfazer o comportamento de um sintetizador pertencem à camada de narração.
+
+### 4.3. Identidade compartilhada
+
+Toda representação equivalente do mesmo capítulo deve carregar o mesmo `work_id` e `chapter_id`.
+
+Exemplo:
+
+```yaml
+work_id: hpmor
+chapter_id: hpmor-001
+chapter_number: 1
+```
+
+A tradução e a narração devem apontar explicitamente para a camada da qual derivam.
+
+### 4.4. Unidades menores que o capítulo
+
+A geração de áudio deve operar sobre segmentos estáveis menores que um capítulo. Um segmento pode ser uma fala, um parágrafo narrativo ou outra unidade suficientemente pequena para regeneração isolada.
+
+Cada segmento deve possuir um `segment_id` estável dentro do capítulo. O mesmo ID deve ser preservado sempre que a unidade correspondente continua semanticamente sendo a mesma.
+
+### 4.5. Provedor de TTS é implementação, não contrato
+
+A camada canônica de narração não deve depender de OpenAI, ElevenLabs, Google, modelo local ou qualquer outro fornecedor específico.
+
+Um adaptador transforma o formato canônico de narração no request particular de cada backend.
+
+### 4.6. Reprodutibilidade por hash
+
+Um segmento de áudio é identificado por uma chave derivada, no mínimo, de:
+
+- texto de narração do segmento;
+- identidade/configuração da voz;
+- backend e modelo de TTS;
+- parâmetros relevantes do backend;
+- versão do schema/adaptador de narração.
+
+Se essa chave não mudar e o artefato existir, a pipeline deve reutilizá-lo.
+
+### 4.7. Git guarda estado; áudio pesado não precisa morar no Git
+
+O repositório deve guardar corpus, manifestos, configuração, proveniência e hashes. Arquivos de áudio pesados podem ser produzidos por Actions e armazenados como artifacts ou em um destino de publicação definido posteriormente.
+
+Não é requisito inicial versionar binários de áudio no histórico Git.
+
+## 5. Modelo de conteúdo
+
+### 5.1. Estrutura-alvo
+
+A estrutura inicial proposta é:
+
+```text
+data/audiobooks/
+  hpmor/
+    original/
+      001.md
+      002.md
+      ...
+    translation/
+      001.md
+      002.md
+      ...
+    narration/
+      001.md
+      002.md
+      ...
+    voices.yaml
+    manifest.json
+```
+
+O corpus fica fora de `src/content/blog/**`: ele não é um post do Hrönir e não deve entrar acidentalmente em ranking, versionamento ou seleção de posts. O site poderá consumi-lo posteriormente por um loader dedicado, seguindo o princípio já usado em outras fontes derivadas do blog.
+
+### 5.2. Original
+
+Exemplo mínimo:
+
+```markdown
+---
+type: Audiobook Source Chapter
+title: Chapter 1
+work_id: hpmor
+chapter_id: hpmor-001
+chapter_number: 1
+lang: en
+source_url: https://hpmor.com/chapter/1
+source_digest: sha256:...
+---
+
+<!-- segment: hpmor-001-s0001 -->
+
+Texto original...
+```
+
+Requisitos:
+
+- preservar a proveniência do texto;
+- registrar digest do conteúdo importado;
+- não incluir adaptações feitas para português ou TTS;
+- manter IDs de segmentos estáveis após a primeira segmentação, salvo quando a própria segmentação precisar mudar.
+
+### 5.3. Tradução
+
+Exemplo mínimo:
+
+```markdown
+---
+type: Audiobook Translation Chapter
+title: Capítulo 1
+work_id: hpmor
+chapter_id: hpmor-001
+chapter_number: 1
+lang: pt-BR
+derived_from: ../original/001.md
+---
+
+<!-- segment: hpmor-001-s0001 -->
+
+Texto traduzido...
+```
+
+Requisitos:
+
+- usar o mesmo `chapter_id` do original;
+- conservar o alinhamento por `segment_id` sempre que possível;
+- ser adequada como tradução para leitura humana;
+- não conter truques específicos de TTS apenas para alterar a pronúncia do sintetizador;
+- permitir comparação automática original <-> tradução por capítulo e segmento.
+
+### 5.4. Narração
+
+Exemplo mínimo:
+
+```markdown
+---
+type: Audiobook Narration Chapter
+title: Capítulo 1 — narração
+work_id: hpmor
+chapter_id: hpmor-001
+chapter_number: 1
+lang: pt-BR
+derived_from: ../translation/001.md
+narration_schema: 1
+---
+
+<!-- tts: {"id":"hpmor-001-s0001","speaker":"narrator"} -->
+
+Texto preparado especificamente para ser narrado...
+```
+
+A sintaxe exata das diretivas poderá evoluir na primeira implementação, mas o contrato é fixo:
+
+- Markdown continua legível sem um renderer especial;
+- cada trecho enviado ao TTS possui identidade estável;
+- `speaker` e demais instruções são provider-neutral;
+- instruções específicas de um fornecedor não entram no corpus canônico;
+- a adaptação pode divergir superficialmente da tradução quando isso melhora a realização oral sem mudar o sentido pretendido.
+
+Casos típicos da camada de narração:
+
+- escrever por extenso uma sigla ou expressão que o TTS pronuncia incorretamente;
+- introduzir ou retirar pontuação para obter a pausa correta;
+- marcar alternância entre narrador e personagens;
+- estabelecer pronúncia canônica de nomes;
+- dividir uma frase longa em dois requests;
+- controlar pausas e ênfases;
+- eliminar artefatos tipográficos que não devem ser verbalizados.
+
+## 6. Vozes
+
+`voices.yaml` define identidades lógicas de voz, não IDs rígidos de um único fornecedor.
+
+Exemplo conceitual:
+
+```yaml
+narrator:
+  role: narrator
+  locale: pt-BR
+
+harry:
+  role: character
+  locale: pt-BR
+
+mcgonagall:
+  role: character
+  locale: pt-BR
+```
+
+Cada backend mantém separadamente o mapeamento de identidade lógica para voz/modelo concreto.
+
+Isso permite:
+
+- trocar o fornecedor sem reescrever o corpus;
+- comparar vozes de diferentes backends;
+- manter a identidade de um personagem ao longo de todos os capítulos;
+- alterar uma voz e invalidar somente os segmentos afetados.
+
+## 7. Pipeline
+
+### 7.1. Estágios
+
+A pipeline deve expor estágios independentes:
+
+1. `import` — obtém/normaliza o original e calcula proveniência/digest;
+2. `translate` — cria ou atualiza a camada de tradução;
+3. `prepare-narration` — cria ou atualiza a camada orientada ao TTS;
+4. `validate` — verifica IDs, alinhamento, links de derivação e schema;
+5. `plan` — calcula quais segmentos precisam ser sintetizados e quanto trabalho será executado;
+6. `synthesize` — gera apenas segmentos ausentes ou invalidados;
+7. `assemble` — concatena segmentos em capítulo, preservando ordem e metadados;
+8. `publish` — disponibiliza artefatos no destino configurado.
+
+Cada estágio deve poder ser executado sem obrigatoriamente executar os posteriores.
+
+### 7.2. Dry-run obrigatório
+
+Qualquer workflow capaz de chamar um serviço pago deve possuir modo `dry-run` que mostre:
+
+- capítulo(s) selecionado(s);
+- número de segmentos a gerar;
+- backend/modelo/voz resolvidos;
+- segmentos reutilizados do cache;
+- segmentos invalidados;
+- estimativa de caracteres ou outra unidade de cobrança disponível.
+
+Nenhum evento de `push` comum deve, na primeira versão, disparar automaticamente uma despesa de TTS.
+
+### 7.3. GitHub Actions
+
+O primeiro workflow de produção deve usar `workflow_dispatch` e aceitar, no mínimo:
+
+- obra;
+- capítulo ou intervalo de capítulos;
+- backend;
+- `dry_run`;
+- `force` para ignorar cache, quando necessário.
+
+Credenciais de serviços externos entram somente por GitHub Actions secrets e nunca são escritas no corpus, logs ou artefatos.
+
+## 8. Manifesto derivado
+
+A pipeline deve produzir um manifesto por build, contendo informação suficiente para reproduzir e auditar o resultado.
+
+Exemplo conceitual:
+
+```json
+{
+  "work_id": "hpmor",
+  "chapter_id": "hpmor-001",
+  "narration_digest": "sha256:...",
+  "backend": "example",
+  "model": "example-model",
+  "segments": [
+    {
+      "segment_id": "hpmor-001-s0001",
+      "speaker": "narrator",
+      "input_digest": "sha256:...",
+      "audio_digest": "sha256:...",
+      "duration_ms": 12345
+    }
+  ]
+}
+```
+
+O manifesto é derivado e pode ser regenerado. Ele não substitui os três bundles textuais.
+
+## 9. Validação
+
+O projeto deve falhar cedo quando houver inconsistência estrutural.
+
+Validações mínimas:
+
+- todos os arquivos possuem `type` OKF;
+- todo capítulo possui `work_id`, `chapter_id`, `chapter_number` e `lang` válidos;
+- original, tradução e narração de um capítulo concordam em `work_id` e `chapter_id`;
+- `derived_from` resolve para arquivo existente;
+- `segment_id` não se repete dentro de uma obra;
+- a ordem dos segmentos é determinística;
+- um segmento de tradução/narração não referencia silenciosamente um segmento inexistente no ancestral;
+- manifestos nunca são tratados como fonte canônica;
+- nenhum segredo aparece em arquivos versionados.
+
+A implementação deve preferir validação por ferramenta existente do ecossistema OKF quando ela já cobre o requisito, complementando somente o que é específico do domínio de audiolivro.
+
+## 10. Site
+
+A primeira entrega não exige uma experiência pública completa, mas a arquitetura deve permitir que o próprio `franklinbaldo.github.io` se torne o frontend do audiolivro.
+
+Uma fase posterior pode oferecer:
+
+- página da obra;
+- índice de capítulos;
+- player por capítulo;
+- indicação do trecho corrente;
+- texto traduzido sincronizado;
+- comparação opcional original/tradução;
+- feed RSS/podcast;
+- M4B ou outros formatos de distribuição.
+
+A interface web consome artefatos da pipeline; não redefine o corpus canônico.
+
+## 11. Escopo autoral e de publicação
+
+O projeto nasce como experimento pessoal, aberto e não comercial. Questões de autorização, política de distribuição ou eventual mudança de alcance não são gate para o kickstart técnico.
+
+Se o projeto adquirir distribuição material, monetização ou outra relevância que altere seu perfil de risco, essa etapa deve receber revisão própria antes de ampliar a publicação. Essa revisão é uma decisão de distribuição, não um requisito para modelar o corpus e construir a pipeline.
+
+## 12. Não-objetivos iniciais
+
+Não fazem parte do kickstart:
+
+- gerar imediatamente todos os capítulos;
+- escolher definitivamente um fornecedor de TTS;
+- criar vozes clonadas de atores ou pessoas reais;
+- produzir uma dramatização com efeitos sonoros e trilha;
+- otimizar o site antes de existir um capítulo end-to-end;
+- armazenar grandes binários de áudio no histórico Git;
+- automatizar gasto de API em todo `push`;
+- transformar a camada de tradução em texto cheio de instruções de sintetizador.
+
+## 13. Fases
+
+### Fase 0 — contrato
+
+Esta PR.
+
+Entregáveis:
+
+- PRD OKF;
+- decisão explícita das três camadas;
+- identidade compartilhada entre as camadas;
+- contrato de pipeline incremental e provider-neutral.
+
+Critério de aceite: o documento é suficiente para implementar a Fase 1 sem precisar decidir novamente a arquitetura fundamental.
+
+### Fase 1 — corpus mínimo e validação
+
+Entregáveis:
+
+- criar `data/audiobooks/hpmor/{original,translation,narration}`;
+- adicionar o capítulo 1 nas três camadas;
+- definir `voices.yaml` mínimo;
+- implementar validador de IDs, `derived_from` e segmentos;
+- adicionar testes/fixtures;
+- nenhuma chamada de rede paga.
+
+Critério de aceite: um agente consegue percorrer deterministicamente `original -> translation -> narration` do capítulo 1 e mapear cada segmento correspondente.
+
+### Fase 2 — planner e backend abstrato
+
+Entregáveis:
+
+- parser da camada de narração;
+- representação interna de requests TTS;
+- interface de backend;
+- cálculo de cache key;
+- comando `plan`/dry-run;
+- backend fake para testes.
+
+Critério de aceite: o sistema informa exatamente quais segmentos seriam gerados sem chamar um serviço externo.
+
+### Fase 3 — primeiro capítulo em áudio
+
+Entregáveis:
+
+- um backend real de TTS;
+- workflow manual em GitHub Actions;
+- geração incremental dos segmentos;
+- montagem do capítulo;
+- manifesto com digests e duração;
+- artifact de Actions com o áudio resultante.
+
+Critério de aceite: o capítulo 1 é reproduzível a partir do commit do corpus e da configuração declarada.
+
+### Fase 4 — experiência no blog
+
+Entregáveis:
+
+- loader/coleção dedicada;
+- página da obra;
+- página/player de capítulo;
+- metadados suficientes para navegação.
+
+Critério de aceite: o capítulo produzido pela Fase 3 pode ser ouvido no frontend sem duplicar manualmente conteúdo ou metadados.
+
+### Fase 5 — escala
+
+Somente após o capítulo 1 estar satisfatório:
+
+- tradução/adaptação dos capítulos seguintes;
+- revisão de consistência de personagens e pronúncia;
+- geração batch incremental;
+- estratégia de armazenamento/publicação durável;
+- formatos de distribuição adicionais.
+
+## 14. Métricas de sucesso
+
+O projeto é bem-sucedido quando:
+
+- qualquer trecho traduzido pode ser rastreado ao original correspondente;
+- qualquer trecho narrado pode ser rastreado à tradução correspondente;
+- qualquer segmento de áudio pode ser rastreado ao texto/configuração que o gerou;
+- corrigir uma única fala não força a regeneração do capítulo inteiro;
+- trocar de backend não exige reescrever o corpus de narração;
+- o capítulo 1 pode ser regenerado deterministicamente por GitHub Actions;
+- o corpus continua compreensível como Markdown sem depender da ferramenta de TTS.
+
+## 15. Decisões já tomadas
+
+Estas decisões são parte do contrato do produto e não devem ser reabertas durante a Fase 1 sem evidência concreta de inviabilidade:
+
+1. haverá três camadas textuais: original, tradução e narração;
+2. todas serão Markdown compatível com OKF;
+3. original e tradução são separados por capítulo;
+4. as camadas correspondentes compartilham o mesmo `chapter_id`;
+5. o alinhamento deve chegar a unidades menores que o capítulo para permitir rastreabilidade e geração incremental;
+6. a narração pode adaptar a forma do texto para TTS, mas não substitui a tradução canônica;
+7. TTS é pluggable e provider-neutral no contrato canônico;
+8. GitHub Actions será um ambiente suportado para a computação de produção;
+9. chamadas pagas começam manuais e com dry-run;
+10. binários de áudio são derivados e não precisam ser commitados no Git;
+11. o HPMOR é o corpus inicial, não uma dependência arquitetural do motor.
+
+## 16. Primeira próxima ação
+
+A próxima PR após este PRD deve implementar exclusivamente a **Fase 1**: estrutura do corpus, capítulo 1 nas três camadas, identidade/alinhamento e validação local, sem integrar ainda um fornecedor real de TTS.


### PR DESCRIPTION
## Objetivo

Kickstart de uma **fábrica multi-work de audiolivros** no blog, com contratos em Markdown/OKF.

HPMOR é a primeira obra end-to-end. Bhagavad Gita é o segundo caso de referência arquitetural para impedir acoplamento do motor a HPMOR, inglês, ficção, diálogo ou múltiplos personagens.

## Decisões fixadas

- o produto é a pipeline `obra -> original -> tradução -> narração -> TTS -> áudio -> podcast`, não um projeto exclusivo de HPMOR;
- cada obra possui `work_id` estável e `work.md` como raiz OKF;
- estrutura genérica `data/audiobooks/<work_id>/...`;
- três camadas textuais rastreáveis por obra: `original -> translation -> narration`;
- IDs de capítulos/unidades e segmentos namespaced por `work_id`;
- tradução canônica separada da adaptação para TTS;
- TTS provider-neutral e escolhido por benchmark pt-BR próprio;
- Breeze TTS 2, Higgs TTS 3, Chatterbox V3/pt-BR, Qwen3-TTS e Fish S2.x como candidatos iniciais;
- zero-shot antes de qualquer fine-tune;
- código CLI-first/script-first, sem `.ipynb` como fonte operacional;
- um único worker Python para todas as obras e runners;
- Colab e Kaggle como compute remoto despachado por CLI;
- GitHub Actions como ponto único de operação, recebendo `work_id` e usando GitHub Secrets;
- nenhum workflow, worker ou publisher específico por livro no caso normal;
- cache, artifacts, manifests, concurrency e publicação isolados por obra;
- cada obra publicável recebe **seu próprio podcast RSS** no blog;
- `/audiobooks/` será catálogo agregado e páginas/feeds serão data-driven por `work_id`;
- GUID de episódio permanece estável mesmo se TTS, codec ou storage mudarem;
- áudio pesado é derivado e fica fora do histórico Git;
- Internet Archive é o destino durável preferencial quando habilitado, com **um item estável por obra**;
- HPMOR é a primeira implementação real; Bhagavad Gita entra depois usando a mesma infraestrutura, sem alteração do motor no caso normal.

## Documentos desta PR

- `docs/okf/audiobook/index.md` — índice da Audiobook Factory;
- `docs/okf/audiobook/prd.md` — PRD multi-work e fases de implementação;
- `docs/okf/audiobook/multi-work-architecture.md` — contrato de `work_id`, estrutura por obra, catálogo e podcasts independentes;
- `docs/okf/audiobook/github-actions-execution.md` — GitHub Actions como control plane multi-work, runners e secrets;
- `docs/okf/audiobook/podcast-publication.md` — RSS por obra, enclosure, GUID, Internet Archive e Podcasting 2.0.

## Escopo desta PR

Somente contrato e arquitetura. Nenhuma chamada TTS nem gasto de API.

A próxima PR é a **Fase 1: motor mínimo genérico + HPMOR como primeira instância**, já com uma segunda fixture estrutural para provar que o código não depende de HPMOR.