### PR TITLE
docs(audiobook): report the first real Breeze TTS 2 benchmark

### DIFF
--- a/docs/okf/audiobook/benchmarks/pt-br-audiobook-v1-breeze.md
+++ b/docs/okf/audiobook/benchmarks/pt-br-audiobook-v1-breeze.md
@@ -1,0 +1,163 @@
+---
+type: Benchmark Report
+title: Audiobook Factory — Breeze TTS 2 no corpus pt-br-audiobook-v1
+description: Primeira execução real de TTS em GPU remota, com medições objetivas de qualidade pt-BR, custo e confiabilidade de runner.
+tags: [audiobook, tts, breeze, benchmark, kaggle, colab, pt-BR]
+timestamp: 2026-08-31T02:00:00Z
+---
+
+# Breeze TTS 2 — corpus `pt-br-audiobook-v1`
+
+Primeiro benchmark **executado**, não estimado. Todos os números abaixo vêm de runs registradas no GitHub Actions, com os artifacts baixados e inspecionados.
+
+## Veredito
+
+**Breeze TTS 2 não serve para audiolivro em pt-BR.** A infraestrutura funciona ponta a ponta — o mesmo `plan.json` e o mesmo worker produzem WAVs e manifesto em Kaggle e Colab —, mas o modelo não fala português: ele lê o texto com fonética inglesa.
+
+Isso não é surpresa retroativa: o próprio model card diz **"Bilingual Support — generates natural English and Chinese speech"**. O benchmark serviu para medir o tamanho do problema e para provar que a fábrica está de pé.
+
+## O que foi executado
+
+|                         |                                                                     |
+| ----------------------- | ------------------------------------------------------------------- |
+| backend                 | `breeze`                                                            |
+| modelo                  | `BreezeBlue/Breeze-TTS-2`                                           |
+| revisão do modelo       | `a3bd0a6e83cd2d046ce783df2f7cb84292869ef7`                          |
+| revisão do código       | `breezeblue-ai/breeze-tts@ca632ce6c4d05f7985da4eab29b1a5d445b43f7b` |
+| modo                    | Voice Design zero-shot (sem áudio de referência), `cfg_scale=4`     |
+| atenção do text encoder | `eager` (ver "Compatibilidade")                                     |
+| corpus                  | `pt-br-audiobook-v1`, 12 segmentos, 3 vozes lógicas                 |
+| saída                   | WAV mono 24 kHz PCM 16-bit                                          |
+
+## Qualidade pt-BR
+
+Não foi possível ouvir os áudios na sessão que produziu este relatório, então a avaliação é **objetiva**: os 12 WAVs foram transcritos com `faster-whisper` (modelo `small`, CPU) e comparados ao texto do corpus.
+
+Detecção automática de idioma, sem forçar nada:
+
+| idioma detectado | segmentos |
+| ---------------- | --------- |
+| inglês           | 10        |
+| albanês          | 1         |
+| latim            | 1         |
+| **português**    | **0**     |
+
+Forçando o decoder para `pt`, o _word error rate_ contra o texto original:
+
+|                                     | WER      |
+| ----------------------------------- | -------- |
+| mediana                             | **0,78** |
+| média                               | 0,77     |
+| melhor segmento (`analytical-long`) | 0,38     |
+| pior segmento (`fear`)              | 1,00     |
+
+Uma segunda execução independente no Kaggle deu **a mesma mediana de 0,78**.
+
+O que a transcrição revela, segmento a segmento:
+
+- **fonética pt-BR** — o segmento `phonetics` ("João arranhou o joelho, Guilherme recolheu as folhas molhadas…") sai como "João Arandu Ocho-Hello, Guilherme Recolher as Fals Molat". Dígrafos `lh`/`nh`, vogais nasais (`ão`, `ãe`) e o `r` inicial não existem no inventário do modelo.
+- **números** — "às oito e quarenta e cinco" vira "Azeite em Quatimfive": numerais por extenso em português são lidos com fonética inglesa.
+- **nomes ingleses** — paradoxalmente o **melhor** caso local: `Harry`, `Hermione`, `McGonagall`, `Hogwarts` e `Richard Feynman` saem corretos. O modelo acerta exatamente o que já é inglês.
+- **code-switch** — o segmento que mistura "fail-safe" e "Bayesian updating" com português tem WER 0,88: os termos ingleses saem bem, o português em volta não.
+- **prosódia e direção** — aqui o modelo **acerta**. O segmento `whisper` saiu medindo −25,4 dBFS de RMS com 31% de silêncio, contra ~−20,5 dBFS e ~13% na média dos demais; a instrução de sussurro foi obedecida. Ironia, medo e transição emocional produzem contornos distintos. O problema é fonético, não interpretativo.
+
+Sanidade acústica dos 12 WAVs: RMS entre −25,4 e −19,7 dBFS, **zero clipping**, nenhum arquivo vazio ou truncado, todos os `audio_digest` do manifesto conferem com o conteúdo baixado, e todos os `input_digest` batem com o `plan.json`.
+
+## Consistência de voz
+
+O seed por personagem é estável e derivado da identidade lógica da voz: as três vozes do corpus produziram exatamente três seeds distintos (`narrator=910591955`, `child_scholar=331951075`, `authority=1422498136`), repetidos idempotentemente em todos os segmentos de cada personagem, e iguais entre execuções diferentes.
+
+## Reprodutibilidade: o áudio **não** é bit-reprodutível
+
+Duas execuções do mesmo `plan.json` no mesmo tipo de GPU produziram:
+
+- **durações idênticas ao milissegundo** nos 12 segmentos;
+- **`audio_digest` diferente em 12 de 12**.
+
+Ou seja: o seed fixa o comportamento do modelo e o número de tokens gerados, mas a redução em GPU não é determinística bit a bit. **Consequência de projeto:** `audio_digest` não pode ser chave de cache nem critério de "já sintetizado". A chave continua sendo o `input_digest` do plano.
+
+## Custo e runners
+
+Os dois runners rodaram o **mesmo `plan.json`, o mesmo `worker.py` e o mesmo backend**, e produziram os mesmos 108,96 s de áudio nos mesmos 12 segmentos — o contrato é de fato runner-independent.
+
+|                                                       | Kaggle                                   | Colab                          |
+| ----------------------------------------------------- | ---------------------------------------- | ------------------------------ |
+| GPU obtida                                            | Tesla T4 ×2, 15 GB (uma usada)           | Tesla T4, 15 GB                |
+| Python da imagem                                      | 3.12                                     | 3.13                           |
+| bootstrap (instalar + baixar pesos + carregar modelo) | **172,8 s**                              | **310,8 s**                    |
+| inferência (12 segmentos)                             | **839,4 s**                              | **843,6 s**                    |
+| áudio produzido                                       | 108,96 s                                 | 108,96 s                       |
+| fator de tempo real                                   | ~7,7× mais lento que o tempo real        | ~7,7×                          |
+| job completo no GitHub Actions                        | 17 min 56 s                              | 20 min 19 s                    |
+| falhas de quota                                       | nenhuma                                  | nenhuma                        |
+| retorno dos artifacts                                 | `result.zip` via `kaggle kernels output` | `colab download` do `/content` |
+
+Leitura:
+
+- **A inferência é indistinguível** (839 s vs 844 s, 0,5% de diferença): mesma
+  GPU, mesmo modelo, mesmo trabalho. O runner não influencia a velocidade.
+- **O bootstrap do Colab custa ~2,3 min a mais.** A sessão do Colab fica `READY`
+  em ~13 s (contra ~30 s de fila no Kaggle), mas a imagem do Colab exige mais
+  reinstalação da pilha pinada.
+- **Confiabilidade:** nenhuma falha de quota nem de alocação de GPU em nenhum
+  dos dois, em todas as tentativas desta sessão. As falhas que ocorreram foram
+  todas de _integração_, não de disponibilidade.
+- **Ergonomia de artifacts:** o Kaggle exige `--file-pattern`, porque um
+  `kernels output` sem filtro baixa o diretório de trabalho inteiro — incluindo
+  vários GB de cache do modelo. O Colab baixa o caminho pedido.
+- **Um run não decide a escolha.** Com essa amostra, Kaggle leva por bootstrap
+  mais barato; a diferença é pequena o bastante para que disponibilidade de GPU,
+  e não velocidade, deva decidir na prática.
+
+## Controle: o problema é o idioma, não a integração
+
+Para separar "modelo ruim" de "modelo que não fala português", os **mesmos**
+worker, backend, revisões e tipo de GPU sintetizaram três frases em inglês —
+inclusive uma tradução literal do segmento `neutral` do corpus:
+
+|                  | pt-BR (12 segmentos)               | inglês (3 segmentos, controle) |
+| ---------------- | ---------------------------------- | ------------------------------ |
+| idioma detectado | inglês em 10/12, português em 0/12 | inglês em 3/3                  |
+| WER mediana      | **0,78**                           | **0,00**                       |
+| WER média        | 0,77                               | 0,02                           |
+
+O único erro do controle foi grafia de nome próprio ("McGonigal" por
+"McGonagall"), num segmento em que o texto de referência é o mesmo tipo de
+conteúdo do segmento `names` em português.
+
+Isto fecha o diagnóstico: a integração está correta, o pin funciona, a Voice
+Design zero-shot funciona, o seed funciona, o transporte de artifacts funciona.
+O que não funciona é pedir português a um modelo treinado em inglês e chinês.
+
+## Compatibilidade descoberta na execução
+
+Quatro problemas reais só apareceram rodando de verdade; todos corrigidos:
+
+1. **`torchvision` incompatível** (#1608) — o Breeze pina `torch==2.9.1` mas não `torchvision`, e imagens de GPU hospedadas trazem um `torchvision` compilado contra o torch delas. `transformers` importa `torchvision` avidamente, então o job morria com `operator torchvision::nms does not exist`.
+2. **FlashAttention 2 forçada pelo checkpoint** (#1608, #1609) — o `config.json` do modelo define `text_encoder_config.preferred_attn_implementation: flash_attention_2`, e o text encoder obedece mesmo quando o chamador pede atenção eager. FlashAttention 2 só tem kernels para compute capability 8.0+, então **nenhuma GPU do Kaggle gratuito (T4 = 7.5, P100 = 6.0) pode satisfazê-la**. O worker passa a montar um checkpoint irmão que faz symlink de todos os arquivos e carrega um `config.json` reescrito, preservando o pin.
+3. **Orçamento de wall-clock do kernel** (#1610) — `kaggle kernels push -t N` é o limite de execução do **kernel**, não um timeout de cliente. Com `-t 600` o Kaggle matava o job no meio da síntese.
+4. **`jupyter-kernel-client`** (#1612, #1613) — a série 1.0.x renomeou a classe que o `google-colab-cli` 0.6.0 importa; sem pin, a sessão do Colab fica `READY`, os uploads passam, e só o `exec` morre.
+
+Nota sobre bf16: ao contrário do que a compute capability sugere, `torch` reporta `is_bf16_supported() == True` numa T4 e o matmul bf16 executa. O bloqueio da T4 é só a FlashAttention.
+
+## Recomendação
+
+1. **Não adotar Breeze TTS 2 para pt-BR.** Ele é um excelente teste de carga da arquitetura e um bom candidato se algum dia houver material em inglês, mas WER 0,78 e detecção de idioma "inglês" em 10 de 12 segmentos não deixam margem.
+2. **Manter a infraestrutura.** O contrato provou ser runner-independent: mesmo plano, mesmo worker, dois provedores. Trocar de backend é trocar uma classe no worker.
+3. **Próximo backend deve ser avaliado neste mesmo corpus**, com o mesmo protocolo objetivo, que agora está no repositório: `scripts/audiobook/benchmark-asr.py <manifest.json> <plan.json>` roda a detecção de idioma e o WER forçado e imprime o resumo. Isso vem antes de qualquer avaliação subjetiva. Candidatos com pt-BR nativo declarado são o ponto de partida.
+4. **Avaliação auditiva humana continua pendente**: os WAVs estão nos artifacts das runs listadas abaixo e valem cinco minutos de escuta para confirmar o diagnóstico.
+
+## Runs
+
+| run                                                                                              | runner         | resultado                                     |
+| ------------------------------------------------------------------------------------------------ | -------------- | --------------------------------------------- |
+| [33341474429](https://github.com/franklinbaldo/franklinbaldo.github.io/actions/runs/33341474429) | local (`fake`) | verde — prova do pipeline                     |
+| [33341528943](https://github.com/franklinbaldo/franklinbaldo.github.io/actions/runs/33341528943) | kaggle         | falhou: `torchvision::nms`                    |
+| [33343469590](https://github.com/franklinbaldo/franklinbaldo.github.io/actions/runs/33343469590) | kaggle         | falhou: `audio_tokenizer/config.json` ausente |
+| [33344144656](https://github.com/franklinbaldo/franklinbaldo.github.io/actions/runs/33344144656) | kaggle         | falhou: kernel morto aos 600s                 |
+| [33345109023](https://github.com/franklinbaldo/franklinbaldo.github.io/actions/runs/33345109023) | kaggle         | **verde — primeiro TTS real**                 |
+| [33346027491](https://github.com/franklinbaldo/franklinbaldo.github.io/actions/runs/33346027491) | colab          | falhou: `jupyter_kernel_client.KernelClient`  |
+| [33346498190](https://github.com/franklinbaldo/franklinbaldo.github.io/actions/runs/33346498190) | colab          | falhou: barra-n literal na linha do pip       |
+| [33346517077](https://github.com/franklinbaldo/franklinbaldo.github.io/actions/runs/33346517077) | kaggle         | verde — run com medições de tempo             |
+
+| [33346938456](https://github.com/franklinbaldo/franklinbaldo.github.io/actions/runs/33346938456) | colab | **verde — mesmo contrato, outro provedor** |

--- a/docs/okf/audiobook/breeze-backend.md
+++ b/docs/okf/audiobook/breeze-backend.md
@@ -8,6 +8,12 @@ timestamp: 2026-08-30T22:30:00Z
 
 # Breeze TTS 2 na Audiobook Factory
 
+> **Resultado do benchmark:** ver
+> [`benchmarks/pt-br-audiobook-v1-breeze.md`](benchmarks/pt-br-audiobook-v1-breeze.md).
+> Executado em Kaggle e Colab; **reprovado para pt-BR** (WER mediana 0,78,
+> idioma detectado "inglês" em 10 de 12 segmentos), aprovado em inglês
+> (WER 0,00) com a mesma integração.
+
 ## Papel
 
 Breeze TTS 2 é o primeiro backend real implementado para testar a arquitetura da fábrica. Ele **não é declarado vencedor por antecipação**. A escolha de produção continua dependente do benchmark pt-BR próprio e da comparação com outros candidatos.

--- a/docs/okf/audiobook/index.md
+++ b/docs/okf/audiobook/index.md
@@ -38,6 +38,7 @@ O trabalho editorial usa o próprio agente do ChatGPT e o estado versionado no G
 - [`multi-work-architecture.md`](./multi-work-architecture.md) — contrato que garante uma única pipeline para HPMOR, Bhagavad Gita e futuras obras, com `work_id`, configuração e podcast independentes.
 - [`editorial-control-plane.md`](./editorial-control-plane.md) — agente recorrente do ChatGPT, persistência de estado e separação entre trabalho editorial e síntese.
 - [`chapter-readiness.md`](./chapter-readiness.md) — gates obrigatórios antes de uma unidade poder ser enviada ao TTS.
+- [`benchmarks/pt-br-audiobook-v1-breeze.md`](./benchmarks/pt-br-audiobook-v1-breeze.md) — primeiro benchmark TTS **executado** em GPU remota: Breeze TTS 2 em Kaggle e Colab, com medições objetivas de qualidade pt-BR, custo e determinismo.
 - [`guides/editorial-style.md`](./guides/editorial-style.md) — defaults editoriais compartilhados por todas as obras.
 - [`guides/translation.md`](./guides/translation.md) — contrato da tradução canônica em pt-BR.
 - [`guides/narration.md`](./guides/narration.md) — preparação provider-neutral da versão destinada à fala.

--- a/scripts/audiobook/benchmark-asr.py
+++ b/scripts/audiobook/benchmark-asr.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11,<3.13"
+# dependencies = ["faster-whisper==1.1.1", "requests"]
+# ///
+"""Score a benchmark's audio against its own text, without listening to it.
+
+A green workflow only proves that a backend produced bytes. To decide whether a
+TTS backend is usable for a language you need evidence about the audio itself,
+and the cheapest objective proxy is automatic speech recognition:
+
+- decoding with language detection left free says which language the backend
+  *actually* spoke, which is how Breeze TTS 2 was caught reading Portuguese with
+  English phonetics;
+- decoding forced to the target language gives a word error rate against the
+  exact text the plan asked for.
+
+Neither replaces a human listening. Both are reproducible and comparable across
+backends, which a subjective note is not.
+
+Usage:
+    scripts/audiobook/benchmark-asr.py <manifest.json> <plan.json> [--out report.json]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import re
+import statistics
+import unicodedata
+
+from faster_whisper import WhisperModel
+
+
+def normalize(text: str) -> list[str]:
+    """Lowercase, strip accents and punctuation, and split into words."""
+    text = unicodedata.normalize("NFD", text.lower())
+    text = "".join(c for c in text if unicodedata.category(c) != "Mn")
+    return re.findall(r"[a-z0-9]+", text)
+
+
+def word_error_rate(reference: list[str], hypothesis: list[str]) -> float:
+    previous = list(range(len(hypothesis) + 1))
+    for index, expected in enumerate(reference, 1):
+        current = [index]
+        for position, actual in enumerate(hypothesis, 1):
+            current.append(
+                min(
+                    previous[position] + 1,
+                    current[position - 1] + 1,
+                    previous[position - 1] + (expected != actual),
+                )
+            )
+        previous = current
+    return previous[-1] / max(len(reference), 1)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("manifest", type=Path)
+    parser.add_argument("plan", type=Path)
+    parser.add_argument("--language", default="pt")
+    parser.add_argument("--model", default="small")
+    parser.add_argument("--out", type=Path)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    manifest = json.loads(args.manifest.read_text(encoding="utf-8"))
+    plan = json.loads(args.plan.read_text(encoding="utf-8"))
+    texts = {segment["segment_id"]: segment["text"] for segment in plan["segments"]}
+    root = args.manifest.parent
+
+    model = WhisperModel(args.model, device="cpu", compute_type="int8")
+    rows = []
+    for segment in manifest["segments"]:
+        audio = str(root / segment["audio_file"])
+        detected, info = model.transcribe(audio, beam_size=5)
+        detected_text = " ".join(piece.text.strip() for piece in detected).strip()
+
+        forced, _ = model.transcribe(audio, beam_size=5, language=args.language)
+        forced_text = " ".join(piece.text.strip() for piece in forced).strip()
+
+        reference = texts.get(segment["segment_id"], "")
+        rows.append(
+            {
+                "segment_id": segment["segment_id"],
+                "detected_language": info.language,
+                "detected_language_probability": round(info.language_probability, 3),
+                "detected_transcript": detected_text,
+                "forced_transcript": forced_text,
+                "wer": round(
+                    word_error_rate(normalize(reference), normalize(forced_text)), 3
+                ),
+            }
+        )
+        row = rows[-1]
+        print(
+            f"{row['segment_id']:44s} lang={row['detected_language']:3s} "
+            f"WER={row['wer']:5.2f}  {row['forced_transcript'][:80]}",
+            flush=True,
+        )
+
+    languages: dict[str, int] = {}
+    for row in rows:
+        languages[row["detected_language"]] = (
+            languages.get(row["detected_language"], 0) + 1
+        )
+    summary = {
+        "backend": manifest.get("backend"),
+        "model": manifest.get("model"),
+        "target_language": args.language,
+        "detected_languages": languages,
+        "median_wer": round(statistics.median(row["wer"] for row in rows), 3),
+        "mean_wer": round(statistics.fmean(row["wer"] for row in rows), 3),
+    }
+    print(f"\n{json.dumps(summary, ensure_ascii=False)}")
+
+    if args.out:
+        args.out.write_text(
+            json.dumps({"summary": summary, "segments": rows}, ensure_ascii=False, indent=2),
+            encoding="utf-8",
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Estado real obtido, com os números vindos de execuções registradas — não de estimativa.

## Veredito

**Breeze TTS 2 está reprovado para pt-BR.** A infraestrutura passou; o modelo não fala português.

| | pt-BR (12 segmentos) | inglês (3 segmentos, controle) |
| --- | --- | --- |
| idioma detectado | inglês 10/12, **português 0/12** | inglês 3/3 |
| WER mediana | **0,78** | **0,00** |

O controle em inglês usa o **mesmo** worker, backend, revisões e tipo de GPU. Isso separa "modelo ruim" de "modelo que não fala português" — e o model card do Breeze confirma: *"Bilingual Support — generates natural English and Chinese speech"*.

## O que também ficou medido

- **Prosódia é obedecida**: o segmento `whisper` saiu a −25,4 dBFS com 31% de silêncio, contra ~−20,5 dBFS e ~13% na média. O defeito é fonético, não interpretativo.
- **Contrato runner-independent provado**: mesmo `plan.json` + mesmo worker em Kaggle e Colab → mesmos 108,96 s de áudio nos mesmos 12 segmentos. Inferência 839,4 s vs 843,6 s (0,5% de diferença); bootstrap 172,8 s (Kaggle) vs 310,8 s (Colab). Nenhuma falha de quota em nenhum dos dois.
- **Seed estável por personagem**, idêntico entre execuções e entre provedores.
- **O áudio não é bit-reprodutível**: duas execuções deram durações idênticas ao milissegundo e `audio_digest` diferente em 12 de 12. Consequência de projeto registrada — `audio_digest` não serve como chave de cache; o `input_digest` do plano continua sendo.
- Sanidade acústica: RMS entre −25,4 e −19,7 dBFS, zero clipping, nenhum arquivo vazio, todos os digests do manifesto conferindo com os bytes baixados.

## Ferramenta

`scripts/audiobook/benchmark-asr.py` (PEP 723, roda com `uv run`) faz detecção de idioma + WER forçado sobre um manifesto e seu plano. O próximo backend passa pelo mesmo crivo antes de qualquer avaliação subjetiva.

## Pendente

Escuta humana dos WAVs — estão nos artifacts das runs listadas no relatório.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y9yy5GokMcFU9SNssSnmTG