### PR TITLE
feat(audiobook): add Breeze TTS 2 zero-shot benchmark backend

### DIFF
--- a/.github/workflows/audiobook-tts-benchmark.yml
+++ b/.github/workflows/audiobook-tts-benchmark.yml
@@ -1,0 +1,187 @@
+name: Audiobook TTS Benchmark
+
+on:
+  workflow_dispatch:
+    inputs:
+      benchmark:
+        description: Benchmark corpus id
+        required: true
+        default: pt-br-audiobook-v1
+        type: string
+      runner:
+        description: Compute runner
+        required: true
+        default: kaggle
+        type: choice
+        options:
+          - kaggle
+          - colab
+          - local
+      backend:
+        description: TTS backend
+        required: true
+        default: breeze
+        type: choice
+        options:
+          - breeze
+          - fake
+      model:
+        description: Model repository/path (empty uses backend default)
+        required: false
+        default: ""
+        type: string
+      accelerator:
+        description: T4 for Colab; NvidiaTeslaT4 for Kaggle
+        required: false
+        default: ""
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: audiobook-benchmark-${{ inputs.benchmark }}-${{ inputs.backend }}-${{ inputs.runner }}
+  cancel-in-progress: false
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 24
+          cache: npm
+
+      - run: npm ci
+
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.12"
+
+      - name: Build deterministic benchmark plan
+        env:
+          BENCHMARK: ${{ inputs.benchmark }}
+        run: |
+          FILE="data/audiobook-benchmarks/$BENCHMARK.yaml"
+          [[ -f "$FILE" ]] || { echo "Unknown benchmark: $BENCHMARK" >&2; exit 2; }
+          node scripts/audiobook/benchmark-plan.mjs \
+            --benchmark "$FILE" \
+            --output "$RUNNER_TEMP/benchmark-plan.json"
+
+      - name: Resolve backend model
+        id: model
+        env:
+          BACKEND: ${{ inputs.backend }}
+          REQUESTED_MODEL: ${{ inputs.model }}
+        run: |
+          if [[ -n "$REQUESTED_MODEL" ]]; then
+            MODEL="$REQUESTED_MODEL"
+          elif [[ "$BACKEND" == "breeze" ]]; then
+            MODEL="BreezeBlue/Breeze-TTS-2"
+          else
+            MODEL="deterministic-tone-v1"
+          fi
+          echo "model=$MODEL" >> "$GITHUB_OUTPUT"
+
+      - name: Configure Kaggle CLI
+        if: ${{ inputs.runner == 'kaggle' }}
+        env:
+          KAGGLE_API_TOKEN: ${{ secrets.KAGGLE_API_TOKEN }}
+          KAGGLE_USERNAME: ${{ vars.KAGGLE_USERNAME }}
+        run: |
+          [[ -n "$KAGGLE_API_TOKEN" ]] || { echo "Missing GitHub secret KAGGLE_API_TOKEN" >&2; exit 2; }
+          [[ -n "$KAGGLE_USERNAME" ]] || { echo "Missing GitHub variable KAGGLE_USERNAME" >&2; exit 2; }
+          python -m pip install --disable-pip-version-check 'kaggle==2.2.4'
+
+      - name: Run benchmark on Kaggle
+        if: ${{ inputs.runner == 'kaggle' }}
+        env:
+          KAGGLE_API_TOKEN: ${{ secrets.KAGGLE_API_TOKEN }}
+          KAGGLE_USERNAME: ${{ vars.KAGGLE_USERNAME }}
+          BACKEND: ${{ inputs.backend }}
+          MODEL: ${{ steps.model.outputs.model }}
+          REQUESTED_ACCELERATOR: ${{ inputs.accelerator }}
+        run: |
+          ACCELERATOR="${REQUESTED_ACCELERATOR:-NvidiaTeslaT4}"
+          bash scripts/audiobook/runners/kaggle.sh \
+            --plan "$RUNNER_TEMP/benchmark-plan.json" \
+            --output "$RUNNER_TEMP/audiobook-result.zip" \
+            --backend "$BACKEND" \
+            --model "$MODEL" \
+            --accelerator "$ACCELERATOR"
+
+      - name: Configure Colab CLI
+        if: ${{ inputs.runner == 'colab' }}
+        env:
+          COLAB_ADC_JSON: ${{ secrets.COLAB_ADC_JSON }}
+        run: |
+          [[ -n "$COLAB_ADC_JSON" ]] || { echo "Missing GitHub secret COLAB_ADC_JSON" >&2; exit 2; }
+          python -m pip install --disable-pip-version-check 'google-colab-cli==0.6.0'
+          printf '%s' "$COLAB_ADC_JSON" > "$RUNNER_TEMP/colab-adc.json"
+          chmod 600 "$RUNNER_TEMP/colab-adc.json"
+          echo "GOOGLE_APPLICATION_CREDENTIALS=$RUNNER_TEMP/colab-adc.json" >> "$GITHUB_ENV"
+
+      - name: Run benchmark on Colab
+        if: ${{ inputs.runner == 'colab' }}
+        env:
+          BACKEND: ${{ inputs.backend }}
+          MODEL: ${{ steps.model.outputs.model }}
+          REQUESTED_ACCELERATOR: ${{ inputs.accelerator }}
+        run: |
+          GPU="${REQUESTED_ACCELERATOR:-T4}"
+          bash scripts/audiobook/runners/colab.sh \
+            --plan "$RUNNER_TEMP/benchmark-plan.json" \
+            --output "$RUNNER_TEMP/audiobook-result.zip" \
+            --backend "$BACKEND" \
+            --model "$MODEL" \
+            --gpu "$GPU"
+
+      - name: Run benchmark locally
+        if: ${{ inputs.runner == 'local' }}
+        env:
+          BACKEND: ${{ inputs.backend }}
+          MODEL: ${{ steps.model.outputs.model }}
+        run: |
+          if [[ "$BACKEND" != "fake" ]]; then
+            echo "Local GitHub runner has no supported GPU; choose Kaggle or Colab for $BACKEND" >&2
+            exit 2
+          fi
+          bash scripts/audiobook/runners/local.sh \
+            --plan "$RUNNER_TEMP/benchmark-plan.json" \
+            --output "$RUNNER_TEMP/audiobook-result.zip" \
+            --backend "$BACKEND" \
+            --model "$MODEL"
+
+      - name: Inspect benchmark result
+        run: |
+          mkdir -p "$RUNNER_TEMP/benchmark-result"
+          unzip -q "$RUNNER_TEMP/audiobook-result.zip" -d "$RUNNER_TEMP/benchmark-result"
+          node - "$RUNNER_TEMP/benchmark-result/manifest.json" >> "$GITHUB_STEP_SUMMARY" <<'NODE'
+          const fs = require('node:fs');
+          const manifest = JSON.parse(fs.readFileSync(process.argv[2], 'utf8'));
+          console.log('## Audiobook TTS benchmark');
+          console.log(`- backend: \`${manifest.backend}\``);
+          console.log(`- model: \`${manifest.model}\``);
+          console.log(`- segments: **${manifest.segments.length}**`);
+          console.log(`- GPU: \`${JSON.stringify(manifest.hardware?.gpu)}\``);
+          console.log(`- backend metadata: \`${JSON.stringify(manifest.backend_metadata ?? {})}\``);
+          NODE
+
+      - name: Upload benchmark audio
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: audiobook-benchmark-${{ inputs.benchmark }}-${{ inputs.backend }}-${{ inputs.runner }}
+          path: ${{ runner.temp }}/benchmark-result/
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Upload benchmark plan
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: audiobook-benchmark-plan-${{ inputs.benchmark }}
+          path: ${{ runner.temp }}/benchmark-plan.json
+          if-no-files-found: error
+          retention-days: 30

--- a/data/audiobook-benchmarks/pt-br-audiobook-v1.yaml
+++ b/data/audiobook-benchmarks/pt-br-audiobook-v1.yaml
@@ -1,0 +1,116 @@
+schema: audiobook-tts-benchmark-v1
+benchmark_id: pt-br-audiobook-v1
+language: pt-BR
+description: >-
+  Corpus sintético e não literário para comparar TTS em tarefas relevantes a
+  audiolivros brasileiros sem depender do conteúdo de nenhuma obra.
+voices:
+  narrator:
+    role: narrator
+    locale: pt-BR
+    description: >-
+      Voz narrativa brasileira adulta, clara e natural; calor moderado, boa
+      dicção e capacidade de sustentar raciocínio longo sem soar como locução
+      publicitária.
+  child_scholar:
+    role: character
+    locale: pt-BR
+    description: >-
+      Voz brasileira jovem, curiosa e muito articulada; inteligência precoce
+      sem caricatura infantil e sem exagerar a energia.
+  authority:
+    role: character
+    locale: pt-BR
+    description: >-
+      Voz brasileira adulta com autoridade contida, precisão e firmeza; emoção
+      perceptível sem perder compostura.
+segments:
+  - id: neutral
+    speaker: narrator
+    direction: {}
+    text: >-
+      A chuva começou depois do almoço, devagar, como se a cidade ainda tivesse
+      tempo de decidir se queria mesmo uma tempestade.
+  - id: question
+    speaker: child_scholar
+    direction:
+      emotion: curious
+      pace: lively
+    text: >-
+      Se a conclusão depende dessa hipótese, por que ninguém tentou retirar a
+      hipótese e observar o que ainda continua verdadeiro?
+  - id: authority
+    speaker: authority
+    direction:
+      emotion: restrained concern
+      pace: measured
+    text: >-
+      Não estou dizendo que você está errado. Estou dizendo que, antes de agir,
+      precisamos saber exatamente qual risco estamos assumindo.
+  - id: irony
+    speaker: narrator
+    direction:
+      emotion: dry irony
+    text: >-
+      Naturalmente, o plano era infalível; só dependia de seis coincidências,
+      três portas destrancadas e ninguém fazer uma pergunta óbvia.
+  - id: fear
+    speaker: child_scholar
+    direction:
+      emotion: controlled fear
+      pace: slightly fast
+    text: >-
+      Eu ouvi o barulho outra vez. Desta vez veio do corredor, bem mais perto,
+      e tenho quase certeza de que não foi o vento.
+  - id: whisper
+    speaker: authority
+    direction:
+      delivery: whisper
+      emotion: urgent
+    text: >-
+      Fale baixo. Se eles perceberem que estamos acordados, não teremos uma
+      segunda oportunidade.
+  - id: phonetics
+    speaker: narrator
+    direction:
+      pace: measured
+    text: >-
+      João arranhou o joelho, Guilherme recolheu as folhas molhadas e a manhã
+      terminou com pão, limão, caminhões e um cachorro correndo pela rua.
+  - id: numbers
+    speaker: narrator
+    direction:
+      pace: measured
+    text: >-
+      Às oito e quarenta e cinco, havia vinte e três pessoas na sala; às nove e
+      dez, restavam apenas sete, e a probabilidade estimada caiu para 2,5 por cento.
+  - id: names
+    speaker: narrator
+    direction: {}
+    text: >-
+      Harry perguntou a Hermione se McGonagall ainda estava em Hogwarts, enquanto
+      uma anotação sobre Richard Feynman permanecia aberta sobre a mesa.
+  - id: code-switch
+    speaker: child_scholar
+    direction:
+      emotion: amused
+    text: >-
+      Ele chamou aquilo de fail-safe, depois corrigiu para mecanismo de segurança,
+      e cinco minutos mais tarde já estava explicando Bayesian updating em português.
+  - id: analytical-long
+    speaker: narrator
+    direction:
+      pace: deliberate
+    text: >-
+      O problema não era descobrir qual explicação parecia mais elegante, mas
+      separar aquilo que havia sido observado daquilo que cada pessoa esperava
+      observar; quando as duas coisas se misturavam, qualquer coincidência ganhava
+      aparência de evidência e qualquer dúvida parecia uma objeção pessoal.
+  - id: emotional-transition
+    speaker: narrator
+    direction:
+      emotion: tenderness turning to unease
+      pace: slow
+    text: >-
+      Por um instante, ela sorriu ao reconhecer a letra no envelope. Então viu a
+      data escrita no canto, e o sorriso desapareceu antes que terminasse de respirar.

--- a/docs/okf/audiobook/breeze-backend.md
+++ b/docs/okf/audiobook/breeze-backend.md
@@ -1,0 +1,145 @@
+---
+type: Implementation Note
+title: Audiobook Factory — Breeze TTS 2 backend
+description: Contrato de execução e benchmark zero-shot do primeiro backend TTS open-weight da fábrica de audiolivros.
+tags: [audiobook, tts, breeze, benchmark, kaggle, colab]
+timestamp: 2026-08-30T22:30:00Z
+---
+
+# Breeze TTS 2 na Audiobook Factory
+
+## Papel
+
+Breeze TTS 2 é o primeiro backend real implementado para testar a arquitetura da fábrica. Ele **não é declarado vencedor por antecipação**. A escolha de produção continua dependente do benchmark pt-BR próprio e da comparação com outros candidatos.
+
+O backend não participa de tradução, preparação de narração nem decisão editorial. Recebe somente um `audiobook-tts-plan-v1` já produzido pela camada editorial/planner.
+
+## Reprodutibilidade
+
+A integração fixa revisões conhecidas em vez de executar `main` flutuante:
+
+```text
+código: https://github.com/breezeblue-ai/breeze-tts.git
+revision: ca632ce6c4d05f7985da4eab29b1a5d445b43f7b
+
+modelo: BreezeBlue/Breeze-TTS-2
+revision: a3bd0a6e83cd2d046ce783df2f7cb84292869ef7
+```
+
+As revisões efetivamente utilizadas são gravadas em `manifest.json`.
+
+Variáveis `BREEZE_CODE_REVISION` e `BREEZE_MODEL_REVISION` permitem experimentação deliberada com outra revisão, sem alterar silenciosamente o default reproduzível.
+
+## Bootstrap no runner remoto
+
+O mesmo `scripts/audiobook/worker.py` usado pelo backend fake:
+
+1. clona o código oficial do Breeze na revisão fixada;
+2. instala o `requirements.txt` oficial;
+3. baixa o snapshot fixado do modelo pelo Hugging Face;
+4. inicia a API streaming oficial localmente;
+5. espera `/health` informar que o runtime está pronto;
+6. mantém a instância carregada para todos os segmentos do job;
+7. encerra o processo ao final.
+
+O cache raiz pode ser definido por `AUDIOBOOK_MODEL_CACHE`. `AUDIOBOOK_SKIP_BACKEND_INSTALL=1` existe apenas para ambientes já preparados e não é o caminho padrão reproduzível.
+
+## Voz lógica para Voice Design
+
+A configuração provider-neutral em `voices.yaml` entra no plano de cada segmento e faz parte de `input_digest`.
+
+Exemplo conceitual:
+
+```yaml
+harry:
+  role: character
+  locale: pt-BR
+  description: >-
+    Menino muito articulado e intelectualmente precoce; energia juvenil sem
+    transformar a voz em caricatura infantil.
+```
+
+No primeiro benchmark, o adapter compila isso para uma instrução natural do Breeze. Não há reference audio nem fine-tune.
+
+A seed é derivada deterministicamente de:
+
+- `speaker`;
+- configuração lógica completa da voz.
+
+Assim, segmentos do mesmo personagem usam a mesma seed de identidade. Texto e direção não alteram essa seed, mas continuam participando do `input_digest` do segmento.
+
+## Direção narrativa
+
+Diretivas provider-neutral são acrescentadas à instrução sem contaminar a camada canônica:
+
+```json
+{"emotion":"controlled fear","pace":"slightly fast"}
+```
+
+vira, conceitualmente:
+
+```text
+<descrição da voz>. Fale naturalmente no idioma e variante pt-BR.
+Emoção: controlled fear. Ritmo: slightly fast.
+```
+
+Esse compilador é deliberadamente simples na primeira rodada. O benchmark deve mostrar quais dimensões realmente obedecem bem ao Breeze antes de sofisticá-lo.
+
+## Formato de áudio
+
+A API oficial retorna PCM mono signed 16-bit little-endian e anuncia o sample rate no header. O worker encapsula o PCM recebido em WAV por segmento e registra:
+
+- `duration_ms`;
+- `sample_rate`;
+- `audio_digest`;
+- seed;
+- instrução compilada;
+- `cfg_scale`.
+
+O encoding final para MP3/AAC continua responsabilidade do assembler, não do backend TTS.
+
+## Benchmark independente de obra
+
+O corpus `data/audiobook-benchmarks/pt-br-audiobook-v1.yaml` não pertence a HPMOR nem a qualquer obra. Ele existe para testar o motor antes de um capítulo editorial ficar pronto.
+
+Cobre pelo menos:
+
+- narrativa neutra;
+- pergunta e diálogo juvenil;
+- autoridade contida;
+- ironia;
+- medo;
+- sussurro;
+- fonemas e encontros do pt-BR;
+- números;
+- nomes ingleses em frase portuguesa;
+- code-switch;
+- passagem analítica longa;
+- transição emocional.
+
+O workflow `Audiobook TTS Benchmark` compila esse corpus para o mesmo contrato `audiobook-tts-plan-v1` usado por livros reais e despacha o mesmo worker para Kaggle ou Colab.
+
+O benchmark **não exige `ready_for_audio`**, porque não representa uma obra editorial e não é publicável. Isso não enfraquece o gate de produção: o workflow normal de mídia continua exigindo readiness antes de sintetizar capítulos.
+
+## Critério de aceitação inicial
+
+Breeze passa da condição de “backend implementado” para “candidato operacional” somente quando uma execução remota real demonstrar:
+
+1. bootstrap completo numa GPU gratuita disponível;
+2. geração dos 12 segmentos sem intervenção manual;
+3. artifact recuperado pelo GitHub Actions;
+4. manifesto com revisão, hardware e parâmetros;
+5. áudio pt-BR inteligível em todos os casos;
+6. ausência de repetição/alucinação catastrófica no corpus curto.
+
+Qualidade relativa, identidade de personagem e expressividade são avaliadas depois, comparando as mesmas entradas com os demais backends.
+
+## Limitações conhecidas desta primeira integração
+
+- Voice Design por descrição pode não manter timbre tão estável quanto uma referência de voz explícita em um livro inteiro;
+- `cfg_scale=4` é o default inicial porque fortalece instruction-following, mas deve ser benchmarkado;
+- o modelo é oficialmente apresentado para inglês/chinês; pt-BR é deliberadamente tratado como hipótese empírica zero-shot;
+- bootstrap inicial baixa vários gigabytes e pode consumir parte relevante de uma sessão gratuita;
+- o backend usa a implementação eager padrão para caber em GPUs de aproximadamente 12–16 GB, em vez de presumir o caminho `--fast-all` mais pesado.
+
+Se Voice Design for linguisticamente bom mas instável entre segmentos, o próximo experimento é gerar uma âncora de voz por personagem e usar Voice Direction com reference audio — sem mudar o contrato canônico de `voices.yaml`.

--- a/scripts/audiobook/benchmark-plan.mjs
+++ b/scripts/audiobook/benchmark-plan.mjs
@@ -1,0 +1,96 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+
+import yaml from "js-yaml";
+
+import { canonicalize, digest } from "../../src/audiobook/plan.js";
+
+function usage() {
+  console.error(
+    "Usage: node scripts/audiobook/benchmark-plan.mjs --benchmark <file.yaml> [--output <plan.json>]"
+  );
+}
+
+function parseArgs(argv) {
+  const args = { benchmarkPath: null, outputPath: null };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--benchmark") args.benchmarkPath = argv[++index] ?? null;
+    else if (arg === "--output") args.outputPath = argv[++index] ?? null;
+    else if (arg === "--help" || arg === "-h") {
+      usage();
+      process.exit(0);
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+  if (!args.benchmarkPath) throw new Error("--benchmark is required");
+  return args;
+}
+
+function createBenchmarkPlan(document, sourcePath) {
+  if (document.schema !== "audiobook-tts-benchmark-v1") {
+    throw new Error(`unsupported benchmark schema: ${document.schema}`);
+  }
+  if (!document.benchmark_id || !document.language) {
+    throw new Error("benchmark_id and language are required");
+  }
+  if (!document.voices || typeof document.voices !== "object") {
+    throw new Error("benchmark voices are required");
+  }
+  if (!Array.isArray(document.segments) || document.segments.length === 0) {
+    throw new Error("benchmark requires at least one segment");
+  }
+
+  const seen = new Set();
+  const segments = document.segments.map((segment, index) => {
+    if (!segment.id || !segment.speaker || !segment.text) {
+      throw new Error(`benchmark segment ${index} requires id, speaker and text`);
+    }
+    if (seen.has(segment.id)) throw new Error(`duplicate benchmark id: ${segment.id}`);
+    seen.add(segment.id);
+    const voice = document.voices[segment.speaker];
+    if (!voice) throw new Error(`${segment.id}: unknown speaker ${segment.speaker}`);
+    const request = {
+      segment_id: `${document.benchmark_id}-${segment.id}`,
+      speaker: segment.speaker,
+      voice: canonicalize(voice),
+      text: segment.text.trim(),
+      direction: canonicalize(segment.direction ?? {}),
+    };
+    return { ...request, input_digest: digest(request) };
+  });
+
+  return {
+    schema: "audiobook-tts-plan-v1",
+    work_id: `benchmark-${document.benchmark_id}`,
+    chapter_id: document.benchmark_id,
+    lang: document.language,
+    benchmark_id: document.benchmark_id,
+    benchmark_source: sourcePath,
+    narration_digest: digest(document),
+    segments,
+  };
+}
+
+try {
+  const args = parseArgs(process.argv.slice(2));
+  const source = fs.readFileSync(args.benchmarkPath, "utf8");
+  const document = yaml.load(source);
+  const plan = createBenchmarkPlan(document, args.benchmarkPath);
+  const output = `${JSON.stringify(plan, null, 2)}\n`;
+  if (args.outputPath) {
+    fs.mkdirSync(path.dirname(args.outputPath), { recursive: true });
+    fs.writeFileSync(args.outputPath, output);
+    console.error(`wrote ${args.outputPath}: ${plan.segments.length} segment(s)`);
+  } else {
+    process.stdout.write(output);
+  }
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  usage();
+  process.exit(2);
+}

--- a/scripts/audiobook/worker.py
+++ b/scripts/audiobook/worker.py
@@ -3,27 +3,41 @@
 
 The worker deliberately has no editorial intelligence. It receives an already
 validated TTS plan and turns each request into audio through a selected backend.
-The initial `fake` backend produces deterministic WAV tones so the complete
-control-plane can be exercised without secrets, network access, or GPU time.
+
+`fake` produces deterministic WAV tones for CI. `breeze` bootstraps a pinned
+Breeze TTS 2 runtime, loads the model once, then synthesizes all segments through
+its official streaming API. Remote runners therefore execute the same worker
+without notebooks or provider-specific editorial logic.
 """
 
 from __future__ import annotations
 
 import argparse
+from contextlib import suppress
 import hashlib
 import json
 import math
 import os
 from pathlib import Path
 import platform
+import socket
 import struct
 import subprocess
 import sys
+import time
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlencode
+from urllib.request import Request, urlopen
 import wave
 import zipfile
 
 PLAN_SCHEMA = "audiobook-tts-plan-v1"
 MANIFEST_SCHEMA = "audiobook-media-manifest-v1"
+
+BREEZE_CODE_REPOSITORY = "https://github.com/breezeblue-ai/breeze-tts.git"
+BREEZE_CODE_REVISION = "ca632ce6c4d05f7985da4eab29b1a5d445b43f7b"
+BREEZE_MODEL_REPOSITORY = "BreezeBlue/Breeze-TTS-2"
+BREEZE_MODEL_REVISION = "a3bd0a6e83cd2d046ce783df2f7cb84292869ef7"
 
 
 def sha256_file(path: Path) -> str:
@@ -68,6 +82,40 @@ def hardware_info() -> dict:
     return result
 
 
+def canonical_json(value: object) -> str:
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+
+def stable_voice_seed(segment: dict) -> int:
+    identity = {
+        "speaker": segment["speaker"],
+        "voice": segment.get("voice", {}),
+    }
+    digest = hashlib.sha256(canonical_json(identity).encode("utf-8")).digest()
+    return int.from_bytes(digest[:4], "big") & 0x7FFFFFFF
+
+
+def write_pcm16_wav(output_path: Path, pcm: bytes, sample_rate: int) -> dict:
+    if sample_rate <= 0:
+        raise ValueError(f"invalid sample rate: {sample_rate}")
+    if not pcm or len(pcm) % 2:
+        raise ValueError("backend returned invalid signed 16-bit PCM")
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with wave.open(str(output_path), "wb") as stream:
+        stream.setnchannels(1)
+        stream.setsampwidth(2)
+        stream.setframerate(sample_rate)
+        stream.writeframes(pcm)
+
+    frames = len(pcm) // 2
+    return {
+        "duration_ms": round(frames * 1000 / sample_rate),
+        "sample_rate": sample_rate,
+        "audio_digest": sha256_file(output_path),
+    }
+
+
 def fake_synthesize(segment: dict, output_path: Path) -> dict:
     """Write deterministic audible proof-of-pipeline audio for one segment."""
 
@@ -84,7 +132,10 @@ def fake_synthesize(segment: dict, output_path: Path) -> dict:
         stream.setsampwidth(2)
         stream.setframerate(sample_rate)
         for index in range(frames):
-            sample = int(amplitude * math.sin(2 * math.pi * frequency * index / sample_rate))
+            sample = int(
+                amplitude
+                * math.sin(2 * math.pi * frequency * index / sample_rate)
+            )
             stream.writeframesraw(struct.pack("<h", sample))
 
     return {
@@ -94,69 +145,343 @@ def fake_synthesize(segment: dict, output_path: Path) -> dict:
     }
 
 
-BACKENDS = {
-    "fake": fake_synthesize,
-}
+class FakeBackend:
+    metadata = {"implementation": "deterministic-tone-v1"}
+
+    def synthesize(self, segment: dict, output_path: Path) -> dict:
+        return fake_synthesize(segment, output_path)
+
+    def close(self) -> None:
+        pass
+
+
+def run_checked(args: list[str], *, cwd: Path | None = None) -> str:
+    completed = subprocess.run(
+        args,
+        cwd=cwd,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if completed.returncode != 0:
+        raise RuntimeError(
+            f"command failed ({completed.returncode}): {' '.join(args)}\n"
+            f"{completed.stderr or completed.stdout}"
+        )
+    return completed.stdout.strip()
+
+
+def ensure_breeze_source(cache_dir: Path, revision: str) -> Path:
+    source_dir = cache_dir / "source" / f"breeze-tts-{revision[:12]}"
+    if source_dir.exists():
+        head = run_checked(["git", "rev-parse", "HEAD"], cwd=source_dir)
+        if head != revision:
+            raise RuntimeError(
+                f"cached Breeze source revision mismatch: {head} != {revision}"
+            )
+        return source_dir
+
+    source_dir.parent.mkdir(parents=True, exist_ok=True)
+    run_checked(
+        [
+            "git",
+            "clone",
+            "--filter=blob:none",
+            "--no-checkout",
+            BREEZE_CODE_REPOSITORY,
+            str(source_dir),
+        ]
+    )
+    run_checked(["git", "checkout", "--detach", revision], cwd=source_dir)
+    return source_dir
+
+
+def install_breeze_dependencies(source_dir: Path) -> None:
+    if os.environ.get("AUDIOBOOK_SKIP_BACKEND_INSTALL") == "1":
+        return
+    run_checked(
+        [
+            sys.executable,
+            "-m",
+            "pip",
+            "install",
+            "--disable-pip-version-check",
+            "-r",
+            str(source_dir / "requirements.txt"),
+        ]
+    )
+
+
+def resolve_breeze_model(
+    model: str,
+    *,
+    cache_dir: Path,
+    revision: str,
+) -> Path:
+    candidate = Path(model).expanduser()
+    if candidate.exists():
+        return candidate.resolve()
+
+    script = (
+        "from huggingface_hub import snapshot_download; "
+        "import sys; "
+        "print(snapshot_download(repo_id=sys.argv[1], revision=sys.argv[2], "
+        "cache_dir=sys.argv[3]))"
+    )
+    model_path = run_checked(
+        [
+            sys.executable,
+            "-c",
+            script,
+            model,
+            revision,
+            str(cache_dir / "huggingface"),
+        ]
+    )
+    return Path(model_path.splitlines()[-1]).resolve()
+
+
+def free_local_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as listener:
+        listener.bind(("127.0.0.1", 0))
+        return int(listener.getsockname()[1])
+
+
+def voice_instruction(segment: dict) -> str:
+    voice = segment.get("voice") or {}
+    direction = segment.get("direction") or {}
+    pieces = []
+
+    description = voice.get("description")
+    if description:
+        pieces.append(str(description).strip())
+    locale = voice.get("locale")
+    if locale:
+        pieces.append(f"Fale naturalmente no idioma e variante {locale}.")
+
+    labels = {
+        "emotion": "Emoção",
+        "pace": "Ritmo",
+        "pitch": "Altura",
+        "energy": "Energia",
+        "style": "Estilo",
+        "delivery": "Interpretação",
+    }
+    for key, value in direction.items():
+        label = labels.get(key, key.replace("_", " ").capitalize())
+        pieces.append(f"{label}: {value}.")
+
+    return " ".join(piece for piece in pieces if piece).strip() or (
+        "Fale com clareza, naturalidade e interpretação apropriada ao texto."
+    )
+
+
+class BreezeBackend:
+    def __init__(self, model: str, output_dir: Path) -> None:
+        self.code_revision = os.environ.get(
+            "BREEZE_CODE_REVISION", BREEZE_CODE_REVISION
+        )
+        self.model_revision = os.environ.get(
+            "BREEZE_MODEL_REVISION", BREEZE_MODEL_REVISION
+        )
+        self.cache_dir = Path(
+            os.environ.get(
+                "AUDIOBOOK_MODEL_CACHE",
+                str(Path.home() / ".cache" / "audiobook-factory"),
+            )
+        ).expanduser()
+        self.source_dir = ensure_breeze_source(self.cache_dir, self.code_revision)
+        install_breeze_dependencies(self.source_dir)
+        self.model_path = resolve_breeze_model(
+            model,
+            cache_dir=self.cache_dir,
+            revision=self.model_revision,
+        )
+        self.port = free_local_port()
+        self.base_url = f"http://127.0.0.1:{self.port}"
+        output_dir.mkdir(parents=True, exist_ok=True)
+        self.log_path = output_dir / "breeze-runtime.log"
+        self.log_stream = self.log_path.open("w", encoding="utf-8")
+        self.process = subprocess.Popen(
+            [
+                sys.executable,
+                "-m",
+                "breeze_infer.api",
+                str(self.model_path),
+                "--host",
+                "127.0.0.1",
+                "--port",
+                str(self.port),
+            ],
+            cwd=self.source_dir,
+            stdout=self.log_stream,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+        self.sample_rate = self._wait_until_ready()
+        self.metadata = {
+            "code_repository": BREEZE_CODE_REPOSITORY,
+            "code_revision": self.code_revision,
+            "model_repository": model,
+            "model_revision": self.model_revision,
+            "api": "official-streaming-v1",
+            "sample_rate": self.sample_rate,
+            "cfg_scale": float(os.environ.get("BREEZE_CFG_SCALE", "4")),
+        }
+
+    def _wait_until_ready(self) -> int:
+        deadline = time.monotonic() + float(
+            os.environ.get("BREEZE_START_TIMEOUT", "1200")
+        )
+        last_error = "not started"
+        while time.monotonic() < deadline:
+            if self.process.poll() is not None:
+                self.log_stream.flush()
+                tail = self.log_path.read_text(encoding="utf-8", errors="replace")[-8000:]
+                raise RuntimeError(
+                    f"Breeze runtime exited during startup ({self.process.returncode}):\n{tail}"
+                )
+            try:
+                with urlopen(f"{self.base_url}/health", timeout=5) as response:
+                    payload = json.load(response)
+                if payload.get("status") == "ok":
+                    return int(payload["sample_rate"])
+            except (HTTPError, URLError, TimeoutError, ValueError) as error:
+                last_error = str(error)
+            time.sleep(2)
+        raise TimeoutError(f"Breeze runtime did not become ready: {last_error}")
+
+    def synthesize(self, segment: dict, output_path: Path) -> dict:
+        seed = stable_voice_seed(segment)
+        instruction = voice_instruction(segment)
+        cfg_scale = float(os.environ.get("BREEZE_CFG_SCALE", "4"))
+        body = urlencode(
+            {
+                "text": segment["text"],
+                "instruction": instruction,
+                "cfg_scale": str(cfg_scale),
+                "seed": str(seed),
+            }
+        ).encode("utf-8")
+        request = Request(
+            f"{self.base_url}/v1/audio/speech",
+            data=body,
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+            method="POST",
+        )
+        try:
+            with urlopen(
+                request,
+                timeout=float(os.environ.get("BREEZE_REQUEST_TIMEOUT", "900")),
+            ) as response:
+                pcm = response.read()
+                sample_rate = int(
+                    response.headers.get("X-Sample-Rate", str(self.sample_rate))
+                )
+        except HTTPError as error:
+            detail = error.read().decode("utf-8", errors="replace")
+            raise RuntimeError(
+                f"Breeze synthesis failed with HTTP {error.code}: {detail}"
+            ) from error
+
+        generated = write_pcm16_wav(output_path, pcm, sample_rate)
+        return {
+            **generated,
+            "seed": seed,
+            "instruction": instruction,
+            "cfg_scale": cfg_scale,
+        }
+
+    def close(self) -> None:
+        if getattr(self, "process", None) is not None:
+            self.process.terminate()
+            with suppress(subprocess.TimeoutExpired):
+                self.process.wait(timeout=15)
+            if self.process.poll() is None:
+                self.process.kill()
+                self.process.wait(timeout=10)
+        if getattr(self, "log_stream", None) is not None:
+            self.log_stream.close()
+
+
+def create_backend(name: str, model: str, output_dir: Path):
+    if name == "fake":
+        return FakeBackend()
+    if name == "breeze":
+        return BreezeBackend(model, output_dir)
+    raise ValueError(f"unsupported backend: {name}; available: breeze, fake")
 
 
 def make_archive(output_dir: Path, archive_path: Path) -> None:
     archive_path.parent.mkdir(parents=True, exist_ok=True)
-    with zipfile.ZipFile(archive_path, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+    with zipfile.ZipFile(
+        archive_path, "w", compression=zipfile.ZIP_DEFLATED
+    ) as archive:
         for file_path in sorted(output_dir.rglob("*")):
             if file_path.is_file():
                 archive.write(file_path, file_path.relative_to(output_dir))
 
 
-def run(plan_path: Path, output_dir: Path, backend: str, model: str, archive_path: Path | None) -> dict:
+def run(
+    plan_path: Path,
+    output_dir: Path,
+    backend: str,
+    model: str,
+    archive_path: Path | None,
+) -> dict:
     plan = load_plan(plan_path)
-    if backend not in BACKENDS:
-        raise ValueError(f"unsupported backend: {backend}; available: {', '.join(sorted(BACKENDS))}")
-
     output_dir.mkdir(parents=True, exist_ok=True)
     segment_dir = output_dir / "segments"
-    synthesize = BACKENDS[backend]
+    runtime = create_backend(backend, model, output_dir)
     manifest_segments = []
 
-    for index, segment in enumerate(plan["segments"]):
-        for field in ("segment_id", "speaker", "text", "input_digest"):
-            if not segment.get(field):
-                raise ValueError(f"segment {index} missing {field}")
-        audio_path = segment_dir / f"{segment['segment_id']}.wav"
-        generated = synthesize(segment, audio_path)
-        manifest_segments.append(
-            {
-                "segment_id": segment["segment_id"],
-                "speaker": segment["speaker"],
-                "input_digest": segment["input_digest"],
-                "audio_file": str(audio_path.relative_to(output_dir)),
-                **generated,
-            }
+    try:
+        for index, segment in enumerate(plan["segments"]):
+            for field in ("segment_id", "speaker", "text", "input_digest"):
+                if not segment.get(field):
+                    raise ValueError(f"segment {index} missing {field}")
+            audio_path = segment_dir / f"{segment['segment_id']}.wav"
+            generated = runtime.synthesize(segment, audio_path)
+            manifest_segments.append(
+                {
+                    "segment_id": segment["segment_id"],
+                    "speaker": segment["speaker"],
+                    "input_digest": segment["input_digest"],
+                    "audio_file": str(audio_path.relative_to(output_dir)),
+                    **generated,
+                }
+            )
+
+        manifest = {
+            "schema": MANIFEST_SCHEMA,
+            "work_id": plan["work_id"],
+            "chapter_id": plan["chapter_id"],
+            "narration_digest": plan.get("narration_digest"),
+            "backend": backend,
+            "model": model,
+            "backend_metadata": runtime.metadata,
+            "hardware": hardware_info(),
+            "segments": manifest_segments,
+        }
+        manifest_path = output_dir / "manifest.json"
+        manifest_path.write_text(
+            json.dumps(manifest, indent=2, ensure_ascii=False) + "\n",
+            encoding="utf-8",
         )
 
-    manifest = {
-        "schema": MANIFEST_SCHEMA,
-        "work_id": plan["work_id"],
-        "chapter_id": plan["chapter_id"],
-        "narration_digest": plan.get("narration_digest"),
-        "backend": backend,
-        "model": model,
-        "hardware": hardware_info(),
-        "segments": manifest_segments,
-    }
-    manifest_path = output_dir / "manifest.json"
-    manifest_path.write_text(json.dumps(manifest, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+        if archive_path is not None:
+            make_archive(output_dir, archive_path)
 
-    if archive_path is not None:
-        make_archive(output_dir, archive_path)
-
-    return manifest
+        return manifest
+    finally:
+        runtime.close()
 
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser()
     parser.add_argument("--plan", required=True, type=Path)
     parser.add_argument("--output-dir", required=True, type=Path)
-    parser.add_argument("--backend", default="fake", choices=sorted(BACKENDS))
+    parser.add_argument("--backend", default="fake", choices=["breeze", "fake"])
     parser.add_argument("--model", default="deterministic-tone-v1")
     parser.add_argument("--result-archive", type=Path)
     return parser.parse_args()
@@ -164,9 +489,17 @@ def parse_args() -> argparse.Namespace:
 
 def main() -> int:
     args = parse_args()
+    if args.backend == "breeze" and args.model == "deterministic-tone-v1":
+        args.model = BREEZE_MODEL_REPOSITORY
     try:
-        manifest = run(args.plan, args.output_dir, args.backend, args.model, args.result_archive)
-    except Exception as error:  # noqa: BLE001 - CLI boundary must surface deterministic non-zero failure.
+        manifest = run(
+            args.plan,
+            args.output_dir,
+            args.backend,
+            args.model,
+            args.result_archive,
+        )
+    except Exception as error:  # noqa: BLE001 - CLI boundary surfaces non-zero failure.
         print(f"audiobook worker failed: {error}", file=sys.stderr)
         return 2
 
@@ -179,7 +512,9 @@ def main() -> int:
                 "backend": manifest["backend"],
                 "segments": len(manifest["segments"]),
                 "output_dir": os.fspath(args.output_dir),
-                "result_archive": os.fspath(args.result_archive) if args.result_archive else None,
+                "result_archive": os.fspath(args.result_archive)
+                if args.result_archive
+                else None,
             },
             ensure_ascii=False,
         )

--- a/src/audiobook/benchmark-plan.test.js
+++ b/src/audiobook/benchmark-plan.test.js
@@ -1,0 +1,35 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+
+test("synthetic pt-BR benchmark compiles into a provider-neutral TTS plan", () => {
+  const outputPath = path.join(
+    fs.mkdtempSync(path.join(os.tmpdir(), "audiobook-benchmark-")),
+    "plan.json",
+  );
+  const result = spawnSync(
+    "node",
+    [
+      "scripts/audiobook/benchmark-plan.mjs",
+      "--benchmark",
+      "data/audiobook-benchmarks/pt-br-audiobook-v1.yaml",
+      "--output",
+      outputPath,
+    ],
+    { cwd: process.cwd(), encoding: "utf8" },
+  );
+
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  const plan = JSON.parse(fs.readFileSync(outputPath, "utf8"));
+  assert.equal(plan.schema, "audiobook-tts-plan-v1");
+  assert.equal(plan.benchmark_id, "pt-br-audiobook-v1");
+  assert.equal(plan.lang, "pt-BR");
+  assert.ok(plan.segments.length >= 10);
+  assert.equal(plan.segments[0].voice.locale, "pt-BR");
+  assert.match(plan.segments[0].input_digest, /^sha256:[0-9a-f]{64}$/);
+  assert.ok(plan.segments.some((segment) => segment.direction.emotion));
+  assert.ok(plan.segments.some((segment) => /Harry/.test(segment.text)));
+});


### PR DESCRIPTION
## Objetivo

Implementar o primeiro backend TTS real da Audiobook Factory e tornar o benchmark pt-BR executável antes de qualquer capítulo editorial ficar `ready_for_audio`.

## Breeze TTS 2

- bootstrap do código oficial em revisão fixa `ca632ce6c4d05f7985da4eab29b1a5d445b43f7b`;
- pesos `BreezeBlue/Breeze-TTS-2` fixados na revisão `a3bd0a6e83cd2d046ce783df2f7cb84292869ef7`;
- instalação das dependências oficiais dentro do runner remoto;
- download/cache do snapshot do modelo;
- uma única instância da API streaming oficial por job;
- Voice Design zero-shot, sem fine-tune e sem reference audio nesta primeira rodada;
- descrição lógica de `voices.yaml` compilada para instruction;
- direção de narração compilada por segmento;
- seed estável derivada da identidade/configuração da voz;
- PCM oficial encapsulado em WAV e parâmetros/revisões persistidos no manifesto;
- implementação eager por padrão para a classe de GPU gratuita de 12–16 GB.

## Correção de contrato na base

A PR depende da correção na #1596 que passa a incluir a configuração lógica da voz no request e no `input_digest`. Alterar a voz de um personagem portanto invalida o áudio afetado em vez de reutilizar cache semanticamente velho.

## Benchmark sem obra protegida

Adiciona `data/audiobook-benchmarks/pt-br-audiobook-v1.yaml` com 12 segmentos sintéticos cobrindo narrativa, diálogo, ironia, medo, sussurro, fonética pt-BR, números, nomes ingleses, code-switch, passagem longa e transição emocional.

`scripts/audiobook/benchmark-plan.mjs` compila esse corpus para o mesmo `audiobook-tts-plan-v1` usado pela produção.

O workflow manual `Audiobook TTS Benchmark` executa o mesmo worker em Kaggle, Colab ou local (`fake` apenas), e devolve todas as amostras + manifesto como artifact. O benchmark não exige `ready_for_audio` porque não representa conteúdo de uma obra e nunca publica mídia.

## Credenciais esperadas

- Kaggle: `KAGGLE_API_TOKEN` + variável `KAGGLE_USERNAME`;
- Colab: `COLAB_ADC_JSON`.

Nenhuma credencial é necessária para o modelo Breeze/Hugging Face público nesta primeira implementação.

## Não faz

- não chama TTS automaticamente;
- não publica mídia;
- não altera HPMOR;
- não escolhe Breeze como vencedor;
- não faz fine-tune/adaptação de idioma.

PR empilhada sobre #1596.