### PR TITLE
feat(audiobook): advance HPMOR chapter 1 through s0041

### DIFF
--- a/changelog/changes/audiobook-hpmor-s0041.md
+++ b/changelog/changes/audiobook-hpmor-s0041.md
@@ -1,0 +1,11 @@
+---
+type: changelog
+date: 2026-09-01
+description: Advance HPMOR chapter 1 through canonical audiobook editorial segment hpmor-001-s0041 across source, translation, and narration OKF layers.
+tags: [audiobook, hpmor, okf, translation, narration]
+published: false
+---
+
+# HPMOR chapter 1 advances through s0041
+
+Adds the next canonical editorial unit in all three aligned OKF layers. The unit keeps Harry's restrained distress while he withdraws from the family argument, uses the existing mixed-dialogue partition contract for narrator/character alternation, and does not dispatch TTS or touch s0042.

--- a/data/audiobooks/hpmor/narration/segments/hpmor-001-s0041.okf.md
+++ b/data/audiobooks/hpmor/narration/segments/hpmor-001-s0041.okf.md
@@ -1,0 +1,22 @@
+---
+type: Audiobook Narration Segment
+work_id: hpmor
+chapter_id: hpmor-001
+segment_id: hpmor-001-s0041
+lang: pt-BR
+derived_from: ../../translation/segments/hpmor-001-s0041.okf.md
+status: canonical-editorial-unit
+speaker: mixed
+voice_partition: mixed-dialogue-pending
+emotion: restrained-distress
+pace: medium-slow
+intensity: low
+pause_before_ms: 100
+pause_after_ms: 180
+---
+
+"Eu vou para o meu quarto", Harry anunciou. Sua voz tremeu um pouco. "Por favor, tentem não brigar demais por causa disso, mãe, pai. Logo vamos saber no que isso vai dar, não é?"
+
+## Nota de realização oral
+
+A unidade contém fala de Harry, uma frase curta do narrador e nova fala de Harry no mesmo `segment_id`, portanto permanece `voice_partition: mixed-dialogue-pending` até que o contrato de áudio suporte partições internas sem quebrar o alinhamento editorial. Harry deve soar tentando manter o controle, com tensão audível mas sem choro, grito ou dramatização adicional. A frase `Sua voz tremeu um pouco` pertence ao narrador e deve ser lida de modo observacional, sem exagerar o tremor. A pergunta final busca desarmar a briga e obter concordância, não vencer a discussão.

--- a/data/audiobooks/hpmor/original/segments/hpmor-001-s0041.okf.md
+++ b/data/audiobooks/hpmor/original/segments/hpmor-001-s0041.okf.md
@@ -1,0 +1,13 @@
+---
+type: Audiobook Source Segment
+work_id: hpmor
+chapter_id: hpmor-001
+segment_id: hpmor-001-s0041
+lang: en
+source_url: https://hpmor.com/chapter/1
+source_digest: sha256:57b747acc45d8b0e0a6bb49399020800981f7dcaac88199d9bd25a3e4039d3eb
+source_anchor: chapter-1 family argument, Harry announces he is going to his room and asks his parents not to fight too much while they wait for the test
+status: canonical-editorial-unit
+---
+
+"I'm going to go to my room," Harry announced. His voice trembled a little. "Please try not to fight too much about this, Mum, Dad, we'll know soon enough how it comes out, right?"

--- a/data/audiobooks/hpmor/translation/segments/hpmor-001-s0041.okf.md
+++ b/data/audiobooks/hpmor/translation/segments/hpmor-001-s0041.okf.md
@@ -1,0 +1,15 @@
+---
+type: Audiobook Translation Segment
+work_id: hpmor
+chapter_id: hpmor-001
+segment_id: hpmor-001-s0041
+lang: pt-BR
+derived_from: ../../original/segments/hpmor-001-s0041.okf.md
+status: canonical-editorial-unit
+---
+
+"Eu vou para o meu quarto", Harry anunciou. Sua voz tremeu um pouco. "Por favor, tentem não brigar demais por causa disso, mãe, pai. Logo vamos saber no que isso vai dar, não é?"
+
+## Nota editorial
+
+A tradução preserva a tentativa de Harry de se retirar sem transformar a fala em desafio. `His voice trembled a little` permanece explícito e contido, e `we'll know soon enough how it comes out` vira `logo vamos saber no que isso vai dar`, que mantém a referência ao teste iminente sem soar técnico ou artificial em português falado.


### PR DESCRIPTION
## Objetivo

Avançar exatamente uma unidade editorial de HPMOR, `hpmor-001-s0041`, pela pipeline canônica source/original OKF -> translation OKF -> narration OKF -> validation/readiness.

Esta PR é empilhada sobre #1644. Nenhum conteúdo de `s0042` é criado ou preparado aqui.

## Unidade editorial

A source corresponde ao parágrafo imediatamente posterior a `s0040`: Harry anuncia que vai para o quarto, com a voz tremendo um pouco, e pede aos pais que tentem não brigar demais porque logo saberão o resultado do teste.

- source: capítulo oficial, anchor semântico e digest SHA-256;
- translation: preserva a retirada conciliatória e o tremor explícito da voz sem intensificar a emoção;
- narration: unidade mista Harry -> narrador -> Harry, `voice_partition: mixed-dialogue-pending`, `emotion: restrained-distress`, ritmo médio-lento e intensidade baixa;
- voice/pronunciation: usa apenas `harry` e `narrator`, já cadastrados, sem introduzir termo que exija nova entrada de pronúncia.

`work_id: hpmor`, `chapter_id: hpmor-001` e `segment_id: hpmor-001-s0041` permanecem idênticos nas três camadas, com lineage source -> translation -> narration.

## Validação e readiness

A base #1644 passou no workflow `Audiobook OKF`, portanto `s0040` estava validado pelo gate do `okf-parser` antes deste avanço. Esta unidade segue o mesmo contrato por segmento: OKF, identidade, lineage, proveniência, voz, léxico e pré-requisitos editoriais globais.

O capítulo inteiro continua não `ready_for_audio`; nenhum TTS, GPU ou API externa de modelo é acionado.

## Próximo cursor

Se esta PR passar o gate, o estado derivado deve apontar `hpmor-001-s0042` como próxima unidade, sem `state.yaml`.