### PR TITLE
feat(audiobook): establish recurring editorial agent and readiness gates

### DIFF
--- a/data/audiobooks/hpmor/editorial.md
+++ b/data/audiobooks/hpmor/editorial.md
@@ -1,0 +1,35 @@
+---
+type: Audiobook Work Editorial Guide
+work_id: hpmor
+title: HPMOR — guia editorial da obra
+derived_from: ../../../docs/okf/audiobook/guides/editorial-style.md
+---
+
+# Guia editorial do HPMOR
+
+## Objetivo
+
+Aplicar os defaults globais da Audiobook Factory preservando a combinação particular de humor, racionalidade explícita, linguagem científica e vozes fortemente diferenciadas do HPMOR.
+
+## Tradução
+
+- priorizar português brasileiro natural sem apagar precisão lógica;
+- preservar piadas, contraste de registro e timing quando possível;
+- manter terminologia científica consistente entre capítulos;
+- não traduzir nomes próprios automaticamente;
+- decisões recorrentes devem ser registradas e reutilizadas, não redescobertas por capítulo;
+- a tradução não recebe hacks de pronúncia ou instruções de TTS.
+
+## Narração
+
+- narrador deve permanecer distinto das vozes de personagens;
+- diálogo deve preservar contraste de personalidade e idade sem caricatura;
+- ironia, hesitação e ênfase só são marcadas quando sustentadas pelo texto/contexto;
+- nomes ingleses e termos científicos suscetíveis a erro entram em `pronunciation.yaml`;
+- frases analíticas longas podem ser divididas para TTS sem perder relações lógicas.
+
+## Continuidade
+
+Quando uma decisão de tradução, pronúncia ou voz reaparecer, movê-la para o documento estruturado apropriado.
+
+Este arquivo não deve virar um diário de capítulo; deve conter apenas regras reutilizáveis da obra.

--- a/data/audiobooks/hpmor/pronunciation.yaml
+++ b/data/audiobooks/hpmor/pronunciation.yaml
@@ -1,0 +1,20 @@
+schema: audiobook-pronunciation-v1
+work_id: hpmor
+locale: pt-BR
+entries:
+  - term: Harry
+    scope: global
+    status: review
+    note: Definir forma oral consistente após benchmark pt-BR; não codificar workaround de backend aqui.
+  - term: Hermione
+    scope: global
+    status: review
+    note: Definir pronúncia canônica para pt-BR após amostras reais.
+  - term: McGonagall
+    scope: global
+    status: review
+    note: Definir pronúncia canônica para pt-BR após amostras reais.
+  - term: Hogwarts
+    scope: global
+    status: review
+    note: Definir pronúncia canônica para pt-BR após amostras reais.

--- a/data/audiobooks/hpmor/state.yaml
+++ b/data/audiobooks/hpmor/state.yaml
@@ -1,0 +1,25 @@
+schema: audiobook-work-state-v1
+work_id: hpmor
+status: preparing
+next_action: import and segment chapter 1 original, then create aligned translation
+project_gates:
+  work_metadata_ready: true
+  global_editorial_guide_ready: true
+  global_translation_guide_ready: true
+  global_narration_guide_ready: true
+  work_editorial_guide_ready: true
+  voices_ready: true
+  pronunciation_lexicon_ready: true
+chapters:
+  hpmor-001:
+    status: not_started
+    next_action: import source snapshot and establish stable segment ids
+    gates:
+      work_ready: true
+      source_ready: false
+      translation_ready: false
+      narration_ready: false
+      consistency_ready: false
+      editorial_review_ready: false
+      audio_contract_ready: false
+    ready_for_audio: false

--- a/data/audiobooks/hpmor/voices.yaml
+++ b/data/audiobooks/hpmor/voices.yaml
@@ -1,0 +1,19 @@
+schema: audiobook-voices-v1
+work_id: hpmor
+default_locale: pt-BR
+voices:
+  narrator:
+    role: narrator
+    description: Voz narrativa principal; clara, controlada e capaz de sustentar passagens analíticas longas sem soar didática demais.
+  harry:
+    role: character
+    description: Menino muito articulado e intelectualmente precoce; energia juvenil sem transformar a voz em caricatura infantil.
+  mcgonagall:
+    role: character
+    description: Adulta, autoridade contida, precisão e firmeza; emoção deve aparecer sem perder compostura.
+  fallback_male:
+    role: fallback
+    description: Fallback provisório para personagem masculino ainda sem direção individual.
+  fallback_female:
+    role: fallback
+    description: Fallback provisório para personagem feminino ainda sem direção individual.

--- a/data/audiobooks/hpmor/work.md
+++ b/data/audiobooks/hpmor/work.md
@@ -1,0 +1,39 @@
+---
+type: Audiobook Work
+work_id: hpmor
+title: Harry Potter and the Methods of Rationality
+author: Eliezer Yudkowsky
+source_language: en
+target_language: pt-BR
+source_url: https://hpmor.com/
+status: preparing
+publication_mode: non-commercial-experimental
+---
+
+# Harry Potter and the Methods of Rationality
+
+## Papel no projeto
+
+HPMOR é a primeira obra end-to-end da Audiobook Factory e deve exercitar ficção longa, narrador, diálogos, múltiplos personagens, nomes ingleses e terminologia técnica.
+
+A implementação da fábrica não pode depender deste título, desta estrutura narrativa ou do inglês como idioma-fonte.
+
+## Fonte
+
+O original canônico deve ser importado por capítulo a partir da fonte declarada, preservando URL/proveniência e digest do snapshot efetivamente usado.
+
+O texto integral não é duplicado neste arquivo de metadata.
+
+## Política editorial
+
+- idioma alvo: português brasileiro;
+- tradução e narração são camadas distintas;
+- decisões recorrentes sobem para `editorial.md`/`pronunciation.yaml`;
+- nomes e terminologia devem permanecer consistentes ao longo da obra;
+- o primeiro capítulo só pode chegar a `ready_for_audio` depois dos gates de `docs/okf/audiobook/chapter-readiness.md`.
+
+## Publicação
+
+O projeto começa como experimento não comercial. Mudanças futuras de alcance/distribuição podem exigir revisão própria, mas não alteram o contrato técnico da fábrica.
+
+Quando habilitada, a obra terá feed RSS próprio no blog e um item estável de mídia no Internet Archive.

--- a/docs/okf/audiobook/chapter-readiness.md
+++ b/docs/okf/audiobook/chapter-readiness.md
@@ -1,0 +1,144 @@
+---
+type: Architecture Contract
+title: Audiobook Factory — chapter readiness
+description: Gates editoriais que uma unidade deve satisfazer antes de ser enviada para síntese TTS.
+tags: [audiobook, readiness, validation, editorial, okf]
+timestamp: 2026-08-30T20:16:00Z
+---
+
+# Chapter readiness
+
+## 1. Objetivo
+
+`ready_for_audio` é um estado verificável, não uma impressão subjetiva.
+
+O workflow TTS só pode aceitar uma unidade quando todos os gates obrigatórios estiverem satisfeitos.
+
+## 2. Gates
+
+### G0 — work ready
+
+A obra possui:
+
+- `work.md` válido;
+- `work_id` estável;
+- proveniência da fonte;
+- idioma da fonte e idioma alvo;
+- política de publicação/direitos registrada;
+- guia editorial específico, ou declaração explícita de que os defaults globais bastam;
+- `voices.yaml` e `pronunciation.yaml`, ainda que inicialmente mínimos.
+
+### G1 — source ready
+
+O original da unidade:
+
+- existe;
+- tem `chapter_id`/`unit_id` válido;
+- tem provenance/digest;
+- está segmentado;
+- não contém transformação editorial da tradução.
+
+### G2 — translation ready
+
+A tradução:
+
+- cobre todos os segmentos obrigatórios do original;
+- preserva IDs compartilhados;
+- não introduz comandos específicos de TTS;
+- segue guia global + overrides da obra;
+- registra dúvidas não resolvidas como bloqueio, em vez de escondê-las.
+
+### G3 — narration ready
+
+A narração:
+
+- deriva da tradução correspondente;
+- cobre os segmentos destinados à fala;
+- identifica speaker lógico;
+- aplica pronúncia, pontuação oral, expansão de símbolos e divisão de requests quando necessário;
+- mantém intenção sem substituir a tradução canônica;
+- usa somente instruções provider-neutral.
+
+### G4 — consistency ready
+
+A unidade passou por revisão de consistência:
+
+- nomes e termos seguem o glossário;
+- vozes/speakers existem em `voices.yaml`;
+- pronúncias especiais estão declaradas;
+- IDs não colidem;
+- ordem dos segmentos é determinística;
+- tradução e narração não omitiram silenciosamente conteúdo relevante.
+
+### G5 — editorial review ready
+
+Uma passada editorial final verifica:
+
+- fluência em pt-BR;
+- fidelidade sem literalismo desnecessário;
+- naturalidade oral;
+- consistência de registro entre personagens/narrador;
+- coerência de pausas/ênfases/direção;
+- ausência de TODOs/bloqueios editoriais.
+
+### G6 — audio contract ready
+
+Antes de síntese:
+
+- backend/modelo podem ser selecionados sem alterar o corpus;
+- todas as vozes lógicas resolvem para uma configuração do backend escolhido ou para fallback explícito;
+- o planner consegue emitir requests TTS determinísticos;
+- cache keys podem ser calculadas;
+- output esperado e estratégia de montagem são conhecidos.
+
+## 3. Estado mínimo persistido
+
+Cada unidade deve poder ser representada por um estado semelhante a:
+
+```yaml
+type: Audiobook Chapter State
+work_id: hpmor
+chapter_id: hpmor-001
+status: narration_in_progress
+next_action: review narration segments hpmor-001-s0041..s0060
+gates:
+  work_ready: true
+  source_ready: true
+  translation_ready: true
+  narration_ready: false
+  consistency_ready: false
+  editorial_review_ready: false
+  audio_contract_ready: false
+ready_for_audio: false
+```
+
+O schema concreto pode usar YAML/JSON derivado, mas os conceitos acima são obrigatórios.
+
+## 4. Invariantes
+
+- `ready_for_audio` só pode ser `true` quando todos os gates obrigatórios forem `true`.
+- alteração no original invalida tradução/narração afetadas.
+- alteração na tradução invalida narração/revisões afetadas.
+- alteração apenas em backend TTS não invalida tradução/narração, mas invalida plano/cache de áudio quando relevante.
+- um capítulo publicado pode voltar a ter áudio regenerado sem mudar seu `chapter_id`/GUID.
+
+## 5. Gate de CI
+
+O workflow de TTS deve começar com um comando equivalente a:
+
+```text
+audiobook validate --work <work_id> --chapter <id> --require-ready-for-audio
+```
+
+Falha nesse comando deve impedir qualquer despacho para API, Colab ou Kaggle.
+
+## 6. Retomada pelo agente recorrente
+
+O agente editorial escolhe prioritariamente:
+
+1. unidades com gate imediatamente desbloqueável;
+2. trabalho já iniciado antes de abrir nova unidade;
+3. dependências globais que bloqueiam múltiplos capítulos;
+4. próximo capítulo ainda não iniciado.
+
+Assim, a rotina horária converge para capítulos completos em vez de espalhar trabalho parcial pela obra inteira.

--- a/docs/okf/audiobook/editorial-control-plane.md
+++ b/docs/okf/audiobook/editorial-control-plane.md
@@ -1,0 +1,150 @@
+---
+type: Architecture Contract
+title: Audiobook Factory — editorial control plane
+description: Contrato do agente editorial recorrente no ChatGPT e sua separação estrita da síntese TTS em GitHub Actions.
+tags: [audiobook, editorial, chatgpt, automation, okf, tts]
+timestamp: 2026-08-30T20:15:00Z
+---
+
+# Plano de controle editorial
+
+## 1. Decisão
+
+A produção editorial da Audiobook Factory acontece no **ChatGPT**, em sessões recorrentes, usando raciocínio do próprio agente e acesso ao repositório.
+
+GitHub Actions **não traduz, não reescreve e não prepara narração por LLM**. Actions começa somente depois que uma unidade editorial já estiver pronta para áudio.
+
+A separação é deliberada:
+
+```text
+ChatGPT / agente editorial recorrente
+  original -> tradução -> narração -> revisão -> ready_for_audio
+                                      |
+                                      v
+GitHub Actions / fábrica de mídia
+  plan -> TTS -> assemble -> validate media -> publish -> podcast
+```
+
+## 2. Regra de uso de modelos externos
+
+A pipeline editorial não chama APIs externas de LLM.
+
+Isso inclui:
+
+- tradução;
+- adaptação de estilo;
+- preparação de narração;
+- segmentação semântica;
+- revisão textual;
+- criação de glossário;
+- decisão sobre emoção, ritmo ou pronúncia;
+- manutenção dos guias editoriais.
+
+O único estágio autorizado a chamar modelos externos é **síntese de voz/TTS** depois do gate `ready_for_audio`.
+
+## 3. Agente recorrente
+
+O fluxo suportado é um agendamento recorrente do ChatGPT, executado aproximadamente a cada hora.
+
+Cada execução deve:
+
+1. ler o estado persistido no repositório;
+2. escolher a próxima unidade editorial incompleta;
+3. trabalhar em uma unidade coerente por vez;
+4. atualizar original/tradução/narração ou documentação necessária;
+5. validar alinhamento e aderência aos guias;
+6. persistir progresso em branch/PR ou no estado editorial definido;
+7. nunca duplicar trabalho já marcado como concluído;
+8. deixar um estado determinístico quando a unidade não puder ser concluída em uma única execução.
+
+O agente não precisa finalizar um capítulo inteiro por execução. A unidade de trabalho pode ser um segmento, bloco ou capítulo, desde que o estado permita retomada sem ambiguidade.
+
+## 4. Ordem editorial
+
+Para cada obra e unidade:
+
+```text
+source_ready
+  -> translation_ready
+  -> narration_ready
+  -> editorial_review_ready
+  -> ready_for_audio
+```
+
+Nenhum estado pode ser inferido apenas porque o arquivo existe. O gate depende das validações definidas em `chapter-readiness.md`.
+
+## 5. Documentos de projeto antes do primeiro capítulo
+
+Antes de declarar o primeiro capítulo de uma obra como `ready_for_audio`, devem existir e ser aplicáveis:
+
+- contrato global da Audiobook Factory;
+- guia global de tradução;
+- guia global de preparação de narração;
+- convenções de segmentação e IDs;
+- política de pronúncia e glossário;
+- política de vozes/personagens;
+- regras de proveniência e direitos;
+- contrato de readiness;
+- metadata da obra em `work.md`;
+- overrides específicos da obra, quando necessários.
+
+A ausência de um desses documentos pode ser resolvida pelo próprio agente recorrente antes de continuar o capítulo.
+
+## 6. Global vs. específico da obra
+
+O projeto mantém duas camadas de orientação:
+
+```text
+docs/okf/audiobook/guides/       regras globais
+
+data/audiobooks/<work_id>/
+  work.md                         identidade/proveniência
+  editorial.md                    overrides editoriais da obra
+  voices.yaml                     identidade lógica das vozes
+  pronunciation.yaml              léxico/pronúncia específica
+```
+
+Regras específicas da obra prevalecem sobre defaults globais apenas quando a exceção é explícita.
+
+## 7. Persistência de estado
+
+O estado de produção deve ser legível do Git. O agente não pode depender de memória privada para saber onde parou.
+
+Cada capítulo/unidade deve expor ao menos:
+
+- estado atual;
+- próxima ação necessária;
+- IDs concluídos;
+- IDs pendentes;
+- digests das fontes relevantes;
+- revisão/gates já executados;
+- bloqueios conhecidos.
+
+O formato concreto pode evoluir, mas deve ser validável por script e revisável em PR.
+
+## 8. Relação com GitHub Actions
+
+Actions recebe conteúdo editorial já pronto e trata somente trabalho mecânico/reprodutível:
+
+- validar readiness;
+- calcular plano de síntese;
+- selecionar backend/runner;
+- despachar TTS para API, Colab ou Kaggle;
+- coletar áudio;
+- montar capítulo;
+- validar mídia;
+- publicar no storage;
+- atualizar RSS/podcast.
+
+Se `ready_for_audio != true`, o workflow de síntese deve falhar antes de qualquer chamada externa.
+
+## 9. Critério de sucesso
+
+A arquitetura está correta quando:
+
+- uma hora editorial pode terminar sem chamar nenhuma API de LLM;
+- o próximo agente consegue retomar apenas lendo o repositório;
+- nenhum GitHub Action precisa decidir como traduzir uma frase;
+- o TTS nunca recebe uma tradução ainda não preparada para oralidade;
+- um capítulo só entra em GPU/API depois de todos os gates editoriais passarem;
+- a mesma rotina funciona para HPMOR, Bhagavad Gita e futuras obras sem código específico por livro.

--- a/docs/okf/audiobook/guides/editorial-style.md
+++ b/docs/okf/audiobook/guides/editorial-style.md
@@ -1,0 +1,69 @@
+---
+type: Style Guide
+title: Audiobook Factory — guia editorial global
+description: Defaults editoriais compartilhados por todas as obras antes de overrides específicos.
+tags: [audiobook, style-guide, editorial, okf]
+timestamp: 2026-08-30T20:17:00Z
+---
+
+# Guia editorial global
+
+## 1. Função
+
+Este documento define defaults da Audiobook Factory. Cada obra pode declarar overrides em `data/audiobooks/<work_id>/editorial.md`.
+
+## 2. Princípios
+
+1. **Rastreabilidade antes de elegância.** Toda transformação deve continuar ligada ao segmento de origem.
+2. **Três textos, três responsabilidades.** Original preserva; tradução comunica; narração realiza oralmente.
+3. **Mudança mínima suficiente.** Não adaptar o que já funciona.
+4. **Consistência longitudinal.** Decisões de nomes, termos, tratamento e voz são reutilizadas nos capítulos seguintes.
+5. **Dúvida explícita.** Incerteza editorial vira nota/bloqueio; não é resolvida silenciosamente por improviso.
+6. **Leitura em voz alta é teste.** A camada de narração deve soar natural sem depender de o ouvinte ver a página.
+7. **Provider-neutral.** O corpus não fala a linguagem proprietária do TTS.
+
+## 3. Segmentação
+
+Segmentos devem ser grandes o suficiente para preservar prosódia e pequenos o suficiente para revisão/regeneração localizada.
+
+Defaults:
+
+- diálogo: uma fala coerente por segmento, salvo quando contexto curto precisa ficar junto;
+- narração: parágrafo ou unidade prosódica coerente;
+- verso: preservar unidade poética definida pela obra;
+- títulos/cabeçalhos: segmentos próprios quando efetivamente narrados;
+- notas/editoriais: não narradas por default, salvo decisão da obra.
+
+IDs não carregam significado editorial mutável. Use sequência estável namespaced por obra/unidade.
+
+## 4. Pontuação e tipografia
+
+A tradução segue convenções de escrita. A narração pode divergir na pontuação apenas quando isso melhora a realização oral.
+
+Não introduzir grafias fonéticas na tradução canônica. Pronúncia especial pertence à configuração de narração/pronúncia.
+
+## 5. Continuidade
+
+Decisões recorrentes devem sair do capítulo e subir para documentos da obra quando aparecerem pela segunda vez ou quando forem claramente globais.
+
+Exemplos:
+
+- forma escolhida para um nome;
+- tradução de termo recorrente;
+- registro de fala de personagem;
+- pronúncia de nome próprio;
+- tratamento formal/informal;
+- regra para números, siglas ou fórmulas.
+
+## 6. Revisão
+
+A revisão final deve procurar principalmente:
+
+- perda de conteúdo;
+- alteração de sentido;
+- português artificial;
+- inconsistência terminológica;
+- fala impossível/estranha em voz alta;
+- speaker incorreto;
+- instrução de TTS vazando para a tradução;
+- dependência de contexto visual ausente no áudio.

--- a/docs/okf/audiobook/guides/narration.md
+++ b/docs/okf/audiobook/guides/narration.md
@@ -1,0 +1,101 @@
+---
+type: Style Guide
+title: Audiobook Factory — guia global de narração
+description: Regras provider-neutral para transformar tradução aprovada em texto e direção prontos para TTS.
+tags: [audiobook, narration, tts, style-guide, okf]
+timestamp: 2026-08-30T20:19:00Z
+---
+
+# Guia global de narração
+
+## 1. Objetivo
+
+A camada de narração adapta uma tradução aprovada para realização oral por TTS sem alterar seu sentido.
+
+Ela pode mudar a forma superficial do texto quando isso melhora pronúncia, prosódia, pausas ou segmentação.
+
+## 2. Transformações permitidas
+
+- ajustar pontuação para obter pausas naturais;
+- expandir siglas, números, símbolos e abreviações quando a forma escrita seria pronunciada incorretamente;
+- dividir frases longas em requests menores;
+- marcar `speaker` lógico;
+- registrar emoção, ritmo, intensidade, pausa e intenção em vocabulário provider-neutral;
+- aplicar regras de pronúncia da obra;
+- remover elementos tipográficos que não devem ser verbalizados;
+- inserir forma oral equivalente quando necessária para preservar compreensão sem contexto visual.
+
+## 3. Transformações proibidas por default
+
+- resumir conteúdo;
+- mudar fatos ou relações lógicas;
+- reescrever humor ou estilo sem necessidade oral;
+- criar falas não existentes;
+- inserir explicações editoriais ao ouvinte;
+- usar tags proprietárias de Breeze, Higgs, Qwen, Fish, Chatterbox ou outro backend no corpus canônico.
+
+## 4. Direção provider-neutral
+
+A direção deve usar conceitos estáveis, por exemplo:
+
+```yaml
+speaker: narrator
+emotion: contemplative
+pace: slow
+intensity: low
+pause_before_ms: 0
+pause_after_ms: 600
+```
+
+Adapters podem traduzir isso para prompting, tokens especiais, parâmetros ou SSML específicos do backend.
+
+## 5. Vozes
+
+A narração referencia nomes lógicos declarados em `voices.yaml`.
+
+Nunca gravar diretamente no capítulo um voice ID efêmero de fornecedor.
+
+Exemplos:
+
+- `narrator`
+- `harry`
+- `mcgonagall`
+- `krishna`
+- `arjuna`
+
+A mesma identidade lógica pode mapear para configurações diferentes conforme o backend do benchmark/produção.
+
+## 6. Pronúncia
+
+Pronúncias recorrentes pertencem a `pronunciation.yaml` da obra, não a correções copiadas em dezenas de capítulos.
+
+Uma exceção local pode existir quando a mesma grafia deve soar de forma diferente naquele contexto.
+
+## 7. Granularidade TTS
+
+O segmento editorial e o request TTS podem coincidir, mas não precisam.
+
+Quando um segmento precisa ser dividido em vários requests, a relação deve ser derivada e determinística. Não destruir o `segment_id` editorial apenas por limitação do modelo.
+
+## 8. Revisão oral
+
+Antes de `narration_ready`, ler mentalmente/em voz alta procurando:
+
+- frases que exigem visão da pontuação para serem entendidas;
+- números/siglas ambíguos;
+- nomes estrangeiros suscetíveis a erro;
+- transições de speaker incorretas;
+- direção emocional excessiva ou arbitrária;
+- pausas que quebram a sintaxe;
+- requests longos demais para geração estável.
+
+## 9. Feedback pós-TTS
+
+Erro observado no áudio deve ser corrigido na camada mais alta adequada:
+
+- erro lexical/semântico -> tradução;
+- problema de forma oral -> narração;
+- pronúncia recorrente -> `pronunciation.yaml`;
+- problema de um backend específico -> adapter/configuração do backend.
+
+Não contaminar o corpus global com workaround específico de modelo quando o adapter consegue resolver.

--- a/docs/okf/audiobook/guides/translation.md
+++ b/docs/okf/audiobook/guides/translation.md
@@ -1,0 +1,78 @@
+---
+type: Style Guide
+title: Audiobook Factory — guia global de tradução
+description: Regras para produzir a camada de tradução antes da adaptação específica para narração.
+tags: [audiobook, translation, style-guide, pt-br, okf]
+timestamp: 2026-08-30T20:18:00Z
+---
+
+# Guia global de tradução
+
+## 1. Objetivo
+
+Produzir uma tradução em português brasileiro que seja fiel, legível e revisável por comparação direta com o original.
+
+A tradução não é ainda a versão enviada ao TTS.
+
+## 2. Prioridades
+
+Em ordem:
+
+1. preservar sentido e relações lógicas;
+2. preservar voz, humor, registro e intenção;
+3. produzir português brasileiro natural;
+4. manter consistência terminológica entre capítulos;
+5. preservar estrutura suficiente para alinhamento por segmentos;
+6. evitar literalismo que torne a frase artificial.
+
+## 3. O que não pertence à tradução
+
+Não colocar na tradução:
+
+- grafia fonética inventada para ajudar sintetizador;
+- tags de emoção/pausa;
+- instruções de voz;
+- quebras artificiais feitas apenas por limite de contexto do TTS;
+- nomes de modelos/providers;
+- SSML ou sintaxe proprietária.
+
+Esses elementos pertencem à camada de narração ou aos adapters.
+
+## 4. Termos e nomes
+
+Decisões recorrentes devem entrar no glossário da obra.
+
+Antes de traduzir um termo recorrente de forma diferente do glossário:
+
+- verificar contexto;
+- registrar a exceção quando intencional;
+- atualizar a regra global da obra se a decisão anterior estiver errada.
+
+Nomes próprios permanecem conforme a política específica da obra. Não traduzir ou abrasileirar automaticamente.
+
+## 5. Estrutura e alinhamento
+
+Cada segmento traduzido preserva o `segment_id` correspondente ao original sempre que houver equivalência semântica clara.
+
+Quando uma tradução exige dividir ou fundir material:
+
+- não reutilizar IDs de forma ambígua;
+- registrar a relação explicitamente;
+- preferir que a mudança estrutural aconteça na camada de narração se a tradução textual não precisa dela.
+
+## 6. Registro
+
+A tradução deve respeitar idade, posição social, época, personalidade e situação dos falantes.
+
+Não nivelar todos os personagens para um mesmo português neutro se o original distingue suas vozes.
+
+## 7. Passada de revisão
+
+Antes de `translation_ready`:
+
+- comparar todos os segmentos com o original;
+- procurar omissões e acréscimos;
+- revisar números, nomes, negações e relações causais;
+- reler trechos longos sem olhar o original para testar fluência;
+- conferir termos recorrentes no glossário;
+- registrar qualquer dúvida que impeça afirmar fidelidade.

--- a/docs/okf/audiobook/index.md
+++ b/docs/okf/audiobook/index.md
@@ -2,8 +2,8 @@
 type: Index
 title: Audiobook Factory
 description: Índice do sistema multi-work que transforma obras textuais em audiolivros e podcasts reproduzíveis.
-tags: [audiobook, okf, multi-work, tts, podcast, github-actions]
-timestamp: 2026-08-30T18:45:00Z
+tags: [audiobook, okf, multi-work, tts, podcast, github-actions, chatgpt]
+timestamp: 2026-08-30T20:20:00Z
 ---
 
 # Audiobook Factory
@@ -12,23 +12,36 @@ Este diretório documenta a **fábrica de audiolivros** do blog: uma pipeline ge
 
 O produto é a pipeline; cada livro é uma instância.
 
+A fábrica tem dois planos de controle deliberadamente separados:
+
 ```text
-book/work
+ChatGPT / agente editorial recorrente
   -> original OKF
   -> translation OKF
   -> narration OKF
-  -> TTS
+  -> editorial review
+  -> ready_for_audio
+
+GitHub Actions / fábrica de mídia
+  -> TTS (API / Colab / Kaggle)
   -> audio
   -> durable media storage
   -> per-work podcast RSS
   -> blog/player
 ```
 
+O trabalho editorial usa o próprio agente do ChatGPT e o estado versionado no Git. **Não há chamada de API externa de LLM para tradução ou preparação de narração.** APIs/modelos externos entram apenas no estágio TTS depois do gate editorial.
+
 ## Documentos
 
 - [`prd.md`](./prd.md) — PRD e plano de implementação inicial, usando HPMOR como primeira obra end-to-end.
 - [`multi-work-architecture.md`](./multi-work-architecture.md) — contrato que garante uma única pipeline para HPMOR, Bhagavad Gita e futuras obras, com `work_id`, configuração e podcast independentes.
-- [`github-actions-execution.md`](./github-actions-execution.md) — GitHub Actions como plano de controle; Colab/Kaggle/API como runners substituíveis e execução totalmente headless.
+- [`editorial-control-plane.md`](./editorial-control-plane.md) — agente recorrente do ChatGPT, persistência de estado e separação entre trabalho editorial e síntese.
+- [`chapter-readiness.md`](./chapter-readiness.md) — gates obrigatórios antes de uma unidade poder ser enviada ao TTS.
+- [`guides/editorial-style.md`](./guides/editorial-style.md) — defaults editoriais compartilhados por todas as obras.
+- [`guides/translation.md`](./guides/translation.md) — contrato da tradução canônica em pt-BR.
+- [`guides/narration.md`](./guides/narration.md) — preparação provider-neutral da versão destinada à fala.
+- [`github-actions-execution.md`](./github-actions-execution.md) — GitHub Actions como plano de controle de mídia; Colab/Kaggle/API como runners substituíveis e execução headless.
 - [`podcast-publication.md`](./podcast-publication.md) — contrato de RSS, episódio, enclosure, transcript, storage e publicação; Internet Archive é o destino durável preferencial da mídia quando habilitado.
 
 ## Casos de referência
@@ -47,9 +60,9 @@ Adicionar uma obra normal deve significar essencialmente:
 
 ```text
 create data/audiobooks/<work_id>/work.md
-add original/translation/narration
-configure voices + publication
-run the same GitHub Actions workflow
+add work-level editorial/pronunciation/voice configuration
+run the recurring editorial agent until chapters become ready_for_audio
+run the same GitHub Actions media workflow
 ```
 
 Não deve significar criar novos workers, novos runners, novo publisher ou workflow específico para aquela obra.


### PR DESCRIPTION
## Objetivo

Separar explicitamente o trabalho editorial da síntese de mídia e deixar a Audiobook Factory pronta para ser produzida capítulo a capítulo por um agente recorrente do ChatGPT.

## Contrato operacional

- ChatGPT faz `original -> tradução -> narração -> revisão -> ready_for_audio`;
- nenhuma API externa de LLM é usada para tradução, reescrita ou preparação editorial;
- GitHub Actions começa somente depois do gate `ready_for_audio`;
- TTS é o único estágio autorizado a chamar modelos/APIs externos;
- o agente recorrente persiste todo estado no Git para retomada determinística;
- prioridade é terminar trabalho iniciado antes de espalhar capítulos parciais.

## Conteúdo

- `editorial-control-plane.md`: contrato do agente recorrente;
- `chapter-readiness.md`: gates G0..G6;
- guias globais de estilo, tradução e narração;
- cadastro inicial do HPMOR (`work.md`);
- overrides editoriais da obra;
- `voices.yaml` e `pronunciation.yaml` iniciais;
- `state.yaml` com capítulo 1 ainda não iniciado e próxima ação explícita;
- índice OKF atualizado com os dois planos de controle.

## Segurança operacional

Esta PR não copia o texto integral do HPMOR, não chama TTS e não usa qualquer segredo. Ela prepara o estado necessário para que as execuções editoriais seguintes consigam avançar sem memória implícita.
