### PR TITLE
feat(audiobook): advance HPMOR chapter 1 through s0037

### DIFF
--- a/changelog/changes/audiobook-hpmor-s0037.md
+++ b/changelog/changes/audiobook-hpmor-s0037.md
@@ -1,0 +1,11 @@
+---
+type: changelog
+date: 2026-09-01
+description: Advance HPMOR chapter 1 through canonical editorial segment hpmor-001-s0037 and register Feynman in the pronunciation review lexicon.
+tags: [audiobook, hpmor, okf, translation, narration]
+published: false
+---
+
+# HPMOR chapter 1 advances through s0037
+
+Adds aligned source, translation, and narration OKF shards for `hpmor-001-s0037`, preserving stable work/chapter/segment identity and source→translation→narration lineage. The unit introduces the Feynman Lectures reference and records `Feynman` in the work pronunciation lexicon for provider-neutral review before audio synthesis.

--- a/data/audiobooks/hpmor/narration/segments/hpmor-001-s0037.okf.md
+++ b/data/audiobooks/hpmor/narration/segments/hpmor-001-s0037.okf.md
@@ -1,0 +1,21 @@
+---
+type: Audiobook Narration Segment
+work_id: hpmor
+chapter_id: hpmor-001
+segment_id: hpmor-001-s0037
+lang: pt-BR
+derived_from: ../../translation/segments/hpmor-001-s0037.okf.md
+status: canonical-editorial-unit
+speaker: harry
+emotion: earnest-analytical-helpfulness
+pace: medium
+intensity: low
+pause_before_ms: 120
+pause_after_ms: 220
+---
+
+“Mãe”, disse Harry. “Se você quiser ganhar essa discussão com o papai, procure no capítulo dois do primeiro volume das Lições de Física de Feynman. Tem uma citação lá sobre como os filósofos dizem um monte de coisas sobre o que a ciência exige de forma absoluta, e está tudo errado, porque a única regra na ciência é que o árbitro final é a observação — que você simplesmente tem de olhar para o mundo e relatar o que vê. Hum… de cabeça, não consigo lembrar onde encontrar alguma coisa sobre como é um ideal da ciência resolver as coisas por experimento em vez de discussão...”
+
+## Nota de realização oral
+
+Harry fala para ajudar Petunia a tornar a discussão testável, não para exibir erudição. Manter energia juvenil sob linguagem técnica, com clareza especial em `Lições de Física de Feynman`, `árbitro final` e `observação`. A pequena hesitação em `Hum…` e `de cabeça` deve soar como busca real de memória. Não acelerar a enumeração conceitual nem adicionar eventos vocais; a pausa final prepara a resposta emocional de Petunia no segmento seguinte.

--- a/data/audiobooks/hpmor/original/segments/hpmor-001-s0037.okf.md
+++ b/data/audiobooks/hpmor/original/segments/hpmor-001-s0037.okf.md
@@ -1,0 +1,13 @@
+---
+type: Audiobook Source Segment
+work_id: hpmor
+chapter_id: hpmor-001
+segment_id: hpmor-001-s0037
+lang: en
+source_url: https://hpmor.com/chapter/1
+source_digest: sha256:60679402155c618943183da0863a14e6849f34e3da146a01405bd1416a32b358
+source_anchor: chapter-1 living-room argument, Harry points Petunia to the Feynman Lectures and observation as science's final arbiter
+status: canonical-editorial-unit
+---
+
+“Mum,” Harry said. “If you want to win this argument with Dad, look in chapter two of the first book of the Feynman Lectures on Physics. There’s a quote there about how philosophers say a great deal about what science absolutely requires, and it is all wrong, because the only rule in science is that the final arbiter is observation – that you just have to look at the world and report what you see. Um… I can’t think offhand of where to find something about how it’s an ideal of science to settle things by experiment instead of arguments -”

--- a/data/audiobooks/hpmor/pronunciation.yaml
+++ b/data/audiobooks/hpmor/pronunciation.yaml
@@ -30,3 +30,7 @@ entries:
     scope: global
     status: review
     note: Definir pronúncia canônica para pt-BR após amostras reais.
+  - term: Feynman
+    scope: global
+    status: review
+    note: Introduzido em hpmor-001-s0037 em `Lições de Física de Feynman`; preservar a grafia editorial e definir a forma oral pt-BR no benchmark, sem alterar o texto para acomodar um backend específico.

--- a/data/audiobooks/hpmor/translation/segments/hpmor-001-s0037.okf.md
+++ b/data/audiobooks/hpmor/translation/segments/hpmor-001-s0037.okf.md
@@ -1,0 +1,15 @@
+---
+type: Audiobook Translation Segment
+work_id: hpmor
+chapter_id: hpmor-001
+segment_id: hpmor-001-s0037
+lang: pt-BR
+derived_from: ../../original/segments/hpmor-001-s0037.okf.md
+status: canonical-editorial-unit
+---
+
+“Mãe”, disse Harry. “Se você quiser ganhar essa discussão com o papai, procure no capítulo dois do primeiro volume das Lições de Física de Feynman. Tem uma citação lá sobre como os filósofos dizem um monte de coisas sobre o que a ciência exige de forma absoluta, e está tudo errado, porque a única regra na ciência é que o árbitro final é a observação — que você simplesmente tem de olhar para o mundo e relatar o que vê. Hum… de cabeça, não consigo lembrar onde encontrar alguma coisa sobre como é um ideal da ciência resolver as coisas por experimento em vez de discussão...”
+
+## Nota editorial
+
+O título `The Feynman Lectures on Physics` foi vertido pelo título consagrado em português brasileiro, `Lições de Física de Feynman`. A fala preserva o registro precoce e técnico de Harry sem deixá-lo artificialmente acadêmico: `final arbiter` vira `árbitro final`, enquanto `offhand` é naturalizado como `de cabeça`. A hesitação final permanece explícita para não transformar a lembrança parcial de Harry em certeza.


### PR DESCRIPTION
## Objetivo

Avançar exatamente uma unidade editorial de HPMOR, `hpmor-001-s0037`, pela pipeline canônica source/original OKF -> translation OKF -> narration OKF -> validation/readiness.

Esta PR é empilhada sobre #1638. Nenhum conteúdo de `s0038` é criado ou preparado aqui.

## Unidade editorial

A source corresponde à fala imediatamente posterior a `s0036`: Harry orienta Petunia a consultar o capítulo 2 do primeiro volume das *Feynman Lectures on Physics* e resume a ideia de que observação é o árbitro final da ciência, encerrando com uma hesitação sobre onde encontrar uma formulação do ideal de decidir por experimento em vez de discussão.

- source: URL oficial do capítulo, anchor semântico e digest SHA-256;
- translation: usa o título consagrado em pt-BR `Lições de Física de Feynman`, preserva `final arbiter` como `árbitro final` e naturaliza `offhand` como `de cabeça`;
- narration: `speaker: harry`, `emotion: earnest-analytical-helpfulness`, ritmo médio, intensidade baixa e hesitação preservada sem eventos vocais inventados;
- pronunciation: registra `Feynman` no léxico da obra como item de revisão provider-neutral, sem alterar o texto para acomodar backend.

`work_id: hpmor`, `chapter_id: hpmor-001` e `segment_id: hpmor-001-s0037` permanecem idênticos nas três camadas, com lineage source -> translation -> narration.

## Validação e readiness

A base #1638 está verde no workflow `Audiobook OKF`. Esta unidade é produzida sob o gate `okf-parser` por segmento, incluindo identidade, lineage, proveniência, voz, léxico e pré-requisitos editoriais globais.

O capítulo inteiro continua não `ready_for_audio`; nenhum TTS, GPU ou API externa de modelo é acionado.

## Próximo cursor

Se esta PR passar o gate, o estado derivado deve apontar `hpmor-001-s0038` como próxima unidade, sem `state.yaml`.