### PR TITLE
feat(audiobook): publish works as independent podcasts

### DIFF
--- a/data/audiobooks/hpmor/work.md
+++ b/data/audiobooks/hpmor/work.md
@@ -8,6 +8,15 @@ target_language: pt-BR
 source_url: https://hpmor.com/
 status: preparing
 publication_mode: non-commercial-experimental
+podcast:
+  enabled: false
+  title: Harry Potter e os Métodos da Racionalidade — Audiolivro
+  description: Edição em português brasileiro produzida pela Audiobook Factory de Franklin Baldo.
+  language: pt-BR
+  author: Franklin Baldo
+media:
+  durable_backend: internet-archive
+  archive_item: franklinbaldo-hpmor-ptbr-audiobook
 ---
 
 # Harry Potter and the Methods of Rationality
@@ -36,4 +45,6 @@ O texto integral não é duplicado neste arquivo de metadata.
 
 O projeto começa como experimento não comercial. Mudanças futuras de alcance/distribuição podem exigir revisão própria, mas não alteram o contrato técnico da fábrica.
 
-Quando habilitada, a obra terá feed RSS próprio no blog e um item estável de mídia no Internet Archive.
+A identidade do podcast já está declarada, mas `podcast.enabled` permanece `false` até haver pelo menos um episódio editorialmente aprovado, sintetizado, armazenado e validado.
+
+O destino durável preferencial de mídia é um item estável por obra no Internet Archive. Alterar o storage no futuro não altera `work_id`, GUID dos episódios nem URL canônica do feed.

--- a/src/audiobook/catalog.js
+++ b/src/audiobook/catalog.js
@@ -72,7 +72,7 @@ export function publishedEpisodes(work) {
       transcript: chapter.publication.transcript ?? null,
       chapters: chapter.publication.chapters ?? null,
     }))
-    .sort((a, b) => new Date(a.publishedAt).valueOf() - new Date(b.publishedAt).valueOf());
+    .sort((a, b) => new Date(b.publishedAt).valueOf() - new Date(a.publishedAt).valueOf());
 }
 
 export { WORK_ID_PATTERN };

--- a/src/audiobook/catalog.js
+++ b/src/audiobook/catalog.js
@@ -1,0 +1,78 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import matter from "gray-matter";
+import yaml from "js-yaml";
+
+const WORK_ID_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+function readYaml(filePath) {
+  return yaml.load(fs.readFileSync(filePath, "utf8")) ?? {};
+}
+
+function readWorkFile(filePath) {
+  const parsed = matter(fs.readFileSync(filePath, "utf8"));
+  return { data: parsed.data, body: parsed.content.trim() };
+}
+
+export function audiobookRoot(rootDir = process.cwd()) {
+  return path.join(rootDir, "data", "audiobooks");
+}
+
+export function listWorkIds(rootDir = process.cwd()) {
+  const root = audiobookRoot(rootDir);
+  if (!fs.existsSync(root)) return [];
+  return fs
+    .readdirSync(root, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory() && WORK_ID_PATTERN.test(entry.name))
+    .filter((entry) => fs.existsSync(path.join(root, entry.name, "work.md")))
+    .map((entry) => entry.name)
+    .sort();
+}
+
+export function loadWork(rootDir, workId) {
+  if (!WORK_ID_PATTERN.test(workId)) throw new Error(`Invalid work_id: ${workId}`);
+
+  const workDir = path.join(audiobookRoot(rootDir), workId);
+  const work = readWorkFile(path.join(workDir, "work.md"));
+  const state = readYaml(path.join(workDir, "state.yaml"));
+
+  if (work.data.type !== "Audiobook Work") throw new Error(`${workId}: work.md type must be Audiobook Work`);
+  if (work.data.work_id !== workId) throw new Error(`${workId}: work.md work_id mismatch`);
+  if (state.work_id !== workId) throw new Error(`${workId}: state.yaml work_id mismatch`);
+
+  const chapters = Object.entries(state.chapters ?? {})
+    .map(([chapterId, chapter]) => ({ chapterId, ...chapter }))
+    .sort((a, b) => a.chapterId.localeCompare(b.chapterId));
+
+  return {
+    workId,
+    workDir,
+    metadata: work.data,
+    body: work.body,
+    state,
+    chapters,
+  };
+}
+
+export function listWorks(rootDir = process.cwd()) {
+  return listWorkIds(rootDir).map((workId) => loadWork(rootDir, workId));
+}
+
+export function publishedEpisodes(work) {
+  return work.chapters
+    .filter((chapter) => chapter.publication?.status === "published")
+    .map((chapter) => ({
+      chapterId: chapter.chapterId,
+      title: chapter.publication.title ?? chapter.chapterId,
+      description: chapter.publication.description ?? "",
+      publishedAt: chapter.publication.published_at,
+      durationSeconds: chapter.publication.duration_seconds ?? null,
+      enclosure: chapter.publication.enclosure ?? null,
+      transcript: chapter.publication.transcript ?? null,
+      chapters: chapter.publication.chapters ?? null,
+    }))
+    .sort((a, b) => new Date(a.publishedAt).valueOf() - new Date(b.publishedAt).valueOf());
+}
+
+export { WORK_ID_PATTERN };

--- a/src/audiobook/catalog.test.js
+++ b/src/audiobook/catalog.test.js
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { listWorkIds, listWorks, loadWork, publishedEpisodes } from "./catalog.js";
+
+function write(root, relativePath, content) {
+  const filePath = path.join(root, relativePath);
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, content);
+}
+
+function fixture() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "audiobook-catalog-"));
+  write(
+    root,
+    "data/audiobooks/example/work.md",
+    `---\ntype: Audiobook Work\nwork_id: example\ntitle: Example Book\nauthor: Example Author\nsource_language: en\ntarget_language: pt-BR\nsource_url: https://example.test/\npodcast:\n  enabled: true\n---\n`,
+  );
+  write(
+    root,
+    "data/audiobooks/example/state.yaml",
+    `schema: audiobook-work-state-v1\nwork_id: example\nstatus: publishing\nnext_action: publish second chapter\nchapters:\n  example-001:\n    status: published\n    publication:\n      status: published\n      title: Capítulo 1\n      published_at: 2026-08-30T12:00:00-04:00\n      duration_seconds: 120\n      enclosure:\n        url: https://archive.example/chapter-001.mp3\n        bytes: 1234\n        type: audio/mpeg\n  example-002:\n    status: ready\n    publication:\n      status: ready\n      title: Capítulo 2\n`,
+  );
+  return root;
+}
+
+test("discovers works by work_id directory", () => {
+  const root = fixture();
+  assert.deepEqual(listWorkIds(root), ["example"]);
+  assert.equal(listWorks(root)[0].metadata.title, "Example Book");
+});
+
+test("loads work metadata and chapter state", () => {
+  const root = fixture();
+  const work = loadWork(root, "example");
+  assert.equal(work.workId, "example");
+  assert.equal(work.chapters.length, 2);
+});
+
+test("exposes only published chapters as podcast episodes", () => {
+  const root = fixture();
+  const episodes = publishedEpisodes(loadWork(root, "example"));
+  assert.deepEqual(episodes.map((episode) => episode.chapterId), ["example-001"]);
+  assert.equal(episodes[0].enclosure.bytes, 1234);
+});
+
+test("rejects unsafe work ids", () => {
+  const root = fixture();
+  assert.throws(() => loadWork(root, "../example"), /Invalid work_id/);
+});

--- a/src/audiobook/catalog.test.js
+++ b/src/audiobook/catalog.test.js
@@ -22,7 +22,7 @@ function fixture() {
   write(
     root,
     "data/audiobooks/example/state.yaml",
-    `schema: audiobook-work-state-v1\nwork_id: example\nstatus: publishing\nnext_action: publish second chapter\nchapters:\n  example-001:\n    status: published\n    publication:\n      status: published\n      title: Capítulo 1\n      published_at: 2026-08-30T12:00:00-04:00\n      duration_seconds: 120\n      enclosure:\n        url: https://archive.example/chapter-001.mp3\n        bytes: 1234\n        type: audio/mpeg\n  example-002:\n    status: ready\n    publication:\n      status: ready\n      title: Capítulo 2\n`,
+    `schema: audiobook-work-state-v1\nwork_id: example\nstatus: publishing\nnext_action: publish third chapter\nchapters:\n  example-001:\n    status: published\n    publication:\n      status: published\n      title: Capítulo 1\n      published_at: 2026-08-30T12:00:00-04:00\n      duration_seconds: 120\n      enclosure:\n        url: https://archive.example/chapter-001.mp3\n        bytes: 1234\n        type: audio/mpeg\n  example-002:\n    status: published\n    publication:\n      status: published\n      title: Capítulo 2\n      published_at: 2026-08-30T13:00:00-04:00\n      duration_seconds: 130\n      enclosure:\n        url: https://archive.example/chapter-002.mp3\n        bytes: 2345\n        type: audio/mpeg\n  example-003:\n    status: ready\n    publication:\n      status: ready\n      title: Capítulo 3\n`,
   );
   return root;
 }
@@ -37,14 +37,17 @@ test("loads work metadata and chapter state", () => {
   const root = fixture();
   const work = loadWork(root, "example");
   assert.equal(work.workId, "example");
-  assert.equal(work.chapters.length, 2);
+  assert.equal(work.chapters.length, 3);
 });
 
-test("exposes only published chapters as podcast episodes", () => {
+test("exposes only published chapters, newest first", () => {
   const root = fixture();
   const episodes = publishedEpisodes(loadWork(root, "example"));
-  assert.deepEqual(episodes.map((episode) => episode.chapterId), ["example-001"]);
-  assert.equal(episodes[0].enclosure.bytes, 1234);
+  assert.deepEqual(episodes.map((episode) => episode.chapterId), [
+    "example-002",
+    "example-001",
+  ]);
+  assert.equal(episodes[0].enclosure.bytes, 2345);
 });
 
 test("rejects unsafe work ids", () => {

--- a/src/audiobook/podcast.js
+++ b/src/audiobook/podcast.js
@@ -1,0 +1,106 @@
+function escapeXml(value) {
+  return String(value ?? "")
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&apos;");
+}
+
+function absoluteUrl(baseUrl, value) {
+  return new URL(value, baseUrl).href;
+}
+
+function rfc2822(value) {
+  const date = new Date(value);
+  if (Number.isNaN(date.valueOf())) throw new Error(`Invalid publication date: ${value}`);
+  return date.toUTCString();
+}
+
+function durationString(seconds) {
+  if (seconds == null) return null;
+  if (!Number.isFinite(Number(seconds)) || Number(seconds) < 0) throw new Error(`Invalid duration: ${seconds}`);
+  const whole = Math.round(Number(seconds));
+  const hours = Math.floor(whole / 3600);
+  const minutes = Math.floor((whole % 3600) / 60);
+  const secs = whole % 60;
+  return hours > 0
+    ? `${hours}:${String(minutes).padStart(2, "0")}:${String(secs).padStart(2, "0")}`
+    : `${minutes}:${String(secs).padStart(2, "0")}`;
+}
+
+export function episodeGuid(workId, chapterId) {
+  return `audiobook:${workId}:${chapterId}`;
+}
+
+function renderEpisode({ workId, episode, siteUrl }) {
+  if (!episode.enclosure?.url) throw new Error(`${episode.chapterId}: published episode needs enclosure.url`);
+  if (!Number.isInteger(episode.enclosure.bytes) || episode.enclosure.bytes <= 0) {
+    throw new Error(`${episode.chapterId}: published episode needs positive enclosure.bytes`);
+  }
+  if (!episode.enclosure.type) throw new Error(`${episode.chapterId}: published episode needs enclosure.type`);
+  if (!episode.publishedAt) throw new Error(`${episode.chapterId}: published episode needs published_at`);
+
+  const link = absoluteUrl(siteUrl, `/audiobooks/${workId}/${episode.chapterId}/`);
+  const enclosureUrl = absoluteUrl(siteUrl, episode.enclosure.url);
+  const duration = durationString(episode.durationSeconds);
+  const transcript = episode.transcript?.url
+    ? `<podcast:transcript url="${escapeXml(absoluteUrl(siteUrl, episode.transcript.url))}" type="${escapeXml(
+        episode.transcript.type ?? "text/vtt",
+      )}" language="${escapeXml(episode.transcript.language ?? "pt-BR")}" rel="captions" />`
+    : "";
+  const chapters = episode.chapters?.url
+    ? `<podcast:chapters url="${escapeXml(absoluteUrl(siteUrl, episode.chapters.url))}" type="${escapeXml(
+        episode.chapters.type ?? "application/json+chapters",
+      )}" />`
+    : "";
+
+  return `<item>
+<title>${escapeXml(episode.title)}</title>
+<description>${escapeXml(episode.description)}</description>
+<link>${escapeXml(link)}</link>
+<guid isPermaLink="false">${escapeXml(episodeGuid(workId, episode.chapterId))}</guid>
+<pubDate>${escapeXml(rfc2822(episode.publishedAt))}</pubDate>
+<enclosure url="${escapeXml(enclosureUrl)}" length="${episode.enclosure.bytes}" type="${escapeXml(
+    episode.enclosure.type,
+  )}" />
+${duration ? `<itunes:duration>${escapeXml(duration)}</itunes:duration>` : ""}
+${transcript}
+${chapters}
+</item>`;
+}
+
+export function buildPodcastXml({ work, episodes, siteUrl }) {
+  const podcast = work.metadata.podcast ?? {};
+  if (podcast.enabled !== true) throw new Error(`${work.workId}: podcast is not enabled`);
+
+  const feedUrl = absoluteUrl(siteUrl, `/audiobooks/${work.workId}/feed.xml`);
+  const workUrl = absoluteUrl(siteUrl, `/audiobooks/${work.workId}/`);
+  const title = podcast.title ?? work.metadata.title;
+  const description = podcast.description ?? `Audiolivro de ${work.metadata.title}`;
+  const language = podcast.language ?? work.metadata.target_language ?? "pt-BR";
+  const author = podcast.author ?? work.metadata.author ?? "Franklin Baldo";
+  const image = podcast.image ? absoluteUrl(siteUrl, podcast.image) : null;
+  const items = episodes.map((episode) => renderEpisode({ workId: work.workId, episode, siteUrl })).join("\n");
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0"
+  xmlns:atom="http://www.w3.org/2005/Atom"
+  xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd"
+  xmlns:podcast="https://podcastindex.org/namespace/1.0">
+<channel>
+<title>${escapeXml(title)}</title>
+<description>${escapeXml(description)}</description>
+<link>${escapeXml(workUrl)}</link>
+<language>${escapeXml(language)}</language>
+<itunes:author>${escapeXml(author)}</itunes:author>
+<itunes:explicit>false</itunes:explicit>
+${image ? `<itunes:image href="${escapeXml(image)}" />` : ""}
+<atom:link href="${escapeXml(feedUrl)}" rel="self" type="application/rss+xml" />
+${items}
+</channel>
+</rss>
+`;
+}
+
+export { durationString, escapeXml, rfc2822 };

--- a/src/audiobook/podcast.test.js
+++ b/src/audiobook/podcast.test.js
@@ -1,0 +1,90 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { XMLParser } from "fast-xml-parser";
+
+import { buildPodcastXml, episodeGuid } from "./podcast.js";
+
+const work = {
+  workId: "example-book",
+  metadata: {
+    title: "Livro de Exemplo",
+    author: "Autora Exemplo",
+    target_language: "pt-BR",
+    podcast: {
+      enabled: true,
+      title: "Livro de Exemplo — Audiolivro",
+      description: "Edição narrada de teste.",
+      image: "/audiobooks/example-book/cover.jpg",
+    },
+  },
+};
+
+const episodes = [
+  {
+    chapterId: "example-book-001",
+    title: "Capítulo 1",
+    description: "Primeiro capítulo.",
+    publishedAt: "2026-08-30T12:00:00-04:00",
+    durationSeconds: 3723,
+    enclosure: {
+      url: "https://archive.example/download/example-book/chapter-001.mp3",
+      bytes: 12345678,
+      type: "audio/mpeg",
+    },
+    transcript: {
+      url: "/audiobooks/example-book/transcripts/001.vtt",
+      type: "text/vtt",
+      language: "pt-BR",
+    },
+    chapters: {
+      url: "/audiobooks/example-book/chapters/001.json",
+    },
+  },
+];
+
+test("uses work/chapter identity for stable podcast GUID", () => {
+  assert.equal(episodeGuid("example-book", "example-book-001"), "audiobook:example-book:example-book-001");
+});
+
+test("builds RSS 2.0 with enclosure and Podcasting 2.0 metadata", () => {
+  const xml = buildPodcastXml({ work, episodes, siteUrl: "https://franklinbaldo.com/" });
+  const parser = new XMLParser({ ignoreAttributes: false, attributeNamePrefix: "@_" });
+  const parsed = parser.parse(xml);
+  const channel = parsed.rss.channel;
+  const item = channel.item;
+
+  assert.equal(parsed.rss["@_version"], "2.0");
+  assert.equal(channel.title, "Livro de Exemplo — Audiolivro");
+  assert.equal(item.guid["#text"], "audiobook:example-book:example-book-001");
+  assert.equal(item.guid["@_isPermaLink"], "false");
+  assert.equal(item.enclosure["@_length"], "12345678");
+  assert.equal(item.enclosure["@_type"], "audio/mpeg");
+  assert.equal(item["itunes:duration"], "1:02:03");
+  assert.equal(item["podcast:transcript"]["@_type"], "text/vtt");
+  assert.equal(item["podcast:chapters"]["@_type"], "application/json+chapters");
+});
+
+test("refuses published episode without a complete enclosure", () => {
+  assert.throws(
+    () =>
+      buildPodcastXml({
+        work,
+        episodes: [{ ...episodes[0], enclosure: { url: "https://example.test/a.mp3", bytes: 0, type: "audio/mpeg" } }],
+        siteUrl: "https://franklinbaldo.com/",
+      }),
+    /positive enclosure.bytes/,
+  );
+});
+
+test("refuses feed generation before podcast is enabled", () => {
+  assert.throws(
+    () =>
+      buildPodcastXml({
+        work: { ...work, metadata: { ...work.metadata, podcast: { enabled: false } } },
+        episodes,
+        siteUrl: "https://franklinbaldo.com/",
+      }),
+    /podcast is not enabled/,
+  );
+});

--- a/src/pages/audiobooks/[workId]/[chapterId].astro
+++ b/src/pages/audiobooks/[workId]/[chapterId].astro
@@ -1,0 +1,87 @@
+---
+import PageLayout from "../../../layouts/PageLayout.astro";
+import { listWorks, publishedEpisodes } from "../../../audiobook/catalog.js";
+
+export function getStaticPaths() {
+  return listWorks().flatMap((work) =>
+    publishedEpisodes(work).map((episode) => ({
+      params: { workId: work.workId, chapterId: episode.chapterId },
+      props: { work, episode },
+    })),
+  );
+}
+
+const { work, episode } = Astro.props;
+const audioUrl = episode.enclosure?.url;
+---
+
+<PageLayout
+  title={`${episode.title} — ${work.metadata.title}`}
+  description={episode.description || work.metadata.podcast?.description || work.metadata.title}
+  lang="pt"
+  breadcrumb={[
+    { name: "Audiolivros", item: "/audiobooks/" },
+    { name: work.metadata.title, item: `/audiobooks/${work.workId}/` },
+    { name: episode.title, item: `/audiobooks/${work.workId}/${episode.chapterId}/` },
+  ]}
+>
+  <main class="container audiobook-episode">
+    <p><a href={`/audiobooks/${work.workId}/`}>← {work.metadata.title}</a></p>
+    <header>
+      <p class="eyebrow">Audiolivro</p>
+      <h1>{episode.title}</h1>
+      {episode.description && <p>{episode.description}</p>}
+    </header>
+
+    {
+      audioUrl && (
+        <audio controls preload="metadata">
+          <source src={audioUrl} type={episode.enclosure.type} />
+          Seu navegador não suporta reprodução de áudio HTML5.
+        </audio>
+      )
+    }
+
+    <dl>
+      <dt>Publicado</dt>
+      <dd>{new Date(episode.publishedAt).toLocaleDateString("pt-BR")}</dd>
+      {episode.durationSeconds != null && (
+        <>
+          <dt>Duração</dt>
+          <dd>{Math.round(episode.durationSeconds / 60)} min</dd>
+        </>
+      )}
+    </dl>
+
+    {episode.transcript?.url && <p><a href={episode.transcript.url}>Transcript / legendas</a></p>}
+  </main>
+</PageLayout>
+
+<style>
+  .audiobook-episode {
+    max-width: 52rem;
+    padding-block: 3rem 5rem;
+  }
+
+  .eyebrow {
+    font-size: 0.8rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    opacity: 0.72;
+  }
+
+  audio {
+    width: 100%;
+    margin-block: 2rem;
+  }
+
+  dl {
+    display: grid;
+    grid-template-columns: max-content 1fr;
+    gap: 0.4rem 1rem;
+  }
+
+  dt {
+    font-weight: 600;
+  }
+</style>

--- a/src/pages/audiobooks/[workId]/feed.xml.js
+++ b/src/pages/audiobooks/[workId]/feed.xml.js
@@ -1,0 +1,22 @@
+import { listWorks, publishedEpisodes } from "../../../audiobook/catalog.js";
+import { buildPodcastXml } from "../../../audiobook/podcast.js";
+
+export function getStaticPaths() {
+  return listWorks()
+    .filter((work) => work.metadata.podcast?.enabled === true)
+    .map((work) => ({ params: { workId: work.workId }, props: { work } }));
+}
+
+export function GET({ props, site }) {
+  if (!site) throw new Error("Astro site URL is required to generate podcast feeds");
+  const { work } = props;
+  const episodes = publishedEpisodes(work);
+  const xml = buildPodcastXml({ work, episodes, siteUrl: site });
+
+  return new Response(xml, {
+    headers: {
+      "Content-Type": "application/rss+xml; charset=utf-8",
+      "Cache-Control": "public, max-age=300",
+    },
+  });
+}

--- a/src/pages/audiobooks/[workId]/index.astro
+++ b/src/pages/audiobooks/[workId]/index.astro
@@ -1,0 +1,93 @@
+---
+import PageLayout from "../../../layouts/PageLayout.astro";
+import { listWorks, publishedEpisodes } from "../../../audiobook/catalog.js";
+
+export function getStaticPaths() {
+  return listWorks().map((work) => ({ params: { workId: work.workId }, props: { work } }));
+}
+
+const { work } = Astro.props;
+const episodes = publishedEpisodes(work);
+const podcastEnabled = work.metadata.podcast?.enabled === true;
+const podcastDescription = work.metadata.podcast?.description ?? work.metadata.title;
+---
+
+<PageLayout
+  title={`${work.metadata.title} — Audiolivro`}
+  description={podcastDescription}
+  lang="pt"
+  breadcrumb={[
+    { name: "Audiolivros", item: "/audiobooks/" },
+    { name: work.metadata.title, item: `/audiobooks/${work.workId}/` },
+  ]}
+>
+  <main class="container audiobook-work">
+    <p><a href="/audiobooks/">← Audiolivros</a></p>
+    <header>
+      <p class="eyebrow">{podcastEnabled ? "Podcast" : "Em preparação"}</p>
+      <h1>{work.metadata.title}</h1>
+      <p>{work.metadata.author}</p>
+      <p>{podcastDescription}</p>
+    </header>
+
+    {
+      podcastEnabled && (
+        <aside class="subscribe">
+          <strong>Assinar por RSS</strong>
+          <p>Adicione este endereço ao seu tocador de podcasts:</p>
+          <p><a href={`/audiobooks/${work.workId}/feed.xml`}>{`/audiobooks/${work.workId}/feed.xml`}</a></p>
+        </aside>
+      )
+    }
+
+    <section>
+      <h2>Capítulos</h2>
+      {
+        episodes.length === 0 ? (
+          <p>O audiolivro ainda não tem capítulos publicados.</p>
+        ) : (
+          <ol class="episodes">
+            {episodes.map((episode) => (
+              <li>
+                <a href={`/audiobooks/${work.workId}/${episode.chapterId}/`}>{episode.title}</a>
+                {episode.durationSeconds != null && (
+                  <small>{` · ${Math.round(episode.durationSeconds / 60)} min`}</small>
+                )}
+              </li>
+            ))}
+          </ol>
+        )
+      }
+    </section>
+  </main>
+</PageLayout>
+
+<style>
+  .audiobook-work {
+    max-width: 52rem;
+    padding-block: 3rem 5rem;
+  }
+
+  .eyebrow {
+    font-size: 0.8rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    opacity: 0.72;
+  }
+
+  .subscribe {
+    margin-block: 2rem;
+    padding: 1rem 1.25rem;
+    border: 1px solid var(--pico-muted-border-color);
+    border-radius: var(--pico-border-radius);
+  }
+
+  .subscribe p:last-child {
+    margin-bottom: 0;
+    overflow-wrap: anywhere;
+  }
+
+  .episodes li {
+    margin-block: 0.6rem;
+  }
+</style>

--- a/src/pages/audiobooks/index.astro
+++ b/src/pages/audiobooks/index.astro
@@ -1,0 +1,81 @@
+---
+import PageLayout from "../../layouts/PageLayout.astro";
+import { listWorks, publishedEpisodes } from "../../audiobook/catalog.js";
+
+const works = listWorks();
+---
+
+<PageLayout
+  title="Audiolivros"
+  description="Audiolivros produzidos de forma reproduzível, capítulo por capítulo."
+  lang="pt"
+>
+  <main class="container audiobook-catalog">
+    <header>
+      <p class="eyebrow">Audiobook Factory</p>
+      <h1>Audiolivros</h1>
+      <p>
+        Obras preparadas em camadas rastreáveis de original, tradução e narração, com síntese de voz e
+        publicação por podcast.
+      </p>
+    </header>
+
+    {
+      works.length === 0 ? (
+        <p>Nenhuma obra cadastrada.</p>
+      ) : (
+        <div class="work-grid">
+          {works.map((work) => {
+            const episodes = publishedEpisodes(work);
+            const enabled = work.metadata.podcast?.enabled === true;
+            return (
+              <article>
+                <p class="status">{enabled ? "podcast" : "em preparação"}</p>
+                <h2><a href={`/audiobooks/${work.workId}/`}>{work.metadata.title}</a></h2>
+                <p>{work.metadata.author}</p>
+                <p>
+                  {episodes.length === 0
+                    ? "Nenhum capítulo publicado ainda."
+                    : `${episodes.length} ${episodes.length === 1 ? "capítulo publicado" : "capítulos publicados"}.`}
+                </p>
+              </article>
+            );
+          })}
+        </div>
+      )
+    }
+  </main>
+</PageLayout>
+
+<style>
+  .audiobook-catalog {
+    max-width: 64rem;
+    padding-block: 3rem 5rem;
+  }
+
+  .eyebrow,
+  .status {
+    font-size: 0.8rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    opacity: 0.72;
+  }
+
+  .work-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(16rem, 1fr));
+    gap: 1rem;
+    margin-top: 2rem;
+  }
+
+  article {
+    padding: 1.25rem;
+    border: 1px solid var(--pico-muted-border-color);
+    border-radius: var(--pico-border-radius);
+  }
+
+  article h2 {
+    margin-block: 0.35rem 0.75rem;
+    font-size: 1.2rem;
+  }
+</style>


### PR DESCRIPTION
## Objetivo

Transformar a Audiobook Factory em uma saída real do blog: catálogo multi-work, página por obra, página por episódio e um feed RSS independente por obra.

## Contrato implementado

- `/audiobooks/` lista todas as obras cadastradas;
- `/audiobooks/<work_id>/` mostra a obra e capítulos publicados;
- `/audiobooks/<work_id>/<chapter_id>/` reproduz o mesmo enclosure usado no podcast;
- `/audiobooks/<work_id>/feed.xml` só é gerado quando `podcast.enabled: true`;
- somente capítulos com `publication.status: published` entram no feed;
- GUID é `audiobook:<work_id>:<chapter_id>` e não muda quando áudio/storage mudam;
- enclosure exige URL, bytes e MIME válidos;
- Podcasting 2.0 suporta transcript e chapters quando presentes;
- catálogo e feed são derivados de `data/audiobooks/<work_id>`, sem catálogo paralelo.

## HPMOR

A obra recebe desde já:

- identidade futura do podcast;
- item preferencial do Internet Archive `franklinbaldo-hpmor-ptbr-audiobook`;
- `podcast.enabled: false` enquanto não existir episódio pronto e publicado.

Assim o site pode mostrar a obra como `em preparação` sem expor um podcast vazio ou um enclosure inexistente.

## Testes

- descoberta e carregamento de obras;
- filtro de capítulos publicados;
- proteção contra `work_id` inseguro;
- RSS 2.0 parseável;
- GUID estável;
- enclosure obrigatório;
- transcript/chapters Podcasting 2.0;
- feed recusado enquanto podcast estiver desabilitado.

PR empilhada sobre #1596.