### PR TITLE
feat(audiobook): record bootstrap and synthesis timings in the manifest

### DIFF
--- a/.github/workflows/audiobook-tts-benchmark.yml
+++ b/.github/workflows/audiobook-tts-benchmark.yml
@@ -179,6 +179,9 @@ jobs:
           console.log(`- segments: **${manifest.segments.length}**`);
           console.log(`- GPU: \`${JSON.stringify(manifest.hardware?.gpu)}\``);
           console.log(`- backend metadata: \`${JSON.stringify(manifest.backend_metadata ?? {})}\``);
+          const t = manifest.timings ?? {};
+          console.log(`- bootstrap: **${((t.bootstrap_ms ?? 0) / 1000).toFixed(1)}s**`);
+          console.log(`- synthesis: **${((t.synthesis_ms ?? 0) / 1000).toFixed(1)}s** for ${((t.audio_ms ?? 0) / 1000).toFixed(1)}s of audio`);
           NODE
 
       - name: Upload benchmark audio

--- a/scripts/audiobook/worker.py
+++ b/scripts/audiobook/worker.py
@@ -539,8 +539,15 @@ def run(
     plan = load_plan(plan_path)
     output_dir.mkdir(parents=True, exist_ok=True)
     segment_dir = output_dir / "segments"
+    # Bootstrap is everything before the first token of audio: cloning the
+    # pinned upstream, installing its stack, downloading the weights and loading
+    # the model. On a cold remote GPU it dominates the job, so the benchmark has
+    # to be able to tell it apart from inference.
+    bootstrap_started = time.monotonic()
     runtime = create_backend(backend, model, output_dir)
+    bootstrap_ms = round((time.monotonic() - bootstrap_started) * 1000)
     manifest_segments = []
+    synthesis_ms = 0
 
     try:
         for index, segment in enumerate(plan["segments"]):
@@ -548,13 +555,17 @@ def run(
                 if not segment.get(field):
                     raise ValueError(f"segment {index} missing {field}")
             audio_path = segment_dir / f"{segment['segment_id']}.wav"
+            segment_started = time.monotonic()
             generated = runtime.synthesize(segment, audio_path)
+            segment_ms = round((time.monotonic() - segment_started) * 1000)
+            synthesis_ms += segment_ms
             manifest_segments.append(
                 {
                     "segment_id": segment["segment_id"],
                     "speaker": segment["speaker"],
                     "input_digest": segment["input_digest"],
                     "audio_file": str(audio_path.relative_to(output_dir)),
+                    "synthesis_ms": segment_ms,
                     **generated,
                 }
             )
@@ -568,6 +579,11 @@ def run(
             "model": model,
             "backend_metadata": runtime.metadata,
             "hardware": hardware_info(),
+            "timings": {
+                "bootstrap_ms": bootstrap_ms,
+                "synthesis_ms": synthesis_ms,
+                "audio_ms": sum(item["duration_ms"] for item in manifest_segments),
+            },
             "segments": manifest_segments,
         }
         manifest_path = output_dir / "manifest.json"

--- a/src/audiobook/worker.test.js
+++ b/src/audiobook/worker.test.js
@@ -72,6 +72,12 @@ test("fake worker emits deterministic segment audio, manifest and archive", () =
   );
   assert.equal(manifest.schema, "audiobook-media-manifest-v1");
   assert.equal(manifest.segments.length, 2);
+  assert.equal(typeof manifest.timings.bootstrap_ms, "number");
+  assert.equal(
+    manifest.timings.audio_ms,
+    manifest.segments.reduce((total, s) => total + s.duration_ms, 0)
+  );
+  assert.ok(manifest.segments.every((s) => typeof s.synthesis_ms === "number"));
   assert.ok(
     fs.statSync(path.join(outputDir, manifest.segments[0].audio_file)).size > 0
   );


### PR DESCRIPTION
Para escolher backend com base em execução real, o benchmark precisa separar **subir o job** de **o modelo falar**. Numa caixa fria do Kaggle o bootstrap (clonar o upstream pinado, instalar a pilha de `torch`, baixar os pesos, carregar o modelo) domina o relógio; um total único não diz qual backend compensa.

O manifesto passa a carregar `timings.bootstrap_ms`, `timings.synthesis_ms` e `timings.audio_ms`, mais `synthesis_ms` por segmento, e o summary do workflow imprime os três.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y9yy5GokMcFU9SNssSnmTG