### PR TITLE
ux: torna audiolivros descobríveis com evidência visual

### DIFF
--- a/.github/workflows/visual-evidence.yml
+++ b/.github/workflows/visual-evidence.yml
@@ -1,0 +1,50 @@
+name: Visual evidence
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  screenshots:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 24
+          cache: npm
+
+      - run: npm ci
+
+      - name: Install Chromium
+        run: npx playwright install --with-deps chromium
+
+      - name: Build
+        run: npm run build
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Start preview
+        run: |
+          npx astro preview --host 127.0.0.1 > /tmp/astro-preview.log 2>&1 &
+          for i in {1..30}; do
+            if curl --fail --silent http://localhost:4321/ >/dev/null; then
+              exit 0
+            fi
+            sleep 1
+          done
+          cat /tmp/astro-preview.log
+          exit 1
+
+      - name: Capture
+        run: node scripts/screenshots.mjs
+
+      - name: Upload screenshots
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: visual-evidence-${{ github.sha }}
+          path: /tmp/screenshots/*.png
+          if-no-files-found: error

--- a/changelog/changes/ci-pr-screenshot-artifacts.md
+++ b/changelog/changes/ci-pr-screenshot-artifacts.md
@@ -1,12 +1,13 @@
 ---
 type: changelog
 date: 2026-09-01
-description: Capture pull-request screenshots in CI so visual changes have reproducible before/after evidence.
-tags: [ci, visual-regression, cobogo]
+description: Capture reproducible visual evidence in CI and make the published audiobooks catalog discoverable from global navigation.
+tags: [ci, visual-regression, navigation, audiobooks, cobogo]
 ---
 
-# PR screenshot artifacts
+# Audiobooks navigation with reproducible evidence
 
 - Runs the existing screenshot harness against an Astro preview in pull-request CI.
-- Uploads the captured routes as a workflow artifact for visual review.
-- Makes the before/after evidence required by the Cobogó surface-review loop reproducible from the PR head.
+- Uploads the captured routes as workflow artifacts for before/after visual review.
+- Adds Audiobooks/Audiolivros to the existing secondary Header and Footer navigation, linking to `/audiobooks/` without promoting it to a primary CTA.
+- Keeps claims scoped to the published catalog surface; it does not imply that a disabled podcast/feed is active.

--- a/changelog/changes/ci-pr-screenshot-artifacts.md
+++ b/changelog/changes/ci-pr-screenshot-artifacts.md
@@ -1,0 +1,12 @@
+---
+type: changelog
+date: 2026-09-01
+description: Capture pull-request screenshots in CI so visual changes have reproducible before/after evidence.
+tags: [ci, visual-regression, cobogo]
+---
+
+# PR screenshot artifacts
+
+- Runs the existing screenshot harness against an Astro preview in pull-request CI.
+- Uploads the captured routes as a workflow artifact for visual review.
+- Makes the before/after evidence required by the Cobogó surface-review loop reproducible from the PR head.

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -9,7 +9,7 @@ const year = new Date().getFullYear();
 const prefix = urlPrefix(lang);
 
 // Same grouping/order as Header.astro's primaryLinks + secondaryLinks
-// (essays/projects/about/search, then music/books/ranking/tags/changelog)
+// (essays/projects/about/search, then music/books/audiobooks/ranking/tags/changelog)
 // so the header and footer agree on how the site's sections are organized
 // — they used to both be one flat list; keep them in sync now that the
 // header groups the second half under "More".
@@ -20,6 +20,7 @@ const footerNav = [
   { href: `${prefix}/search/`, label: t(lang, 'nav.search') },
   { href: lang === 'pt' ? `${prefix}/musicas/` : '/music/', label: t(lang, 'nav.music') },
   { href: lang === 'pt' ? `${prefix}/livros/` : '/books/', label: t(lang, 'nav.books') },
+  { href: '/audiobooks/', label: lang === 'pt' ? 'Audiolivros' : 'Audiobooks' },
   { href: `${prefix}/ranking/`, label: t(lang, 'nav.ranking') },
   { href: `${prefix}/tags/`, label: t(lang, 'nav.tags') },
   // English-only by deliberate exception (CLAUDE.md "Línguas") — no /pt/ prefix.

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -14,6 +14,8 @@ const archiveHref = `${prefix}/archive/`;
 const tagsHref = `${prefix}/tags/`;
 const musicHref = lang === 'pt' ? `${prefix}/musicas/` : '/music/';
 const booksHref = lang === 'pt' ? `${prefix}/livros/` : '/books/';
+const audiobooksHref = '/audiobooks/';
+const audiobooksLabel = lang === 'pt' ? 'Audiolivros' : 'Audiobooks';
 const searchHref = `${prefix}/search/`;
 const projectsHref = `${prefix}/projects/`;
 const rankingHref = `${prefix}/ranking/`;
@@ -44,6 +46,7 @@ const primaryLinks = [
 const secondaryLinks = [
   { href: musicHref, label: t(lang, 'nav.music') },
   { href: booksHref, label: t(lang, 'nav.books') },
+  { href: audiobooksHref, label: audiobooksLabel },
   { href: rankingHref, label: t(lang, 'nav.ranking') },
   { href: tagsHref, label: t(lang, 'nav.tags') },
   { href: changelogHref, label: 'Changelog' },


### PR DESCRIPTION
Fecha #1637.

Primeiro commit adiciona uma captura visual reproduzível no CI sem alterar a navegação, para materializar o `before` da home pelo `scripts/screenshots.mjs` já versionado. Depois que esse artefato existir, a mesma PR receberá a mudança mínima em Header/Footer; o push em `main` produzirá o `after` pelo mesmo workflow.

Critério pré-registrado: Header e Footer devem oferecer Audiobooks/Audiolivros para `/audiobooks/` dentro da hierarquia secundária atual, sem virar CTA principal nem anunciar podcast/feed desabilitado.