### PR TITLE
fix(audiobook): give the Kaggle kernel a realistic runtime budget

### DIFF
--- a/docs/okf/audiobook/media-runners.md
+++ b/docs/okf/audiobook/media-runners.md
@@ -108,6 +108,12 @@ kaggle==2.2.4
 
 O CLI oficial aceita autenticação não interativa por `KAGGLE_API_TOKEN` e kernels com `kernel_type: script`.
 
+`kaggle kernels push -t N` define o **orçamento de wall-clock do próprio kernel**,
+não um timeout de cliente. Com `-t 600` o Kaggle matou o job no meio da síntese,
+depois de já ter gasto ~2,5 min instalando a pilha pinada de torch e baixando os
+pesos. Default do projeto: `KAGGLE_KERNEL_TIMEOUT=10800` (3 h), com a janela de
+polling (`KAGGLE_STATUS_POLLS`) dimensionada para cobri-lo.
+
 O runner gera um `job.py` autocontido e um `kernel-metadata.json`, depois executa:
 
 ```text

--- a/scripts/audiobook/runners/kaggle.sh
+++ b/scripts/audiobook/runners/kaggle.sh
@@ -52,6 +52,7 @@ dump_kernel_log() {
     if [[ -n "$log" ]]; then
       echo "----- kaggle kernel log -----" >&2
       run_script scripts/audiobook/kaggle-log.py "$log" >&2 || true
+      [[ -s "$log" ]] || echo "(kernel log is empty; a cancelled kernel often exposes none)" >&2
       echo "----- end kaggle kernel log -----" >&2
     fi
   fi
@@ -106,9 +107,13 @@ cat > "$STAGE/kernel-metadata.json" <<JSON
 }
 JSON
 
-kaggle kernels push -p "$STAGE" --accelerator "$ACCELERATOR" -t "${KAGGLE_PUSH_TIMEOUT:-600}"
+# -t is the kernel's own wall-clock budget, not a client-side push timeout: at
+# 600s Kaggle killed the job mid-synthesis, after it had already spent ~2.5min
+# installing the pinned torch stack and downloading the weights. Give the whole
+# job room; Kaggle still caps GPU kernels at its own global maximum.
+kaggle kernels push -p "$STAGE" --accelerator "$ACCELERATOR" -t "${KAGGLE_KERNEL_TIMEOUT:-${KAGGLE_PUSH_TIMEOUT:-10800}}"
 
-for _ in $(seq 1 "${KAGGLE_STATUS_POLLS:-120}"); do
+for _ in $(seq 1 "${KAGGLE_STATUS_POLLS:-400}"); do
   STATUS="$(kaggle kernels status "$KERNEL_ID" 2>&1)"
   echo "$STATUS"
   if grep -Eqi 'complete|success' <<<"$STATUS"; then


### PR DESCRIPTION
Encontrado na execução real ([run 33344144656](https://github.com/franklinbaldo/franklinbaldo.github.io/actions/runs/33344144656)).

Com #1609 o Breeze finalmente **carregou** na T4 e começou a sintetizar. Aí o kernel morreu exatamente aos ~600s com `KernelWorkerStatus.CANCEL_ACKNOWLEDGED` e log vazio.

Causa: `kaggle kernels push -t N` não é um timeout de cliente — é o **orçamento de wall-clock do próprio kernel**. O runner passava `-t 600`, e só o bootstrap (instalar a pilha pinada de `torch` + baixar os pesos) já consome ~2,5 min.

- default passa a `KAGGLE_KERNEL_TIMEOUT=10800` (3 h), com `KAGGLE_STATUS_POLLS` dimensionado para cobrir;
- quando o log do kernel volta vazio (típico de kernel cancelado), o runner diz isso em vez de imprimir um bloco em branco;
- documentado em `media-runners.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y9yy5GokMcFU9SNssSnmTG