### PR TITLE
feat(audiobook): assemble and publish verified media to Internet Archive

### DIFF
--- a/.github/workflows/audiobook-media.yml
+++ b/.github/workflows/audiobook-media.yml
@@ -1,0 +1,221 @@
+name: Audiobook Media
+
+on:
+  workflow_dispatch:
+    inputs:
+      work_id:
+        description: Audiobook work_id
+        required: true
+        default: hpmor
+        type: string
+      chapter_id:
+        description: Canonical chapter/unit id
+        required: true
+        default: hpmor-001
+        type: string
+      runner:
+        description: Media compute runner
+        required: true
+        default: local
+        type: choice
+        options:
+          - local
+          - colab
+          - kaggle
+      backend:
+        description: TTS backend adapter (fake is the CI/proof backend)
+        required: true
+        default: fake
+        type: string
+      model:
+        description: Backend model identifier
+        required: true
+        default: deterministic-tone-v1
+        type: string
+      accelerator:
+        description: Remote accelerator (T4 for Colab, NvidiaTeslaT4 for Kaggle)
+        required: false
+        default: ""
+        type: string
+      dry_run:
+        description: Validate/plan only; never invoke media compute
+        required: true
+        default: true
+        type: boolean
+      force:
+        description: Reserved for future cache bypass
+        required: true
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+
+concurrency:
+  group: audiobook-media-${{ inputs.work_id }}-${{ inputs.chapter_id }}
+  cancel-in-progress: false
+
+jobs:
+  media:
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 24
+          cache: npm
+
+      - run: npm ci
+
+      - name: Inspect editorial readiness
+        id: readiness
+        env:
+          WORK_ID: ${{ inputs.work_id }}
+          CHAPTER_ID: ${{ inputs.chapter_id }}
+        run: |
+          npm run audiobook:validate -- \
+            --work "$WORK_ID" \
+            --chapter "$CHAPTER_ID" \
+            --json > "$RUNNER_TEMP/readiness.json"
+          cat "$RUNNER_TEMP/readiness.json"
+          node - "$RUNNER_TEMP/readiness.json" >> "$GITHUB_OUTPUT" <<'NODE'
+          const fs = require('node:fs');
+          const result = JSON.parse(fs.readFileSync(process.argv[2], 'utf8'));
+          const chapter = result.chapters[0];
+          console.log(`ready=${chapter.readyForAudio}`);
+          console.log(`narration_ready=${!chapter.pendingGates.includes('narration_ready')}`);
+          NODE
+
+      - name: Require ready_for_audio before synthesis
+        if: ${{ inputs.dry_run == false }}
+        env:
+          WORK_ID: ${{ inputs.work_id }}
+          CHAPTER_ID: ${{ inputs.chapter_id }}
+        run: |
+          npm run audiobook:validate -- \
+            --work "$WORK_ID" \
+            --chapter "$CHAPTER_ID" \
+            --require-ready-for-audio
+
+      - name: Create deterministic TTS plan
+        if: ${{ inputs.dry_run == false || steps.readiness.outputs.narration_ready == 'true' }}
+        env:
+          WORK_ID: ${{ inputs.work_id }}
+          CHAPTER_ID: ${{ inputs.chapter_id }}
+        run: |
+          node scripts/audiobook/plan.mjs \
+            --work "$WORK_ID" \
+            --chapter "$CHAPTER_ID" \
+            --output "$RUNNER_TEMP/plan.json"
+          node - "$RUNNER_TEMP/plan.json" >> "$GITHUB_STEP_SUMMARY" <<'NODE'
+          const fs = require('node:fs');
+          const plan = JSON.parse(fs.readFileSync(process.argv[2], 'utf8'));
+          console.log('## TTS plan');
+          console.log(`- work: \`${plan.work_id}\``);
+          console.log(`- chapter: \`${plan.chapter_id}\``);
+          console.log(`- segments: **${plan.segments.length}**`);
+          console.log(`- narration digest: \`${plan.narration_digest}\``);
+          NODE
+
+      - name: Report editorial block in dry-run
+        if: ${{ inputs.dry_run == true && steps.readiness.outputs.narration_ready != 'true' }}
+        env:
+          WORK_ID: ${{ inputs.work_id }}
+          CHAPTER_ID: ${{ inputs.chapter_id }}
+        run: |
+          {
+            echo "## Audiobook dry-run"
+            echo
+            echo "\`$WORK_ID / $CHAPTER_ID\` is not yet narration-ready."
+            echo "No TTS plan or external compute was started."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        if: ${{ inputs.dry_run == false }}
+        with:
+          python-version: "3.12"
+
+      - name: Run local media worker
+        if: ${{ inputs.dry_run == false && inputs.runner == 'local' }}
+        env:
+          BACKEND: ${{ inputs.backend }}
+          MODEL: ${{ inputs.model }}
+        run: |
+          bash scripts/audiobook/runners/local.sh \
+            --plan "$RUNNER_TEMP/plan.json" \
+            --output "$RUNNER_TEMP/audiobook-result.zip" \
+            --backend "$BACKEND" \
+            --model "$MODEL"
+
+      - name: Configure Colab CLI
+        if: ${{ inputs.dry_run == false && inputs.runner == 'colab' }}
+        env:
+          COLAB_ADC_JSON: ${{ secrets.COLAB_ADC_JSON }}
+        run: |
+          [[ -n "$COLAB_ADC_JSON" ]] || { echo "Missing GitHub secret COLAB_ADC_JSON" >&2; exit 2; }
+          python -m pip install --disable-pip-version-check 'google-colab-cli==0.6.0'
+          printf '%s' "$COLAB_ADC_JSON" > "$RUNNER_TEMP/colab-adc.json"
+          chmod 600 "$RUNNER_TEMP/colab-adc.json"
+          echo "GOOGLE_APPLICATION_CREDENTIALS=$RUNNER_TEMP/colab-adc.json" >> "$GITHUB_ENV"
+
+      - name: Run Colab media worker
+        if: ${{ inputs.dry_run == false && inputs.runner == 'colab' }}
+        env:
+          BACKEND: ${{ inputs.backend }}
+          MODEL: ${{ inputs.model }}
+          REQUESTED_ACCELERATOR: ${{ inputs.accelerator }}
+        run: |
+          GPU="${REQUESTED_ACCELERATOR:-T4}"
+          bash scripts/audiobook/runners/colab.sh \
+            --plan "$RUNNER_TEMP/plan.json" \
+            --output "$RUNNER_TEMP/audiobook-result.zip" \
+            --backend "$BACKEND" \
+            --model "$MODEL" \
+            --gpu "$GPU"
+
+      - name: Configure Kaggle CLI
+        if: ${{ inputs.dry_run == false && inputs.runner == 'kaggle' }}
+        env:
+          KAGGLE_API_TOKEN: ${{ secrets.KAGGLE_API_TOKEN }}
+          KAGGLE_USERNAME: ${{ vars.KAGGLE_USERNAME }}
+        run: |
+          [[ -n "$KAGGLE_API_TOKEN" ]] || { echo "Missing GitHub secret KAGGLE_API_TOKEN" >&2; exit 2; }
+          [[ -n "$KAGGLE_USERNAME" ]] || { echo "Missing GitHub variable KAGGLE_USERNAME" >&2; exit 2; }
+          python -m pip install --disable-pip-version-check 'kaggle==2.2.4'
+
+      - name: Run Kaggle media worker
+        if: ${{ inputs.dry_run == false && inputs.runner == 'kaggle' }}
+        env:
+          BACKEND: ${{ inputs.backend }}
+          MODEL: ${{ inputs.model }}
+          REQUESTED_ACCELERATOR: ${{ inputs.accelerator }}
+          KAGGLE_API_TOKEN: ${{ secrets.KAGGLE_API_TOKEN }}
+          KAGGLE_USERNAME: ${{ vars.KAGGLE_USERNAME }}
+        run: |
+          ACCELERATOR="${REQUESTED_ACCELERATOR:-NvidiaTeslaT4}"
+          bash scripts/audiobook/runners/kaggle.sh \
+            --plan "$RUNNER_TEMP/plan.json" \
+            --output "$RUNNER_TEMP/audiobook-result.zip" \
+            --backend "$BACKEND" \
+            --model "$MODEL" \
+            --accelerator "$ACCELERATOR"
+
+      - name: Upload plan
+        if: ${{ always() && (inputs.dry_run == false || steps.readiness.outputs.narration_ready == 'true') }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: audiobook-plan-${{ inputs.work_id }}-${{ inputs.chapter_id }}
+          path: ${{ runner.temp }}/plan.json
+          if-no-files-found: ignore
+          retention-days: 14
+
+      - name: Upload media result
+        if: ${{ inputs.dry_run == false }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: audiobook-media-${{ inputs.work_id }}-${{ inputs.chapter_id }}
+          path: ${{ runner.temp }}/audiobook-result.zip
+          if-no-files-found: error
+          retention-days: 30

--- a/.github/workflows/audiobook-media.yml
+++ b/.github/workflows/audiobook-media.yml
@@ -42,6 +42,11 @@ on:
         required: true
         default: true
         type: boolean
+      publish:
+        description: Publish assembled chapter to Internet Archive and persist enclosure state
+        required: true
+        default: false
+        type: boolean
       force:
         description: Reserved for future cache bypass
         required: true
@@ -49,7 +54,7 @@ on:
         type: boolean
 
 permissions:
-  contents: read
+  contents: write
 
 concurrency:
   group: audiobook-media-${{ inputs.work_id }}-${{ inputs.chapter_id }}
@@ -61,6 +66,8 @@ jobs:
     timeout-minutes: 360
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
@@ -68,6 +75,19 @@ jobs:
           cache: npm
 
       - run: npm ci
+
+      - name: Validate publish invocation
+        if: ${{ inputs.publish == true }}
+        env:
+          DRY_RUN: ${{ inputs.dry_run }}
+          BACKEND: ${{ inputs.backend }}
+        run: |
+          [[ "$DRY_RUN" == "false" ]] || { echo "publish=true requires dry_run=false" >&2; exit 2; }
+          [[ "$BACKEND" != "fake" ]] || { echo "refusing to publish fake TTS output" >&2; exit 2; }
+          [[ "$GITHUB_REF" == "refs/heads/main" ]] || {
+            echo "publishing is allowed only from the default main branch" >&2
+            exit 2
+          }
 
       - name: Inspect editorial readiness
         id: readiness
@@ -202,6 +222,79 @@ jobs:
             --model "$MODEL" \
             --accelerator "$ACCELERATOR"
 
+      - name: Extract media result
+        if: ${{ inputs.dry_run == false }}
+        run: |
+          mkdir -p "$RUNNER_TEMP/media"
+          unzip -q "$RUNNER_TEMP/audiobook-result.zip" -d "$RUNNER_TEMP/media"
+
+      - name: Assemble chapter and transcript
+        if: ${{ inputs.dry_run == false }}
+        run: |
+          python3 scripts/audiobook/assemble.py \
+            --plan "$RUNNER_TEMP/plan.json" \
+            --media-dir "$RUNNER_TEMP/media" \
+            --output-dir "$RUNNER_TEMP/assembled"
+
+      - name: Configure Internet Archive client
+        if: ${{ inputs.publish == true }}
+        env:
+          IA_ACCESS_KEY_ID: ${{ secrets.IA_ACCESS_KEY_ID }}
+          IA_SECRET_ACCESS_KEY: ${{ secrets.IA_SECRET_ACCESS_KEY }}
+        run: |
+          [[ -n "$IA_ACCESS_KEY_ID" ]] || { echo "Missing GitHub secret IA_ACCESS_KEY_ID" >&2; exit 2; }
+          [[ -n "$IA_SECRET_ACCESS_KEY" ]] || { echo "Missing GitHub secret IA_SECRET_ACCESS_KEY" >&2; exit 2; }
+          python -m pip install --disable-pip-version-check 'internetarchive==5.11.1'
+
+      - name: Upload and verify Internet Archive enclosure
+        if: ${{ inputs.publish == true }}
+        env:
+          WORK_ID: ${{ inputs.work_id }}
+          CHAPTER_ID: ${{ inputs.chapter_id }}
+          IA_ACCESS_KEY_ID: ${{ secrets.IA_ACCESS_KEY_ID }}
+          IA_SECRET_ACCESS_KEY: ${{ secrets.IA_SECRET_ACCESS_KEY }}
+        run: |
+          node scripts/audiobook/publish-internet-archive.mjs \
+            --work "$WORK_ID" \
+            --chapter "$CHAPTER_ID" \
+            --assembly-dir "$RUNNER_TEMP/assembled" \
+            --output "$RUNNER_TEMP/publication.json"
+
+      - name: Persist publication state
+        if: ${{ inputs.publish == true }}
+        env:
+          WORK_ID: ${{ inputs.work_id }}
+          CHAPTER_ID: ${{ inputs.chapter_id }}
+        run: |
+          node scripts/audiobook/apply-publication.mjs \
+            --work "$WORK_ID" \
+            --chapter "$CHAPTER_ID" \
+            --publication "$RUNNER_TEMP/publication.json"
+
+          npm run audiobook:validate -- --work "$WORK_ID" --chapter "$CHAPTER_ID" --require-ready-for-audio
+          npm run build
+
+      - name: Commit published episode state
+        if: ${{ inputs.publish == true }}
+        env:
+          WORK_ID: ${{ inputs.work_id }}
+          CHAPTER_ID: ${{ inputs.chapter_id }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add "data/audiobooks/$WORK_ID/state.yaml" "data/audiobooks/$WORK_ID/work.md"
+          git commit -m "feat(audiobook): publish $WORK_ID $CHAPTER_ID"
+          for attempt in 1 2 3; do
+            if git push origin HEAD:main; then
+              exit 0
+            fi
+            echo "Push rejected (attempt $attempt/3), rebasing onto latest main..."
+            git fetch origin main
+            git rebase origin/main
+          done
+          echo "Push failed after 3 attempts; media is uploaded but publication state was not persisted." >&2
+          exit 1
+
       - name: Upload plan
         if: ${{ always() && (inputs.dry_run == false || steps.readiness.outputs.narration_ready == 'true') }}
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
@@ -211,7 +304,7 @@ jobs:
           if-no-files-found: ignore
           retention-days: 14
 
-      - name: Upload media result
+      - name: Upload raw media result
         if: ${{ inputs.dry_run == false }}
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
@@ -219,3 +312,21 @@ jobs:
           path: ${{ runner.temp }}/audiobook-result.zip
           if-no-files-found: error
           retention-days: 30
+
+      - name: Upload assembled chapter
+        if: ${{ inputs.dry_run == false }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: audiobook-assembled-${{ inputs.work_id }}-${{ inputs.chapter_id }}
+          path: ${{ runner.temp }}/assembled/
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Upload publication receipt
+        if: ${{ inputs.publish == true }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: audiobook-publication-${{ inputs.work_id }}-${{ inputs.chapter_id }}
+          path: ${{ runner.temp }}/publication.json
+          if-no-files-found: error
+          retention-days: 90

--- a/data/audiobooks/hpmor/state.yaml
+++ b/data/audiobooks/hpmor/state.yaml
@@ -14,6 +14,10 @@ chapters:
   hpmor-001:
     status: not_started
     next_action: import source snapshot and establish stable segment ids
+    files:
+      original: original/001.md
+      translation: translation/001.md
+      narration: narration/001.md
     gates:
       work_ready: true
       source_ready: false

--- a/data/audiobooks/hpmor/work.md
+++ b/data/audiobooks/hpmor/work.md
@@ -8,6 +8,15 @@ target_language: pt-BR
 source_url: https://hpmor.com/
 status: preparing
 publication_mode: non-commercial-experimental
+podcast:
+  enabled: false
+  title: Harry Potter e os Métodos da Racionalidade — Audiolivro
+  description: Edição em português brasileiro produzida pela Audiobook Factory de Franklin Baldo.
+  language: pt-BR
+  author: Franklin Baldo
+media:
+  durable_backend: internet-archive
+  archive_item: franklinbaldo-hpmor-ptbr-audiobook
 ---
 
 # Harry Potter and the Methods of Rationality
@@ -36,4 +45,6 @@ O texto integral não é duplicado neste arquivo de metadata.
 
 O projeto começa como experimento não comercial. Mudanças futuras de alcance/distribuição podem exigir revisão própria, mas não alteram o contrato técnico da fábrica.
 
-Quando habilitada, a obra terá feed RSS próprio no blog e um item estável de mídia no Internet Archive.
+A identidade do podcast já está declarada, mas `podcast.enabled` permanece `false` até haver pelo menos um episódio editorialmente aprovado, sintetizado, armazenado e validado.
+
+O destino durável preferencial de mídia é um item estável por obra no Internet Archive. Alterar o storage no futuro não altera `work_id`, GUID dos episódios nem URL canônica do feed.

--- a/docs/okf/audiobook/media-runners.md
+++ b/docs/okf/audiobook/media-runners.md
@@ -1,0 +1,164 @@
+---
+type: Operations Guide
+title: Audiobook Factory — media runners
+description: Configuração operacional dos runners local, Colab e Kaggle usados pelo GitHub Actions após ready_for_audio.
+tags: [audiobook, github-actions, colab, kaggle, tts, secrets]
+timestamp: 2026-08-30T20:30:00Z
+---
+
+# Media runners
+
+## 1. Escopo
+
+Este documento cobre somente a execução de mídia após o gate editorial `ready_for_audio`.
+
+Nenhum runner remoto participa da tradução, revisão ou preparação de narração.
+
+## 2. Workflow
+
+`.github/workflows/audiobook-media.yml` recebe:
+
+- `work_id`;
+- `chapter_id`;
+- `runner` (`local`, `colab`, `kaggle`);
+- backend/modelo;
+- acelerador opcional;
+- `dry_run`.
+
+`dry_run=true` nunca aciona compute remoto.
+
+`dry_run=false` executa primeiro:
+
+```text
+npm run audiobook:validate -- \
+  --work <work_id> \
+  --chapter <chapter_id> \
+  --require-ready-for-audio
+```
+
+Só depois desse comando passam a ser acessadas credenciais externas.
+
+## 3. Local
+
+O runner local é a implementação de referência e usa o mesmo `scripts/audiobook/worker.py`.
+
+O backend inicial `fake` produz WAVs determinísticos e existe para provar a pipeline sem TTS, rede ou GPU.
+
+## 4. Google Colab
+
+### CLI
+
+Versão inicial pinada no workflow:
+
+```text
+google-colab-cli==0.6.0
+```
+
+O fluxo usa somente comandos não interativos:
+
+```text
+colab --auth=adc new
+colab --auth=adc upload
+colab --auth=adc exec
+colab --auth=adc download
+colab --auth=adc stop
+```
+
+O CLI oficial recomenda ADC para automação/headless. A identidade precisa ter os scopes necessários ao Colab.
+
+### GitHub Secret
+
+Criar:
+
+```text
+COLAB_ADC_JSON
+```
+
+O valor esperado é o conteúdo JSON de Application Default Credentials de uma conta autorizada a usar o Colab. O workflow materializa o JSON num arquivo temporário com permissão restrita e define `GOOGLE_APPLICATION_CREDENTIALS` apenas durante o job.
+
+**Gate de realidade:** armazenamento correto da credencial não prova que a conta terá direito a uma GPU gratuita em execução headless. Isso deve ser validado por uma execução real com a conta do projeto. Falha de quota/alocação é falha do runner, não do corpus ou do modelo TTS.
+
+Default do projeto: `T4`.
+
+## 5. Kaggle
+
+### CLI
+
+Versão inicial pinada:
+
+```text
+kaggle==2.2.4
+```
+
+O CLI oficial aceita autenticação não interativa por `KAGGLE_API_TOKEN` e kernels com `kernel_type: script`.
+
+O runner gera um `job.py` autocontido e um `kernel-metadata.json`, depois executa:
+
+```text
+kaggle kernels push
+kaggle kernels status
+kaggle kernels output
+```
+
+Default do projeto: `NvidiaTeslaT4`.
+
+A T4 é preferida ao P100 no ambiente atual porque a própria documentação do CLI alerta que o PyTorch default recente pode não conter kernels Pascal (`sm_60`) necessários ao P100.
+
+### GitHub Secret e variável
+
+Criar secret:
+
+```text
+KAGGLE_API_TOKEN
+```
+
+Criar repository variable:
+
+```text
+KAGGLE_USERNAME
+```
+
+O kernel default será:
+
+```text
+<KAGGLE_USERNAME>/audiobook-factory-tts
+```
+
+O token é passado somente ao step que configura/executa Kaggle; não é escrito no corpus nem no artifact.
+
+## 6. Backend TTS e runner são eixos separados
+
+`runner=kaggle` não significa `backend=breeze`.
+
+Exemplos válidos no futuro:
+
+```text
+runner=kaggle, backend=breeze
+runner=kaggle, backend=qwen3-tts
+runner=colab, backend=higgs
+runner=local, backend=fake
+```
+
+O backend escolhe **como sintetizar**. O runner escolhe **onde executar**.
+
+## 7. Resultado comum
+
+Todos os runners precisam devolver o mesmo contrato:
+
+```text
+audiobook-result.zip
+  manifest.json
+  segments/
+    <segment_id>.wav
+    ...
+```
+
+Assim Actions não precisa saber se o arquivo veio de CPU local, T4 do Colab ou T4 do Kaggle.
+
+## 8. Referências verificadas em 2026-08-30
+
+- Google Colab CLI: https://github.com/googlecolab/google-colab-cli
+- Kaggle CLI kernels: https://github.com/Kaggle/kaggle-cli/blob/main/docs/kernels.md
+- Kaggle auth: https://github.com/Kaggle/kaggle-cli/blob/main/skills/references/auth.md
+
+As versões e superfícies desses CLIs podem mudar; upgrades devem ser PRs explícitas e acompanhadas de smoke test headless.

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "check:links": "node scripts/check-links.mjs",
     "check:translations": "node scripts/check-translations.mjs",
     "audiobook:validate": "node scripts/audiobook/validate.mjs",
+    "audiobook:plan": "node scripts/audiobook/plan.mjs",
     "dev": "astro dev",
     "build": "astro build && node scripts/fix-redirect-html.mjs && pagefind --site dist && node --import tsx/esm scripts/generate-ranking-snapshot.mjs",
     "preview": "astro preview",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "check:changelog": "node scripts/check-changelog.mjs",
     "check:links": "node scripts/check-links.mjs",
     "check:translations": "node scripts/check-translations.mjs",
+    "audiobook:validate": "node scripts/audiobook/validate.mjs",
     "dev": "astro dev",
     "build": "astro build && node scripts/fix-redirect-html.mjs && pagefind --site dist && node --import tsx/esm scripts/generate-ranking-snapshot.mjs",
     "preview": "astro preview",

--- a/scripts/audiobook/apply-publication.mjs
+++ b/scripts/audiobook/apply-publication.mjs
@@ -1,0 +1,102 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+
+import matter from "gray-matter";
+import yaml from "js-yaml";
+
+function parseArgs(argv) {
+  const args = { workId: null, chapterId: null, publicationPath: null };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--work") args.workId = argv[++index] ?? null;
+    else if (arg === "--chapter") args.chapterId = argv[++index] ?? null;
+    else if (arg === "--publication") args.publicationPath = argv[++index] ?? null;
+    else throw new Error(`Unknown argument: ${arg}`);
+  }
+  if (!args.workId || !args.chapterId || !args.publicationPath) {
+    throw new Error("--work, --chapter and --publication are required");
+  }
+  return args;
+}
+
+function yamlText(value) {
+  return yaml.dump(value, { noRefs: true, lineWidth: -1, sortKeys: false, quotingType: '"' });
+}
+
+function updateWorkPodcast(workPath) {
+  const parsed = matter(fs.readFileSync(workPath, "utf8"));
+  if (!parsed.data.podcast) throw new Error("work.md must declare podcast metadata before publication");
+  if (parsed.data.podcast.enabled === true) return false;
+
+  parsed.data.podcast.enabled = true;
+  const frontmatter = yamlText(parsed.data).trimEnd();
+  const body = parsed.content.startsWith("\n") ? parsed.content : `\n${parsed.content}`;
+  fs.writeFileSync(workPath, `---\n${frontmatter}\n---${body}`);
+  return true;
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const workDir = path.join(process.cwd(), "data", "audiobooks", args.workId);
+  const statePath = path.join(workDir, "state.yaml");
+  const workPath = path.join(workDir, "work.md");
+  const state = yaml.load(fs.readFileSync(statePath, "utf8")) ?? {};
+  const publication = JSON.parse(fs.readFileSync(args.publicationPath, "utf8"));
+
+  if (state.work_id !== args.workId) throw new Error("state work_id mismatch");
+  if (publication.work_id !== args.workId || publication.chapter_id !== args.chapterId) {
+    throw new Error("publication identity mismatch");
+  }
+  if (publication.dry_run) throw new Error("refusing to apply dry-run publication");
+
+  const chapter = state.chapters?.[args.chapterId];
+  if (!chapter) throw new Error(`unknown chapter ${args.chapterId}`);
+  if (chapter.ready_for_audio !== true) throw new Error(`${args.chapterId} is not ready_for_audio`);
+  if (!publication.enclosure?.url || !publication.enclosure?.bytes || !publication.enclosure?.type) {
+    throw new Error("publication is missing a complete enclosure");
+  }
+  if (!publication.verification) throw new Error("publication enclosure was not verified");
+
+  chapter.status = "published";
+  chapter.publication = {
+    ...(chapter.publication ?? {}),
+    status: "published",
+    title: publication.title,
+    description: publication.description,
+    published_at: publication.published_at,
+    duration_seconds: publication.duration_seconds,
+    audio_digest: publication.audio_digest,
+    enclosure: publication.enclosure,
+    transcript: publication.transcript,
+    archive_item: publication.archive_item,
+  };
+  chapter.next_action = "published; regenerate only if editorial or TTS inputs change";
+
+  const pending = Object.entries(state.chapters)
+    .filter(([, value]) => value.publication?.status !== "published")
+    .map(([chapterId]) => chapterId);
+  state.status = pending.length ? "in_progress" : "published";
+  state.next_action = pending.length ? `continue editorial work on ${pending[0]}` : "all registered chapters published";
+
+  fs.writeFileSync(statePath, yamlText(state));
+  const podcastChanged = updateWorkPodcast(workPath);
+
+  console.log(
+    JSON.stringify({
+      work_id: args.workId,
+      chapter_id: args.chapterId,
+      state_path: path.relative(process.cwd(), statePath),
+      podcast_enabled: podcastChanged ? "enabled_now" : "already_enabled",
+    }),
+  );
+}
+
+try {
+  main();
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(2);
+}

--- a/scripts/audiobook/apply-publication.mjs
+++ b/scripts/audiobook/apply-publication.mjs
@@ -13,8 +13,11 @@ function parseArgs(argv) {
     const arg = argv[index];
     if (arg === "--work") args.workId = argv[++index] ?? null;
     else if (arg === "--chapter") args.chapterId = argv[++index] ?? null;
-    else if (arg === "--publication") args.publicationPath = argv[++index] ?? null;
-    else throw new Error(`Unknown argument: ${arg}`);
+    else if (arg === "--publication") {
+      args.publicationPath = argv[++index] ?? null;
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
   }
   if (!args.workId || !args.chapterId || !args.publicationPath) {
     throw new Error("--work, --chapter and --publication are required");
@@ -23,17 +26,26 @@ function parseArgs(argv) {
 }
 
 function yamlText(value) {
-  return yaml.dump(value, { noRefs: true, lineWidth: -1, sortKeys: false, quotingType: '"' });
+  return yaml.dump(value, {
+    noRefs: true,
+    lineWidth: -1,
+    sortKeys: false,
+    quotingType: '"',
+  });
 }
 
 function updateWorkPodcast(workPath) {
   const parsed = matter(fs.readFileSync(workPath, "utf8"));
-  if (!parsed.data.podcast) throw new Error("work.md must declare podcast metadata before publication");
+  if (!parsed.data.podcast) {
+    throw new Error("work.md must declare podcast metadata before publication");
+  }
   if (parsed.data.podcast.enabled === true) return false;
 
   parsed.data.podcast.enabled = true;
   const frontmatter = yamlText(parsed.data).trimEnd();
-  const body = parsed.content.startsWith("\n") ? parsed.content : `\n${parsed.content}`;
+  const body = parsed.content.startsWith("\n")
+    ? parsed.content
+    : `\n${parsed.content}`;
   fs.writeFileSync(workPath, `---\n${frontmatter}\n---${body}`);
   return true;
 }
@@ -44,21 +56,44 @@ function main() {
   const statePath = path.join(workDir, "state.yaml");
   const workPath = path.join(workDir, "work.md");
   const state = yaml.load(fs.readFileSync(statePath, "utf8")) ?? {};
-  const publication = JSON.parse(fs.readFileSync(args.publicationPath, "utf8"));
+  const publication = JSON.parse(
+    fs.readFileSync(args.publicationPath, "utf8"),
+  );
 
   if (state.work_id !== args.workId) throw new Error("state work_id mismatch");
-  if (publication.work_id !== args.workId || publication.chapter_id !== args.chapterId) {
+  if (state.publication?.public_distribution_authorized !== true) {
+    throw new Error(
+      "public distribution is not authorized in state.yaml; refusing to persist a public episode",
+    );
+  }
+  if (
+    publication.work_id !== args.workId ||
+    publication.chapter_id !== args.chapterId
+  ) {
     throw new Error("publication identity mismatch");
   }
-  if (publication.dry_run) throw new Error("refusing to apply dry-run publication");
+  if (publication.dry_run) {
+    throw new Error("refusing to apply dry-run publication");
+  }
 
   const chapter = state.chapters?.[args.chapterId];
   if (!chapter) throw new Error(`unknown chapter ${args.chapterId}`);
-  if (chapter.ready_for_audio !== true) throw new Error(`${args.chapterId} is not ready_for_audio`);
-  if (!publication.enclosure?.url || !publication.enclosure?.bytes || !publication.enclosure?.type) {
+  if (chapter.ready_for_audio !== true) {
+    throw new Error(`${args.chapterId} is not ready_for_audio`);
+  }
+  if (
+    !publication.enclosure?.url ||
+    !publication.enclosure?.bytes ||
+    !publication.enclosure?.type
+  ) {
     throw new Error("publication is missing a complete enclosure");
   }
-  if (!publication.verification) throw new Error("publication enclosure was not verified");
+  if (!publication.verification) {
+    throw new Error("publication enclosure was not verified");
+  }
+  if (!publication.transcript?.verification) {
+    throw new Error("publication transcript was not verified");
+  }
 
   chapter.status = "published";
   chapter.publication = {
@@ -73,13 +108,16 @@ function main() {
     transcript: publication.transcript,
     archive_item: publication.archive_item,
   };
-  chapter.next_action = "published; regenerate only if editorial or TTS inputs change";
+  chapter.next_action =
+    "published; regenerate only if editorial or TTS inputs change";
 
   const pending = Object.entries(state.chapters)
     .filter(([, value]) => value.publication?.status !== "published")
     .map(([chapterId]) => chapterId);
   state.status = pending.length ? "in_progress" : "published";
-  state.next_action = pending.length ? `continue editorial work on ${pending[0]}` : "all registered chapters published";
+  state.next_action = pending.length
+    ? `continue editorial work on ${pending[0]}`
+    : "all registered chapters published";
 
   fs.writeFileSync(statePath, yamlText(state));
   const podcastChanged = updateWorkPodcast(workPath);

--- a/scripts/audiobook/assemble.py
+++ b/scripts/audiobook/assemble.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+"""Assemble TTS segments into a distributable chapter.
+
+This stage is intentionally model-agnostic. It consumes the common media
+manifest plus the original TTS plan, concatenates segment audio with ffmpeg,
+and emits a stable MP3, WebVTT transcript and assembly manifest.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+import subprocess
+import sys
+
+ASSEMBLY_SCHEMA = "audiobook-assembly-v1"
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return f"sha256:{digest.hexdigest()}"
+
+
+def load_json(path: Path) -> dict:
+    with path.open("r", encoding="utf-8") as stream:
+        return json.load(stream)
+
+
+def vtt_time(milliseconds: int) -> str:
+    if milliseconds < 0:
+        raise ValueError("negative VTT timestamp")
+    hours, remainder = divmod(milliseconds, 3_600_000)
+    minutes, remainder = divmod(remainder, 60_000)
+    seconds, millis = divmod(remainder, 1_000)
+    return f"{hours:02d}:{minutes:02d}:{seconds:02d}.{millis:03d}"
+
+
+def vtt_text(value: str) -> str:
+    return value.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+
+
+def make_vtt(plan: dict, media_manifest: dict) -> tuple[str, int]:
+    media_by_id = {segment["segment_id"]: segment for segment in media_manifest["segments"]}
+    lines = ["WEBVTT", ""]
+    cursor_ms = 0
+
+    for index, segment in enumerate(plan["segments"], start=1):
+        segment_id = segment["segment_id"]
+        media = media_by_id.get(segment_id)
+        if media is None:
+            raise ValueError(f"media manifest missing segment {segment_id}")
+        duration_ms = int(media["duration_ms"])
+        if duration_ms <= 0:
+            raise ValueError(f"invalid duration for {segment_id}: {duration_ms}")
+        end_ms = cursor_ms + duration_ms
+        speaker = vtt_text(str(segment["speaker"]))
+        text = vtt_text(str(segment["text"]).strip())
+        lines.extend(
+            [
+                str(index),
+                f"{vtt_time(cursor_ms)} --> {vtt_time(end_ms)}",
+                f"<v {speaker}>{text}",
+                "",
+            ]
+        )
+        cursor_ms = end_ms
+
+    extra_ids = set(media_by_id) - {segment["segment_id"] for segment in plan["segments"]}
+    if extra_ids:
+        raise ValueError(f"media manifest contains unplanned segments: {', '.join(sorted(extra_ids))}")
+
+    return "\n".join(lines), cursor_ms
+
+
+def quote_concat_path(path: Path) -> str:
+    # ffmpeg concat files use single-quoted paths; embedded quotes are escaped
+    # using the shell-compatible sequence accepted by the concat demuxer.
+    return "'" + str(path.resolve()).replace("'", "'\\''") + "'"
+
+
+def assemble(plan_path: Path, media_dir: Path, output_dir: Path, bitrate: str) -> dict:
+    plan = load_json(plan_path)
+    media_manifest_path = media_dir / "manifest.json"
+    media_manifest = load_json(media_manifest_path)
+
+    for field in ("work_id", "chapter_id"):
+        if plan.get(field) != media_manifest.get(field):
+            raise ValueError(f"{field} mismatch between plan and media manifest")
+
+    media_by_id = {segment["segment_id"]: segment for segment in media_manifest["segments"]}
+    ordered_paths = []
+    for segment in plan["segments"]:
+        media = media_by_id.get(segment["segment_id"])
+        if media is None:
+            raise ValueError(f"media manifest missing segment {segment['segment_id']}")
+        audio_path = media_dir / media["audio_file"]
+        if not audio_path.is_file():
+            raise ValueError(f"missing segment audio: {audio_path}")
+        if sha256_file(audio_path) != media["audio_digest"]:
+            raise ValueError(f"audio digest mismatch: {segment['segment_id']}")
+        ordered_paths.append(audio_path)
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    chapter_id = plan["chapter_id"]
+    audio_path = output_dir / f"{chapter_id}.mp3"
+    transcript_path = output_dir / f"{chapter_id}.vtt"
+    concat_path = output_dir / "concat.txt"
+    concat_path.write_text(
+        "".join(f"file {quote_concat_path(path)}\n" for path in ordered_paths),
+        encoding="utf-8",
+    )
+
+    command = [
+        "ffmpeg",
+        "-hide_banner",
+        "-loglevel",
+        "error",
+        "-y",
+        "-f",
+        "concat",
+        "-safe",
+        "0",
+        "-i",
+        str(concat_path),
+        "-vn",
+        "-ac",
+        "1",
+        "-c:a",
+        "libmp3lame",
+        "-b:a",
+        bitrate,
+        str(audio_path),
+    ]
+    subprocess.run(command, check=True)
+
+    transcript, duration_ms = make_vtt(plan, media_manifest)
+    transcript_path.write_text(transcript, encoding="utf-8")
+    concat_path.unlink(missing_ok=True)
+
+    result = {
+        "schema": ASSEMBLY_SCHEMA,
+        "work_id": plan["work_id"],
+        "chapter_id": chapter_id,
+        "narration_digest": plan.get("narration_digest"),
+        "backend": media_manifest.get("backend"),
+        "model": media_manifest.get("model"),
+        "duration_seconds": round(duration_ms / 1000, 3),
+        "audio": {
+            "file": audio_path.name,
+            "bytes": audio_path.stat().st_size,
+            "sha256": sha256_file(audio_path),
+            "type": "audio/mpeg",
+            "bitrate": bitrate,
+        },
+        "transcript": {
+            "file": transcript_path.name,
+            "bytes": transcript_path.stat().st_size,
+            "sha256": sha256_file(transcript_path),
+            "type": "text/vtt",
+            "language": plan.get("lang", "pt-BR"),
+        },
+    }
+    (output_dir / "assembly.json").write_text(
+        json.dumps(result, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+    return result
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--plan", required=True, type=Path)
+    parser.add_argument("--media-dir", required=True, type=Path)
+    parser.add_argument("--output-dir", required=True, type=Path)
+    parser.add_argument("--bitrate", default="96k")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        result = assemble(args.plan, args.media_dir, args.output_dir, args.bitrate)
+    except Exception as error:  # CLI boundary.
+        print(f"audiobook assemble failed: {error}", file=sys.stderr)
+        return 2
+    print(json.dumps(result, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/audiobook/plan.mjs
+++ b/scripts/audiobook/plan.mjs
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+
+import { createPlan, createWorkPlan } from "../../src/audiobook/plan.js";
+
+function usage() {
+  console.error(
+    "Usage: node scripts/audiobook/plan.mjs (--work <work_id> --chapter <chapter_id> | --narration <file.md> --voices <voices.yaml>) [--output <plan.json>]",
+  );
+}
+
+function parseArgs(argv) {
+  const args = {
+    workId: null,
+    chapterId: null,
+    narrationPath: null,
+    voicesPath: null,
+    outputPath: null,
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--work") args.workId = argv[++index] ?? null;
+    else if (arg === "--chapter") args.chapterId = argv[++index] ?? null;
+    else if (arg === "--narration") args.narrationPath = argv[++index] ?? null;
+    else if (arg === "--voices") args.voicesPath = argv[++index] ?? null;
+    else if (arg === "--output") args.outputPath = argv[++index] ?? null;
+    else if (arg === "--help" || arg === "-h") {
+      usage();
+      process.exit(0);
+    } else throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  const byWork = args.workId && args.chapterId;
+  const byFiles = args.narrationPath && args.voicesPath;
+  if (!byWork && !byFiles) throw new Error("provide --work/--chapter or --narration/--voices");
+  if (byWork && byFiles) throw new Error("choose either work/chapter resolution or explicit file paths");
+  return args;
+}
+
+try {
+  const args = parseArgs(process.argv.slice(2));
+  const plan = args.workId
+    ? createWorkPlan({ rootDir: process.cwd(), workId: args.workId, chapterId: args.chapterId })
+    : createPlan(args);
+  const json = `${JSON.stringify(plan, null, 2)}\n`;
+  if (args.outputPath) {
+    fs.mkdirSync(path.dirname(args.outputPath), { recursive: true });
+    fs.writeFileSync(args.outputPath, json);
+    console.error(`wrote ${args.outputPath}: ${plan.segments.length} segment(s)`);
+  } else {
+    process.stdout.write(json);
+  }
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  if (error?.details) for (const detail of error.details) console.error(`- ${detail}`);
+  usage();
+  process.exit(2);
+}

--- a/scripts/audiobook/publish-internet-archive.mjs
+++ b/scripts/audiobook/publish-internet-archive.mjs
@@ -1,0 +1,200 @@
+#!/usr/bin/env node
+
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+import { spawnSync } from "node:child_process";
+
+import { loadWork } from "../../src/audiobook/catalog.js";
+
+function usage() {
+  console.error(
+    "Usage: node scripts/audiobook/publish-internet-archive.mjs --work <work_id> --chapter <chapter_id> --assembly-dir <dir> --output <publication.json> [--dry-run]",
+  );
+}
+
+function parseArgs(argv) {
+  const args = { workId: null, chapterId: null, assemblyDir: null, outputPath: null, dryRun: false };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--work") args.workId = argv[++index] ?? null;
+    else if (arg === "--chapter") args.chapterId = argv[++index] ?? null;
+    else if (arg === "--assembly-dir") args.assemblyDir = argv[++index] ?? null;
+    else if (arg === "--output") args.outputPath = argv[++index] ?? null;
+    else if (arg === "--dry-run") args.dryRun = true;
+    else if (arg === "--help" || arg === "-h") {
+      usage();
+      process.exit(0);
+    } else throw new Error(`Unknown argument: ${arg}`);
+  }
+  for (const [flag, value] of [
+    ["--work", args.workId],
+    ["--chapter", args.chapterId],
+    ["--assembly-dir", args.assemblyDir],
+    ["--output", args.outputPath],
+  ]) {
+    if (!value) throw new Error(`${flag} is required`);
+  }
+  return args;
+}
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, "utf8"));
+}
+
+function sha256File(filePath) {
+  const digest = crypto.createHash("sha256");
+  digest.update(fs.readFileSync(filePath));
+  return `sha256:${digest.digest("hex")}`;
+}
+
+function run(command, args, { env = process.env } = {}) {
+  const result = spawnSync(command, args, { encoding: "utf8", env, stdio: ["ignore", "pipe", "pipe"] });
+  if (result.status !== 0) {
+    throw new Error(`${command} ${args.join(" ")} failed (${result.status}): ${result.stderr || result.stdout}`);
+  }
+  return result.stdout;
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function verifyEnclosure(url, expectedBytes, attempts = 18) {
+  let lastError;
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    try {
+      const head = await fetch(url, { method: "HEAD", redirect: "follow" });
+      if (!head.ok) throw new Error(`HEAD ${head.status}`);
+      const length = Number(head.headers.get("content-length"));
+      if (Number.isFinite(length) && length > 0 && length !== expectedBytes) {
+        throw new Error(`Content-Length ${length} != expected ${expectedBytes}`);
+      }
+
+      const range = await fetch(url, {
+        headers: { Range: "bytes=0-0" },
+        redirect: "follow",
+      });
+      if (![200, 206].includes(range.status)) throw new Error(`range request ${range.status}`);
+      const bytes = new Uint8Array(await range.arrayBuffer());
+      if (bytes.length < 1) throw new Error("range request returned no bytes");
+      return {
+        headStatus: head.status,
+        rangeStatus: range.status,
+        contentType: head.headers.get("content-type"),
+        acceptRanges: head.headers.get("accept-ranges"),
+      };
+    } catch (error) {
+      lastError = error;
+      if (attempt < attempts) await sleep(Math.min(5000 * attempt, 20_000));
+    }
+  }
+  throw new Error(`Internet Archive enclosure did not become readable: ${lastError}`);
+}
+
+function publicationTitle(work, chapter) {
+  const title = chapter.publication?.title;
+  if (!title) throw new Error(`${chapter.chapterId}: publication.title must be set before publishing`);
+  return title;
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const work = loadWork(process.cwd(), args.workId);
+  const chapter = work.chapters.find((entry) => entry.chapterId === args.chapterId);
+  if (!chapter) throw new Error(`Unknown chapter ${args.chapterId}`);
+  if (chapter.ready_for_audio !== true) throw new Error(`${args.chapterId} is not ready_for_audio`);
+
+  const archiveItem = work.metadata.media?.archive_item;
+  if (!archiveItem) throw new Error(`${args.workId}: media.archive_item is required`);
+
+  const assemblyDir = path.resolve(args.assemblyDir);
+  const assembly = readJson(path.join(assemblyDir, "assembly.json"));
+  if (assembly.work_id !== args.workId || assembly.chapter_id !== args.chapterId) {
+    throw new Error("assembly work/chapter identity mismatch");
+  }
+
+  const audioPath = path.join(assemblyDir, assembly.audio.file);
+  const transcriptPath = path.join(assemblyDir, assembly.transcript.file);
+  for (const filePath of [audioPath, transcriptPath]) {
+    if (!fs.statSync(filePath).isFile()) throw new Error(`Missing assembly file: ${filePath}`);
+  }
+  if (fs.statSync(audioPath).size !== assembly.audio.bytes || sha256File(audioPath) !== assembly.audio.sha256) {
+    throw new Error("assembled audio failed local size/digest validation");
+  }
+
+  const title = publicationTitle(work, chapter);
+  const description = chapter.publication?.description ?? work.metadata.podcast?.description ?? work.metadata.title;
+  const publishedAt = chapter.publication?.published_at ?? new Date().toISOString();
+  const audioName = path.basename(audioPath);
+  const transcriptName = path.basename(transcriptPath);
+  const baseUrl = `https://archive.org/download/${encodeURIComponent(archiveItem)}/`;
+  const enclosureUrl = new URL(encodeURIComponent(audioName), baseUrl).href;
+  const transcriptUrl = new URL(encodeURIComponent(transcriptName), baseUrl).href;
+
+  const publication = {
+    schema: "audiobook-publication-v1",
+    work_id: args.workId,
+    chapter_id: args.chapterId,
+    backend: "internet-archive",
+    archive_item: archiveItem,
+    published_at: publishedAt,
+    title,
+    description,
+    duration_seconds: assembly.duration_seconds,
+    audio_digest: assembly.audio.sha256,
+    enclosure: {
+      url: enclosureUrl,
+      bytes: assembly.audio.bytes,
+      type: assembly.audio.type,
+    },
+    transcript: {
+      url: transcriptUrl,
+      type: assembly.transcript.type,
+      language: assembly.transcript.language,
+      sha256: assembly.transcript.sha256,
+    },
+  };
+
+  if (args.dryRun) {
+    publication.dry_run = true;
+  } else {
+    if (!process.env.IA_ACCESS_KEY_ID || !process.env.IA_SECRET_ACCESS_KEY) {
+      throw new Error("IA_ACCESS_KEY_ID and IA_SECRET_ACCESS_KEY are required");
+    }
+
+    run("ia", [
+      "upload",
+      archiveItem,
+      audioPath,
+      transcriptPath,
+      path.join(assemblyDir, "assembly.json"),
+      "--retries",
+      "10",
+      "--metadata",
+      "mediatype:audio",
+      "--metadata",
+      "collection:opensource_audio",
+      "--metadata",
+      `title:${work.metadata.podcast?.title ?? work.metadata.title}`,
+      "--metadata",
+      `creator:${work.metadata.author ?? "Unknown"}`,
+      "--metadata",
+      `description:${work.metadata.podcast?.description ?? description}`,
+    ]);
+
+    publication.verification = await verifyEnclosure(enclosureUrl, assembly.audio.bytes);
+    const transcriptVerification = await verifyEnclosure(transcriptUrl, assembly.transcript.bytes);
+    publication.transcript.verification = transcriptVerification;
+  }
+
+  fs.mkdirSync(path.dirname(args.outputPath), { recursive: true });
+  fs.writeFileSync(args.outputPath, `${JSON.stringify(publication, null, 2)}\n`);
+  console.log(JSON.stringify(publication));
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(2);
+});

--- a/scripts/audiobook/publish-internet-archive.mjs
+++ b/scripts/audiobook/publish-internet-archive.mjs
@@ -15,7 +15,13 @@ function usage() {
 }
 
 function parseArgs(argv) {
-  const args = { workId: null, chapterId: null, assemblyDir: null, outputPath: null, dryRun: false };
+  const args = {
+    workId: null,
+    chapterId: null,
+    assemblyDir: null,
+    outputPath: null,
+    dryRun: false,
+  };
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index];
     if (arg === "--work") args.workId = argv[++index] ?? null;
@@ -26,7 +32,9 @@ function parseArgs(argv) {
     else if (arg === "--help" || arg === "-h") {
       usage();
       process.exit(0);
-    } else throw new Error(`Unknown argument: ${arg}`);
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
   }
   for (const [flag, value] of [
     ["--work", args.workId],
@@ -44,15 +52,25 @@ function readJson(filePath) {
 }
 
 function sha256File(filePath) {
-  const digest = crypto.createHash("sha256");
-  digest.update(fs.readFileSync(filePath));
-  return `sha256:${digest.digest("hex")}`;
+  return new Promise((resolve, reject) => {
+    const digest = crypto.createHash("sha256");
+    const stream = fs.createReadStream(filePath);
+    stream.on("data", (chunk) => digest.update(chunk));
+    stream.on("error", reject);
+    stream.on("end", () => resolve(`sha256:${digest.digest("hex")}`));
+  });
 }
 
 function run(command, args, { env = process.env } = {}) {
-  const result = spawnSync(command, args, { encoding: "utf8", env, stdio: ["ignore", "pipe", "pipe"] });
+  const result = spawnSync(command, args, {
+    encoding: "utf8",
+    env,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
   if (result.status !== 0) {
-    throw new Error(`${command} ${args.join(" ")} failed (${result.status}): ${result.stderr || result.stdout}`);
+    throw new Error(
+      `${command} ${args.join(" ")} failed (${result.status}): ${result.stderr || result.stdout}`,
+    );
   }
   return result.stdout;
 }
@@ -61,7 +79,7 @@ function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-async function verifyEnclosure(url, expectedBytes, attempts = 18) {
+async function verifyRemoteFile(url, expectedBytes, attempts = 18) {
   let lastError;
   for (let attempt = 1; attempt <= attempts; attempt += 1) {
     try {
@@ -69,14 +87,18 @@ async function verifyEnclosure(url, expectedBytes, attempts = 18) {
       if (!head.ok) throw new Error(`HEAD ${head.status}`);
       const length = Number(head.headers.get("content-length"));
       if (Number.isFinite(length) && length > 0 && length !== expectedBytes) {
-        throw new Error(`Content-Length ${length} != expected ${expectedBytes}`);
+        throw new Error(
+          `Content-Length ${length} != expected ${expectedBytes}`,
+        );
       }
 
       const range = await fetch(url, {
         headers: { Range: "bytes=0-0" },
         redirect: "follow",
       });
-      if (![200, 206].includes(range.status)) throw new Error(`range request ${range.status}`);
+      if (![200, 206].includes(range.status)) {
+        throw new Error(`range request ${range.status}`);
+      }
       const bytes = new Uint8Array(await range.arrayBuffer());
       if (bytes.length < 1) throw new Error("range request returned no bytes");
       return {
@@ -87,51 +109,92 @@ async function verifyEnclosure(url, expectedBytes, attempts = 18) {
       };
     } catch (error) {
       lastError = error;
-      if (attempt < attempts) await sleep(Math.min(5000 * attempt, 20_000));
+      if (attempt < attempts) {
+        await sleep(Math.min(5000 * attempt, 20_000));
+      }
     }
   }
-  throw new Error(`Internet Archive enclosure did not become readable: ${lastError}`);
+  throw new Error(
+    `Internet Archive file did not become readable: ${lastError}`,
+  );
 }
 
-function publicationTitle(work, chapter) {
+function publicationTitle(chapter) {
   const title = chapter.publication?.title;
-  if (!title) throw new Error(`${chapter.chapterId}: publication.title must be set before publishing`);
+  if (!title) {
+    throw new Error(
+      `${chapter.chapterId}: publication.title must be set before publishing`,
+    );
+  }
   return title;
+}
+
+async function validateAssemblyFile(filePath, expected) {
+  if (!fs.existsSync(filePath) || !fs.statSync(filePath).isFile()) {
+    throw new Error(`Missing assembly file: ${filePath}`);
+  }
+  if (fs.statSync(filePath).size !== expected.bytes) {
+    throw new Error(`assembly size mismatch: ${filePath}`);
+  }
+  if ((await sha256File(filePath)) !== expected.sha256) {
+    throw new Error(`assembly digest mismatch: ${filePath}`);
+  }
 }
 
 async function main() {
   const args = parseArgs(process.argv.slice(2));
   const work = loadWork(process.cwd(), args.workId);
-  const chapter = work.chapters.find((entry) => entry.chapterId === args.chapterId);
+  const chapter = work.chapters.find(
+    (entry) => entry.chapterId === args.chapterId,
+  );
   if (!chapter) throw new Error(`Unknown chapter ${args.chapterId}`);
-  if (chapter.ready_for_audio !== true) throw new Error(`${args.chapterId} is not ready_for_audio`);
+  if (chapter.ready_for_audio !== true) {
+    throw new Error(`${args.chapterId} is not ready_for_audio`);
+  }
 
   const archiveItem = work.metadata.media?.archive_item;
-  if (!archiveItem) throw new Error(`${args.workId}: media.archive_item is required`);
+  if (!archiveItem) {
+    throw new Error(`${args.workId}: media.archive_item is required`);
+  }
+
+  if (
+    !args.dryRun &&
+    work.state.publication?.public_distribution_authorized !== true
+  ) {
+    throw new Error(
+      "public distribution is not authorized in state.yaml; refusing Internet Archive upload",
+    );
+  }
 
   const assemblyDir = path.resolve(args.assemblyDir);
   const assembly = readJson(path.join(assemblyDir, "assembly.json"));
-  if (assembly.work_id !== args.workId || assembly.chapter_id !== args.chapterId) {
+  if (
+    assembly.work_id !== args.workId ||
+    assembly.chapter_id !== args.chapterId
+  ) {
     throw new Error("assembly work/chapter identity mismatch");
   }
 
   const audioPath = path.join(assemblyDir, assembly.audio.file);
   const transcriptPath = path.join(assemblyDir, assembly.transcript.file);
-  for (const filePath of [audioPath, transcriptPath]) {
-    if (!fs.statSync(filePath).isFile()) throw new Error(`Missing assembly file: ${filePath}`);
-  }
-  if (fs.statSync(audioPath).size !== assembly.audio.bytes || sha256File(audioPath) !== assembly.audio.sha256) {
-    throw new Error("assembled audio failed local size/digest validation");
-  }
+  await validateAssemblyFile(audioPath, assembly.audio);
+  await validateAssemblyFile(transcriptPath, assembly.transcript);
 
-  const title = publicationTitle(work, chapter);
-  const description = chapter.publication?.description ?? work.metadata.podcast?.description ?? work.metadata.title;
-  const publishedAt = chapter.publication?.published_at ?? new Date().toISOString();
+  const title = publicationTitle(chapter);
+  const description =
+    chapter.publication?.description ??
+    work.metadata.podcast?.description ??
+    work.metadata.title;
+  const publishedAt =
+    chapter.publication?.published_at ?? new Date().toISOString();
   const audioName = path.basename(audioPath);
   const transcriptName = path.basename(transcriptPath);
   const baseUrl = `https://archive.org/download/${encodeURIComponent(archiveItem)}/`;
   const enclosureUrl = new URL(encodeURIComponent(audioName), baseUrl).href;
-  const transcriptUrl = new URL(encodeURIComponent(transcriptName), baseUrl).href;
+  const transcriptUrl = new URL(
+    encodeURIComponent(transcriptName),
+    baseUrl,
+  ).href;
 
   const publication = {
     schema: "audiobook-publication-v1",
@@ -161,7 +224,9 @@ async function main() {
     publication.dry_run = true;
   } else {
     if (!process.env.IA_ACCESS_KEY_ID || !process.env.IA_SECRET_ACCESS_KEY) {
-      throw new Error("IA_ACCESS_KEY_ID and IA_SECRET_ACCESS_KEY are required");
+      throw new Error(
+        "IA_ACCESS_KEY_ID and IA_SECRET_ACCESS_KEY are required",
+      );
     }
 
     run("ia", [
@@ -184,13 +249,21 @@ async function main() {
       `description:${work.metadata.podcast?.description ?? description}`,
     ]);
 
-    publication.verification = await verifyEnclosure(enclosureUrl, assembly.audio.bytes);
-    const transcriptVerification = await verifyEnclosure(transcriptUrl, assembly.transcript.bytes);
-    publication.transcript.verification = transcriptVerification;
+    publication.verification = await verifyRemoteFile(
+      enclosureUrl,
+      assembly.audio.bytes,
+    );
+    publication.transcript.verification = await verifyRemoteFile(
+      transcriptUrl,
+      assembly.transcript.bytes,
+    );
   }
 
   fs.mkdirSync(path.dirname(args.outputPath), { recursive: true });
-  fs.writeFileSync(args.outputPath, `${JSON.stringify(publication, null, 2)}\n`);
+  fs.writeFileSync(
+    args.outputPath,
+    `${JSON.stringify(publication, null, 2)}\n`,
+  );
   console.log(JSON.stringify(publication));
 }
 

--- a/scripts/audiobook/runners/colab.sh
+++ b/scripts/audiobook/runners/colab.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PLAN=""
+OUTPUT=""
+BACKEND="fake"
+MODEL="deterministic-tone-v1"
+GPU="${COLAB_GPU:-T4}"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --plan) PLAN="$2"; shift 2 ;;
+    --output) OUTPUT="$2"; shift 2 ;;
+    --backend) BACKEND="$2"; shift 2 ;;
+    --model) MODEL="$2"; shift 2 ;;
+    --gpu) GPU="$2"; shift 2 ;;
+    *) echo "unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+
+[[ -n "$PLAN" ]] || { echo "--plan is required" >&2; exit 2; }
+[[ -n "$OUTPUT" ]] || { echo "--output is required" >&2; exit 2; }
+command -v colab >/dev/null || { echo "colab CLI not found" >&2; exit 2; }
+
+SESSION="audiobook-${GITHUB_RUN_ID:-$$}-${GITHUB_RUN_ATTEMPT:-1}"
+SESSION="${SESSION,,}"
+TMPDIR_LOCAL="$(mktemp -d)"
+LAUNCHER="$TMPDIR_LOCAL/launcher.py"
+BACKEND_JSON="$(python3 -c 'import json,sys; print(json.dumps(sys.argv[1]))' "$BACKEND")"
+MODEL_JSON="$(python3 -c 'import json,sys; print(json.dumps(sys.argv[1]))' "$MODEL")"
+
+cat > "$LAUNCHER" <<PY
+import runpy
+import sys
+sys.argv = [
+    "/content/worker.py",
+    "--plan", "/content/plan.json",
+    "--output-dir", "/content/audiobook-output",
+    "--backend", $BACKEND_JSON,
+    "--model", $MODEL_JSON,
+    "--result-archive", "/content/audiobook-result.zip",
+]
+runpy.run_path("/content/worker.py", run_name="__main__")
+PY
+
+cleanup() {
+  colab --auth=adc stop -s "$SESSION" >/dev/null 2>&1 || true
+  rm -rf "$TMPDIR_LOCAL"
+}
+trap cleanup EXIT
+
+if [[ -n "$GPU" ]]; then
+  colab --auth=adc new -s "$SESSION" --gpu "$GPU"
+else
+  colab --auth=adc new -s "$SESSION"
+fi
+
+colab --auth=adc upload -s "$SESSION" scripts/audiobook/worker.py /content/worker.py
+colab --auth=adc upload -s "$SESSION" "$PLAN" /content/plan.json
+colab --auth=adc exec -s "$SESSION" --timeout "${COLAB_EXEC_TIMEOUT:-3600}" -f "$LAUNCHER"
+mkdir -p "$(dirname "$OUTPUT")"
+colab --auth=adc download -s "$SESSION" /content/audiobook-result.zip "$OUTPUT"
+
+echo "colab result: $OUTPUT"

--- a/scripts/audiobook/runners/kaggle.sh
+++ b/scripts/audiobook/runners/kaggle.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PLAN=""
+OUTPUT=""
+BACKEND="fake"
+MODEL="deterministic-tone-v1"
+ACCELERATOR="${KAGGLE_ACCELERATOR:-NvidiaTeslaT4}"
+KERNEL_ID="${KAGGLE_KERNEL_ID:-}"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --plan) PLAN="$2"; shift 2 ;;
+    --output) OUTPUT="$2"; shift 2 ;;
+    --backend) BACKEND="$2"; shift 2 ;;
+    --model) MODEL="$2"; shift 2 ;;
+    --accelerator) ACCELERATOR="$2"; shift 2 ;;
+    --kernel-id) KERNEL_ID="$2"; shift 2 ;;
+    *) echo "unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+
+[[ -n "$PLAN" ]] || { echo "--plan is required" >&2; exit 2; }
+[[ -n "$OUTPUT" ]] || { echo "--output is required" >&2; exit 2; }
+if [[ -z "$KERNEL_ID" && -n "${KAGGLE_USERNAME:-}" ]]; then
+  KERNEL_ID="${KAGGLE_USERNAME}/audiobook-factory-tts"
+fi
+[[ "$KERNEL_ID" == */* && "$KERNEL_ID" != /* ]] || {
+  echo "KAGGLE_KERNEL_ID or KAGGLE_USERNAME is required" >&2
+  exit 2
+}
+command -v kaggle >/dev/null || { echo "kaggle CLI not found" >&2; exit 2; }
+
+STAGE="$(mktemp -d)"
+DOWNLOAD="$(mktemp -d)"
+trap 'rm -rf "$STAGE" "$DOWNLOAD"' EXIT
+
+python3 - "$PLAN" "$BACKEND" "$MODEL" > "$STAGE/job.py" <<'PY'
+import base64
+import json
+from pathlib import Path
+import sys
+
+plan_path, backend, model = sys.argv[1:]
+worker = Path("scripts/audiobook/worker.py").read_bytes()
+plan = Path(plan_path).read_bytes()
+worker_b64 = base64.b64encode(worker).decode("ascii")
+plan_b64 = base64.b64encode(plan).decode("ascii")
+
+print("import base64, pathlib, runpy, sys")
+print(f"pathlib.Path('/kaggle/working/worker.py').write_bytes(base64.b64decode({worker_b64!r}))")
+print(f"pathlib.Path('/kaggle/working/plan.json').write_bytes(base64.b64decode({plan_b64!r}))")
+argv = [
+    "/kaggle/working/worker.py",
+    "--plan", "/kaggle/working/plan.json",
+    "--output-dir", "/kaggle/working/audiobook-output",
+    "--backend", backend,
+    "--model", model,
+    "--result-archive", "/kaggle/working/audiobook-result.zip",
+]
+print(f"sys.argv = {argv!r}")
+print("runpy.run_path('/kaggle/working/worker.py', run_name='__main__')")
+PY
+
+cat > "$STAGE/kernel-metadata.json" <<JSON
+{
+  "id": "$KERNEL_ID",
+  "title": "Audiobook Factory TTS",
+  "code_file": "job.py",
+  "language": "python",
+  "kernel_type": "script",
+  "is_private": true,
+  "enable_gpu": true,
+  "enable_internet": true,
+  "dataset_sources": [],
+  "competition_sources": [],
+  "kernel_sources": [],
+  "model_sources": []
+}
+JSON
+
+kaggle kernels push -p "$STAGE" --accelerator "$ACCELERATOR" -t "${KAGGLE_PUSH_TIMEOUT:-600}"
+
+for _ in $(seq 1 "${KAGGLE_STATUS_POLLS:-120}"); do
+  STATUS="$(kaggle kernels status "$KERNEL_ID" 2>&1)"
+  echo "$STATUS"
+  if grep -Eqi 'complete|success' <<<"$STATUS"; then
+    break
+  fi
+  if grep -Eqi 'error|failed|cancel' <<<"$STATUS"; then
+    echo "Kaggle job failed" >&2
+    exit 1
+  fi
+  sleep "${KAGGLE_STATUS_INTERVAL:-30}"
+done
+
+STATUS="$(kaggle kernels status "$KERNEL_ID" 2>&1)"
+if ! grep -Eqi 'complete|success' <<<"$STATUS"; then
+  echo "Kaggle job did not complete within polling window: $STATUS" >&2
+  exit 1
+fi
+
+kaggle kernels output "$KERNEL_ID" -p "$DOWNLOAD" -o --file-pattern '.*audiobook-result\.zip$'
+RESULT="$(find "$DOWNLOAD" -type f -name 'audiobook-result.zip' -print -quit)"
+[[ -n "$RESULT" ]] || { echo "Kaggle output did not contain audiobook-result.zip" >&2; exit 1; }
+mkdir -p "$(dirname "$OUTPUT")"
+cp "$RESULT" "$OUTPUT"
+
+echo "kaggle result: $OUTPUT"

--- a/scripts/audiobook/runners/local.sh
+++ b/scripts/audiobook/runners/local.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PLAN=""
+OUTPUT=""
+BACKEND="fake"
+MODEL="deterministic-tone-v1"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --plan) PLAN="$2"; shift 2 ;;
+    --output) OUTPUT="$2"; shift 2 ;;
+    --backend) BACKEND="$2"; shift 2 ;;
+    --model) MODEL="$2"; shift 2 ;;
+    *) echo "unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+
+[[ -n "$PLAN" ]] || { echo "--plan is required" >&2; exit 2; }
+[[ -n "$OUTPUT" ]] || { echo "--output is required" >&2; exit 2; }
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+mkdir -p "$(dirname "$OUTPUT")"
+python3 scripts/audiobook/worker.py \
+  --plan "$PLAN" \
+  --output-dir "$TMP/output" \
+  --backend "$BACKEND" \
+  --model "$MODEL" \
+  --result-archive "$OUTPUT"
+
+echo "local result: $OUTPUT"

--- a/scripts/audiobook/validate.mjs
+++ b/scripts/audiobook/validate.mjs
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+
+import process from "node:process";
+
+import { AudiobookValidationError, validateWork } from "../../src/audiobook/validate.js";
+
+function usage() {
+  console.error(
+    "Usage: node scripts/audiobook/validate.mjs --work <work_id> [--chapter <chapter_id>] [--require-ready-for-audio] [--json]",
+  );
+}
+
+function parseArgs(argv) {
+  const args = {
+    workId: null,
+    chapterId: null,
+    requireReadyForAudio: false,
+    json: false,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--work") args.workId = argv[++index] ?? null;
+    else if (arg === "--chapter") args.chapterId = argv[++index] ?? null;
+    else if (arg === "--require-ready-for-audio") args.requireReadyForAudio = true;
+    else if (arg === "--json") args.json = true;
+    else if (arg === "--help" || arg === "-h") {
+      usage();
+      process.exit(0);
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  if (!args.workId) throw new Error("--work is required");
+  return args;
+}
+
+try {
+  const args = parseArgs(process.argv.slice(2));
+  const result = validateWork(process.cwd(), args.workId, args);
+
+  if (args.json) {
+    console.log(JSON.stringify(result, null, 2));
+  } else {
+    console.log(`work: ${result.workId} — ${result.title}`);
+    console.log(`status: ${result.status ?? "unknown"}`);
+    console.log(`next: ${result.nextAction}`);
+    for (const chapter of result.chapters) {
+      console.log(
+        `${chapter.chapterId}: ${chapter.readyForAudio ? "ready_for_audio" : chapter.status ?? "not_ready"}`,
+      );
+      if (chapter.pendingGates.length) console.log(`  pending: ${chapter.pendingGates.join(", ")}`);
+      if (chapter.nextAction) console.log(`  next: ${chapter.nextAction}`);
+    }
+  }
+} catch (error) {
+  if (error instanceof AudiobookValidationError) {
+    console.error(error.message);
+    for (const detail of error.details) console.error(`- ${detail}`);
+    process.exit(2);
+  }
+
+  console.error(error instanceof Error ? error.message : String(error));
+  usage();
+  process.exit(2);
+}

--- a/scripts/audiobook/worker.py
+++ b/scripts/audiobook/worker.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""Audiobook Factory media worker.
+
+The worker deliberately has no editorial intelligence. It receives an already
+validated TTS plan and turns each request into audio through a selected backend.
+The initial `fake` backend produces deterministic WAV tones so the complete
+control-plane can be exercised without secrets, network access, or GPU time.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import os
+from pathlib import Path
+import platform
+import struct
+import subprocess
+import sys
+import wave
+import zipfile
+
+PLAN_SCHEMA = "audiobook-tts-plan-v1"
+MANIFEST_SCHEMA = "audiobook-media-manifest-v1"
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return f"sha256:{digest.hexdigest()}"
+
+
+def load_plan(path: Path) -> dict:
+    with path.open("r", encoding="utf-8") as stream:
+        plan = json.load(stream)
+    if plan.get("schema") != PLAN_SCHEMA:
+        raise ValueError(f"unsupported plan schema: {plan.get('schema')!r}")
+    if not plan.get("work_id") or not plan.get("chapter_id"):
+        raise ValueError("plan requires work_id and chapter_id")
+    segments = plan.get("segments")
+    if not isinstance(segments, list) or not segments:
+        raise ValueError("plan requires a non-empty segments array")
+    return plan
+
+
+def hardware_info() -> dict:
+    result = {
+        "python": platform.python_version(),
+        "platform": platform.platform(),
+        "gpu": None,
+    }
+    try:
+        completed = subprocess.run(
+            ["nvidia-smi", "--query-gpu=name,memory.total", "--format=csv,noheader"],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if completed.returncode == 0 and completed.stdout.strip():
+            result["gpu"] = completed.stdout.strip().splitlines()
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        pass
+    return result
+
+
+def fake_synthesize(segment: dict, output_path: Path) -> dict:
+    """Write deterministic audible proof-of-pipeline audio for one segment."""
+
+    seed = hashlib.sha256(segment["input_digest"].encode("utf-8")).digest()
+    sample_rate = 16_000
+    duration_ms = 220 + seed[0]
+    frequency = 220 + seed[1] * 2
+    frames = round(sample_rate * duration_ms / 1000)
+    amplitude = 0.12 * 32767
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with wave.open(str(output_path), "wb") as stream:
+        stream.setnchannels(1)
+        stream.setsampwidth(2)
+        stream.setframerate(sample_rate)
+        for index in range(frames):
+            sample = int(amplitude * math.sin(2 * math.pi * frequency * index / sample_rate))
+            stream.writeframesraw(struct.pack("<h", sample))
+
+    return {
+        "duration_ms": duration_ms,
+        "sample_rate": sample_rate,
+        "audio_digest": sha256_file(output_path),
+    }
+
+
+BACKENDS = {
+    "fake": fake_synthesize,
+}
+
+
+def make_archive(output_dir: Path, archive_path: Path) -> None:
+    archive_path.parent.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(archive_path, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+        for file_path in sorted(output_dir.rglob("*")):
+            if file_path.is_file():
+                archive.write(file_path, file_path.relative_to(output_dir))
+
+
+def run(plan_path: Path, output_dir: Path, backend: str, model: str, archive_path: Path | None) -> dict:
+    plan = load_plan(plan_path)
+    if backend not in BACKENDS:
+        raise ValueError(f"unsupported backend: {backend}; available: {', '.join(sorted(BACKENDS))}")
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    segment_dir = output_dir / "segments"
+    synthesize = BACKENDS[backend]
+    manifest_segments = []
+
+    for index, segment in enumerate(plan["segments"]):
+        for field in ("segment_id", "speaker", "text", "input_digest"):
+            if not segment.get(field):
+                raise ValueError(f"segment {index} missing {field}")
+        audio_path = segment_dir / f"{segment['segment_id']}.wav"
+        generated = synthesize(segment, audio_path)
+        manifest_segments.append(
+            {
+                "segment_id": segment["segment_id"],
+                "speaker": segment["speaker"],
+                "input_digest": segment["input_digest"],
+                "audio_file": str(audio_path.relative_to(output_dir)),
+                **generated,
+            }
+        )
+
+    manifest = {
+        "schema": MANIFEST_SCHEMA,
+        "work_id": plan["work_id"],
+        "chapter_id": plan["chapter_id"],
+        "narration_digest": plan.get("narration_digest"),
+        "backend": backend,
+        "model": model,
+        "hardware": hardware_info(),
+        "segments": manifest_segments,
+    }
+    manifest_path = output_dir / "manifest.json"
+    manifest_path.write_text(json.dumps(manifest, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+
+    if archive_path is not None:
+        make_archive(output_dir, archive_path)
+
+    return manifest
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--plan", required=True, type=Path)
+    parser.add_argument("--output-dir", required=True, type=Path)
+    parser.add_argument("--backend", default="fake", choices=sorted(BACKENDS))
+    parser.add_argument("--model", default="deterministic-tone-v1")
+    parser.add_argument("--result-archive", type=Path)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        manifest = run(args.plan, args.output_dir, args.backend, args.model, args.result_archive)
+    except Exception as error:  # noqa: BLE001 - CLI boundary must surface deterministic non-zero failure.
+        print(f"audiobook worker failed: {error}", file=sys.stderr)
+        return 2
+
+    print(
+        json.dumps(
+            {
+                "status": "ok",
+                "work_id": manifest["work_id"],
+                "chapter_id": manifest["chapter_id"],
+                "backend": manifest["backend"],
+                "segments": len(manifest["segments"]),
+                "output_dir": os.fspath(args.output_dir),
+                "result_archive": os.fspath(args.result_archive) if args.result_archive else None,
+            },
+            ensure_ascii=False,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/audiobook/catalog.js
+++ b/src/audiobook/catalog.js
@@ -1,0 +1,78 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import matter from "gray-matter";
+import yaml from "js-yaml";
+
+const WORK_ID_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+function readYaml(filePath) {
+  return yaml.load(fs.readFileSync(filePath, "utf8")) ?? {};
+}
+
+function readWorkFile(filePath) {
+  const parsed = matter(fs.readFileSync(filePath, "utf8"));
+  return { data: parsed.data, body: parsed.content.trim() };
+}
+
+export function audiobookRoot(rootDir = process.cwd()) {
+  return path.join(rootDir, "data", "audiobooks");
+}
+
+export function listWorkIds(rootDir = process.cwd()) {
+  const root = audiobookRoot(rootDir);
+  if (!fs.existsSync(root)) return [];
+  return fs
+    .readdirSync(root, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory() && WORK_ID_PATTERN.test(entry.name))
+    .filter((entry) => fs.existsSync(path.join(root, entry.name, "work.md")))
+    .map((entry) => entry.name)
+    .sort();
+}
+
+export function loadWork(rootDir, workId) {
+  if (!WORK_ID_PATTERN.test(workId)) throw new Error(`Invalid work_id: ${workId}`);
+
+  const workDir = path.join(audiobookRoot(rootDir), workId);
+  const work = readWorkFile(path.join(workDir, "work.md"));
+  const state = readYaml(path.join(workDir, "state.yaml"));
+
+  if (work.data.type !== "Audiobook Work") throw new Error(`${workId}: work.md type must be Audiobook Work`);
+  if (work.data.work_id !== workId) throw new Error(`${workId}: work.md work_id mismatch`);
+  if (state.work_id !== workId) throw new Error(`${workId}: state.yaml work_id mismatch`);
+
+  const chapters = Object.entries(state.chapters ?? {})
+    .map(([chapterId, chapter]) => ({ chapterId, ...chapter }))
+    .sort((a, b) => a.chapterId.localeCompare(b.chapterId));
+
+  return {
+    workId,
+    workDir,
+    metadata: work.data,
+    body: work.body,
+    state,
+    chapters,
+  };
+}
+
+export function listWorks(rootDir = process.cwd()) {
+  return listWorkIds(rootDir).map((workId) => loadWork(rootDir, workId));
+}
+
+export function publishedEpisodes(work) {
+  return work.chapters
+    .filter((chapter) => chapter.publication?.status === "published")
+    .map((chapter) => ({
+      chapterId: chapter.chapterId,
+      title: chapter.publication.title ?? chapter.chapterId,
+      description: chapter.publication.description ?? "",
+      publishedAt: chapter.publication.published_at,
+      durationSeconds: chapter.publication.duration_seconds ?? null,
+      enclosure: chapter.publication.enclosure ?? null,
+      transcript: chapter.publication.transcript ?? null,
+      chapters: chapter.publication.chapters ?? null,
+    }))
+    .sort((a, b) => new Date(a.publishedAt).valueOf() - new Date(b.publishedAt).valueOf());
+}
+
+export { WORK_ID_PATTERN };

--- a/src/audiobook/catalog.test.js
+++ b/src/audiobook/catalog.test.js
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { listWorkIds, listWorks, loadWork, publishedEpisodes } from "./catalog.js";
+
+function write(root, relativePath, content) {
+  const filePath = path.join(root, relativePath);
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, content);
+}
+
+function fixture() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "audiobook-catalog-"));
+  write(
+    root,
+    "data/audiobooks/example/work.md",
+    `---\ntype: Audiobook Work\nwork_id: example\ntitle: Example Book\nauthor: Example Author\nsource_language: en\ntarget_language: pt-BR\nsource_url: https://example.test/\npodcast:\n  enabled: true\n---\n`,
+  );
+  write(
+    root,
+    "data/audiobooks/example/state.yaml",
+    `schema: audiobook-work-state-v1\nwork_id: example\nstatus: publishing\nnext_action: publish second chapter\nchapters:\n  example-001:\n    status: published\n    publication:\n      status: published\n      title: Capítulo 1\n      published_at: 2026-08-30T12:00:00-04:00\n      duration_seconds: 120\n      enclosure:\n        url: https://archive.example/chapter-001.mp3\n        bytes: 1234\n        type: audio/mpeg\n  example-002:\n    status: ready\n    publication:\n      status: ready\n      title: Capítulo 2\n`,
+  );
+  return root;
+}
+
+test("discovers works by work_id directory", () => {
+  const root = fixture();
+  assert.deepEqual(listWorkIds(root), ["example"]);
+  assert.equal(listWorks(root)[0].metadata.title, "Example Book");
+});
+
+test("loads work metadata and chapter state", () => {
+  const root = fixture();
+  const work = loadWork(root, "example");
+  assert.equal(work.workId, "example");
+  assert.equal(work.chapters.length, 2);
+});
+
+test("exposes only published chapters as podcast episodes", () => {
+  const root = fixture();
+  const episodes = publishedEpisodes(loadWork(root, "example"));
+  assert.deepEqual(episodes.map((episode) => episode.chapterId), ["example-001"]);
+  assert.equal(episodes[0].enclosure.bytes, 1234);
+});
+
+test("rejects unsafe work ids", () => {
+  const root = fixture();
+  assert.throws(() => loadWork(root, "../example"), /Invalid work_id/);
+});

--- a/src/audiobook/plan.js
+++ b/src/audiobook/plan.js
@@ -1,0 +1,139 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+
+import matter from "gray-matter";
+import yaml from "js-yaml";
+
+function canonicalize(value) {
+  if (Array.isArray(value)) return value.map(canonicalize);
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.keys(value)
+        .sort()
+        .map((key) => [key, canonicalize(value[key])]),
+    );
+  }
+  return value;
+}
+
+function digest(value) {
+  const serialized = typeof value === "string" ? value : JSON.stringify(canonicalize(value));
+  return `sha256:${crypto.createHash("sha256").update(serialized, "utf8").digest("hex")}`;
+}
+
+function readYaml(filePath) {
+  return yaml.load(fs.readFileSync(filePath, "utf8")) ?? {};
+}
+
+function readVoices(filePath) {
+  return readYaml(filePath).voices ?? {};
+}
+
+export function resolveChapterFiles(rootDir, workId, chapterId) {
+  const workDir = path.join(rootDir, "data", "audiobooks", workId);
+  const state = readYaml(path.join(workDir, "state.yaml"));
+  if (state.work_id !== workId) throw new Error(`state.work_id does not match ${workId}`);
+  const chapter = state.chapters?.[chapterId];
+  if (!chapter) throw new Error(`unknown chapter ${chapterId} for work ${workId}`);
+  if (!chapter.files?.narration) throw new Error(`${chapterId}.files.narration is required`);
+
+  return {
+    workDir,
+    narrationPath: path.join(workDir, chapter.files.narration),
+    voicesPath: path.join(workDir, "voices.yaml"),
+    chapterState: chapter,
+  };
+}
+
+export function parseNarrationText(markdown, { voices = null, sourcePath = null } = {}) {
+  const parsed = matter(markdown);
+  const frontmatter = parsed.data;
+  const errors = [];
+
+  if (frontmatter.type !== "Audiobook Narration Chapter") {
+    errors.push(`type must be Audiobook Narration Chapter, got ${JSON.stringify(frontmatter.type)}`);
+  }
+  for (const field of ["work_id", "chapter_id", "lang", "derived_from"]) {
+    if (!frontmatter[field]) errors.push(`${field} is required in narration frontmatter`);
+  }
+
+  const segments = [];
+  const seen = new Set();
+  const pattern = /<!--\s*tts:\s*(\{[^\n]*\})\s*-->\s*([\s\S]*?)(?=<!--\s*tts:|$)/g;
+  let match;
+  while ((match = pattern.exec(parsed.content)) !== null) {
+    let directive;
+    try {
+      directive = JSON.parse(match[1]);
+    } catch (error) {
+      errors.push(`invalid tts directive JSON near offset ${match.index}: ${error.message}`);
+      continue;
+    }
+
+    const segmentId = directive.id ?? directive.segment_id;
+    const speaker = directive.speaker;
+    const text = match[2].trim();
+
+    if (!segmentId) errors.push(`tts directive near offset ${match.index} is missing id`);
+    if (!speaker) errors.push(`${segmentId ?? "segment"} is missing speaker`);
+    if (!text) errors.push(`${segmentId ?? "segment"} has empty narration text`);
+    if (segmentId && seen.has(segmentId)) errors.push(`duplicate segment id: ${segmentId}`);
+    if (segmentId) seen.add(segmentId);
+    if (voices && speaker && !voices[speaker]) {
+      errors.push(`${segmentId ?? "segment"} references unknown speaker: ${speaker}`);
+    }
+
+    const direction = Object.fromEntries(
+      Object.entries(directive).filter(([key]) => !["id", "segment_id", "speaker"].includes(key)),
+    );
+
+    if (segmentId && speaker && text) {
+      const request = {
+        segment_id: segmentId,
+        speaker,
+        text,
+        direction,
+      };
+      segments.push({ ...request, input_digest: digest(request) });
+    }
+  }
+
+  if (segments.length === 0) errors.push("narration contains no <!-- tts: {...} --> segments");
+
+  if (errors.length) {
+    const error = new Error(`Invalid narration${sourcePath ? ` ${sourcePath}` : ""}`);
+    error.details = errors;
+    throw error;
+  }
+
+  return {
+    schema: "audiobook-tts-plan-v1",
+    work_id: frontmatter.work_id,
+    chapter_id: frontmatter.chapter_id,
+    lang: frontmatter.lang,
+    narration_source: sourcePath,
+    narration_digest: digest(markdown),
+    segments,
+  };
+}
+
+export function createPlan({ narrationPath, voicesPath }) {
+  const narration = fs.readFileSync(narrationPath, "utf8");
+  const voices = readVoices(voicesPath);
+  return parseNarrationText(narration, { voices, sourcePath: narrationPath });
+}
+
+export function createWorkPlan({ rootDir, workId, chapterId }) {
+  const resolved = resolveChapterFiles(rootDir, workId, chapterId);
+  const plan = createPlan(resolved);
+  if (plan.work_id !== workId) {
+    throw new Error(`narration work_id ${plan.work_id} does not match requested work ${workId}`);
+  }
+  if (plan.chapter_id !== chapterId) {
+    throw new Error(`narration chapter_id ${plan.chapter_id} does not match requested chapter ${chapterId}`);
+  }
+  return plan;
+}
+
+export { canonicalize, digest };

--- a/src/audiobook/plan.test.js
+++ b/src/audiobook/plan.test.js
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { parseNarrationText } from "./plan.js";
+
+const NARRATION = `---
+type: Audiobook Narration Chapter
+work_id: example
+chapter_id: example-001
+lang: pt-BR
+derived_from: ../translation/001.md
+---
+
+<!-- tts: {"id":"example-001-s0001","speaker":"narrator","pace":"slow"} -->
+Primeiro trecho.
+
+<!-- tts: {"id":"example-001-s0002","speaker":"alice","emotion":"curious"} -->
+Segundo trecho.
+`;
+
+test("creates deterministic TTS plan from narration directives", () => {
+  const voices = { narrator: {}, alice: {} };
+  const first = parseNarrationText(NARRATION, { voices, sourcePath: "001.md" });
+  const second = parseNarrationText(NARRATION, { voices, sourcePath: "001.md" });
+
+  assert.equal(first.schema, "audiobook-tts-plan-v1");
+  assert.equal(first.work_id, "example");
+  assert.equal(first.chapter_id, "example-001");
+  assert.equal(first.segments.length, 2);
+  assert.equal(first.segments[0].speaker, "narrator");
+  assert.deepEqual(first.segments[0].direction, { pace: "slow" });
+  assert.equal(first.segments[0].input_digest, second.segments[0].input_digest);
+});
+
+test("rejects unknown logical speaker", () => {
+  assert.throws(
+    () => parseNarrationText(NARRATION, { voices: { narrator: {} } }),
+    (error) => error.details?.some((detail) => detail.includes("unknown speaker: alice")),
+  );
+});
+
+test("rejects duplicate segment ids", () => {
+  const duplicate = NARRATION.replace("example-001-s0002", "example-001-s0001");
+  assert.throws(
+    () => parseNarrationText(duplicate, { voices: { narrator: {}, alice: {} } }),
+    (error) => error.details?.some((detail) => detail.includes("duplicate segment id")),
+  );
+});

--- a/src/audiobook/podcast.js
+++ b/src/audiobook/podcast.js
@@ -1,0 +1,106 @@
+function escapeXml(value) {
+  return String(value ?? "")
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&apos;");
+}
+
+function absoluteUrl(baseUrl, value) {
+  return new URL(value, baseUrl).href;
+}
+
+function rfc2822(value) {
+  const date = new Date(value);
+  if (Number.isNaN(date.valueOf())) throw new Error(`Invalid publication date: ${value}`);
+  return date.toUTCString();
+}
+
+function durationString(seconds) {
+  if (seconds == null) return null;
+  if (!Number.isFinite(Number(seconds)) || Number(seconds) < 0) throw new Error(`Invalid duration: ${seconds}`);
+  const whole = Math.round(Number(seconds));
+  const hours = Math.floor(whole / 3600);
+  const minutes = Math.floor((whole % 3600) / 60);
+  const secs = whole % 60;
+  return hours > 0
+    ? `${hours}:${String(minutes).padStart(2, "0")}:${String(secs).padStart(2, "0")}`
+    : `${minutes}:${String(secs).padStart(2, "0")}`;
+}
+
+export function episodeGuid(workId, chapterId) {
+  return `audiobook:${workId}:${chapterId}`;
+}
+
+function renderEpisode({ workId, episode, siteUrl }) {
+  if (!episode.enclosure?.url) throw new Error(`${episode.chapterId}: published episode needs enclosure.url`);
+  if (!Number.isInteger(episode.enclosure.bytes) || episode.enclosure.bytes <= 0) {
+    throw new Error(`${episode.chapterId}: published episode needs positive enclosure.bytes`);
+  }
+  if (!episode.enclosure.type) throw new Error(`${episode.chapterId}: published episode needs enclosure.type`);
+  if (!episode.publishedAt) throw new Error(`${episode.chapterId}: published episode needs published_at`);
+
+  const link = absoluteUrl(siteUrl, `/audiobooks/${workId}/${episode.chapterId}/`);
+  const enclosureUrl = absoluteUrl(siteUrl, episode.enclosure.url);
+  const duration = durationString(episode.durationSeconds);
+  const transcript = episode.transcript?.url
+    ? `<podcast:transcript url="${escapeXml(absoluteUrl(siteUrl, episode.transcript.url))}" type="${escapeXml(
+        episode.transcript.type ?? "text/vtt",
+      )}" language="${escapeXml(episode.transcript.language ?? "pt-BR")}" rel="captions" />`
+    : "";
+  const chapters = episode.chapters?.url
+    ? `<podcast:chapters url="${escapeXml(absoluteUrl(siteUrl, episode.chapters.url))}" type="${escapeXml(
+        episode.chapters.type ?? "application/json+chapters",
+      )}" />`
+    : "";
+
+  return `<item>
+<title>${escapeXml(episode.title)}</title>
+<description>${escapeXml(episode.description)}</description>
+<link>${escapeXml(link)}</link>
+<guid isPermaLink="false">${escapeXml(episodeGuid(workId, episode.chapterId))}</guid>
+<pubDate>${escapeXml(rfc2822(episode.publishedAt))}</pubDate>
+<enclosure url="${escapeXml(enclosureUrl)}" length="${episode.enclosure.bytes}" type="${escapeXml(
+    episode.enclosure.type,
+  )}" />
+${duration ? `<itunes:duration>${escapeXml(duration)}</itunes:duration>` : ""}
+${transcript}
+${chapters}
+</item>`;
+}
+
+export function buildPodcastXml({ work, episodes, siteUrl }) {
+  const podcast = work.metadata.podcast ?? {};
+  if (podcast.enabled !== true) throw new Error(`${work.workId}: podcast is not enabled`);
+
+  const feedUrl = absoluteUrl(siteUrl, `/audiobooks/${work.workId}/feed.xml`);
+  const workUrl = absoluteUrl(siteUrl, `/audiobooks/${work.workId}/`);
+  const title = podcast.title ?? work.metadata.title;
+  const description = podcast.description ?? `Audiolivro de ${work.metadata.title}`;
+  const language = podcast.language ?? work.metadata.target_language ?? "pt-BR";
+  const author = podcast.author ?? work.metadata.author ?? "Franklin Baldo";
+  const image = podcast.image ? absoluteUrl(siteUrl, podcast.image) : null;
+  const items = episodes.map((episode) => renderEpisode({ workId: work.workId, episode, siteUrl })).join("\n");
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0"
+  xmlns:atom="http://www.w3.org/2005/Atom"
+  xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd"
+  xmlns:podcast="https://podcastindex.org/namespace/1.0">
+<channel>
+<title>${escapeXml(title)}</title>
+<description>${escapeXml(description)}</description>
+<link>${escapeXml(workUrl)}</link>
+<language>${escapeXml(language)}</language>
+<itunes:author>${escapeXml(author)}</itunes:author>
+<itunes:explicit>false</itunes:explicit>
+${image ? `<itunes:image href="${escapeXml(image)}" />` : ""}
+<atom:link href="${escapeXml(feedUrl)}" rel="self" type="application/rss+xml" />
+${items}
+</channel>
+</rss>
+`;
+}
+
+export { durationString, escapeXml, rfc2822 };

--- a/src/audiobook/podcast.test.js
+++ b/src/audiobook/podcast.test.js
@@ -1,0 +1,90 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { XMLParser } from "fast-xml-parser";
+
+import { buildPodcastXml, episodeGuid } from "./podcast.js";
+
+const work = {
+  workId: "example-book",
+  metadata: {
+    title: "Livro de Exemplo",
+    author: "Autora Exemplo",
+    target_language: "pt-BR",
+    podcast: {
+      enabled: true,
+      title: "Livro de Exemplo — Audiolivro",
+      description: "Edição narrada de teste.",
+      image: "/audiobooks/example-book/cover.jpg",
+    },
+  },
+};
+
+const episodes = [
+  {
+    chapterId: "example-book-001",
+    title: "Capítulo 1",
+    description: "Primeiro capítulo.",
+    publishedAt: "2026-08-30T12:00:00-04:00",
+    durationSeconds: 3723,
+    enclosure: {
+      url: "https://archive.example/download/example-book/chapter-001.mp3",
+      bytes: 12345678,
+      type: "audio/mpeg",
+    },
+    transcript: {
+      url: "/audiobooks/example-book/transcripts/001.vtt",
+      type: "text/vtt",
+      language: "pt-BR",
+    },
+    chapters: {
+      url: "/audiobooks/example-book/chapters/001.json",
+    },
+  },
+];
+
+test("uses work/chapter identity for stable podcast GUID", () => {
+  assert.equal(episodeGuid("example-book", "example-book-001"), "audiobook:example-book:example-book-001");
+});
+
+test("builds RSS 2.0 with enclosure and Podcasting 2.0 metadata", () => {
+  const xml = buildPodcastXml({ work, episodes, siteUrl: "https://franklinbaldo.com/" });
+  const parser = new XMLParser({ ignoreAttributes: false, attributeNamePrefix: "@_" });
+  const parsed = parser.parse(xml);
+  const channel = parsed.rss.channel;
+  const item = channel.item;
+
+  assert.equal(parsed.rss["@_version"], "2.0");
+  assert.equal(channel.title, "Livro de Exemplo — Audiolivro");
+  assert.equal(item.guid["#text"], "audiobook:example-book:example-book-001");
+  assert.equal(item.guid["@_isPermaLink"], "false");
+  assert.equal(item.enclosure["@_length"], "12345678");
+  assert.equal(item.enclosure["@_type"], "audio/mpeg");
+  assert.equal(item["itunes:duration"], "1:02:03");
+  assert.equal(item["podcast:transcript"]["@_type"], "text/vtt");
+  assert.equal(item["podcast:chapters"]["@_type"], "application/json+chapters");
+});
+
+test("refuses published episode without a complete enclosure", () => {
+  assert.throws(
+    () =>
+      buildPodcastXml({
+        work,
+        episodes: [{ ...episodes[0], enclosure: { url: "https://example.test/a.mp3", bytes: 0, type: "audio/mpeg" } }],
+        siteUrl: "https://franklinbaldo.com/",
+      }),
+    /positive enclosure.bytes/,
+  );
+});
+
+test("refuses feed generation before podcast is enabled", () => {
+  assert.throws(
+    () =>
+      buildPodcastXml({
+        work: { ...work, metadata: { ...work.metadata, podcast: { enabled: false } } },
+        episodes,
+        siteUrl: "https://franklinbaldo.com/",
+      }),
+    /podcast is not enabled/,
+  );
+});

--- a/src/audiobook/runners.test.js
+++ b/src/audiobook/runners.test.js
@@ -1,0 +1,14 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+
+for (const script of [
+  "scripts/audiobook/runners/local.sh",
+  "scripts/audiobook/runners/colab.sh",
+  "scripts/audiobook/runners/kaggle.sh",
+]) {
+  test(`shell syntax: ${script}`, () => {
+    const result = spawnSync("bash", ["-n", script], { cwd: process.cwd(), encoding: "utf8" });
+    assert.equal(result.status, 0, result.stderr);
+  });
+}

--- a/src/audiobook/validate.js
+++ b/src/audiobook/validate.js
@@ -1,0 +1,155 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import matter from "gray-matter";
+import yaml from "js-yaml";
+
+const REQUIRED_GATES = [
+  "work_ready",
+  "source_ready",
+  "translation_ready",
+  "narration_ready",
+  "consistency_ready",
+  "editorial_review_ready",
+  "audio_contract_ready",
+];
+
+export class AudiobookValidationError extends Error {
+  constructor(message, details = []) {
+    super(message);
+    this.name = "AudiobookValidationError";
+    this.details = details;
+  }
+}
+
+function readUtf8(filePath) {
+  try {
+    return fs.readFileSync(filePath, "utf8");
+  } catch (error) {
+    throw new AudiobookValidationError(`Missing or unreadable file: ${filePath}`, [String(error)]);
+  }
+}
+
+function readYaml(filePath) {
+  try {
+    return yaml.load(readUtf8(filePath)) ?? {};
+  } catch (error) {
+    if (error instanceof AudiobookValidationError) throw error;
+    throw new AudiobookValidationError(`Invalid YAML: ${filePath}`, [String(error)]);
+  }
+}
+
+function readMarkdownFrontmatter(filePath) {
+  try {
+    return matter(readUtf8(filePath)).data;
+  } catch (error) {
+    if (error instanceof AudiobookValidationError) throw error;
+    throw new AudiobookValidationError(`Invalid Markdown frontmatter: ${filePath}`, [String(error)]);
+  }
+}
+
+function requireEqual(errors, actual, expected, label) {
+  if (actual !== expected) errors.push(`${label}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
+}
+
+function requireTruthy(errors, value, label) {
+  if (!value) errors.push(`${label} is required`);
+}
+
+export function validateChapterState(chapterId, chapterState, { requireReadyForAudio = false } = {}) {
+  const errors = [];
+
+  if (!chapterState || typeof chapterState !== "object") {
+    throw new AudiobookValidationError(`Chapter ${chapterId} has no state`);
+  }
+
+  const gates = chapterState.gates;
+  if (!gates || typeof gates !== "object") {
+    errors.push(`${chapterId}.gates is required`);
+  } else {
+    for (const gate of REQUIRED_GATES) {
+      if (typeof gates[gate] !== "boolean") errors.push(`${chapterId}.gates.${gate} must be boolean`);
+    }
+  }
+
+  const allReady = Boolean(gates) && REQUIRED_GATES.every((gate) => gates[gate] === true);
+  if (typeof chapterState.ready_for_audio !== "boolean") {
+    errors.push(`${chapterId}.ready_for_audio must be boolean`);
+  } else if (chapterState.ready_for_audio !== allReady) {
+    errors.push(
+      `${chapterId}.ready_for_audio must equal the conjunction of all required gates (expected ${allReady})`,
+    );
+  }
+
+  if (requireReadyForAudio && !allReady) {
+    const pending = REQUIRED_GATES.filter((gate) => gates?.[gate] !== true);
+    errors.push(`${chapterId} is not ready for audio; pending gates: ${pending.join(", ")}`);
+  }
+
+  if (errors.length) throw new AudiobookValidationError(`Invalid chapter state: ${chapterId}`, errors);
+
+  return {
+    chapterId,
+    readyForAudio: allReady,
+    pendingGates: REQUIRED_GATES.filter((gate) => gates[gate] !== true),
+    status: chapterState.status ?? null,
+    nextAction: chapterState.next_action ?? null,
+  };
+}
+
+export function validateWork(rootDir, workId, options = {}) {
+  const workDir = path.join(rootDir, "data", "audiobooks", workId);
+  const errors = [];
+
+  const work = readMarkdownFrontmatter(path.join(workDir, "work.md"));
+  const state = readYaml(path.join(workDir, "state.yaml"));
+  const voices = readYaml(path.join(workDir, "voices.yaml"));
+  const pronunciation = readYaml(path.join(workDir, "pronunciation.yaml"));
+
+  requireEqual(errors, work.type, "Audiobook Work", "work.type");
+  requireEqual(errors, work.work_id, workId, "work.work_id");
+  requireTruthy(errors, work.title, "work.title");
+  requireTruthy(errors, work.source_language, "work.source_language");
+  requireTruthy(errors, work.target_language, "work.target_language");
+  requireTruthy(errors, work.source_url, "work.source_url");
+
+  requireEqual(errors, state.schema, "audiobook-work-state-v1", "state.schema");
+  requireEqual(errors, state.work_id, workId, "state.work_id");
+  requireTruthy(errors, state.next_action, "state.next_action");
+  if (!state.chapters || typeof state.chapters !== "object") errors.push("state.chapters is required");
+
+  requireEqual(errors, voices.schema, "audiobook-voices-v1", "voices.schema");
+  requireEqual(errors, voices.work_id, workId, "voices.work_id");
+  if (!voices.voices || typeof voices.voices !== "object" || Object.keys(voices.voices).length === 0) {
+    errors.push("voices.voices must contain at least one logical voice");
+  }
+
+  requireEqual(errors, pronunciation.schema, "audiobook-pronunciation-v1", "pronunciation.schema");
+  requireEqual(errors, pronunciation.work_id, workId, "pronunciation.work_id");
+  if (!Array.isArray(pronunciation.entries)) errors.push("pronunciation.entries must be an array");
+
+  if (errors.length) throw new AudiobookValidationError(`Invalid audiobook work: ${workId}`, errors);
+
+  const chapterResults = [];
+  const chapterIds = options.chapterId ? [options.chapterId] : Object.keys(state.chapters);
+  for (const chapterId of chapterIds) {
+    if (!(chapterId in state.chapters)) {
+      throw new AudiobookValidationError(`Unknown chapter ${chapterId} for work ${workId}`);
+    }
+    chapterResults.push(
+      validateChapterState(chapterId, state.chapters[chapterId], {
+        requireReadyForAudio: options.requireReadyForAudio ?? false,
+      }),
+    );
+  }
+
+  return {
+    workId,
+    title: work.title,
+    status: state.status ?? null,
+    nextAction: state.next_action,
+    chapters: chapterResults,
+  };
+}
+
+export { REQUIRED_GATES };

--- a/src/audiobook/validate.test.js
+++ b/src/audiobook/validate.test.js
@@ -1,0 +1,96 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { AudiobookValidationError, validateChapterState, validateWork } from "./validate.js";
+
+const ALL_TRUE = {
+  work_ready: true,
+  source_ready: true,
+  translation_ready: true,
+  narration_ready: true,
+  consistency_ready: true,
+  editorial_review_ready: true,
+  audio_contract_ready: true,
+};
+
+function write(root, relativePath, content) {
+  const filePath = path.join(root, relativePath);
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, content);
+}
+
+function fixture({ ready = false } = {}) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "audiobook-validator-"));
+  const gates = ready
+    ? ALL_TRUE
+    : { ...ALL_TRUE, source_ready: false, translation_ready: false, narration_ready: false };
+
+  write(
+    root,
+    "data/audiobooks/example/work.md",
+    `---\ntype: Audiobook Work\nwork_id: example\ntitle: Example\nsource_language: en\ntarget_language: pt-BR\nsource_url: https://example.test/\n---\n`,
+  );
+  write(
+    root,
+    "data/audiobooks/example/state.yaml",
+    `schema: audiobook-work-state-v1\nwork_id: example\nstatus: preparing\nnext_action: continue\nchapters:\n  example-001:\n    status: ${ready ? "ready" : "in_progress"}\n    next_action: continue chapter\n    gates:\n${Object.entries(gates)
+      .map(([key, value]) => `      ${key}: ${value}`)
+      .join("\n")}\n    ready_for_audio: ${ready}\n`,
+  );
+  write(
+    root,
+    "data/audiobooks/example/voices.yaml",
+    "schema: audiobook-voices-v1\nwork_id: example\nvoices:\n  narrator:\n    role: narrator\n",
+  );
+  write(
+    root,
+    "data/audiobooks/example/pronunciation.yaml",
+    "schema: audiobook-pronunciation-v1\nwork_id: example\nentries: []\n",
+  );
+  return root;
+}
+
+test("validates a not-yet-ready work without requiring audio readiness", () => {
+  const root = fixture();
+  const result = validateWork(root, "example", { chapterId: "example-001" });
+  assert.equal(result.chapters[0].readyForAudio, false);
+  assert.ok(result.chapters[0].pendingGates.includes("source_ready"));
+});
+
+test("blocks TTS gate until every readiness gate is true", () => {
+  const root = fixture();
+  assert.throws(
+    () => validateWork(root, "example", { chapterId: "example-001", requireReadyForAudio: true }),
+    (error) => error instanceof AudiobookValidationError && /not ready for audio/.test(error.details.join(" ")),
+  );
+});
+
+test("accepts a chapter when every required gate is true", () => {
+  const root = fixture({ ready: true });
+  const result = validateWork(root, "example", {
+    chapterId: "example-001",
+    requireReadyForAudio: true,
+  });
+  assert.equal(result.chapters[0].readyForAudio, true);
+});
+
+test("rejects ready_for_audio when it disagrees with gates", () => {
+  assert.throws(
+    () =>
+      validateChapterState("example-001", {
+        gates: { ...ALL_TRUE, narration_ready: false },
+        ready_for_audio: true,
+      }),
+    AudiobookValidationError,
+  );
+});
+
+test("validates the repository HPMOR work state", () => {
+  const result = validateWork(process.cwd(), "hpmor", { chapterId: "hpmor-001" });
+  assert.equal(result.workId, "hpmor");
+  assert.equal(result.chapters[0].readyForAudio, false);
+  assert.equal(result.chapters[0].nextAction, "import source snapshot and establish stable segment ids");
+});

--- a/src/audiobook/worker.test.js
+++ b/src/audiobook/worker.test.js
@@ -1,0 +1,71 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+
+function makePlan(root) {
+  const planPath = path.join(root, "plan.json");
+  fs.writeFileSync(
+    planPath,
+    `${JSON.stringify(
+      {
+        schema: "audiobook-tts-plan-v1",
+        work_id: "example",
+        chapter_id: "example-001",
+        lang: "pt-BR",
+        narration_digest: "sha256:test",
+        segments: [
+          {
+            segment_id: "example-001-s0001",
+            speaker: "narrator",
+            text: "Teste.",
+            direction: {},
+            input_digest: "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+          },
+          {
+            segment_id: "example-001-s0002",
+            speaker: "alice",
+            text: "Outro teste.",
+            direction: { emotion: "curious" },
+            input_digest: "sha256:2222222222222222222222222222222222222222222222222222222222222222",
+          },
+        ],
+      },
+      null,
+      2,
+    )}\n`,
+  );
+  return planPath;
+}
+
+test("fake worker emits deterministic segment audio, manifest and archive", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "audiobook-worker-"));
+  const planPath = makePlan(root);
+  const outputDir = path.join(root, "output");
+  const archivePath = path.join(root, "result.zip");
+
+  const result = spawnSync(
+    "python3",
+    [
+      "scripts/audiobook/worker.py",
+      "--plan",
+      planPath,
+      "--output-dir",
+      outputDir,
+      "--backend",
+      "fake",
+      "--result-archive",
+      archivePath,
+    ],
+    { cwd: process.cwd(), encoding: "utf8" },
+  );
+
+  assert.equal(result.status, 0, result.stderr);
+  const manifest = JSON.parse(fs.readFileSync(path.join(outputDir, "manifest.json"), "utf8"));
+  assert.equal(manifest.schema, "audiobook-media-manifest-v1");
+  assert.equal(manifest.segments.length, 2);
+  assert.ok(fs.statSync(path.join(outputDir, manifest.segments[0].audio_file)).size > 0);
+  assert.ok(fs.statSync(archivePath).size > 0);
+});

--- a/src/pages/audiobooks/[workId]/[chapterId].astro
+++ b/src/pages/audiobooks/[workId]/[chapterId].astro
@@ -1,0 +1,87 @@
+---
+import PageLayout from "../../../layouts/PageLayout.astro";
+import { listWorks, publishedEpisodes } from "../../../audiobook/catalog.js";
+
+export function getStaticPaths() {
+  return listWorks().flatMap((work) =>
+    publishedEpisodes(work).map((episode) => ({
+      params: { workId: work.workId, chapterId: episode.chapterId },
+      props: { work, episode },
+    })),
+  );
+}
+
+const { work, episode } = Astro.props;
+const audioUrl = episode.enclosure?.url;
+---
+
+<PageLayout
+  title={`${episode.title} — ${work.metadata.title}`}
+  description={episode.description || work.metadata.podcast?.description || work.metadata.title}
+  lang="pt"
+  breadcrumb={[
+    { name: "Audiolivros", item: "/audiobooks/" },
+    { name: work.metadata.title, item: `/audiobooks/${work.workId}/` },
+    { name: episode.title, item: `/audiobooks/${work.workId}/${episode.chapterId}/` },
+  ]}
+>
+  <main class="container audiobook-episode">
+    <p><a href={`/audiobooks/${work.workId}/`}>← {work.metadata.title}</a></p>
+    <header>
+      <p class="eyebrow">Audiolivro</p>
+      <h1>{episode.title}</h1>
+      {episode.description && <p>{episode.description}</p>}
+    </header>
+
+    {
+      audioUrl && (
+        <audio controls preload="metadata">
+          <source src={audioUrl} type={episode.enclosure.type} />
+          Seu navegador não suporta reprodução de áudio HTML5.
+        </audio>
+      )
+    }
+
+    <dl>
+      <dt>Publicado</dt>
+      <dd>{new Date(episode.publishedAt).toLocaleDateString("pt-BR")}</dd>
+      {episode.durationSeconds != null && (
+        <>
+          <dt>Duração</dt>
+          <dd>{Math.round(episode.durationSeconds / 60)} min</dd>
+        </>
+      )}
+    </dl>
+
+    {episode.transcript?.url && <p><a href={episode.transcript.url}>Transcript / legendas</a></p>}
+  </main>
+</PageLayout>
+
+<style>
+  .audiobook-episode {
+    max-width: 52rem;
+    padding-block: 3rem 5rem;
+  }
+
+  .eyebrow {
+    font-size: 0.8rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    opacity: 0.72;
+  }
+
+  audio {
+    width: 100%;
+    margin-block: 2rem;
+  }
+
+  dl {
+    display: grid;
+    grid-template-columns: max-content 1fr;
+    gap: 0.4rem 1rem;
+  }
+
+  dt {
+    font-weight: 600;
+  }
+</style>

--- a/src/pages/audiobooks/[workId]/feed.xml.js
+++ b/src/pages/audiobooks/[workId]/feed.xml.js
@@ -1,0 +1,22 @@
+import { listWorks, publishedEpisodes } from "../../../audiobook/catalog.js";
+import { buildPodcastXml } from "../../../audiobook/podcast.js";
+
+export function getStaticPaths() {
+  return listWorks()
+    .filter((work) => work.metadata.podcast?.enabled === true)
+    .map((work) => ({ params: { workId: work.workId }, props: { work } }));
+}
+
+export function GET({ props, site }) {
+  if (!site) throw new Error("Astro site URL is required to generate podcast feeds");
+  const { work } = props;
+  const episodes = publishedEpisodes(work);
+  const xml = buildPodcastXml({ work, episodes, siteUrl: site });
+
+  return new Response(xml, {
+    headers: {
+      "Content-Type": "application/rss+xml; charset=utf-8",
+      "Cache-Control": "public, max-age=300",
+    },
+  });
+}

--- a/src/pages/audiobooks/[workId]/index.astro
+++ b/src/pages/audiobooks/[workId]/index.astro
@@ -1,0 +1,93 @@
+---
+import PageLayout from "../../../layouts/PageLayout.astro";
+import { listWorks, publishedEpisodes } from "../../../audiobook/catalog.js";
+
+export function getStaticPaths() {
+  return listWorks().map((work) => ({ params: { workId: work.workId }, props: { work } }));
+}
+
+const { work } = Astro.props;
+const episodes = publishedEpisodes(work);
+const podcastEnabled = work.metadata.podcast?.enabled === true;
+const podcastDescription = work.metadata.podcast?.description ?? work.metadata.title;
+---
+
+<PageLayout
+  title={`${work.metadata.title} — Audiolivro`}
+  description={podcastDescription}
+  lang="pt"
+  breadcrumb={[
+    { name: "Audiolivros", item: "/audiobooks/" },
+    { name: work.metadata.title, item: `/audiobooks/${work.workId}/` },
+  ]}
+>
+  <main class="container audiobook-work">
+    <p><a href="/audiobooks/">← Audiolivros</a></p>
+    <header>
+      <p class="eyebrow">{podcastEnabled ? "Podcast" : "Em preparação"}</p>
+      <h1>{work.metadata.title}</h1>
+      <p>{work.metadata.author}</p>
+      <p>{podcastDescription}</p>
+    </header>
+
+    {
+      podcastEnabled && (
+        <aside class="subscribe">
+          <strong>Assinar por RSS</strong>
+          <p>Adicione este endereço ao seu tocador de podcasts:</p>
+          <p><a href={`/audiobooks/${work.workId}/feed.xml`}>{`/audiobooks/${work.workId}/feed.xml`}</a></p>
+        </aside>
+      )
+    }
+
+    <section>
+      <h2>Capítulos</h2>
+      {
+        episodes.length === 0 ? (
+          <p>O audiolivro ainda não tem capítulos publicados.</p>
+        ) : (
+          <ol class="episodes">
+            {episodes.map((episode) => (
+              <li>
+                <a href={`/audiobooks/${work.workId}/${episode.chapterId}/`}>{episode.title}</a>
+                {episode.durationSeconds != null && (
+                  <small>{` · ${Math.round(episode.durationSeconds / 60)} min`}</small>
+                )}
+              </li>
+            ))}
+          </ol>
+        )
+      }
+    </section>
+  </main>
+</PageLayout>
+
+<style>
+  .audiobook-work {
+    max-width: 52rem;
+    padding-block: 3rem 5rem;
+  }
+
+  .eyebrow {
+    font-size: 0.8rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    opacity: 0.72;
+  }
+
+  .subscribe {
+    margin-block: 2rem;
+    padding: 1rem 1.25rem;
+    border: 1px solid var(--pico-muted-border-color);
+    border-radius: var(--pico-border-radius);
+  }
+
+  .subscribe p:last-child {
+    margin-bottom: 0;
+    overflow-wrap: anywhere;
+  }
+
+  .episodes li {
+    margin-block: 0.6rem;
+  }
+</style>

--- a/src/pages/audiobooks/index.astro
+++ b/src/pages/audiobooks/index.astro
@@ -1,0 +1,81 @@
+---
+import PageLayout from "../../layouts/PageLayout.astro";
+import { listWorks, publishedEpisodes } from "../../audiobook/catalog.js";
+
+const works = listWorks();
+---
+
+<PageLayout
+  title="Audiolivros"
+  description="Audiolivros produzidos de forma reproduzível, capítulo por capítulo."
+  lang="pt"
+>
+  <main class="container audiobook-catalog">
+    <header>
+      <p class="eyebrow">Audiobook Factory</p>
+      <h1>Audiolivros</h1>
+      <p>
+        Obras preparadas em camadas rastreáveis de original, tradução e narração, com síntese de voz e
+        publicação por podcast.
+      </p>
+    </header>
+
+    {
+      works.length === 0 ? (
+        <p>Nenhuma obra cadastrada.</p>
+      ) : (
+        <div class="work-grid">
+          {works.map((work) => {
+            const episodes = publishedEpisodes(work);
+            const enabled = work.metadata.podcast?.enabled === true;
+            return (
+              <article>
+                <p class="status">{enabled ? "podcast" : "em preparação"}</p>
+                <h2><a href={`/audiobooks/${work.workId}/`}>{work.metadata.title}</a></h2>
+                <p>{work.metadata.author}</p>
+                <p>
+                  {episodes.length === 0
+                    ? "Nenhum capítulo publicado ainda."
+                    : `${episodes.length} ${episodes.length === 1 ? "capítulo publicado" : "capítulos publicados"}.`}
+                </p>
+              </article>
+            );
+          })}
+        </div>
+      )
+    }
+  </main>
+</PageLayout>
+
+<style>
+  .audiobook-catalog {
+    max-width: 64rem;
+    padding-block: 3rem 5rem;
+  }
+
+  .eyebrow,
+  .status {
+    font-size: 0.8rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    opacity: 0.72;
+  }
+
+  .work-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(16rem, 1fr));
+    gap: 1rem;
+    margin-top: 2rem;
+  }
+
+  article {
+    padding: 1.25rem;
+    border: 1px solid var(--pico-muted-border-color);
+    border-radius: var(--pico-border-radius);
+  }
+
+  article h2 {
+    margin-block: 0.35rem 0.75rem;
+    font-size: 1.2rem;
+  }
+</style>


### PR DESCRIPTION
## Objetivo

Completar a etapa de publicação da Audiobook Factory depois da geração TTS: montar segmentos em um capítulo distribuível, produzir transcript derivado e publicar mídia durável no Internet Archive sem acoplar o podcast ao GitHub Pages.

## Pipeline implementada

`result.zip -> assemble -> MP3 + WebVTT + assembly.json -> Internet Archive -> verify -> publication.json -> state.yaml -> podcast`

- assembler Python model-agnostic usando `ffmpeg`;
- concatenação na ordem canônica do plano;
- validação de digest dos segmentos antes da montagem;
- MP3 mono de distribuição separado do áudio intermediário;
- WebVTT produzido diretamente dos segmentos/timestamps conhecidos, sem retranscrição;
- `assembly.json` com digests, bytes, duração, backend e modelo;
- publisher Internet Archive via CLI `ia`;
- um item estável de Archive por obra;
- verificação HTTP `HEAD` + range após upload antes de persistir enclosure;
- validação local de tamanho e SHA-256 tanto do áudio quanto do transcript;
- hashing em streaming para não carregar capítulos grandes inteiros na memória;
- `publication.json` como recibo auditável;
- aplicação do estado publicado e habilitação do podcast somente depois de enclosure/transcript verificados;
- workflow `Audiobook Media` ganha `publish` explícito e artifacts de assembly/publication;
- upload público exige `ready_for_audio` e `public_distribution_authorized: true`; dry-run continua possível sem publicação;
- publicação real só é aceita a partir de `main` e recusa o backend `fake`.

## Credenciais

GitHub Secrets esperados quando a publicação for habilitada:

- `IA_ACCESS_KEY_ID`;
- `IA_SECRET_ACCESS_KEY`.

## Importante

Esta PR não publica nenhum capítulo por si só e não contém credenciais. Ela apenas fecha o caminho técnico. O HPMOR atual continua com distribuição pública bloqueada no estado editorial.

PR empilhada sobre #1597.