### PR TITLE
feat(audiobook): assemble and publish verified media to Internet Archive

### DIFF
--- a/.github/workflows/audiobook-media.yml
+++ b/.github/workflows/audiobook-media.yml
@@ -42,6 +42,11 @@ on:
         required: true
         default: true
         type: boolean
+      publish:
+        description: Publish assembled chapter to Internet Archive and persist enclosure state
+        required: true
+        default: false
+        type: boolean
       force:
         description: Reserved for future cache bypass
         required: true
@@ -49,7 +54,7 @@ on:
         type: boolean
 
 permissions:
-  contents: read
+  contents: write
 
 concurrency:
   group: audiobook-media-${{ inputs.work_id }}-${{ inputs.chapter_id }}
@@ -61,6 +66,8 @@ jobs:
     timeout-minutes: 360
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
@@ -68,6 +75,19 @@ jobs:
           cache: npm
 
       - run: npm ci
+
+      - name: Validate publish invocation
+        if: ${{ inputs.publish == true }}
+        env:
+          DRY_RUN: ${{ inputs.dry_run }}
+          BACKEND: ${{ inputs.backend }}
+        run: |
+          [[ "$DRY_RUN" == "false" ]] || { echo "publish=true requires dry_run=false" >&2; exit 2; }
+          [[ "$BACKEND" != "fake" ]] || { echo "refusing to publish fake TTS output" >&2; exit 2; }
+          [[ "$GITHUB_REF" == "refs/heads/main" ]] || {
+            echo "publishing is allowed only from the default main branch" >&2
+            exit 2
+          }
 
       - name: Inspect editorial readiness
         id: readiness
@@ -218,6 +238,79 @@ jobs:
             --model "$MODEL" \
             --accelerator "$ACCELERATOR"
 
+      - name: Extract media result
+        if: ${{ inputs.dry_run == false }}
+        run: |
+          mkdir -p "$RUNNER_TEMP/media"
+          unzip -q "$RUNNER_TEMP/audiobook-result.zip" -d "$RUNNER_TEMP/media"
+
+      - name: Assemble chapter and transcript
+        if: ${{ inputs.dry_run == false }}
+        run: |
+          python3 scripts/audiobook/assemble.py \
+            --plan "$RUNNER_TEMP/plan.json" \
+            --media-dir "$RUNNER_TEMP/media" \
+            --output-dir "$RUNNER_TEMP/assembled"
+
+      - name: Configure Internet Archive client
+        if: ${{ inputs.publish == true }}
+        env:
+          IA_ACCESS_KEY_ID: ${{ secrets.IA_ACCESS_KEY_ID }}
+          IA_SECRET_ACCESS_KEY: ${{ secrets.IA_SECRET_ACCESS_KEY }}
+        run: |
+          [[ -n "$IA_ACCESS_KEY_ID" ]] || { echo "Missing GitHub secret IA_ACCESS_KEY_ID" >&2; exit 2; }
+          [[ -n "$IA_SECRET_ACCESS_KEY" ]] || { echo "Missing GitHub secret IA_SECRET_ACCESS_KEY" >&2; exit 2; }
+          python -m pip install --disable-pip-version-check 'internetarchive==5.11.1'
+
+      - name: Upload and verify Internet Archive enclosure
+        if: ${{ inputs.publish == true }}
+        env:
+          WORK_ID: ${{ inputs.work_id }}
+          CHAPTER_ID: ${{ inputs.chapter_id }}
+          IA_ACCESS_KEY_ID: ${{ secrets.IA_ACCESS_KEY_ID }}
+          IA_SECRET_ACCESS_KEY: ${{ secrets.IA_SECRET_ACCESS_KEY }}
+        run: |
+          node scripts/audiobook/publish-internet-archive.mjs \
+            --work "$WORK_ID" \
+            --chapter "$CHAPTER_ID" \
+            --assembly-dir "$RUNNER_TEMP/assembled" \
+            --output "$RUNNER_TEMP/publication.json"
+
+      - name: Persist publication state
+        if: ${{ inputs.publish == true }}
+        env:
+          WORK_ID: ${{ inputs.work_id }}
+          CHAPTER_ID: ${{ inputs.chapter_id }}
+        run: |
+          node scripts/audiobook/apply-publication.mjs \
+            --work "$WORK_ID" \
+            --chapter "$CHAPTER_ID" \
+            --publication "$RUNNER_TEMP/publication.json"
+
+          npm run audiobook:validate -- --work "$WORK_ID" --chapter "$CHAPTER_ID" --require-ready-for-audio
+          npm run build
+
+      - name: Commit published episode state
+        if: ${{ inputs.publish == true }}
+        env:
+          WORK_ID: ${{ inputs.work_id }}
+          CHAPTER_ID: ${{ inputs.chapter_id }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add "data/audiobooks/$WORK_ID/state.yaml" "data/audiobooks/$WORK_ID/work.md"
+          git commit -m "feat(audiobook): publish $WORK_ID $CHAPTER_ID"
+          for attempt in 1 2 3; do
+            if git push origin HEAD:main; then
+              exit 0
+            fi
+            echo "Push rejected (attempt $attempt/3), rebasing onto latest main..."
+            git fetch origin main
+            git rebase origin/main
+          done
+          echo "Push failed after 3 attempts; media is uploaded but publication state was not persisted." >&2
+          exit 1
+
       - name: Upload plan
         if: ${{ always() && (inputs.dry_run == false || steps.readiness.outputs.narration_ready == 'true') }}
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
@@ -227,7 +320,7 @@ jobs:
           if-no-files-found: ignore
           retention-days: 14
 
-      - name: Upload media result
+      - name: Upload raw media result
         if: ${{ inputs.dry_run == false }}
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
@@ -235,3 +328,21 @@ jobs:
           path: ${{ runner.temp }}/audiobook-result.zip
           if-no-files-found: error
           retention-days: 30
+
+      - name: Upload assembled chapter
+        if: ${{ inputs.dry_run == false }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: audiobook-assembled-${{ inputs.work_id }}-${{ inputs.chapter_id }}
+          path: ${{ runner.temp }}/assembled/
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Upload publication receipt
+        if: ${{ inputs.publish == true }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: audiobook-publication-${{ inputs.work_id }}-${{ inputs.chapter_id }}
+          path: ${{ runner.temp }}/publication.json
+          if-no-files-found: error
+          retention-days: 90

--- a/scripts/audiobook/apply-publication.mjs
+++ b/scripts/audiobook/apply-publication.mjs
@@ -1,0 +1,138 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+
+import matter from "gray-matter";
+import yaml from "js-yaml";
+
+function parseArgs(argv) {
+  const args = { workId: null, chapterId: null, publicationPath: null };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--work") args.workId = argv[++index] ?? null;
+    else if (arg === "--chapter") args.chapterId = argv[++index] ?? null;
+    else if (arg === "--publication") {
+      args.publicationPath = argv[++index] ?? null;
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+  if (!args.workId || !args.chapterId || !args.publicationPath) {
+    throw new Error("--work, --chapter and --publication are required");
+  }
+  return args;
+}
+
+function yamlText(value) {
+  return yaml.dump(value, {
+    noRefs: true,
+    lineWidth: -1,
+    sortKeys: false,
+    quotingType: '"',
+  });
+}
+
+function updateWorkPodcast(workPath) {
+  const parsed = matter(fs.readFileSync(workPath, "utf8"));
+  if (!parsed.data.podcast) {
+    throw new Error("work.md must declare podcast metadata before publication");
+  }
+  if (parsed.data.podcast.enabled === true) return false;
+
+  parsed.data.podcast.enabled = true;
+  const frontmatter = yamlText(parsed.data).trimEnd();
+  const body = parsed.content.startsWith("\n")
+    ? parsed.content
+    : `\n${parsed.content}`;
+  fs.writeFileSync(workPath, `---\n${frontmatter}\n---${body}`);
+  return true;
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const workDir = path.join(process.cwd(), "data", "audiobooks", args.workId);
+  const statePath = path.join(workDir, "state.yaml");
+  const workPath = path.join(workDir, "work.md");
+  const state = yaml.load(fs.readFileSync(statePath, "utf8")) ?? {};
+  const publication = JSON.parse(fs.readFileSync(args.publicationPath, "utf8"));
+
+  if (state.work_id !== args.workId) throw new Error("state work_id mismatch");
+  if (state.publication?.public_distribution_authorized !== true) {
+    throw new Error(
+      "public distribution is not authorized in state.yaml; refusing to persist a public episode"
+    );
+  }
+  if (
+    publication.work_id !== args.workId ||
+    publication.chapter_id !== args.chapterId
+  ) {
+    throw new Error("publication identity mismatch");
+  }
+  if (publication.dry_run) {
+    throw new Error("refusing to apply dry-run publication");
+  }
+
+  const chapter = state.chapters?.[args.chapterId];
+  if (!chapter) throw new Error(`unknown chapter ${args.chapterId}`);
+  if (chapter.ready_for_audio !== true) {
+    throw new Error(`${args.chapterId} is not ready_for_audio`);
+  }
+  if (
+    !publication.enclosure?.url ||
+    !publication.enclosure?.bytes ||
+    !publication.enclosure?.type
+  ) {
+    throw new Error("publication is missing a complete enclosure");
+  }
+  if (!publication.verification) {
+    throw new Error("publication enclosure was not verified");
+  }
+  if (!publication.transcript?.verification) {
+    throw new Error("publication transcript was not verified");
+  }
+
+  chapter.status = "published";
+  chapter.publication = {
+    ...(chapter.publication ?? {}),
+    status: "published",
+    title: publication.title,
+    description: publication.description,
+    published_at: publication.published_at,
+    duration_seconds: publication.duration_seconds,
+    audio_digest: publication.audio_digest,
+    enclosure: publication.enclosure,
+    transcript: publication.transcript,
+    archive_item: publication.archive_item,
+  };
+  chapter.next_action =
+    "published; regenerate only if editorial or TTS inputs change";
+
+  const pending = Object.entries(state.chapters)
+    .filter(([, value]) => value.publication?.status !== "published")
+    .map(([chapterId]) => chapterId);
+  state.status = pending.length ? "in_progress" : "published";
+  state.next_action = pending.length
+    ? `continue editorial work on ${pending[0]}`
+    : "all registered chapters published";
+
+  fs.writeFileSync(statePath, yamlText(state));
+  const podcastChanged = updateWorkPodcast(workPath);
+
+  console.log(
+    JSON.stringify({
+      work_id: args.workId,
+      chapter_id: args.chapterId,
+      state_path: path.relative(process.cwd(), statePath),
+      podcast_enabled: podcastChanged ? "enabled_now" : "already_enabled",
+    })
+  );
+}
+
+try {
+  main();
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(2);
+}

--- a/scripts/audiobook/apply-publication.mjs
+++ b/scripts/audiobook/apply-publication.mjs
@@ -95,7 +95,7 @@ function main() {
 
   chapter.status = "published";
   chapter.publication = {
-    ...(chapter.publication ?? {}),
+    ...chapter.publication,
     status: "published",
     title: publication.title,
     description: publication.description,

--- a/scripts/audiobook/assemble.py
+++ b/scripts/audiobook/assemble.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = []
+# ///
+"""Assemble TTS segments into a distributable chapter.
+
+This stage is intentionally model-agnostic. It consumes the common media
+manifest plus the original TTS plan, concatenates segment audio with ffmpeg,
+and emits a stable MP3, WebVTT transcript and assembly manifest.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+import subprocess
+import sys
+
+ASSEMBLY_SCHEMA = "audiobook-assembly-v1"
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return f"sha256:{digest.hexdigest()}"
+
+
+def load_json(path: Path) -> dict:
+    with path.open("r", encoding="utf-8") as stream:
+        return json.load(stream)
+
+
+def vtt_time(milliseconds: int) -> str:
+    if milliseconds < 0:
+        raise ValueError("negative VTT timestamp")
+    hours, remainder = divmod(milliseconds, 3_600_000)
+    minutes, remainder = divmod(remainder, 60_000)
+    seconds, millis = divmod(remainder, 1_000)
+    return f"{hours:02d}:{minutes:02d}:{seconds:02d}.{millis:03d}"
+
+
+def vtt_text(value: str) -> str:
+    return value.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+
+
+def make_vtt(plan: dict, media_manifest: dict) -> tuple[str, int]:
+    media_by_id = {segment["segment_id"]: segment for segment in media_manifest["segments"]}
+    lines = ["WEBVTT", ""]
+    cursor_ms = 0
+
+    for index, segment in enumerate(plan["segments"], start=1):
+        segment_id = segment["segment_id"]
+        media = media_by_id.get(segment_id)
+        if media is None:
+            raise ValueError(f"media manifest missing segment {segment_id}")
+        duration_ms = int(media["duration_ms"])
+        if duration_ms <= 0:
+            raise ValueError(f"invalid duration for {segment_id}: {duration_ms}")
+        end_ms = cursor_ms + duration_ms
+        speaker = vtt_text(str(segment["speaker"]))
+        text = vtt_text(str(segment["text"]).strip())
+        lines.extend(
+            [
+                str(index),
+                f"{vtt_time(cursor_ms)} --> {vtt_time(end_ms)}",
+                f"<v {speaker}>{text}",
+                "",
+            ]
+        )
+        cursor_ms = end_ms
+
+    extra_ids = set(media_by_id) - {segment["segment_id"] for segment in plan["segments"]}
+    if extra_ids:
+        raise ValueError(f"media manifest contains unplanned segments: {', '.join(sorted(extra_ids))}")
+
+    return "\n".join(lines), cursor_ms
+
+
+def quote_concat_path(path: Path) -> str:
+    # ffmpeg concat files use single-quoted paths; embedded quotes are escaped
+    # using the shell-compatible sequence accepted by the concat demuxer.
+    return "'" + str(path.resolve()).replace("'", "'\\''") + "'"
+
+
+def assemble(plan_path: Path, media_dir: Path, output_dir: Path, bitrate: str) -> dict:
+    plan = load_json(plan_path)
+    media_manifest_path = media_dir / "manifest.json"
+    media_manifest = load_json(media_manifest_path)
+
+    for field in ("work_id", "chapter_id"):
+        if plan.get(field) != media_manifest.get(field):
+            raise ValueError(f"{field} mismatch between plan and media manifest")
+
+    media_by_id = {segment["segment_id"]: segment for segment in media_manifest["segments"]}
+    ordered_paths = []
+    for segment in plan["segments"]:
+        media = media_by_id.get(segment["segment_id"])
+        if media is None:
+            raise ValueError(f"media manifest missing segment {segment['segment_id']}")
+        audio_path = media_dir / media["audio_file"]
+        if not audio_path.is_file():
+            raise ValueError(f"missing segment audio: {audio_path}")
+        if sha256_file(audio_path) != media["audio_digest"]:
+            raise ValueError(f"audio digest mismatch: {segment['segment_id']}")
+        ordered_paths.append(audio_path)
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    chapter_id = plan["chapter_id"]
+    audio_path = output_dir / f"{chapter_id}.mp3"
+    transcript_path = output_dir / f"{chapter_id}.vtt"
+    concat_path = output_dir / "concat.txt"
+    concat_path.write_text(
+        "".join(f"file {quote_concat_path(path)}\n" for path in ordered_paths),
+        encoding="utf-8",
+    )
+
+    command = [
+        "ffmpeg",
+        "-hide_banner",
+        "-loglevel",
+        "error",
+        "-y",
+        "-f",
+        "concat",
+        "-safe",
+        "0",
+        "-i",
+        str(concat_path),
+        "-vn",
+        "-ac",
+        "1",
+        "-c:a",
+        "libmp3lame",
+        "-b:a",
+        bitrate,
+        str(audio_path),
+    ]
+    subprocess.run(command, check=True)
+
+    transcript, duration_ms = make_vtt(plan, media_manifest)
+    transcript_path.write_text(transcript, encoding="utf-8")
+    concat_path.unlink(missing_ok=True)
+
+    result = {
+        "schema": ASSEMBLY_SCHEMA,
+        "work_id": plan["work_id"],
+        "chapter_id": chapter_id,
+        "narration_digest": plan.get("narration_digest"),
+        "backend": media_manifest.get("backend"),
+        "model": media_manifest.get("model"),
+        "duration_seconds": round(duration_ms / 1000, 3),
+        "audio": {
+            "file": audio_path.name,
+            "bytes": audio_path.stat().st_size,
+            "sha256": sha256_file(audio_path),
+            "type": "audio/mpeg",
+            "bitrate": bitrate,
+        },
+        "transcript": {
+            "file": transcript_path.name,
+            "bytes": transcript_path.stat().st_size,
+            "sha256": sha256_file(transcript_path),
+            "type": "text/vtt",
+            "language": plan.get("lang", "pt-BR"),
+        },
+    }
+    (output_dir / "assembly.json").write_text(
+        json.dumps(result, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+    return result
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--plan", required=True, type=Path)
+    parser.add_argument("--media-dir", required=True, type=Path)
+    parser.add_argument("--output-dir", required=True, type=Path)
+    parser.add_argument("--bitrate", default="96k")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        result = assemble(args.plan, args.media_dir, args.output_dir, args.bitrate)
+    except Exception as error:  # CLI boundary.
+        print(f"audiobook assemble failed: {error}", file=sys.stderr)
+        return 2
+    print(json.dumps(result, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/audiobook/publish-internet-archive.mjs
+++ b/scripts/audiobook/publish-internet-archive.mjs
@@ -1,0 +1,269 @@
+#!/usr/bin/env node
+
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+import { spawnSync } from "node:child_process";
+
+import { loadWork } from "../../src/audiobook/catalog.js";
+
+function usage() {
+  console.error(
+    "Usage: node scripts/audiobook/publish-internet-archive.mjs --work <work_id> --chapter <chapter_id> --assembly-dir <dir> --output <publication.json> [--dry-run]"
+  );
+}
+
+function parseArgs(argv) {
+  const args = {
+    workId: null,
+    chapterId: null,
+    assemblyDir: null,
+    outputPath: null,
+    dryRun: false,
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--work") args.workId = argv[++index] ?? null;
+    else if (arg === "--chapter") args.chapterId = argv[++index] ?? null;
+    else if (arg === "--assembly-dir") args.assemblyDir = argv[++index] ?? null;
+    else if (arg === "--output") args.outputPath = argv[++index] ?? null;
+    else if (arg === "--dry-run") args.dryRun = true;
+    else if (arg === "--help" || arg === "-h") {
+      usage();
+      process.exit(0);
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+  for (const [flag, value] of [
+    ["--work", args.workId],
+    ["--chapter", args.chapterId],
+    ["--assembly-dir", args.assemblyDir],
+    ["--output", args.outputPath],
+  ]) {
+    if (!value) throw new Error(`${flag} is required`);
+  }
+  return args;
+}
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, "utf8"));
+}
+
+function sha256File(filePath) {
+  return new Promise((resolve, reject) => {
+    const digest = crypto.createHash("sha256");
+    const stream = fs.createReadStream(filePath);
+    stream.on("data", (chunk) => digest.update(chunk));
+    stream.on("error", reject);
+    stream.on("end", () => resolve(`sha256:${digest.digest("hex")}`));
+  });
+}
+
+function run(command, args, { env = process.env } = {}) {
+  const result = spawnSync(command, args, {
+    encoding: "utf8",
+    env,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  if (result.status !== 0) {
+    throw new Error(
+      `${command} ${args.join(" ")} failed (${result.status}): ${result.stderr || result.stdout}`
+    );
+  }
+  return result.stdout;
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function verifyRemoteFile(url, expectedBytes, attempts = 18) {
+  let lastError;
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    try {
+      const head = await fetch(url, { method: "HEAD", redirect: "follow" });
+      if (!head.ok) throw new Error(`HEAD ${head.status}`);
+      const length = Number(head.headers.get("content-length"));
+      if (Number.isFinite(length) && length > 0 && length !== expectedBytes) {
+        throw new Error(
+          `Content-Length ${length} != expected ${expectedBytes}`
+        );
+      }
+
+      const range = await fetch(url, {
+        headers: { Range: "bytes=0-0" },
+        redirect: "follow",
+      });
+      if (![200, 206].includes(range.status)) {
+        throw new Error(`range request ${range.status}`);
+      }
+      const bytes = new Uint8Array(await range.arrayBuffer());
+      if (bytes.length < 1) throw new Error("range request returned no bytes");
+      return {
+        headStatus: head.status,
+        rangeStatus: range.status,
+        contentType: head.headers.get("content-type"),
+        acceptRanges: head.headers.get("accept-ranges"),
+      };
+    } catch (error) {
+      lastError = error;
+      if (attempt < attempts) {
+        await sleep(Math.min(5000 * attempt, 20_000));
+      }
+    }
+  }
+  throw new Error(
+    `Internet Archive file did not become readable: ${lastError}`
+  );
+}
+
+function publicationTitle(chapter) {
+  const title = chapter.publication?.title;
+  if (!title) {
+    throw new Error(
+      `${chapter.chapterId}: publication.title must be set before publishing`
+    );
+  }
+  return title;
+}
+
+async function validateAssemblyFile(filePath, expected) {
+  if (!fs.existsSync(filePath) || !fs.statSync(filePath).isFile()) {
+    throw new Error(`Missing assembly file: ${filePath}`);
+  }
+  if (fs.statSync(filePath).size !== expected.bytes) {
+    throw new Error(`assembly size mismatch: ${filePath}`);
+  }
+  if ((await sha256File(filePath)) !== expected.sha256) {
+    throw new Error(`assembly digest mismatch: ${filePath}`);
+  }
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const work = loadWork(process.cwd(), args.workId);
+  const chapter = work.chapters.find(
+    (entry) => entry.chapterId === args.chapterId
+  );
+  if (!chapter) throw new Error(`Unknown chapter ${args.chapterId}`);
+  if (chapter.ready_for_audio !== true) {
+    throw new Error(`${args.chapterId} is not ready_for_audio`);
+  }
+
+  const archiveItem = work.metadata.media?.archive_item;
+  if (!archiveItem) {
+    throw new Error(`${args.workId}: media.archive_item is required`);
+  }
+
+  if (
+    !args.dryRun &&
+    work.state.publication?.public_distribution_authorized !== true
+  ) {
+    throw new Error(
+      "public distribution is not authorized in state.yaml; refusing Internet Archive upload"
+    );
+  }
+
+  const assemblyDir = path.resolve(args.assemblyDir);
+  const assembly = readJson(path.join(assemblyDir, "assembly.json"));
+  if (
+    assembly.work_id !== args.workId ||
+    assembly.chapter_id !== args.chapterId
+  ) {
+    throw new Error("assembly work/chapter identity mismatch");
+  }
+
+  const audioPath = path.join(assemblyDir, assembly.audio.file);
+  const transcriptPath = path.join(assemblyDir, assembly.transcript.file);
+  await validateAssemblyFile(audioPath, assembly.audio);
+  await validateAssemblyFile(transcriptPath, assembly.transcript);
+
+  const title = publicationTitle(chapter);
+  const description =
+    chapter.publication?.description ??
+    work.metadata.podcast?.description ??
+    work.metadata.title;
+  const publishedAt =
+    chapter.publication?.published_at ?? new Date().toISOString();
+  const audioName = path.basename(audioPath);
+  const transcriptName = path.basename(transcriptPath);
+  const baseUrl = `https://archive.org/download/${encodeURIComponent(archiveItem)}/`;
+  const enclosureUrl = new URL(encodeURIComponent(audioName), baseUrl).href;
+  const transcriptUrl = new URL(encodeURIComponent(transcriptName), baseUrl)
+    .href;
+
+  const publication = {
+    schema: "audiobook-publication-v1",
+    work_id: args.workId,
+    chapter_id: args.chapterId,
+    backend: "internet-archive",
+    archive_item: archiveItem,
+    published_at: publishedAt,
+    title,
+    description,
+    duration_seconds: assembly.duration_seconds,
+    audio_digest: assembly.audio.sha256,
+    enclosure: {
+      url: enclosureUrl,
+      bytes: assembly.audio.bytes,
+      type: assembly.audio.type,
+    },
+    transcript: {
+      url: transcriptUrl,
+      type: assembly.transcript.type,
+      language: assembly.transcript.language,
+      sha256: assembly.transcript.sha256,
+    },
+  };
+
+  if (args.dryRun) {
+    publication.dry_run = true;
+  } else {
+    if (!process.env.IA_ACCESS_KEY_ID || !process.env.IA_SECRET_ACCESS_KEY) {
+      throw new Error("IA_ACCESS_KEY_ID and IA_SECRET_ACCESS_KEY are required");
+    }
+
+    run("ia", [
+      "upload",
+      archiveItem,
+      audioPath,
+      transcriptPath,
+      path.join(assemblyDir, "assembly.json"),
+      "--retries",
+      "10",
+      "--metadata",
+      "mediatype:audio",
+      "--metadata",
+      "collection:opensource_audio",
+      "--metadata",
+      `title:${work.metadata.podcast?.title ?? work.metadata.title}`,
+      "--metadata",
+      `creator:${work.metadata.author ?? "Unknown"}`,
+      "--metadata",
+      `description:${work.metadata.podcast?.description ?? description}`,
+    ]);
+
+    publication.verification = await verifyRemoteFile(
+      enclosureUrl,
+      assembly.audio.bytes
+    );
+    publication.transcript.verification = await verifyRemoteFile(
+      transcriptUrl,
+      assembly.transcript.bytes
+    );
+  }
+
+  fs.mkdirSync(path.dirname(args.outputPath), { recursive: true });
+  fs.writeFileSync(
+    args.outputPath,
+    `${JSON.stringify(publication, null, 2)}\n`
+  );
+  console.log(JSON.stringify(publication));
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(2);
+});


### PR DESCRIPTION
Restack de #1599 sobre `main`. A PR original foi fechada automaticamente quando #1596 e #1597 foram squashados e as base branches apagadas.

## ⚠️ Não mergear sem sua decisão explícita

Diferente das outras PRs desta sequência, **eu não mergeei esta**. Ela:

- eleva a permissão do workflow para `contents: write` e **dá push em `main`** a partir do Actions;
- **envia mídia para um item público no Internet Archive**;
- exige dois secrets novos (`IA_ACCESS_KEY_ID`, `IA_SECRET_ACCESS_KEY`) que **não configurei** — a autorização desta sessão cobria Kaggle e Colab;
- não pode ser exercitada hoje: nenhum capítulo do HPMOR está `ready_for_audio`, e o gate editorial (corretamente) barra qualquer tentativa.

Restaquei para que a PR volte a existir e passe no CI. O merge é seu.

## O que a camada faz

`assemble.py` concatena o áudio dos segmentos num MP3 estável com transcript WebVTT e manifesto de montagem; `publish-internet-archive.mjs` sobe e verifica o enclosure; `apply-publication.mjs` grava o estado do episódio de volta.

## Guard de distribuição preservado

A publicação continua **gated separadamente da síntese**. Os dois scripts recusam agir sem `publication.public_distribution_authorized: true`, e o workflow ainda recusa `publish=true` quando é dry run, quando o backend é `fake`, ou quando o dispatch não veio de `main`.

## Diferenças em relação à versão original

A branch original é anterior à camada de podcast atual e trazia um `catalog.js` desatualizado, que invertia a ordem dos episódios e removia o typedef de episódio; esses arquivos ficam como estão em `main`. Os hunks do workflow foram reaplicados sobre o arquivo atual, de modo que o tratamento de credencial do Colab e o pin de `jupyter-kernel-client` sobrevivem. `assemble.py` ganhou header PEP 723, como os demais scripts Python da fábrica.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y9yy5GokMcFU9SNssSnmTG