### PR TITLE
CI: require OKF change cards for repository changes

### DIFF
--- a/.github/workflows/change-cards.yml
+++ b/.github/workflows/change-cards.yml
@@ -1,0 +1,35 @@
+name: Change cards
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  changelog:
+    name: OKF change card policy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          fetch-depth: 0
+
+      - uses: astral-sh/setup-uv@v6
+
+      - name: Require a card for this PR
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_REF: origin/${{ github.base_ref }}
+        run: node scripts/check-change-card.mjs
+
+      - name: Validate change cards as OKF knowledge
+        run: >-
+          uvx
+          --from git+https://github.com/franklinbaldo/okf-parser@fa357cc377becd6465ed404f10be01b032d6037b
+          okf-parser check changelog/changes
+          --require-spec specs/okf-types/{slug}.md
+          --normative-spec

--- a/.github/workflows/change-cards.yml
+++ b/.github/workflows/change-cards.yml
@@ -31,5 +31,5 @@ jobs:
           uvx
           --from git+https://github.com/franklinbaldo/okf-parser@fa357cc377becd6465ed404f10be01b032d6037b
           okf-parser check changelog/changes
-          --require-spec specs/okf-types/{slug}.md
+          --require-spec ../../specs/okf-types/{slug}.md
           --normative-spec

--- a/changelog/changes/require-okf-change-cards.md
+++ b/changelog/changes/require-okf-change-cards.md
@@ -1,0 +1,13 @@
+---
+type: changelog
+date: 2026-08-31
+description: Require an OKF change card for every pull request that changes the repository.
+tags: [ci, okf, changelog]
+---
+
+# Change cards become the unit of change history
+
+- Adds merge-relative CI enforcement: a pull request that changes source, content, docs, workflows, data, or other repository files must add at least one new card under `changelog/changes/`.
+- Validates change cards as OKF knowledge with the same `okf-parser` pattern used by Pink.
+- Keeps the historical versioned changelog entry as legacy history instead of requiring artificial version bumps for a continuously deployed site.
+- Updates `/changelog/` to render independent change cards alongside the legacy release entry, newest first.

--- a/scripts/check-change-card.mjs
+++ b/scripts/check-change-card.mjs
@@ -8,7 +8,9 @@ const CHANGES_DIR = "changelog/changes/";
 const baseRef = process.env.BASE_REF?.trim();
 
 if (!baseRef) {
-  console.log("✔ check-change-card: no BASE_REF; merge-relative card requirement skipped.");
+  console.log(
+    "✔ check-change-card: no BASE_REF; merge-relative card requirement skipped."
+  );
   process.exit(0);
 }
 
@@ -50,7 +52,9 @@ const addedCards = gitDiff([
 ]).filter((path) => path.endsWith(".md"));
 
 if (addedCards.length === 0) {
-  console.error("\n✗ check-change-card: this PR changes the repository but adds no change card.\n");
+  console.error(
+    "\n✗ check-change-card: this PR changes the repository but adds no change card.\n"
+  );
   console.error("Add at least one Markdown card under changelog/changes/.\n");
   console.error("Required OKF frontmatter:");
   console.error("  ---");

--- a/scripts/check-change-card.mjs
+++ b/scripts/check-change-card.mjs
@@ -1,0 +1,68 @@
+// Require every pull request that changes the repository to add at least one
+// independent changelog change card. Card structure is validated separately by
+// okf-parser; this script owns only the merge-relative policy question:
+// "did this PR record its change?"
+import { execFileSync } from "node:child_process";
+
+const CHANGES_DIR = "changelog/changes/";
+const baseRef = process.env.BASE_REF?.trim();
+
+if (!baseRef) {
+  console.log("✔ check-change-card: no BASE_REF; merge-relative card requirement skipped.");
+  process.exit(0);
+}
+
+function gitDiff(args) {
+  try {
+    return execFileSync("git", ["diff", ...args], { encoding: "utf8" })
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter(Boolean);
+  } catch (error) {
+    console.error(`✗ check-change-card: could not compare against ${baseRef}.`);
+    if (error?.stderr) console.error(String(error.stderr));
+    process.exit(1);
+  }
+}
+
+const changed = gitDiff(["--name-only", `${baseRef}...HEAD`]);
+
+if (changed.length === 0) {
+  console.log("✔ check-change-card: PR has no changed files.");
+  process.exit(0);
+}
+
+// A PR that only edits existing change cards is bookkeeping, not a new product
+// change. Everything else — source, content, CI, docs, data, workflows — must
+// leave a card. This intentionally has no broad `skip-changelog` escape hatch.
+const substantive = changed.filter((path) => !path.startsWith(CHANGES_DIR));
+if (substantive.length === 0) {
+  console.log("✔ check-change-card: PR only changes changelog cards.");
+  process.exit(0);
+}
+
+const addedCards = gitDiff([
+  "--name-only",
+  "--diff-filter=A",
+  `${baseRef}...HEAD`,
+  "--",
+  "changelog/changes",
+]).filter((path) => path.endsWith(".md"));
+
+if (addedCards.length === 0) {
+  console.error("\n✗ check-change-card: this PR changes the repository but adds no change card.\n");
+  console.error("Add at least one Markdown card under changelog/changes/.\n");
+  console.error("Required OKF frontmatter:");
+  console.error("  ---");
+  console.error("  type: changelog");
+  console.error("  date: YYYY-MM-DD");
+  console.error("  description: Short reader-facing summary");
+  console.error("  ---\n");
+  console.error("Changed files that require a card:");
+  for (const path of substantive) console.error(`  • ${path}`);
+  process.exit(1);
+}
+
+console.log(
+  `✔ check-change-card: ${addedCards.length} new card(s) record this PR: ${addedCards.join(", ")}`
+);

--- a/specs/okf-types/changelog.md
+++ b/specs/okf-types/changelog.md
@@ -14,11 +14,11 @@ Change cards are the durable, reader-facing record of changes to the site and it
 
 ## Required fields
 
-| Field         | Type   | Meaning                                    |
-| ------------- | ------ | ------------------------------------------ |
-| `type`        | string | Always `changelog`                         |
-| `date`        | date   | Date associated with the change            |
-| `description` | string | Short reader-facing summary of the change  |
+| Field         | Type   | Meaning                                   |
+| ------------- | ------ | ----------------------------------------- |
+| `type`        | string | Always `changelog`                        |
+| `date`        | date   | Date associated with the change           |
+| `description` | string | Short reader-facing summary of the change |
 
 ## Optional fields
 

--- a/specs/okf-types/changelog.md
+++ b/specs/okf-types/changelog.md
@@ -1,0 +1,29 @@
+---
+type: okf-type-spec
+filename: changelog.md
+title: "OKF Type: changelog"
+description: "Normative spec for site change cards"
+resource: okf-type:changelog
+tags: [okf, changelog, spec]
+timestamp: "2026-08-31T00:00:00Z"
+---
+
+# OKF Type: `changelog`
+
+Change cards are the durable, reader-facing record of changes to the site and its supporting automation.
+
+## Required fields
+
+| Field | Type | Meaning |
+| --- | --- | --- |
+| `type` | string | Always `changelog` |
+| `date` | date | Date associated with the change |
+| `description` | string | Short reader-facing summary of the change |
+
+## Optional fields
+
+| Field | Type | Meaning |
+| --- | --- | --- |
+| `tags` | array[string] | Small set of discovery labels |
+
+Change cards describe historical change. They are not normative documentation of current behavior.

--- a/specs/okf-types/changelog.md
+++ b/specs/okf-types/changelog.md
@@ -14,16 +14,16 @@ Change cards are the durable, reader-facing record of changes to the site and it
 
 ## Required fields
 
-| Field | Type | Meaning |
-| --- | --- | --- |
-| `type` | string | Always `changelog` |
-| `date` | date | Date associated with the change |
-| `description` | string | Short reader-facing summary of the change |
+| Field         | Type   | Meaning                                    |
+| ------------- | ------ | ------------------------------------------ |
+| `type`        | string | Always `changelog`                         |
+| `date`        | date   | Date associated with the change            |
+| `description` | string | Short reader-facing summary of the change  |
 
 ## Optional fields
 
-| Field | Type | Meaning |
-| --- | --- | --- |
+| Field  | Type          | Meaning                       |
+| ------ | ------------- | ----------------------------- |
 | `tags` | array[string] | Small set of discovery labels |
 
 Change cards describe historical change. They are not normative documentation of current behavior.

--- a/src/pages/changelog/index.astro
+++ b/src/pages/changelog/index.astro
@@ -2,13 +2,51 @@
 import { getCollection, render } from "astro:content";
 import PageLayout from "../../layouts/PageLayout.astro";
 
-// Changelog entries are English-only by deliberate exception (CLAUDE.md
-// "Línguas") — a single page serves both EN and PT readers, no /pt/ route.
-const entries = await getCollection("changelog");
-entries.sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf());
+type ChangeCardModule = {
+  frontmatter: {
+    type: "changelog";
+    date: string | Date;
+    description: string;
+    tags?: string[];
+  };
+  Content: unknown;
+};
 
-const rendered = await Promise.all(
-  entries.map(async (entry) => ({ entry, Content: (await render(entry)).Content }))
+// Historical release entries stay in the Astro content collection. New change
+// history is card-based (like Pink): stable semantic filenames under
+// changelog/changes/, independent from package/site versions.
+const legacyEntries = await getCollection("changelog");
+const legacyRendered = await Promise.all(
+  legacyEntries.map(async (entry) => ({
+    kind: "release" as const,
+    id: `version-${entry.data.version}`,
+    label: `v${entry.data.version}`,
+    date: entry.data.date,
+    description: entry.data.description,
+    tags: entry.data.tags,
+    Content: (await render(entry)).Content,
+  }))
+);
+
+const modules = import.meta.glob<ChangeCardModule>("../../../changelog/changes/*.md", {
+  eager: true,
+});
+
+const changeCards = Object.entries(modules).map(([path, module]) => {
+  const slug = path.split("/").at(-1)?.replace(/\.md$/, "") ?? path;
+  return {
+    kind: "change" as const,
+    id: `change-${slug}`,
+    label: module.frontmatter.description,
+    date: new Date(module.frontmatter.date),
+    description: module.frontmatter.description,
+    tags: module.frontmatter.tags,
+    Content: module.Content,
+  };
+});
+
+const entries = [...changeCards, ...legacyRendered].sort(
+  (a, b) => b.date.valueOf() - a.date.valueOf()
 );
 
 const fmt = new Intl.DateTimeFormat("en-US", {
@@ -23,7 +61,7 @@ const repositoryUrl = "https://github.com/franklinbaldo/franklinbaldo.github.io"
 
 <PageLayout
   title="Changelog | Franklin Baldo"
-  description="Release notes for the site and Hrönir, listed version by version."
+  description="Changes to the site and its supporting automation, newest first."
   lang="en"
   breadcrumb={[
     { name: "Home", item: new URL("/", Astro.site).href },
@@ -32,55 +70,45 @@ const repositoryUrl = "https://github.com/franklinbaldo/franklinbaldo.github.io"
 >
   <header class="changelog-intro">
     <h1>Changelog</h1>
-    <p>Release notes for the site and Hrönir, newest first.</p>
+    <p>Changes to the site and its supporting automation, newest first.</p>
     <nav class="changelog-resources" aria-label="Changelog resources">
-      <a href={`${repositoryUrl}/tree/main/changelog`}>Source files</a>
+      <a href={`${repositoryUrl}/tree/main/changelog/changes`}>Change cards</a>
       <span aria-hidden="true">·</span>
-      <a href={`${repositoryUrl}/blob/main/docs/okf/README.md`}>Changelog format</a>
+      <a href={`${repositoryUrl}/blob/main/specs/okf-types/changelog.md`}>OKF format</a>
     </nav>
   </header>
 
   <div class="changelog-list">
     {
-      rendered.map(({ entry, Content }) => {
-        const anchor = `version-${entry.data.version}`;
-
-        return (
-          <article id={anchor} class="changelog-entry">
-            <header class="release-header">
-              <div>
-                <p class="release-label">Release</p>
-                <h2>
-                  <a
-                    href={`#${anchor}`}
-                    aria-label={`Permanent link to version ${entry.data.version}`}
-                  >
-                    <span aria-hidden="true">v</span>
-                    {entry.data.version}
-                  </a>
-                </h2>
-              </div>
-              <time datetime={entry.data.date.toISOString()}>
-                {fmt.format(entry.data.date)}
-              </time>
-            </header>
-
-            <p class="release-summary">{entry.data.description}</p>
-
-            {entry.data.tags && entry.data.tags.length > 0 && (
-              <ul class="changelog-tags" aria-label="Release tags">
-                {entry.data.tags.map((tag) => (
-                  <li>#{tag}</li>
-                ))}
-              </ul>
-            )}
-
-            <div class="prose">
-              <Content />
+      entries.map(({ kind, id, label, date, description, tags, Content }) => (
+        <article id={id} class="changelog-entry">
+          <header class="release-header">
+            <div>
+              <p class="release-label">{kind === "change" ? "Change" : "Legacy release"}</p>
+              <h2>
+                <a href={`#${id}`} aria-label={`Permanent link to ${label}`}>
+                  {label}
+                </a>
+              </h2>
             </div>
-          </article>
-        );
-      })
+            <time datetime={date.toISOString()}>{fmt.format(date)}</time>
+          </header>
+
+          {kind === "release" && <p class="release-summary">{description}</p>}
+
+          {tags && tags.length > 0 && (
+            <ul class="changelog-tags" aria-label="Change tags">
+              {tags.map((tag) => (
+                <li>#{tag}</li>
+              ))}
+            </ul>
+          )}
+
+          <div class="prose">
+            <Content />
+          </div>
+        </article>
+      ))
     }
   </div>
 </PageLayout>
@@ -154,7 +182,8 @@ const repositoryUrl = "https://github.com/franklinbaldo/franklinbaldo.github.io"
 
   .release-header h2 {
     margin: 0;
-    font-size: clamp(1.45rem, 4vw, 1.9rem);
+    font-size: clamp(1.25rem, 3vw, 1.65rem);
+    line-height: 1.25;
   }
 
   .release-header h2 a {
@@ -191,12 +220,18 @@ const repositoryUrl = "https://github.com/franklinbaldo/franklinbaldo.github.io"
     list-style: none;
   }
 
+  .prose :global(h1),
+  .prose :global(h2) {
+    margin-top: 1.5rem;
+    font-size: 1rem;
+  }
+
   .prose :global(h3) {
     margin-top: 1.75rem;
+    color: var(--pico-muted-color);
     font-size: 0.78rem;
     letter-spacing: 0.08em;
     text-transform: uppercase;
-    color: var(--pico-muted-color);
   }
 
   .prose :global(li + li) {


### PR DESCRIPTION
Adopts the same change-card model already used by Pink, adapted to a continuously deployed site.

What changes:
- every PR that changes repository content outside `changelog/changes/` must add at least one new change card;
- cards live under `changelog/changes/*.md` with `type: changelog`, `date`, and `description`;
- cards are validated by `okf-parser` against a normative `specs/okf-types/changelog.md` spec;
- `/changelog/` renders independent change cards together with the historical `0.1.0` release entry;
- the old release file remains legacy history instead of forcing artificial `package.json` version bumps.

The first card in this PR records adoption of the policy itself.