### PR TITLE
fix(about): align colophon with shipped typography

### DIFF
--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -97,7 +97,7 @@ const faqLd = {
 
     <p>
       Built with <a href="https://astro.build/">Astro</a> and vanilla <a href="https://picocss.com/">Pico.css</a> —
-      no JS framework, system fonts. Search is powered by
+      no JS framework; Fraunces for body text and Inter for UI. Search is powered by
       <a href="https://pagefind.app/">Pagefind</a>. The source lives at
       <a href="https://github.com/franklinbaldo/franklinbaldo.github.io">franklinbaldo/franklinbaldo.github.io</a>.
     </p>

--- a/src/pages/pt/about.astro
+++ b/src/pages/pt/about.astro
@@ -97,7 +97,7 @@ const faqLd = {
 
     <p>
       Construído com <a href="https://astro.build/">Astro</a> e <a href="https://picocss.com/">Pico.css</a>
-      vanilla — sem framework JS, fontes do sistema. Busca alimentada por
+      vanilla — sem framework JS; Fraunces no corpo e Inter na interface. Busca alimentada por
       <a href="https://pagefind.app/">Pagefind</a>. O fonte está em
       <a href="https://github.com/franklinbaldo/franklinbaldo.github.io">franklinbaldo/franklinbaldo.github.io</a>.
     </p>


### PR DESCRIPTION
## Problem

The public `/about/` and `/pt/about/` colophon still says the site uses system fonts, but current `main` ships local web fonts and documents Fraunces for body text and Inter for UI.

This is a factual surface drift, not a redesign.

## Change

- EN: replace `system fonts` with the shipped Fraunces/Inter roles;
- PT: make the same factual correction;
- preserve the existing Colophon/Colofão structure, Astro/Pico/Pagefind/source claims and local editorial identity.

## Frozen Cobogó criterion

After the change, neither route claims system fonts; both name the typography actually proven by the repository, without expanding the page into technical documentation.

## Evidence before

The deployed pages currently render the stale claim, and `src/styles/global.css` contains local `@font-face` declarations while the README names Fraunces/Inter.

This is copy-only: no CSS, geometry, state, motion or component structure changes. The repository's existing screenshot script is not modified and this round is not counted as visual before/after evidence for pattern promotion.
