### PR TITLE
ux: aria-labels de ranking/battles e changelog identificam o item

### DIFF
--- a/.routines/2026-09-01T05-09-01-ux-ui-run.md
+++ b/.routines/2026-09-01T05-09-01-ux-ui-run.md
@@ -1,0 +1,28 @@
+---
+date: "2026-09-01T05:09:01Z"
+branch: ux-ui/run-2026-09-01T05-05-04
+status: open
+---
+
+# Sessão 2026-09-01T05-09-01 — UX/UI
+
+Issues fechadas: #1559, #1560
+
+O que foi feito:
+- `battles/index.astro` e `battles/page/[n].astro`: placeholder "rates not
+  available" agora identifica o duelo (`${winnerName} vs ${loserName} —
+  rates not available`) em vez de repetir o mesmo aria-label genérico em
+  todo card sem dados de tensão.
+- `changelog/index.astro`: a lista de tags de cada entrada de changelog
+  agora usa `Tags for ${label}` em vez do genérico "Change tags" repetido
+  (a página foi refatorada desde que a issue foi aberta — cards de mudança
+  substituíram parte do release legado — mas o mesmo bug de aria-label
+  duplicado seguia presente).
+
+Passo 0 da rotina: 9 PRs pendentes desta rotina mesclados com squash (bloqueio
+de merge documentado em sessões anteriores está resolvido — CLAUDE.md agora
+declara squash como canônico). Um deles (#1591) precisou de resolução manual
+de conflito com main + novo change card (política "OKF change card policy",
+adicionada a main em 31/08, agora se aplica a todo PR).
+
+CI local: astro check ✅ (0 erros) · prettier ✅ · build ✅ (3881 páginas)

--- a/changelog/changes/ranking-changelog-duplicate-aria-labels.md
+++ b/changelog/changes/ranking-changelog-duplicate-aria-labels.md
@@ -1,0 +1,16 @@
+---
+type: changelog
+date: 2026-09-01
+description: Fix duplicate aria-labels on battle cards and changelog release tags.
+tags: [a11y, ranking, changelog]
+---
+
+# Screen reader labels identify which item they describe
+
+- `src/pages/ranking/battles/index.astro` and `battles/page/[n].astro`: the
+  "rates not available" placeholder on a battle card without tension data
+  now includes the two posts in its `aria-label`, instead of repeating the
+  same generic label for every card that lacks rates.
+- `src/pages/changelog/index.astro`: the tag list under each changelog entry
+  now labels itself with that entry's title (`Tags for <label>`) instead of
+  the identical `"Change tags"` on every entry.

--- a/src/pages/changelog/index.astro
+++ b/src/pages/changelog/index.astro
@@ -98,7 +98,7 @@ const repositoryUrl = "https://github.com/franklinbaldo/franklinbaldo.github.io"
           {kind === "release" && <p class="release-summary">{description}</p>}
 
           {tags && tags.length > 0 && (
-            <ul class="changelog-tags" aria-label="Change tags">
+            <ul class="changelog-tags" aria-label={`Tags for ${label}`}>
               {tags.map((tag) => (
                 <li>#{tag}</li>
               ))}

--- a/src/pages/ranking/battles/index.astro
+++ b/src/pages/ranking/battles/index.astro
@@ -169,7 +169,7 @@ const crumbs = [
                 <div class="tf loser-fill" style={`width:${100 - tensionPct}%`}></div>
               </div>
             ) : (
-              <div class="tension-absent" aria-label="Rates not available">—</div>
+              <div class="tension-absent" aria-label={`${winnerName} vs ${loserName} — rates not available`}>—</div>
             )}
             <div class="read-cta">Read analysis →</div>
           </a>

--- a/src/pages/ranking/battles/page/[n].astro
+++ b/src/pages/ranking/battles/page/[n].astro
@@ -180,7 +180,7 @@ const crumbs = [
                 <div class="tf loser-fill" style={`width:${100 - tensionPct}%`}></div>
               </div>
             ) : (
-              <div class="tension-absent" aria-label="Rates not available">—</div>
+              <div class="tension-absent" aria-label={`${winnerName} vs ${loserName} — rates not available`}>—</div>
             )}
             <div class="read-cta">Read analysis →</div>
           </a>


### PR DESCRIPTION
## Summary

- `src/pages/ranking/battles/index.astro` e `battles/page/[n].astro`: o placeholder "rates not available" de um card de duelo sem dados de tensão tinha `aria-label="Rates not available"` idêntico em todo card sem dados — um leitor de tela navegando pela lista ouvia o mesmo texto repetido sem saber a qual duelo pertence. Agora interpola `winnerName`/`loserName`, já disponíveis no escopo do `.map()`.
- `src/pages/changelog/index.astro`: a lista de tags de cada entrada tinha `aria-label="Change tags"` idêntico para toda entrada da página. A página foi refatorada desde que a issue #1560 foi aberta (cards de change independentes substituíram parte do fluxo de release legado), mas o mesmo bug de aria-label duplicado seguia presente sob o novo nome. Agora usa `Tags for ${label}`, mesmo padrão já usado no link permanente da própria entry.

Closes #1559, Closes #1560

## Passo 0 da rotina (revisar/mesclar PRs abertos)

O bloqueio de merge documentado por 9+ sessões anteriores (#1564–#1617) está resolvido: o `CLAUDE.md` agora declara squash como o método canônico e habilitado do repositório. Mesclei os 9 PRs pendentes desta rotina com `merge_method: squash` (#1573, #1575, #1579, #1583, #1585, #1587, #1589, #1591, #1617). O #1591 precisou de resolução manual de conflito com `main` (mesmo arquivo tocado por #1573) e de um novo change card — a política "OKF change card policy" foi adicionada a `main` em 31/08 e agora exige um card em `changelog/changes/` para todo PR que muda o repositório substantivamente; adicionei o card correspondente a esse PR também.

## Test plan

- [x] `npx astro check` — 0 erros, 0 warnings novos (80 hints pré-existentes)
- [x] `npx prettier --check .` — passou
- [x] `npm run build` — build completo (3881 páginas, pagefind ok)
- [x] Confirmado no HTML gerado (`dist/changelog/index.html`): `aria-label="Tags for <título da entrada>"`, único por entrada
- [x] Nenhum duelo do dataset atual está sem dados de tensão (`grep -c tension-absent dist/ranking/battles/**` = 0), então o fix de `battles/index.astro`/`battles/page/[n].astro` não é exercitado no build atual — mesma situação já documentada por sessões anteriores para issues semelhantes; verificado por leitura que `winnerName`/`loserName` já estão no escopo correto do `.map()`
- [x] `src/generated/*.json` regenerados pelo build local foram revertidos antes do commit

---
_Generated by [Claude Code](https://claude.ai/code/session_01WTHrU9LfJ18SHdgUafdv9z)_