### PR TITLE
ux: marca lang PT/EN nas descrições de repo em /projects/

### DIFF
--- a/.routines/2026-08-31T05-12-42-ux-ui-run.md
+++ b/.routines/2026-08-31T05-12-42-ux-ui-run.md
@@ -1,0 +1,63 @@
+---
+date: "2026-08-31T05:12:42Z"
+branch: claude/ecstatic-hawking-l08ak3
+status: open
+---
+
+# Sessão 2026-08-31T05-12-42 — UX/UI
+
+## Passo 0 da rotina (revisar/mesclar PRs abertos)
+
+Reconfirmado o bloqueio sistêmico já documentado por 9+ sessões anteriores
+(#1564 até #1591, desde 19/08): `merge_pull_request` com `merge_method: merge`
+continua retornando `405 Merge commits are not allowed on this repository`
+(testado em #1564, CI verde, sem conflitos documentados). Squash é proibido
+pela convenção do `CLAUDE.md` ("Merge commits, not squash"), então não
+mesclei nenhum dos PRs pendentes. Não repeti a tentativa em todos os 11 PRs
+acumulados — já está exaustivamente documentado (inclusive com pedido
+explícito de decisão humana em #1589) e uma nova tentativa idêntica não
+adiciona informação nova. Segue precisando de decisão humana (Settings →
+General → Pull Requests → permitir merge commit, ou atualizar a convenção).
+
+## O que foi feito
+
+Todas as issues abertas com label `routine` já tinham PR pendente cobrindo-as
+(bloqueadas pelo problema acima), exceto #1083 (decisão de escopo maior,
+deliberadamente deixada aberta por sessões anteriores). Para não duplicar
+trabalho já em voo, fiz uma nova auditoria manual (via subagente Explore) em
+componentes/páginas fora do escopo já coberto pelos PRs pendentes.
+
+Achado: `src/pages/projects.astro` e `src/pages/pt/projects.astro`
+renderizam `repo.description` (buscado ao vivo da API do GitHub em build
+time) sem nenhuma marcação de idioma, mesmo a página tendo um `lang` fixo
+("en"/"pt"). Confirmado via listagem pública real do GitHub que vários repos
+de Franklin têm descrição em português (`rossio`, `quem-sao-eles`, `suj`,
+`dinossauro`) misturados com a maioria em inglês — violação real de WCAG
+3.1.2 (Language of Parts), não hipotética.
+
+Fix: `src/lib/repoDescriptionLang.ts` — mapa curado (mesmo padrão de
+`tagDescriptions.ts`) com os repos cuja descrição é PT; default "en" para
+qualquer repo não listado. As duas páginas passam `lang={idioma}` no `<p>`
+da descrição só quando o idioma real diverge do idioma da própria página
+(`lang={x !== PAGE_LANG ? x : undefined}`, mesmo idiom já usado em
+`Header.astro:85` para atributos condicionais).
+
+## Nota — não exercitado no build local
+
+A API do GitHub retornou `401 Bad credentials` no `npm run build` local
+deste sandbox (sem `GITHUB_TOKEN` válido para chamadas REST arbitrárias —
+mesma limitação de rede já documentada em #1585 para o card do
+`github-readme-stats`), então o branch `repos.map(...)` não roda neste
+ambiente e não há `dist/projects/` com repos para grepar. Verifiquei a
+lógica isoladamente com um script Node standalone reproduzindo exatamente a
+função e o ternário JSX usados nas páginas — confirma `lang="pt"` para
+`rossio` na página EN, `lang="en"` para `cobogo` na página PT, e nenhum
+atributo quando o idioma já bate com o da página.
+
+## CI local
+
+- `npx astro check` — 0 erros, 0 warnings novos (78 hints pré-existentes)
+- `npx prettier --check .` — passou
+- `npm run build` — build completo (3881 páginas, pagefind ok)
+- `src/generated/*.json` regenerados pelo build local foram revertidos antes
+  do commit — não fazem parte desta mudança

--- a/src/lib/repoDescriptionLang.ts
+++ b/src/lib/repoDescriptionLang.ts
@@ -1,0 +1,16 @@
+// Language of `repo.description` shown in the repo cards on `/projects/`
+// and `/pt/projects/` (fetched live from the GitHub API at build time —
+// GitHub doesn't report the description's language). Most public repos
+// have English descriptions, so that's the default; this map only needs to
+// list the exceptions written in Portuguese — same pattern as
+// `tagDescriptions.ts`.
+const ptDescriptionRepos = new Set([
+  "rossio",
+  "quem-sao-eles",
+  "suj",
+  "dinossauro",
+]);
+
+export function repoDescriptionLang(repoName: string): "en" | "pt" {
+  return ptDescriptionRepos.has(repoName) ? "pt" : "en";
+}

--- a/src/pages/projects.astro
+++ b/src/pages/projects.astro
@@ -1,6 +1,8 @@
 ---
 import PageLayout from "../layouts/PageLayout.astro";
+import { repoDescriptionLang } from "../lib/repoDescriptionLang";
 
+const PAGE_LANG = "en";
 const USER = "franklinbaldo";
 const token = import.meta.env.GITHUB_TOKEN ?? process.env.GITHUB_TOKEN;
 
@@ -80,7 +82,11 @@ const fmt = new Intl.DateTimeFormat("en-US", { year: "numeric", month: "short", 
       <header>
         <hgroup>
           <h3><a href={repo.html_url}>{repo.name}</a> {repo.stargazers_count > 0 && <mark>★ {repo.stargazers_count}</mark>}</h3>
-          {repo.description && <p>{repo.description}</p>}
+          {repo.description && (
+            <p lang={repoDescriptionLang(repo.name) !== PAGE_LANG ? repoDescriptionLang(repo.name) : undefined}>
+              {repo.description}
+            </p>
+          )}
         </hgroup>
       </header>
       <footer>

--- a/src/pages/pt/projects.astro
+++ b/src/pages/pt/projects.astro
@@ -1,6 +1,8 @@
 ---
 import PageLayout from "../../layouts/PageLayout.astro";
+import { repoDescriptionLang } from "../../lib/repoDescriptionLang";
 
+const PAGE_LANG = "pt";
 const USER = "franklinbaldo";
 const token = import.meta.env.GITHUB_TOKEN ?? process.env.GITHUB_TOKEN;
 
@@ -80,7 +82,11 @@ const fmt = new Intl.DateTimeFormat("pt-BR", { year: "numeric", month: "short", 
       <header>
         <hgroup>
           <h3><a href={repo.html_url}>{repo.name}</a> {repo.stargazers_count > 0 && <mark>★ {repo.stargazers_count}</mark>}</h3>
-          {repo.description && <p>{repo.description}</p>}
+          {repo.description && (
+            <p lang={repoDescriptionLang(repo.name) !== PAGE_LANG ? repoDescriptionLang(repo.name) : undefined}>
+              {repo.description}
+            </p>
+          )}
         </hgroup>
       </header>
       <footer>


### PR DESCRIPTION
## Summary

- `src/pages/projects.astro` (`lang="en"`) e `src/pages/pt/projects.astro` (`lang="pt"`) renderizam `repo.description` — buscado ao vivo da API do GitHub em build time — sem nenhuma marcação de idioma. Confirmei via a listagem pública real do GitHub (`github.com/franklinbaldo?tab=repositories`) que os repos de Franklin misturam idioma livremente: `rossio`, `quem-sao-eles`, `suj` e `dinossauro` têm descrição em português, enquanto a maioria (`cobogo`, `leizilla`, `papers`, etc.) é em inglês. Cada um desses PT aparece sem `lang` na página EN, e o inverso (a maioria EN) aparece sem `lang` na página PT — violação real de WCAG 3.1.2 (Language of Parts), não hipotética.
- Novo `src/lib/repoDescriptionLang.ts`: mapa curado listando só os repos PT (default "en" para qualquer repo não listado), mesmo padrão já usado em `tagDescriptions.ts` ("só precisa cobrir as exceções, não o corpus inteiro").
- Ambas as páginas agora passam `lang={idioma}` no `<p>` da descrição só quando o idioma real diverge do idioma da própria página (`lang={x !== PAGE_LANG ? x : undefined}`) — mesmo idiom de atributo condicional já usado em `Header.astro:85` (`data-search-link={cond ? true : undefined}`).

## Passo 0 da rotina (revisar/mesclar PRs abertos)

Reconfirmei o bloqueio sistêmico já documentado por 9+ sessões anteriores (#1564–#1591, desde 19/08): `merge_pull_request` com `merge_method: merge` continua retornando `405 Merge commits are not allowed on this repository` (testado em #1564, CI verde). Squash é proibido pela convenção do `CLAUDE.md` ("Merge commits, not squash"), então não mesclei nenhum PR pendente. Não repeti a tentativa nos 11 PRs acumulados — já está exaustivamente documentado, inclusive com pedido explícito de decisão humana em #1589. Segue precisando de decisão humana (Settings → General → Pull Requests → permitir merge commit, ou atualizar a convenção).

Como todas as issues abertas com label `routine` já tinham PR pendente cobrindo-as (exceto #1083, decisão de escopo maior deixada aberta deliberadamente), fiz uma nova auditoria manual fora do escopo já coberto pelos PRs em voo, para não duplicar trabalho.

## Nota — não exercitado no build local

A API do GitHub retornou `401 Bad credentials` no `npm run build` local deste sandbox (sem `GITHUB_TOKEN` válido para chamadas REST arbitrárias — mesma limitação de rede já documentada em #1585 para o card do `github-readme-stats`), então `repos.map(...)` não roda neste ambiente e não há `dist/projects/` com repos reais para grepar. Verifiquei a lógica isoladamente com um script Node standalone reproduzindo a função e o ternário JSX usados nas páginas: confirma `lang="pt"` para `rossio` na página EN, `lang="en"` para `cobogo` na página PT, e nenhum atributo quando o idioma já bate com o da página.

## Test plan

- [x] `npx astro check` — 0 erros, 0 warnings novos (78 hints pré-existentes)
- [x] `npx prettier --check .` — passou
- [x] `npm run build` — build completo (3881 páginas, pagefind ok)
- [x] `npm run check:hygiene` — verde
- [x] Lógica verificada isoladamente (script Node, ver nota acima) — não exercitável no `dist/` deste sandbox por falta de rede para a API do GitHub
- [x] `src/generated/*.json` regenerados pelo build local foram revertidos antes do commit — não fazem parte desta mudança

---
_Generated by [Claude Code](https://claude.ai/code/session_01MQmF98N1YL785VGg8g9Rjx)_