### PR TITLE
fix(audiobook): pin jupyter-kernel-client for the Colab CLI

### DIFF
--- a/.github/workflows/audiobook-media.yml
+++ b/.github/workflows/audiobook-media.yml
@@ -155,7 +155,12 @@ jobs:
           COLAB_TOKEN_JSON: ${{ secrets.COLAB_TOKEN_JSON }}
           COLAB_ADC_JSON: ${{ secrets.COLAB_ADC_JSON }}
         run: |
-          python -m pip install --disable-pip-version-check 'google-colab-cli==0.6.0'
+          # jupyter-kernel-client 1.0.x renamed the client class and
+          # google-colab-cli 0.6.0 still imports the old name, so an
+          # unpinned install creates a ready session that cannot execute:
+          # AttributeError: module 'jupyter_kernel_client' has no attribute
+          # 'KernelClient'.
+          python -m pip install --disable-pip-version-check \n            'google-colab-cli==0.6.0' 'jupyter-kernel-client==0.9.0'
           if [[ -n "$COLAB_TOKEN_JSON" ]]; then
             install -d -m 700 "$HOME/.config/colab-cli"
             printf '%s' "$COLAB_TOKEN_JSON" > "$HOME/.config/colab-cli/token.json"

--- a/.github/workflows/audiobook-tts-benchmark.yml
+++ b/.github/workflows/audiobook-tts-benchmark.yml
@@ -119,7 +119,12 @@ jobs:
           COLAB_TOKEN_JSON: ${{ secrets.COLAB_TOKEN_JSON }}
           COLAB_ADC_JSON: ${{ secrets.COLAB_ADC_JSON }}
         run: |
-          python -m pip install --disable-pip-version-check 'google-colab-cli==0.6.0'
+          # jupyter-kernel-client 1.0.x renamed the client class and
+          # google-colab-cli 0.6.0 still imports the old name, so an
+          # unpinned install creates a ready session that cannot execute:
+          # AttributeError: module 'jupyter_kernel_client' has no attribute
+          # 'KernelClient'.
+          python -m pip install --disable-pip-version-check \n            'google-colab-cli==0.6.0' 'jupyter-kernel-client==0.9.0'
           if [[ -n "$COLAB_TOKEN_JSON" ]]; then
             install -d -m 700 "$HOME/.config/colab-cli"
             printf '%s' "$COLAB_TOKEN_JSON" > "$HOME/.config/colab-cli/token.json"

--- a/docs/okf/audiobook/media-runners.md
+++ b/docs/okf/audiobook/media-runners.md
@@ -52,7 +52,14 @@ Versão inicial pinada no workflow:
 
 ```text
 google-colab-cli==0.6.0
+jupyter-kernel-client==0.9.0
 ```
+
+`jupyter-kernel-client` precisa ser pinado junto: a série 1.0.x renomeou a
+classe de cliente e o `google-colab-cli` 0.6.0 ainda importa o nome antigo.
+Sem o pin, a sessão é criada e fica `READY`, os uploads passam, e só o
+`colab exec` morre com `AttributeError: module 'jupyter_kernel_client' has no
+attribute 'KernelClient'`.
 
 O fluxo usa somente comandos não interativos:
 


### PR DESCRIPTION
Encontrado na primeira execução real no Colab ([run 33346027491](https://github.com/franklinbaldo/franklinbaldo.github.io/actions/runs/33346027491)).

O caminho do Colab chegou longe: autenticou com `COLAB_TOKEN_JSON`, criou a sessão com GPU, ficou `READY` em ~13s e subiu `worker.py` e `plan.json`. Só o `colab exec` morreu:

```
AttributeError: module 'jupyter_kernel_client' has no attribute 'KernelClient'
```

`google-colab-cli==0.6.0` importa `jupyter_kernel_client.KernelClient`, nome que a série 1.0.x renomeou; sem pin o pip resolveu `1.0.2`. A instalação local que funciona (WSL) tem `0.9.0`. Pinado nos dois workflows e documentado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y9yy5GokMcFU9SNssSnmTG