### PR TITLE
feat(audiobook): make okf-parser the per-segment validation boundary

### DIFF
--- a/.github/workflows/audiobook-okf.yml
+++ b/.github/workflows/audiobook-okf.yml
@@ -1,0 +1,28 @@
+name: Audiobook OKF
+
+on:
+  pull_request:
+    paths:
+      - "data/audiobooks/**"
+      - "scripts/audiobook/**"
+      - "src/audiobook/**"
+      - ".github/workflows/audiobook-*.yml"
+  push:
+    branches: [main]
+    paths:
+      - "data/audiobooks/**"
+      - "scripts/audiobook/**"
+      - "src/audiobook/**"
+      - ".github/workflows/audiobook-*.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  validate-hpmor:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: astral-sh/setup-uv@v6
+      - name: Validate OKF and per-segment invariants
+        run: uv run scripts/audiobook/validate-okf.py --work hpmor

--- a/changelog/changes/audiobook-okf-parser-segment-gates.md
+++ b/changelog/changes/audiobook-okf-parser-segment-gates.md
@@ -1,0 +1,11 @@
+---
+type: changelog
+date: 2026-09-01
+description: Make okf-parser the mandatory validation boundary for canonical audiobook segments and enforce per-segment identity, lineage, provenance, narration metadata, and orphan checks before readiness/TTS.
+tags: [audiobook, okf, validation, ci, tts]
+published: false
+---
+
+# Audiobook segments now pass through okf-parser
+
+Canonical source, translation, and narration shards are loaded through pinned `okf-parser` before the existing audiobook readiness validator runs. The gate fails closed on malformed OKF, missing layer-specific metadata, unstable IDs, orphan layers, broken source→translation→narration lineage, or canonical shard filename mismatches.

--- a/scripts/audiobook/validate-okf.py
+++ b/scripts/audiobook/validate-okf.py
@@ -2,6 +2,7 @@
 # requires-python = ">=3.12"
 # dependencies = [
 #   "okf-parser==0.45.4",
+#   "PyYAML==6.0.2",
 # ]
 # ///
 
@@ -14,6 +15,7 @@ import sys
 from collections import defaultdict
 from pathlib import Path, PurePosixPath
 
+import yaml
 from okf_parser import load_bundle, validate_path
 
 CANONICAL_STATUSES = {"canonical", "canonical-editorial-unit"}
@@ -23,45 +25,22 @@ LAYER_TYPES = {
     "Audiobook Narration Segment": "narration",
 }
 REQUIRED_FIELDS = {
-    "original": (
-        "work_id",
-        "chapter_id",
-        "segment_id",
-        "lang",
-        "source_url",
-        "source_digest",
-        "source_anchor",
-        "status",
-    ),
-    "translation": (
-        "work_id",
-        "chapter_id",
-        "segment_id",
-        "lang",
-        "derived_from",
-        "status",
-    ),
-    "narration": (
-        "work_id",
-        "chapter_id",
-        "segment_id",
-        "lang",
-        "derived_from",
-        "status",
-        "speaker",
-        "emotion",
-        "pace",
-        "intensity",
-        "pause_before_ms",
-        "pause_after_ms",
-    ),
+    "original": ("work_id", "chapter_id", "segment_id", "lang", "source_url", "source_digest", "source_anchor", "status"),
+    "translation": ("work_id", "chapter_id", "segment_id", "lang", "derived_from", "status"),
+    "narration": ("work_id", "chapter_id", "segment_id", "lang", "derived_from", "status", "speaker", "emotion", "pace", "intensity", "pause_before_ms", "pause_after_ms"),
 }
+PROJECT_GUIDES = (
+    "docs/okf/audiobook/editorial-control-plane.md",
+    "docs/okf/audiobook/guides/translation.md",
+    "docs/okf/audiobook/guides/narration.md",
+    "docs/okf/audiobook/chapter-readiness.md",
+    "docs/okf/audiobook/multi-work-architecture.md",
+)
+WORK_PREREQUISITES = ("work.md", "editorial.md", "rights.md", "voices.yaml", "pronunciation.yaml")
 
 
 def _args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(
-        description="Validate audiobook OKF syntax plus per-segment editorial invariants."
-    )
+    parser = argparse.ArgumentParser(description="Validate audiobook OKF syntax plus per-segment editorial invariants.")
     parser.add_argument("--work", required=True)
     parser.add_argument("--chapter")
     parser.add_argument("--json", action="store_true")
@@ -69,19 +48,40 @@ def _args() -> argparse.Namespace:
 
 
 def _resolved_link(source_path: str, target: str) -> str:
-    base = PurePosixPath(source_path).parent
-    return posixpath.normpath(str(base / target))
+    return posixpath.normpath(str(PurePosixPath(source_path).parent / target))
+
+
+def _load_yaml(path: Path) -> dict:
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    return data if isinstance(data, dict) else {}
 
 
 def main() -> int:
     args = _args()
     root = Path(__file__).resolve().parents[2]
     work_dir = root / "data" / "audiobooks" / args.work
+    errors: list[str] = []
+
+    for rel in PROJECT_GUIDES:
+        if not (root / rel).is_file():
+            errors.append(f"project prerequisite missing: {rel}")
+    for name in WORK_PREREQUISITES:
+        if not (work_dir / name).is_file():
+            errors.append(f"work prerequisite missing: {name}")
 
     report = validate_path(work_dir)
-    errors: list[str] = []
     if not report.is_conformant:
         errors.append("okf-parser reports normative OKF errors")
+
+    voices = _load_yaml(work_dir / "voices.yaml") if (work_dir / "voices.yaml").is_file() else {}
+    pronunciation = _load_yaml(work_dir / "pronunciation.yaml") if (work_dir / "pronunciation.yaml").is_file() else {}
+    if voices.get("schema") != "audiobook-voices-v1" or voices.get("work_id") != args.work:
+        errors.append("voices.yaml must use audiobook-voices-v1 and matching work_id")
+    voice_ids = set((voices.get("voices") or {}).keys()) if isinstance(voices.get("voices"), dict) else set()
+    if pronunciation.get("schema") != "audiobook-pronunciation-v1" or pronunciation.get("work_id") != args.work:
+        errors.append("pronunciation.yaml must use audiobook-pronunciation-v1 and matching work_id")
+    if not isinstance(pronunciation.get("entries"), list):
+        errors.append("pronunciation.yaml entries must be a list")
 
     bundle = load_bundle(work_dir)
     rows = bundle.concepts.execute().to_dict(orient="records")
@@ -92,19 +92,16 @@ def main() -> int:
         layer = LAYER_TYPES.get(concept_type)
         if layer is None:
             continue
-
         raw = row.get("frontmatter_json")
         if not isinstance(raw, str):
             errors.append(f"{row.get('path')}: missing parser-produced frontmatter_json")
             continue
         data = json.loads(raw)
         path = str(row.get("path") or "")
-
         work_id = data.get("work_id")
         chapter_id = data.get("chapter_id")
         segment_id = data.get("segment_id")
         status = data.get("status")
-
         if work_id != args.work:
             errors.append(f"{path}: work_id must be {args.work!r}, got {work_id!r}")
         if args.chapter and chapter_id != args.chapter:
@@ -116,16 +113,19 @@ def main() -> int:
             errors.append(f"{path}: segment_id {segment_id!r} is not namespaced by {chapter_id!r}")
         if status not in CANONICAL_STATUSES:
             continue
-
         for field in REQUIRED_FIELDS[layer]:
             value = data.get(field)
             if value is None or value == "":
                 errors.append(f"{path}: required {layer} field {field!r} is missing")
-
-        expected_filename = f"{segment_id}.okf.md"
-        if PurePosixPath(path).name != expected_filename:
-            errors.append(f"{path}: canonical shard filename must be {expected_filename}")
-
+        if PurePosixPath(path).name != f"{segment_id}.okf.md":
+            errors.append(f"{path}: canonical shard filename must be {segment_id}.okf.md")
+        if layer == "narration":
+            speaker = data.get("speaker")
+            if speaker == "mixed":
+                if not data.get("voice_partition"):
+                    errors.append(f"{path}: mixed narration requires voice_partition")
+            elif isinstance(speaker, str) and speaker not in voice_ids:
+                errors.append(f"{path}: speaker {speaker!r} has no entry in voices.yaml")
         key = (chapter_id, segment_id)
         if layer in segments[key]:
             errors.append(f"{chapter_id}/{segment_id}: duplicate canonical {layer} shard")
@@ -134,55 +134,36 @@ def main() -> int:
     for (chapter_id, segment_id), layers in sorted(segments.items()):
         missing = [name for name in ("original", "translation", "narration") if name not in layers]
         if missing:
-            errors.append(
-                f"{chapter_id}/{segment_id}: orphan canonical segment; missing {', '.join(missing)}"
-            )
+            errors.append(f"{chapter_id}/{segment_id}: orphan canonical segment; missing {', '.join(missing)}")
             continue
-
-        original = layers["original"]
-        translation = layers["translation"]
-        narration = layers["narration"]
-
+        original, translation, narration = layers["original"], layers["translation"], layers["narration"]
         for layer_name, item in layers.items():
             data = item["data"]
             if data.get("work_id") != args.work or data.get("chapter_id") != chapter_id or data.get("segment_id") != segment_id:
                 errors.append(f"{item['path']}: stable identity mismatch in {layer_name} layer")
-
-        translation_target = _resolved_link(
-            str(translation["path"]), str(translation["data"].get("derived_from") or "")
-        )
+        translation_target = _resolved_link(str(translation["path"]), str(translation["data"].get("derived_from") or ""))
         if translation_target != str(original["path"]):
-            errors.append(
-                f"{translation['path']}: derived_from must resolve to {original['path']}, got {translation_target}"
-            )
-
-        narration_target = _resolved_link(
-            str(narration["path"]), str(narration["data"].get("derived_from") or "")
-        )
+            errors.append(f"{translation['path']}: derived_from must resolve to {original['path']}, got {translation_target}")
+        narration_target = _resolved_link(str(narration["path"]), str(narration["data"].get("derived_from") or ""))
         if narration_target != str(translation["path"]):
-            errors.append(
-                f"{narration['path']}: derived_from must resolve to {translation['path']}, got {narration_target}"
-            )
+            errors.append(f"{narration['path']}: derived_from must resolve to {translation['path']}, got {narration_target}")
 
     result = {
         "schema": "audiobook-okf-segment-validation-v1",
         "work_id": args.work,
         "chapter_id": args.chapter,
         "okf_conformant": report.is_conformant,
+        "project_prerequisites_checked": len(PROJECT_GUIDES),
         "canonical_segments_checked": len(segments),
         "valid": not errors,
         "errors": errors,
     }
-
     if args.json:
         print(json.dumps(result, ensure_ascii=False, indent=2))
     else:
-        print(
-            f"Audiobook OKF validation: work={args.work} segments={len(segments)} valid={not errors}"
-        )
+        print(f"Audiobook OKF validation: work={args.work} segments={len(segments)} valid={not errors}")
         for error in errors:
             print(f"- {error}", file=sys.stderr)
-
     return 0 if not errors else 1
 
 

--- a/scripts/audiobook/validate-okf.py
+++ b/scripts/audiobook/validate-okf.py
@@ -1,0 +1,190 @@
+# /// script
+# requires-python = ">=3.12"
+# dependencies = [
+#   "okf-parser==0.45.4",
+# ]
+# ///
+
+from __future__ import annotations
+
+import argparse
+import json
+import posixpath
+import sys
+from collections import defaultdict
+from pathlib import Path, PurePosixPath
+
+from okf_parser import load_bundle, validate_path
+
+CANONICAL_STATUSES = {"canonical", "canonical-editorial-unit"}
+LAYER_TYPES = {
+    "Audiobook Source Segment": "original",
+    "Audiobook Translation Segment": "translation",
+    "Audiobook Narration Segment": "narration",
+}
+REQUIRED_FIELDS = {
+    "original": (
+        "work_id",
+        "chapter_id",
+        "segment_id",
+        "lang",
+        "source_url",
+        "source_digest",
+        "source_anchor",
+        "status",
+    ),
+    "translation": (
+        "work_id",
+        "chapter_id",
+        "segment_id",
+        "lang",
+        "derived_from",
+        "status",
+    ),
+    "narration": (
+        "work_id",
+        "chapter_id",
+        "segment_id",
+        "lang",
+        "derived_from",
+        "status",
+        "speaker",
+        "emotion",
+        "pace",
+        "intensity",
+        "pause_before_ms",
+        "pause_after_ms",
+    ),
+}
+
+
+def _args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Validate audiobook OKF syntax plus per-segment editorial invariants."
+    )
+    parser.add_argument("--work", required=True)
+    parser.add_argument("--chapter")
+    parser.add_argument("--json", action="store_true")
+    return parser.parse_args()
+
+
+def _resolved_link(source_path: str, target: str) -> str:
+    base = PurePosixPath(source_path).parent
+    return posixpath.normpath(str(base / target))
+
+
+def main() -> int:
+    args = _args()
+    root = Path(__file__).resolve().parents[2]
+    work_dir = root / "data" / "audiobooks" / args.work
+
+    report = validate_path(work_dir)
+    errors: list[str] = []
+    if not report.is_conformant:
+        errors.append("okf-parser reports normative OKF errors")
+
+    bundle = load_bundle(work_dir)
+    rows = bundle.concepts.execute().to_dict(orient="records")
+    segments: dict[tuple[str, str], dict[str, dict[str, object]]] = defaultdict(dict)
+
+    for row in rows:
+        concept_type = str(row.get("concept_type") or "")
+        layer = LAYER_TYPES.get(concept_type)
+        if layer is None:
+            continue
+
+        raw = row.get("frontmatter_json")
+        if not isinstance(raw, str):
+            errors.append(f"{row.get('path')}: missing parser-produced frontmatter_json")
+            continue
+        data = json.loads(raw)
+        path = str(row.get("path") or "")
+
+        work_id = data.get("work_id")
+        chapter_id = data.get("chapter_id")
+        segment_id = data.get("segment_id")
+        status = data.get("status")
+
+        if work_id != args.work:
+            errors.append(f"{path}: work_id must be {args.work!r}, got {work_id!r}")
+        if args.chapter and chapter_id != args.chapter:
+            continue
+        if not isinstance(chapter_id, str) or not isinstance(segment_id, str):
+            errors.append(f"{path}: chapter_id and segment_id must be strings")
+            continue
+        if not segment_id.startswith(f"{chapter_id}-s"):
+            errors.append(f"{path}: segment_id {segment_id!r} is not namespaced by {chapter_id!r}")
+        if status not in CANONICAL_STATUSES:
+            continue
+
+        for field in REQUIRED_FIELDS[layer]:
+            value = data.get(field)
+            if value is None or value == "":
+                errors.append(f"{path}: required {layer} field {field!r} is missing")
+
+        expected_filename = f"{segment_id}.okf.md"
+        if PurePosixPath(path).name != expected_filename:
+            errors.append(f"{path}: canonical shard filename must be {expected_filename}")
+
+        key = (chapter_id, segment_id)
+        if layer in segments[key]:
+            errors.append(f"{chapter_id}/{segment_id}: duplicate canonical {layer} shard")
+        segments[key][layer] = {"path": path, "data": data}
+
+    for (chapter_id, segment_id), layers in sorted(segments.items()):
+        missing = [name for name in ("original", "translation", "narration") if name not in layers]
+        if missing:
+            errors.append(
+                f"{chapter_id}/{segment_id}: orphan canonical segment; missing {', '.join(missing)}"
+            )
+            continue
+
+        original = layers["original"]
+        translation = layers["translation"]
+        narration = layers["narration"]
+
+        for layer_name, item in layers.items():
+            data = item["data"]
+            if data.get("work_id") != args.work or data.get("chapter_id") != chapter_id or data.get("segment_id") != segment_id:
+                errors.append(f"{item['path']}: stable identity mismatch in {layer_name} layer")
+
+        translation_target = _resolved_link(
+            str(translation["path"]), str(translation["data"].get("derived_from") or "")
+        )
+        if translation_target != str(original["path"]):
+            errors.append(
+                f"{translation['path']}: derived_from must resolve to {original['path']}, got {translation_target}"
+            )
+
+        narration_target = _resolved_link(
+            str(narration["path"]), str(narration["data"].get("derived_from") or "")
+        )
+        if narration_target != str(translation["path"]):
+            errors.append(
+                f"{narration['path']}: derived_from must resolve to {translation['path']}, got {narration_target}"
+            )
+
+    result = {
+        "schema": "audiobook-okf-segment-validation-v1",
+        "work_id": args.work,
+        "chapter_id": args.chapter,
+        "okf_conformant": report.is_conformant,
+        "canonical_segments_checked": len(segments),
+        "valid": not errors,
+        "errors": errors,
+    }
+
+    if args.json:
+        print(json.dumps(result, ensure_ascii=False, indent=2))
+    else:
+        print(
+            f"Audiobook OKF validation: work={args.work} segments={len(segments)} valid={not errors}"
+        )
+        for error in errors:
+            print(f"- {error}", file=sys.stderr)
+
+    return 0 if not errors else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/audiobook/validate-okf.py
+++ b/scripts/audiobook/validate-okf.py
@@ -1,7 +1,7 @@
 # /// script
 # requires-python = ">=3.12"
 # dependencies = [
-#   "okf-parser==0.45.4",
+#   "okf-parser @ git+https://github.com/franklinbaldo/okf-parser@5ee72add40d3372682e528fd70641455143269ce",
 #   "PyYAML==6.0.2",
 # ]
 # ///

--- a/scripts/audiobook/validate.mjs
+++ b/scripts/audiobook/validate.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import process from "node:process";
+import { spawnSync } from "node:child_process";
 
 import {
   AudiobookValidationError,
@@ -40,14 +41,58 @@ function parseArgs(argv) {
   return args;
 }
 
+function validateOkf(args) {
+  const command = [
+    "run",
+    "scripts/audiobook/validate-okf.py",
+    "--work",
+    args.workId,
+    "--json",
+  ];
+  if (args.chapterId) command.push("--chapter", args.chapterId);
+
+  const result = spawnSync("uv", command, {
+    cwd: process.cwd(),
+    encoding: "utf8",
+  });
+
+  if (result.error) {
+    throw new Error(
+      `OKF validation could not start: ${result.error.message}. Install uv; audiobook validation fails closed without okf-parser.`
+    );
+  }
+
+  let report;
+  try {
+    report = JSON.parse(result.stdout || "{}");
+  } catch {
+    throw new Error(
+      `OKF validator returned unreadable output: ${(result.stdout || result.stderr).trim()}`
+    );
+  }
+
+  if (result.status !== 0 || report.valid !== true) {
+    const details = Array.isArray(report.errors) ? report.errors : [];
+    throw new AudiobookValidationError(
+      `Invalid audiobook OKF contract: ${args.workId}`,
+      details.length ? details : [result.stderr.trim() || "okf-parser validation failed"]
+    );
+  }
+
+  return report;
+}
+
 try {
   const args = parseArgs(process.argv.slice(2));
+  const okf = validateOkf(args);
   const result = validateWork(process.cwd(), args.workId, args);
+  const output = { ...result, okf };
 
   if (args.json) {
-    console.log(JSON.stringify(result, null, 2));
+    console.log(JSON.stringify(output, null, 2));
   } else {
     console.log(`work: ${result.workId} — ${result.title}`);
+    console.log(`okf: valid (${okf.canonical_segments_checked} canonical segments checked)`);
     console.log(`status: ${result.status ?? "unknown"}`);
     console.log(`next: ${result.nextAction}`);
     for (const chapter of result.chapters) {

--- a/scripts/audiobook/validate.mjs
+++ b/scripts/audiobook/validate.mjs
@@ -41,6 +41,32 @@ function parseArgs(argv) {
   return args;
 }
 
+function runUv(command) {
+  let result = spawnSync("uv", command, {
+    cwd: process.cwd(),
+    encoding: "utf8",
+  });
+
+  if (result.error?.code === "ENOENT") {
+    const bootstrap = spawnSync(
+      "python3",
+      ["-m", "pip", "install", "--disable-pip-version-check", "--user", "uv==0.8.13"],
+      { cwd: process.cwd(), encoding: "utf8" }
+    );
+    if (bootstrap.status !== 0) {
+      throw new Error(
+        `OKF validation requires uv; bootstrap failed: ${(bootstrap.stderr || bootstrap.stdout).trim()}`
+      );
+    }
+    result = spawnSync("python3", ["-m", "uv", ...command], {
+      cwd: process.cwd(),
+      encoding: "utf8",
+    });
+  }
+
+  return result;
+}
+
 function validateOkf(args) {
   const command = [
     "run",
@@ -51,14 +77,10 @@ function validateOkf(args) {
   ];
   if (args.chapterId) command.push("--chapter", args.chapterId);
 
-  const result = spawnSync("uv", command, {
-    cwd: process.cwd(),
-    encoding: "utf8",
-  });
-
+  const result = runUv(command);
   if (result.error) {
     throw new Error(
-      `OKF validation could not start: ${result.error.message}. Install uv; audiobook validation fails closed without okf-parser.`
+      `OKF validation could not start: ${result.error.message}. Audiobook validation fails closed without okf-parser.`
     );
   }
 


### PR DESCRIPTION
## Objetivo

Tornar `okf-parser` a fronteira obrigatória de validação da Audiobook Factory antes de qualquer readiness/TTS, sem avançar `hpmor-001-s0035`.

Esta PR é empilhada sobre #1634 e é deliberadamente de infraestrutura/editorial-control-plane.

## Implementação

- adiciona `scripts/audiobook/validate-okf.py` como script PEP 723 com `okf-parser==0.45.4` pinado;
- carrega os conceitos pelo `okf-parser` e usa o `frontmatter_json` produzido pelo parser, em vez de reinterpretar os shards com `gray-matter`;
- valida cada shard canônico de source/translation/narration por `work_id/chapter_id/segment_id`;
- exige metadata específica por camada: proveniência da source, lineage da translation e direção de narração/TTS;
- falha em shard órfão, duplicado, filename desalinhado ou `derived_from` que não resolve exatamente source -> translation -> narration;
- faz `npm run audiobook:validate` executar esse gate primeiro e falhar fechado se `okf-parser` não puder rodar;
- adiciona workflow `Audiobook OKF` para validar HPMOR em PRs que alterem a fábrica.

## TTS

O workflow de mídia já entra por `npm run audiobook:validate`; portanto o gate OKF passa a preceder a checagem de `ready_for_audio`. Não há caminho intencional de síntese que pule essa validação.

## Delimitação

Nenhum novo segmento editorial é criado nesta PR. `s0035` continua sendo a próxima unidade somente depois que esta infraestrutura estiver verde.

## Validação esperada

A CI deve retrovalidar os shards canônicos já existentes de HPMOR. Se algum shard legado não satisfizer o contrato agora explicitado, a PR deve ficar vermelha e o próprio diagnóstico passa a ser a fila determinística de saneamento — não devemos afrouxar o gate para fazê-lo passar.