### PR TITLE
fix: usar embed oficial do Suno

### DIFF
--- a/src/components/SunoEmbed.astro
+++ b/src/components/SunoEmbed.astro
@@ -4,7 +4,7 @@ interface Props {
   caption?: string;
   height?: number;
 }
-const { id, caption, height = 160 } = Astro.props;
+const { id, caption, height = 240 } = Astro.props;
 ---
 
 <figure class="suno-embed">
@@ -13,7 +13,13 @@ const { id, caption, height = 160 } = Astro.props;
     width="100%"
     height={height}
     frameborder="0"
+    allow="autoplay; encrypted-media; fullscreen"
+    allowfullscreen
     loading="lazy"
-    title={`Suno track ${id}`}></iframe>
+    referrerpolicy="no-referrer-when-downgrade"
+    title={`Suno track ${id}`}
+  >
+    <a href={`https://suno.com/song/${id}`}>Listen on Suno</a>
+  </iframe>
   {caption && <figcaption>{caption}</figcaption>}
 </figure>


### PR DESCRIPTION
## Problema

O Suno deixou de ser confiável para reprodução direta via `audio_url`. O site já possui `SunoEmbed.astro`, mas o componente não refletia integralmente o contrato atual do embed oficial.

## Mudança

Atualiza `SunoEmbed.astro` para usar o iframe oficial no formato publicado pelo Suno:

- `https://suno.com/embed/{id}`
- altura padrão de 240px
- `allow="autoplay; encrypted-media; fullscreen"`
- `allowfullscreen`
- `loading="lazy"`
- `referrerpolicy="no-referrer-when-downgrade"`
- fallback com link `https://suno.com/song/{id}`

Isso torna o componente canônico compatível com o embed que o Suno aceita atualmente, em vez de depender de reprodução direta.

## Observação

As páginas `/music` e `/pt/musicas` e o `GlobalMusicPlayer` ainda contêm caminhos antigos baseados em `audio_url`; eles precisam migrar para o mesmo contrato de embed para eliminarmos completamente essa dependência.