### PR TITLE
fix(audiobook): make remote TTS runners work against the real providers

### DIFF
--- a/.github/workflows/audiobook-media.yml
+++ b/.github/workflows/audiobook-media.yml
@@ -152,13 +152,24 @@ jobs:
       - name: Configure Colab CLI
         if: ${{ inputs.dry_run == false && inputs.runner == 'colab' }}
         env:
+          COLAB_TOKEN_JSON: ${{ secrets.COLAB_TOKEN_JSON }}
           COLAB_ADC_JSON: ${{ secrets.COLAB_ADC_JSON }}
         run: |
-          [[ -n "$COLAB_ADC_JSON" ]] || { echo "Missing GitHub secret COLAB_ADC_JSON" >&2; exit 2; }
           python -m pip install --disable-pip-version-check 'google-colab-cli==0.6.0'
-          printf '%s' "$COLAB_ADC_JSON" > "$RUNNER_TEMP/colab-adc.json"
-          chmod 600 "$RUNNER_TEMP/colab-adc.json"
-          echo "GOOGLE_APPLICATION_CREDENTIALS=$RUNNER_TEMP/colab-adc.json" >> "$GITHUB_ENV"
+          if [[ -n "$COLAB_TOKEN_JSON" ]]; then
+            install -d -m 700 "$HOME/.config/colab-cli"
+            printf '%s' "$COLAB_TOKEN_JSON" > "$HOME/.config/colab-cli/token.json"
+            chmod 600 "$HOME/.config/colab-cli/token.json"
+            echo "COLAB_AUTH_PROVIDER=oauth2" >> "$GITHUB_ENV"
+          elif [[ -n "$COLAB_ADC_JSON" ]]; then
+            printf '%s' "$COLAB_ADC_JSON" > "$RUNNER_TEMP/colab-adc.json"
+            chmod 600 "$RUNNER_TEMP/colab-adc.json"
+            echo "GOOGLE_APPLICATION_CREDENTIALS=$RUNNER_TEMP/colab-adc.json" >> "$GITHUB_ENV"
+            echo "COLAB_AUTH_PROVIDER=adc" >> "$GITHUB_ENV"
+          else
+            echo "Missing GitHub secret COLAB_TOKEN_JSON (or COLAB_ADC_JSON)" >&2
+            exit 2
+          fi
 
       - name: Run Colab media worker
         if: ${{ inputs.dry_run == false && inputs.runner == 'colab' }}

--- a/.github/workflows/audiobook-tts-benchmark.yml
+++ b/.github/workflows/audiobook-tts-benchmark.yml
@@ -116,13 +116,24 @@ jobs:
       - name: Configure Colab CLI
         if: ${{ inputs.runner == 'colab' }}
         env:
+          COLAB_TOKEN_JSON: ${{ secrets.COLAB_TOKEN_JSON }}
           COLAB_ADC_JSON: ${{ secrets.COLAB_ADC_JSON }}
         run: |
-          [[ -n "$COLAB_ADC_JSON" ]] || { echo "Missing GitHub secret COLAB_ADC_JSON" >&2; exit 2; }
           python -m pip install --disable-pip-version-check 'google-colab-cli==0.6.0'
-          printf '%s' "$COLAB_ADC_JSON" > "$RUNNER_TEMP/colab-adc.json"
-          chmod 600 "$RUNNER_TEMP/colab-adc.json"
-          echo "GOOGLE_APPLICATION_CREDENTIALS=$RUNNER_TEMP/colab-adc.json" >> "$GITHUB_ENV"
+          if [[ -n "$COLAB_TOKEN_JSON" ]]; then
+            install -d -m 700 "$HOME/.config/colab-cli"
+            printf '%s' "$COLAB_TOKEN_JSON" > "$HOME/.config/colab-cli/token.json"
+            chmod 600 "$HOME/.config/colab-cli/token.json"
+            echo "COLAB_AUTH_PROVIDER=oauth2" >> "$GITHUB_ENV"
+          elif [[ -n "$COLAB_ADC_JSON" ]]; then
+            printf '%s' "$COLAB_ADC_JSON" > "$RUNNER_TEMP/colab-adc.json"
+            chmod 600 "$RUNNER_TEMP/colab-adc.json"
+            echo "GOOGLE_APPLICATION_CREDENTIALS=$RUNNER_TEMP/colab-adc.json" >> "$GITHUB_ENV"
+            echo "COLAB_AUTH_PROVIDER=adc" >> "$GITHUB_ENV"
+          else
+            echo "Missing GitHub secret COLAB_TOKEN_JSON (or COLAB_ADC_JSON)" >&2
+            exit 2
+          fi
 
       - name: Run benchmark on Colab
         if: ${{ inputs.runner == 'colab' }}

--- a/docs/okf/audiobook/media-runners.md
+++ b/docs/okf/audiobook/media-runners.md
@@ -57,24 +57,40 @@ google-colab-cli==0.6.0
 O fluxo usa somente comandos não interativos:
 
 ```text
-colab --auth=adc new
-colab --auth=adc upload
-colab --auth=adc exec
-colab --auth=adc download
-colab --auth=adc stop
+colab --auth=$COLAB_AUTH_PROVIDER new
+colab --auth=$COLAB_AUTH_PROVIDER upload
+colab --auth=$COLAB_AUTH_PROVIDER exec
+colab --auth=$COLAB_AUTH_PROVIDER download
+colab --auth=$COLAB_AUTH_PROVIDER stop
 ```
 
-O CLI oficial recomenda ADC para automação/headless. A identidade precisa ter os scopes necessários ao Colab.
+O CLI aceita duas formas de credencial, e a escolha não é indiferente:
+
+- `oauth2` (**default do projeto**) — o token de usuário que o próprio `colab` emite
+  e renova, gravado em `~/.config/colab-cli/token.json`. Ele já nasce com os scopes
+  que o backend do Colab exige, incluindo `.../auth/colaboratory`, e se renova
+  sozinho pelo `refresh_token`.
+- `adc` — Application Default Credentials. Credenciais **de usuário** obtidas por
+  `gcloud auth application-default login` não podem ser re-escopadas depois
+  (`with_scopes` não é suportado), então precisam ser emitidas já com
+  `--scopes=openid,.../cloud-platform,.../userinfo.email,.../colaboratory`;
+  caso contrário o keep-alive da sessão devolve `403 SCOPE_NOT_PERMITTED`.
 
 ### GitHub Secret
 
-Criar:
+Criar um dos dois:
 
 ```text
+COLAB_TOKEN_JSON
 COLAB_ADC_JSON
 ```
 
-O valor esperado é o conteúdo JSON de Application Default Credentials de uma conta autorizada a usar o Colab. O workflow materializa o JSON num arquivo temporário com permissão restrita e define `GOOGLE_APPLICATION_CREDENTIALS` apenas durante o job.
+`COLAB_TOKEN_JSON` é o conteúdo de `~/.config/colab-cli/token.json` de uma conta
+já autorizada; o workflow o materializa em `~/.config/colab-cli/token.json` com
+permissão restrita e seleciona `COLAB_AUTH_PROVIDER=oauth2`. `COLAB_ADC_JSON` é o
+fallback: materializa um arquivo temporário, aponta
+`GOOGLE_APPLICATION_CREDENTIALS` para ele e seleciona `COLAB_AUTH_PROVIDER=adc`.
+Nenhum dos dois é impresso em log.
 
 **Gate de realidade:** armazenamento correto da credencial não prova que a conta terá direito a uma GPU gratuita em execução headless. Isso deve ser validado por uma execução real com a conta do projeto. Falha de quota/alocação é falha do runner, não do corpus ou do modelo TTS.
 

--- a/scripts/audiobook/kaggle-log.py
+++ b/scripts/audiobook/kaggle-log.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""Render a Kaggle kernel log (a JSON array of stream records) as plain text.
+
+Kaggle only exposes a coarse kernel status; the actual traceback of a failed
+run lives in this log, so the remote runner prints it before giving up.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import sys
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print("usage: kaggle-log.py <kernel.log>", file=sys.stderr)
+        return 2
+    try:
+        entries = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+    except (OSError, ValueError) as error:
+        print(f"unreadable kernel log: {error}", file=sys.stderr)
+        return 1
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        stream = entry.get("stream_name", "?")
+        data = str(entry.get("data", "")).rstrip()
+        print(f"[{stream}] {data}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/audiobook/kaggle-log.py
+++ b/scripts/audiobook/kaggle-log.py
@@ -1,4 +1,8 @@
-#!/usr/bin/env python3
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = []
+# ///
 """Render a Kaggle kernel log (a JSON array of stream records) as plain text.
 
 Kaggle only exposes a coarse kernel status; the actual traceback of a failed

--- a/scripts/audiobook/runners/colab.sh
+++ b/scripts/audiobook/runners/colab.sh
@@ -22,6 +22,13 @@ done
 [[ -n "$OUTPUT" ]] || { echo "--output is required" >&2; exit 2; }
 command -v colab >/dev/null || { echo "colab CLI not found" >&2; exit 2; }
 
+# The CLI supports two credential shapes: its own OAuth2 user token at
+# ~/.config/colab-cli/token.json (the one `colab` mints and refreshes), and
+# Application Default Credentials. Default to OAuth2 because ADC user
+# credentials cannot be re-scoped and must be minted with the colaboratory
+# scope explicitly.
+AUTH="${COLAB_AUTH_PROVIDER:-oauth2}"
+
 SESSION="audiobook-${GITHUB_RUN_ID:-$$}-${GITHUB_RUN_ATTEMPT:-1}"
 SESSION="${SESSION,,}"
 TMPDIR_LOCAL="$(mktemp -d)"
@@ -44,21 +51,21 @@ runpy.run_path("/content/worker.py", run_name="__main__")
 PY
 
 cleanup() {
-  colab --auth=adc stop -s "$SESSION" >/dev/null 2>&1 || true
+  colab "--auth=$AUTH" stop -s "$SESSION" >/dev/null 2>&1 || true
   rm -rf "$TMPDIR_LOCAL"
 }
 trap cleanup EXIT
 
 if [[ -n "$GPU" ]]; then
-  colab --auth=adc new -s "$SESSION" --gpu "$GPU"
+  colab "--auth=$AUTH" new -s "$SESSION" --gpu "$GPU"
 else
-  colab --auth=adc new -s "$SESSION"
+  colab "--auth=$AUTH" new -s "$SESSION"
 fi
 
-colab --auth=adc upload -s "$SESSION" scripts/audiobook/worker.py /content/worker.py
-colab --auth=adc upload -s "$SESSION" "$PLAN" /content/plan.json
-colab --auth=adc exec -s "$SESSION" --timeout "${COLAB_EXEC_TIMEOUT:-3600}" -f "$LAUNCHER"
+colab "--auth=$AUTH" upload -s "$SESSION" scripts/audiobook/worker.py /content/worker.py
+colab "--auth=$AUTH" upload -s "$SESSION" "$PLAN" /content/plan.json
+colab "--auth=$AUTH" exec -s "$SESSION" --timeout "${COLAB_EXEC_TIMEOUT:-3600}" -f "$LAUNCHER"
 mkdir -p "$(dirname "$OUTPUT")"
-colab --auth=adc download -s "$SESSION" /content/audiobook-result.zip "$OUTPUT"
+colab "--auth=$AUTH" download -s "$SESSION" /content/audiobook-result.zip "$OUTPUT"
 
 echo "colab result: $OUTPUT"

--- a/scripts/audiobook/runners/kaggle.sh
+++ b/scripts/audiobook/runners/kaggle.sh
@@ -31,16 +31,27 @@ fi
 }
 command -v kaggle >/dev/null || { echo "kaggle CLI not found" >&2; exit 2; }
 
+# Prefer uv so the script's PEP 723 header decides the interpreter; fall back to
+# the ambient python3 where uv is not installed.
+if command -v uv >/dev/null; then
+  run_script() { uv run --script "$@"; }
+else
+  run_script() { python3 "$@"; }
+fi
+
 # Kaggle reports only a coarse status; the real traceback lives in the kernel
 # log. Without this the CI job fails with an opaque "Kaggle job failed".
 dump_kernel_log() {
   local dir log
   dir="$(mktemp -d)"
-  if kaggle kernels output "$KERNEL_ID" -p "$dir" -o -q >/dev/null 2>&1; then
+  # The log is fetched regardless of --file-pattern; the pattern matches no
+  # filename so we do not also pull the kernel's whole working directory, which
+  # holds the multi-gigabyte model cache.
+  if kaggle kernels output "$KERNEL_ID" -p "$dir" -o -q --file-pattern '^$' >/dev/null 2>&1; then
     log="$(find "$dir" -maxdepth 1 -type f -name '*.log' -print -quit)"
     if [[ -n "$log" ]]; then
       echo "----- kaggle kernel log -----" >&2
-      python3 scripts/audiobook/kaggle-log.py "$log" >&2 || true
+      run_script scripts/audiobook/kaggle-log.py "$log" >&2 || true
       echo "----- end kaggle kernel log -----" >&2
     fi
   fi

--- a/scripts/audiobook/runners/kaggle.sh
+++ b/scripts/audiobook/runners/kaggle.sh
@@ -31,6 +31,22 @@ fi
 }
 command -v kaggle >/dev/null || { echo "kaggle CLI not found" >&2; exit 2; }
 
+# Kaggle reports only a coarse status; the real traceback lives in the kernel
+# log. Without this the CI job fails with an opaque "Kaggle job failed".
+dump_kernel_log() {
+  local dir log
+  dir="$(mktemp -d)"
+  if kaggle kernels output "$KERNEL_ID" -p "$dir" -o -q >/dev/null 2>&1; then
+    log="$(find "$dir" -maxdepth 1 -type f -name '*.log' -print -quit)"
+    if [[ -n "$log" ]]; then
+      echo "----- kaggle kernel log -----" >&2
+      python3 scripts/audiobook/kaggle-log.py "$log" >&2 || true
+      echo "----- end kaggle kernel log -----" >&2
+    fi
+  fi
+  rm -rf "$dir"
+}
+
 STAGE="$(mktemp -d)"
 DOWNLOAD="$(mktemp -d)"
 trap 'rm -rf "$STAGE" "$DOWNLOAD"' EXIT
@@ -89,6 +105,7 @@ for _ in $(seq 1 "${KAGGLE_STATUS_POLLS:-120}"); do
   fi
   if grep -Eqi 'error|failed|cancel' <<<"$STATUS"; then
     echo "Kaggle job failed" >&2
+    dump_kernel_log
     exit 1
   fi
   sleep "${KAGGLE_STATUS_INTERVAL:-30}"
@@ -97,6 +114,7 @@ done
 STATUS="$(kaggle kernels status "$KERNEL_ID" 2>&1)"
 if ! grep -Eqi 'complete|success' <<<"$STATUS"; then
   echo "Kaggle job did not complete within polling window: $STATUS" >&2
+  dump_kernel_log
   exit 1
 fi
 

--- a/scripts/audiobook/runners/local.sh
+++ b/scripts/audiobook/runners/local.sh
@@ -19,10 +19,18 @@ done
 [[ -n "$PLAN" ]] || { echo "--plan is required" >&2; exit 2; }
 [[ -n "$OUTPUT" ]] || { echo "--output is required" >&2; exit 2; }
 
+# Prefer uv so the script's PEP 723 header decides the interpreter; fall back to
+# the ambient python3 where uv is not installed.
+if command -v uv >/dev/null; then
+  run_script() { uv run --script "$@"; }
+else
+  run_script() { python3 "$@"; }
+fi
+
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
 mkdir -p "$(dirname "$OUTPUT")"
-python3 scripts/audiobook/worker.py \
+run_script scripts/audiobook/worker.py \
   --plan "$PLAN" \
   --output-dir "$TMP/output" \
   --backend "$BACKEND" \

--- a/scripts/audiobook/worker.py
+++ b/scripts/audiobook/worker.py
@@ -1,8 +1,17 @@
-#!/usr/bin/env python3
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = []
+# ///
 """Audiobook Factory media worker.
 
 The worker deliberately has no editorial intelligence. It receives an already
 validated TTS plan and turns each request into audio through a selected backend.
+
+The script declares no PEP 723 dependencies on purpose: the `fake` backend is
+stdlib-only, and the `breeze` backend must install its pinned stack into the
+interpreter that is actually running, because on a hosted GPU box the CUDA build
+of torch has to match that image's driver.
 
 `fake` produces deterministic WAV tones for CI. `breeze` bootstraps a pinned
 Breeze TTS 2 runtime, loads the model once, then synthesizes all segments through
@@ -248,6 +257,73 @@ def resolve_breeze_model(
     return Path(model_path.splitlines()[-1]).resolve()
 
 
+def flash_attention_available() -> bool:
+    """Whether this box can actually run FlashAttention 2.
+
+    The package only builds kernels for Ampere and newer (compute capability
+    8.0+), so a T4 (7.5) can never satisfy it regardless of installation.
+    """
+    probe = (
+        "import sys, torch, importlib.util;"
+        "ok = importlib.util.find_spec('flash_attn') is not None"
+        " and torch.cuda.is_available()"
+        " and torch.cuda.get_device_capability(0)[0] >= 8;"
+        "sys.exit(0 if ok else 1)"
+    )
+    completed = subprocess.run(
+        [sys.executable, "-c", probe], check=False, capture_output=True
+    )
+    return completed.returncode == 0
+
+
+def prepare_breeze_checkpoint(snapshot_dir: Path, cache_dir: Path) -> tuple[Path, str]:
+    """Return a checkpoint directory whose attention backend this GPU supports.
+
+    Breeze's checkpoint sets `text_encoder_config.preferred_attn_implementation`
+    to `flash_attention_2`, and the text encoder honours it even when the caller
+    asks for eager attention, so loading the model on a pre-Ampere GPU dies with
+    `FlashAttention2 has been toggled on, but it cannot be used`.
+
+    The Hugging Face snapshot is content-addressed by revision and must stay
+    byte-identical, so instead of editing it we build a sibling directory that
+    symlinks every file and carries a rewritten `config.json`. The pin is
+    preserved; only the attention backend differs, and the manifest records it.
+    """
+    requested = os.environ.get("BREEZE_TEXT_ENCODER_ATTENTION")
+    if not requested:
+        if flash_attention_available():
+            return snapshot_dir, "flash_attention_2"
+        requested = "eager"
+
+    config_path = snapshot_dir / "config.json"
+    config = json.loads(config_path.read_text(encoding="utf-8"))
+    if config.get("text_encoder_config", {}).get(
+        "preferred_attn_implementation"
+    ) == requested:
+        return snapshot_dir, requested
+
+    overlay = cache_dir / "checkpoints" / f"{snapshot_dir.name}-{requested}"
+    if not overlay.exists():
+        staging = overlay.with_name(f"{overlay.name}.partial")
+        if staging.exists():
+            raise RuntimeError(f"stale Breeze checkpoint overlay: {staging}")
+        for source in snapshot_dir.rglob("*"):
+            if source.is_dir():
+                continue
+            target = staging / source.relative_to(snapshot_dir)
+            target.parent.mkdir(parents=True, exist_ok=True)
+            if source.name != "config.json":
+                target.symlink_to(source.resolve())
+        config.setdefault("text_encoder_config", {})[
+            "preferred_attn_implementation"
+        ] = requested
+        (staging / "config.json").write_text(
+            json.dumps(config, ensure_ascii=False, indent=2), encoding="utf-8"
+        )
+        staging.rename(overlay)
+    return overlay, requested
+
+
 def free_local_port() -> int:
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as listener:
         listener.bind(("127.0.0.1", 0))
@@ -299,10 +375,13 @@ class BreezeBackend:
         ).expanduser()
         self.source_dir = ensure_breeze_source(self.cache_dir, self.code_revision)
         install_breeze_dependencies(self.source_dir)
-        self.model_path = resolve_breeze_model(
+        snapshot_dir = resolve_breeze_model(
             model,
             cache_dir=self.cache_dir,
             revision=self.model_revision,
+        )
+        self.model_path, self.text_encoder_attention = prepare_breeze_checkpoint(
+            snapshot_dir, self.cache_dir
         )
         self.port = free_local_port()
         self.base_url = f"http://127.0.0.1:{self.port}"
@@ -332,6 +411,7 @@ class BreezeBackend:
             "model_repository": model,
             "model_revision": self.model_revision,
             "api": "official-streaming-v1",
+            "text_encoder_attn_implementation": self.text_encoder_attention,
             "sample_rate": self.sample_rate,
             "cfg_scale": float(os.environ.get("BREEZE_CFG_SCALE", "4")),
         }

--- a/scripts/audiobook/worker.py
+++ b/scripts/audiobook/worker.py
@@ -39,6 +39,12 @@ BREEZE_CODE_REVISION = "ca632ce6c4d05f7985da4eab29b1a5d445b43f7b"
 BREEZE_MODEL_REPOSITORY = "BreezeBlue/Breeze-TTS-2"
 BREEZE_MODEL_REVISION = "a3bd0a6e83cd2d046ce783df2f7cb84292869ef7"
 
+# Breeze pins `torch==2.9.1` but does not pin `torchvision`. Hosted GPU images
+# (Kaggle, Colab) ship a `torchvision` built against their own older torch, and
+# `transformers` imports it eagerly, so upgrading torch alone breaks the import
+# with `operator torchvision::nms does not exist`. Install the matching release.
+BREEZE_TORCHVISION = "torchvision==0.24.1"
+
 
 def sha256_file(path: Path) -> str:
     digest = hashlib.sha256()
@@ -208,6 +214,7 @@ def install_breeze_dependencies(source_dir: Path) -> None:
             "--disable-pip-version-check",
             "-r",
             str(source_dir / "requirements.txt"),
+            BREEZE_TORCHVISION,
         ]
     )
 


### PR DESCRIPTION
Correções descobertas executando de verdade o benchmark no Kaggle (run [33341528943](https://github.com/franklinbaldo/franklinbaldo.github.io/actions/runs/33341528943)), não por inspeção.

## 1. `torchvision` incompatível quebra o import do `transformers`

`requirements.txt` do Breeze pina `torch==2.9.1` e `torchaudio==2.9.1`, mas **não** `torchvision`. As imagens de GPU hospedadas (Kaggle, Colab) já trazem um `torchvision` compilado contra o torch delas, e `transformers.image_utils` importa `torchvision` avidamente. Resultado no kernel Kaggle:

```
RuntimeError: operator torchvision::nms does not exist
```

O runtime do Breeze morria no import, antes de qualquer coisa. Passa a instalar `torchvision==0.24.1` (o par de `torch 2.9.1`).

## 2. Falha do Kaggle era opaca

O runner só imprimia `Kaggle job failed` — o traceback fica no log do kernel, que ninguém buscava. Agora o log é baixado e impresso tanto na falha quanto no estouro da janela de polling (`scripts/audiobook/kaggle-log.py`).

## 3. Credencial do Colab: o formato esperado não era o formato existente

O runner fixava `--auth=adc` e o workflow exigia `COLAB_ADC_JSON`. Mas a credencial que o `colab` CLI realmente emite e renova é o **token OAuth2 de usuário** em `~/.config/colab-cli/token.json`, já com os scopes que o backend exige (inclusive `.../auth/colaboratory`).

Credenciais **de usuário** via ADC não podem ser re-escopadas depois (`with_scopes` não é suportado para esse tipo), então só funcionam se emitidas com `--scopes=...,colaboratory` explicitamente — caso contrário o keep-alive devolve `403 SCOPE_NOT_PERMITTED`.

Passa a aceitar `COLAB_TOKEN_JSON` (default, `--auth=oauth2`) e mantém `COLAB_ADC_JSON` como fallback (`--auth=adc`). Nenhum dos dois aparece em log.

Nenhum gate editorial é tocado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y9yy5GokMcFU9SNssSnmTG