### PR TITLE
fix(audiobook): repair the mangled pip line in the Colab setup step

### DIFF
--- a/.github/workflows/audiobook-media.yml
+++ b/.github/workflows/audiobook-media.yml
@@ -160,7 +160,7 @@ jobs:
           # unpinned install creates a ready session that cannot execute:
           # AttributeError: module 'jupyter_kernel_client' has no attribute
           # 'KernelClient'.
-          python -m pip install --disable-pip-version-check \n            'google-colab-cli==0.6.0' 'jupyter-kernel-client==0.9.0'
+          python -m pip install --disable-pip-version-check 'google-colab-cli==0.6.0' 'jupyter-kernel-client==0.9.0'
           if [[ -n "$COLAB_TOKEN_JSON" ]]; then
             install -d -m 700 "$HOME/.config/colab-cli"
             printf '%s' "$COLAB_TOKEN_JSON" > "$HOME/.config/colab-cli/token.json"

--- a/.github/workflows/audiobook-tts-benchmark.yml
+++ b/.github/workflows/audiobook-tts-benchmark.yml
@@ -124,7 +124,7 @@ jobs:
           # unpinned install creates a ready session that cannot execute:
           # AttributeError: module 'jupyter_kernel_client' has no attribute
           # 'KernelClient'.
-          python -m pip install --disable-pip-version-check \n            'google-colab-cli==0.6.0' 'jupyter-kernel-client==0.9.0'
+          python -m pip install --disable-pip-version-check 'google-colab-cli==0.6.0' 'jupyter-kernel-client==0.9.0'
           if [[ -n "$COLAB_TOKEN_JSON" ]]; then
             install -d -m 700 "$HOME/.config/colab-cli"
             printf '%s' "$COLAB_TOKEN_JSON" > "$HOME/.config/colab-cli/token.json"


### PR DESCRIPTION
Regressão introduzida por #1612: a linha do `pip install` ficou com um `\n` **literal** no lugar de uma continuação de linha, então o pip recebeu um requisito chamado `n`:

```
ERROR: Could not find a version that satisfies the requirement n
```

Nada no CI executa o shell dos workflows, então os checks passaram verdes; só o dispatch real no Colab ([run 33346498190](https://github.com/franklinbaldo/franklinbaldo.github.io/actions/runs/33346498190)) revelou.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y9yy5GokMcFU9SNssSnmTG