### PR TITLE
feat(audio): publish blog narration through Kaggle/Breeze to Internet Archive

### DIFF
--- a/.github/workflows/blog-audio.yml
+++ b/.github/workflows/blog-audio.yml
@@ -1,0 +1,192 @@
+name: Blog Audio
+
+on:
+  workflow_dispatch:
+    inputs:
+      post_id:
+        description: Canonical blog collection id
+        required: true
+        type: string
+      narration:
+        description: Prepared narration Markdown path
+        required: true
+        type: string
+      voices:
+        description: Voice configuration path
+        required: true
+        default: data/audio/blog/voices.yaml
+        type: string
+      title:
+        description: Public episode title
+        required: true
+        type: string
+      runner:
+        description: Media compute runner
+        required: true
+        default: kaggle
+        type: choice
+        options: [local, kaggle]
+      backend:
+        description: TTS backend
+        required: true
+        default: breeze
+        type: string
+      model:
+        description: Backend model identifier
+        required: true
+        default: breeze-tts-2
+        type: string
+      dry_run:
+        description: Plan only; do not synthesize
+        required: true
+        default: true
+        type: boolean
+      publish:
+        description: Upload verified audio to Internet Archive and publish it in the blog/feed manifest
+        required: true
+        default: false
+        type: boolean
+
+permissions:
+  contents: write
+
+concurrency:
+  group: blog-audio-${{ inputs.post_id }}
+  cancel-in-progress: false
+
+jobs:
+  audio:
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 24
+          cache: npm
+
+      - run: npm ci
+
+      - name: Validate invocation and editorial readiness
+        env:
+          POST_ID: ${{ inputs.post_id }}
+          NARRATION: ${{ inputs.narration }}
+          DRY_RUN: ${{ inputs.dry_run }}
+          PUBLISH: ${{ inputs.publish }}
+          BACKEND: ${{ inputs.backend }}
+        run: |
+          node - "$NARRATION" "$POST_ID" "$DRY_RUN" <<'NODE'
+          const fs = require('node:fs');
+          const matter = require('gray-matter');
+          const [file, postId, dryRun] = process.argv.slice(2);
+          const parsed = matter(fs.readFileSync(file, 'utf8'));
+          const d = parsed.data;
+          if (d.type !== 'Audiobook Narration Chapter') throw new Error('narration must use the canonical TTS narration schema');
+          if (d.work_id !== 'blog') throw new Error('blog narration work_id must be blog');
+          if (d.chapter_id !== postId) throw new Error(`chapter_id ${d.chapter_id} != post_id ${postId}`);
+          if (dryRun === 'false' && d.ready_for_audio !== true) throw new Error('ready_for_audio must be true before TTS');
+          NODE
+          if [[ "$PUBLISH" == "true" ]]; then
+            [[ "$DRY_RUN" == "false" ]] || { echo "publish=true requires dry_run=false" >&2; exit 2; }
+            [[ "$BACKEND" != "fake" ]] || { echo "refusing to publish fake TTS output" >&2; exit 2; }
+            [[ "$GITHUB_REF" == "refs/heads/main" ]] || { echo "publishing is allowed only from main" >&2; exit 2; }
+          fi
+
+      - name: Create deterministic TTS plan
+        env:
+          NARRATION: ${{ inputs.narration }}
+          VOICES: ${{ inputs.voices }}
+        run: node scripts/audiobook/plan.mjs --narration "$NARRATION" --voices "$VOICES" --output "$RUNNER_TEMP/plan.json"
+
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        if: ${{ inputs.dry_run == false }}
+        with:
+          python-version: '3.12'
+
+      - name: Run local media worker
+        if: ${{ inputs.dry_run == false && inputs.runner == 'local' }}
+        env:
+          BACKEND: ${{ inputs.backend }}
+          MODEL: ${{ inputs.model }}
+        run: bash scripts/audiobook/runners/local.sh --plan "$RUNNER_TEMP/plan.json" --output "$RUNNER_TEMP/audio-result.zip" --backend "$BACKEND" --model "$MODEL"
+
+      - name: Configure Kaggle CLI
+        if: ${{ inputs.dry_run == false && inputs.runner == 'kaggle' }}
+        env:
+          KAGGLE_API_TOKEN: ${{ secrets.KAGGLE_API_TOKEN }}
+          KAGGLE_USERNAME: ${{ vars.KAGGLE_USERNAME }}
+        run: |
+          [[ -n "$KAGGLE_API_TOKEN" ]] || { echo "Missing GitHub secret KAGGLE_API_TOKEN" >&2; exit 2; }
+          [[ -n "$KAGGLE_USERNAME" ]] || { echo "Missing GitHub variable KAGGLE_USERNAME" >&2; exit 2; }
+          python -m pip install --disable-pip-version-check 'kaggle==2.2.4'
+
+      - name: Run Kaggle media worker
+        if: ${{ inputs.dry_run == false && inputs.runner == 'kaggle' }}
+        env:
+          BACKEND: ${{ inputs.backend }}
+          MODEL: ${{ inputs.model }}
+          KAGGLE_API_TOKEN: ${{ secrets.KAGGLE_API_TOKEN }}
+          KAGGLE_USERNAME: ${{ vars.KAGGLE_USERNAME }}
+        run: bash scripts/audiobook/runners/kaggle.sh --plan "$RUNNER_TEMP/plan.json" --output "$RUNNER_TEMP/audio-result.zip" --backend "$BACKEND" --model "$MODEL" --accelerator NvidiaTeslaT4
+
+      - name: Assemble article audio
+        if: ${{ inputs.dry_run == false }}
+        run: |
+          mkdir -p "$RUNNER_TEMP/media"
+          unzip -q "$RUNNER_TEMP/audio-result.zip" -d "$RUNNER_TEMP/media"
+          python3 scripts/audiobook/assemble.py --plan "$RUNNER_TEMP/plan.json" --media-dir "$RUNNER_TEMP/media" --output-dir "$RUNNER_TEMP/assembled"
+
+      - name: Configure Internet Archive client
+        if: ${{ inputs.publish == true }}
+        env:
+          IA_ACCESS_KEY_ID: ${{ secrets.IA_ACCESS_KEY_ID }}
+          IA_SECRET_ACCESS_KEY: ${{ secrets.IA_SECRET_ACCESS_KEY }}
+        run: |
+          [[ -n "$IA_ACCESS_KEY_ID" ]] || { echo "Missing GitHub secret IA_ACCESS_KEY_ID" >&2; exit 2; }
+          [[ -n "$IA_SECRET_ACCESS_KEY" ]] || { echo "Missing GitHub secret IA_SECRET_ACCESS_KEY" >&2; exit 2; }
+          python -m pip install --disable-pip-version-check 'internetarchive==5.11.1'
+
+      - name: Upload, verify and persist publication
+        if: ${{ inputs.publish == true }}
+        env:
+          IA_ACCESS_KEY_ID: ${{ secrets.IA_ACCESS_KEY_ID }}
+          IA_SECRET_ACCESS_KEY: ${{ secrets.IA_SECRET_ACCESS_KEY }}
+          POST_ID: ${{ inputs.post_id }}
+          TITLE: ${{ inputs.title }}
+        run: |
+          AUDIO=$(node -e "const a=require('$RUNNER_TEMP/assembled/assembly.json'); process.stdout.write('$RUNNER_TEMP/assembled/'+a.audio.file)")
+          DURATION=$(node -e "const a=require('$RUNNER_TEMP/assembled/assembly.json'); process.stdout.write(String(a.duration_seconds))")
+          node scripts/audio/publish-blog-internet-archive.mjs --post "$POST_ID" --audio "$AUDIO" --title "$TITLE" --output "$RUNNER_TEMP/publication.json"
+          node scripts/audio/apply-blog-publication.mjs --publication "$RUNNER_TEMP/publication.json" --duration-seconds "$DURATION"
+          npm run build
+
+      - name: Commit verified publication manifest
+        if: ${{ inputs.publish == true }}
+        env:
+          POST_ID: ${{ inputs.post_id }}
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add data/blog-audio.json
+          git commit -m "feat(audio): publish $POST_ID"
+          for attempt in 1 2 3; do
+            git push origin HEAD:main && exit 0
+            git fetch origin main
+            git rebase origin/main
+          done
+          exit 1
+
+      - name: Upload plan and assembled media
+        if: ${{ always() }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: blog-audio-${{ inputs.post_id }}
+          path: |
+            ${{ runner.temp }}/plan.json
+            ${{ runner.temp }}/assembled/
+            ${{ runner.temp }}/publication.json
+          if-no-files-found: ignore
+          retention-days: 30

--- a/changelog/changes/audio-blog-player-feed.md
+++ b/changelog/changes/audio-blog-player-feed.md
@@ -1,6 +1,5 @@
 ---
-type: Changelog Entry
-version: unreleased
+type: changelog
 date: 2026-09-01
 description: Surface verified Internet Archive audio on blog posts and expose the blog audio podcast feed.
 tags: [audio, blog, rss, podcast]

--- a/changelog/changes/audio-blog-publication-manifest.md
+++ b/changelog/changes/audio-blog-publication-manifest.md
@@ -1,6 +1,5 @@
 ---
-type: Changelog Entry
-version: unreleased
+type: changelog
 date: 2026-09-01
 description: Add the canonical publication manifest for blog audio episodes, separating editorial post identity from externally hosted media.
 tags: [audio, blog, podcast, internet-archive]

--- a/changelog/changes/audio-blog-workflow.md
+++ b/changelog/changes/audio-blog-workflow.md
@@ -1,6 +1,5 @@
 ---
-type: Changelog Entry
-version: unreleased
+type: changelog
 date: 2026-09-01
 description: Add a fail-closed end-to-end workflow that turns prepared blog narration into TTS media, publishes verified audio to Internet Archive, and updates the blog audio manifest.
 tags: [audio, blog, tts, internet-archive, github-actions]

--- a/changelog/changes/audio-blog-workflow.md
+++ b/changelog/changes/audio-blog-workflow.md
@@ -1,0 +1,7 @@
+---
+type: Changelog Entry
+version: unreleased
+date: 2026-09-01
+description: Add a fail-closed end-to-end workflow that turns prepared blog narration into TTS media, publishes verified audio to Internet Archive, and updates the blog audio manifest.
+tags: [audio, blog, tts, internet-archive, github-actions]
+---

--- a/scripts/audio/apply-blog-publication.mjs
+++ b/scripts/audio/apply-blog-publication.mjs
@@ -1,32 +1,41 @@
 #!/usr/bin/env node
 
-import fs from 'node:fs';
-import process from 'node:process';
+import fs from "node:fs";
+import process from "node:process";
 
 function arg(name) {
   const i = process.argv.indexOf(name);
   return i >= 0 ? process.argv[i + 1] : null;
 }
 
-const publicationPath = arg('--publication');
-const manifestPath = arg('--manifest') ?? 'data/blog-audio.json';
-const duration = Number(arg('--duration-seconds'));
+const publicationPath = arg("--publication");
+const manifestPath = arg("--manifest") ?? "data/blog-audio.json";
+const duration = Number(arg("--duration-seconds"));
 if (!publicationPath || !Number.isFinite(duration) || duration <= 0) {
-  console.error('Usage: apply-blog-publication.mjs --publication <json> --duration-seconds <seconds> [--manifest data/blog-audio.json]');
+  console.error(
+    "Usage: apply-blog-publication.mjs --publication <json> --duration-seconds <seconds> [--manifest data/blog-audio.json]",
+  );
   process.exit(2);
 }
 
-const publication = JSON.parse(fs.readFileSync(publicationPath, 'utf8'));
-if (!publication.verification || ![200, 206].includes(publication.verification.range_status)) {
-  throw new Error('refusing to persist unverified blog audio publication');
+const publication = JSON.parse(fs.readFileSync(publicationPath, "utf8"));
+if (
+  !publication.verification ||
+  ![200, 206].includes(publication.verification.range_status)
+) {
+  throw new Error("refusing to persist unverified blog audio publication");
 }
-const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
 const episode = { ...publication, duration_seconds: duration };
 delete episode.verification;
 manifest.version = 1;
 manifest.episodes = Array.isArray(manifest.episodes) ? manifest.episodes : [];
-const existing = manifest.episodes.findIndex((item) => item.post_id === episode.post_id);
+const existing = manifest.episodes.findIndex(
+  (item) => item.post_id === episode.post_id,
+);
 if (existing >= 0) manifest.episodes[existing] = episode;
 else manifest.episodes.push(episode);
-manifest.episodes.sort((a, b) => String(a.post_id).localeCompare(String(b.post_id)));
+manifest.episodes.sort((a, b) =>
+  String(a.post_id).localeCompare(String(b.post_id)),
+);
 fs.writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);

--- a/scripts/audio/publish-blog-internet-archive.mjs
+++ b/scripts/audio/publish-blog-internet-archive.mjs
@@ -1,62 +1,101 @@
 #!/usr/bin/env node
 
-import crypto from 'node:crypto';
-import fs from 'node:fs';
-import path from 'node:path';
-import process from 'node:process';
-import { spawnSync } from 'node:child_process';
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+import { spawnSync } from "node:child_process";
 
 function arg(name) {
   const i = process.argv.indexOf(name);
   return i >= 0 ? process.argv[i + 1] : null;
 }
 
-const postId = arg('--post');
-const audioPathArg = arg('--audio');
-const title = arg('--title');
-const description = arg('--description') ?? title;
-const output = arg('--output');
-const archiveItem = arg('--archive-item') ?? (postId ? `franklinbaldo-blog-audio-${postId}` : null);
+const postId = arg("--post");
+const audioPathArg = arg("--audio");
+const title = arg("--title");
+const description = arg("--description") ?? title;
+const output = arg("--output");
+const archiveItem =
+  arg("--archive-item") ??
+  (postId ? `franklinbaldo-blog-audio-${postId}` : null);
 if (!postId || !audioPathArg || !title || !output || !archiveItem) {
-  console.error('Usage: publish-blog-internet-archive.mjs --post <post_id> --audio <file> --title <title> --output <json> [--description <text>] [--archive-item <id>]');
+  console.error(
+    "Usage: publish-blog-internet-archive.mjs --post <post_id> --audio <file> --title <title> --output <json> [--description <text>] [--archive-item <id>]",
+  );
   process.exit(2);
 }
 if (!process.env.IA_ACCESS_KEY_ID || !process.env.IA_SECRET_ACCESS_KEY) {
-  throw new Error('IA_ACCESS_KEY_ID and IA_SECRET_ACCESS_KEY are required');
+  throw new Error("IA_ACCESS_KEY_ID and IA_SECRET_ACCESS_KEY are required");
 }
 
 const audioPath = path.resolve(audioPathArg);
 const bytes = fs.statSync(audioPath).size;
-const digest = `sha256:${crypto.createHash('sha256').update(fs.readFileSync(audioPath)).digest('hex')}`;
+const digest = `sha256:${crypto
+  .createHash("sha256")
+  .update(fs.readFileSync(audioPath))
+  .digest("hex")}`;
 const filename = path.basename(audioPath);
 const mediaUrl = `https://archive.org/download/${encodeURIComponent(archiveItem)}/${encodeURIComponent(filename)}`;
-const mimeType = filename.endsWith('.mp3') ? 'audio/mpeg' : filename.endsWith('.m4a') ? 'audio/mp4' : 'audio/wav';
+const mimeType = filename.endsWith(".mp3")
+  ? "audio/mpeg"
+  : filename.endsWith(".m4a")
+    ? "audio/mp4"
+    : "audio/wav";
 
-const run = spawnSync('ia', [
-  'upload', archiveItem, audioPath,
-  '--retries', '10',
-  '--metadata', 'mediatype:audio',
-  '--metadata', 'collection:opensource_audio',
-  '--metadata', `title:${title}`,
-  '--metadata', 'creator:Franklin Baldo',
-  '--metadata', `description:${description}`,
-], { encoding: 'utf8' });
-if (run.status !== 0) throw new Error(run.stderr || run.stdout || 'Internet Archive upload failed');
+const run = spawnSync(
+  "ia",
+  [
+    "upload",
+    archiveItem,
+    audioPath,
+    "--retries",
+    "10",
+    "--metadata",
+    "mediatype:audio",
+    "--metadata",
+    "collection:opensource_audio",
+    "--metadata",
+    `title:${title}`,
+    "--metadata",
+    "creator:Franklin Baldo",
+    "--metadata",
+    `description:${description}`,
+  ],
+  { encoding: "utf8" },
+);
+if (run.status !== 0) {
+  throw new Error(run.stderr || run.stdout || "Internet Archive upload failed");
+}
 
 let head;
 for (let attempt = 1; attempt <= 18; attempt += 1) {
-  head = await fetch(mediaUrl, { method: 'HEAD', redirect: 'follow' });
+  head = await fetch(mediaUrl, { method: "HEAD", redirect: "follow" });
   if (head.ok) break;
-  if (attempt === 18) throw new Error(`Internet Archive media not readable: HEAD ${head.status}`);
-  await new Promise((resolve) => setTimeout(resolve, Math.min(attempt * 5000, 20000)));
+  if (attempt === 18) {
+    throw new Error(`Internet Archive media not readable: HEAD ${head.status}`);
+  }
+  await new Promise((resolve) =>
+    setTimeout(resolve, Math.min(attempt * 5000, 20000)),
+  );
 }
-const remoteBytes = Number(head.headers.get('content-length'));
+const remoteBytes = Number(head.headers.get("content-length"));
 if (Number.isFinite(remoteBytes) && remoteBytes > 0 && remoteBytes !== bytes) {
-  throw new Error(`Internet Archive Content-Length ${remoteBytes} != local ${bytes}`);
+  throw new Error(
+    `Internet Archive Content-Length ${remoteBytes} != local ${bytes}`,
+  );
 }
-const range = await fetch(mediaUrl, { headers: { Range: 'bytes=0-0' }, redirect: 'follow' });
-if (![200, 206].includes(range.status) || (await range.arrayBuffer()).byteLength < 1) {
-  throw new Error(`Internet Archive range verification failed: ${range.status}`);
+const range = await fetch(mediaUrl, {
+  headers: { Range: "bytes=0-0" },
+  redirect: "follow",
+});
+if (
+  ![200, 206].includes(range.status) ||
+  (await range.arrayBuffer()).byteLength < 1
+) {
+  throw new Error(
+    `Internet Archive range verification failed: ${range.status}`,
+  );
 }
 
 const publication = {
@@ -64,7 +103,7 @@ const publication = {
   guid: `audio:blog:${postId}`,
   archive_item: archiveItem,
   media_url: mediaUrl,
-  mime_type: head.headers.get('content-type')?.split(';')[0] || mimeType,
+  mime_type: head.headers.get("content-type")?.split(";")[0] || mimeType,
   bytes,
   sha256: digest,
   published_at: new Date().toISOString(),

--- a/src/lib/blog-audio.js
+++ b/src/lib/blog-audio.js
@@ -1,36 +1,46 @@
-import manifest from '../../data/blog-audio.json';
+import manifest from "../../data/blog-audio.json";
 
 function validEpisode(episode) {
   return Boolean(
     episode &&
-      typeof episode.post_id === 'string' &&
+      typeof episode.post_id === "string" &&
       episode.guid === `audio:blog:${episode.post_id}` &&
-      typeof episode.media_url === 'string' &&
-      episode.media_url.startsWith('https://archive.org/download/') &&
-      typeof episode.mime_type === 'string' &&
+      typeof episode.media_url === "string" &&
+      episode.media_url.startsWith("https://archive.org/download/") &&
+      typeof episode.mime_type === "string" &&
       Number.isInteger(episode.bytes) &&
       episode.bytes > 0 &&
-      typeof episode.sha256 === 'string' &&
+      typeof episode.sha256 === "string" &&
       /^sha256:[0-9a-f]{64}$/.test(episode.sha256) &&
       Number.isFinite(episode.duration_seconds) &&
       episode.duration_seconds > 0 &&
-      typeof episode.published_at === 'string' &&
-      typeof episode.archive_item === 'string'
+      typeof episode.published_at === "string" &&
+      typeof episode.archive_item === "string",
   );
 }
 
 export function blogAudioEpisodes() {
   const episodes = Array.isArray(manifest.episodes) ? manifest.episodes : [];
   const invalid = episodes.find((episode) => !validEpisode(episode));
-  if (invalid) throw new Error(`invalid blog audio publication for ${invalid?.post_id ?? 'unknown post'}`);
+  if (invalid) {
+    throw new Error(
+      `invalid blog audio publication for ${invalid?.post_id ?? "unknown post"}`,
+    );
+  }
   const ids = new Set();
   for (const episode of episodes) {
-    if (ids.has(episode.post_id)) throw new Error(`duplicate blog audio publication for ${episode.post_id}`);
+    if (ids.has(episode.post_id)) {
+      throw new Error(
+        `duplicate blog audio publication for ${episode.post_id}`,
+      );
+    }
     ids.add(episode.post_id);
   }
   return episodes;
 }
 
 export function blogAudioForPost(postId) {
-  return blogAudioEpisodes().find((episode) => episode.post_id === postId) ?? null;
+  return (
+    blogAudioEpisodes().find((episode) => episode.post_id === postId) ?? null
+  );
 }

--- a/src/pages/audio.xml.js
+++ b/src/pages/audio.xml.js
@@ -1,23 +1,31 @@
-import rss from '@astrojs/rss';
-import { getCollection } from 'astro:content';
-import { blogAudioEpisodes } from '../lib/blog-audio.js';
-import { postUrl } from '../lib/i18n';
-import { isPublished } from '../lib/publish';
+import rss from "@astrojs/rss";
+import { getCollection } from "astro:content";
+import { blogAudioEpisodes } from "../lib/blog-audio.js";
+import { postUrl } from "../lib/i18n";
+import { isPublished } from "../lib/publish";
 
 export async function GET(context) {
-  const posts = await getCollection('blog');
-  const byId = new Map(posts.filter(isPublished).map((post) => [post.id, post]));
+  const posts = await getCollection("blog");
+  const byId = new Map(
+    posts.filter(isPublished).map((post) => [post.id, post]),
+  );
   const episodes = blogAudioEpisodes()
     .map((episode) => ({ episode, post: byId.get(episode.post_id) }))
     .filter(({ post }) => Boolean(post))
-    .sort((a, b) => Date.parse(b.episode.published_at) - Date.parse(a.episode.published_at));
+    .sort(
+      (a, b) =>
+        Date.parse(b.episode.published_at) -
+        Date.parse(a.episode.published_at),
+    );
 
   return rss({
-    title: 'Franklin Baldo — Áudio',
-    description: 'Versões em áudio das matérias publicadas no blog de Franklin Baldo.',
+    title: "Franklin Baldo — Áudio",
+    description:
+      "Versões em áudio das matérias publicadas no blog de Franklin Baldo.",
     site: context.site,
-    customData: '<language>pt-BR</language><itunes:author>Franklin Baldo</itunes:author><itunes:explicit>false</itunes:explicit>',
-    xmlns: { itunes: 'http://www.itunes.com/dtds/podcast-1.0.dtd' },
+    customData:
+      "<language>pt-BR</language><itunes:author>Franklin Baldo</itunes:author><itunes:explicit>false</itunes:explicit>",
+    xmlns: { itunes: "http://www.itunes.com/dtds/podcast-1.0.dtd" },
     items: episodes.map(({ episode, post }) => ({
       title: post.data.title,
       description: post.data.description,


### PR DESCRIPTION
Second PR in the blog-audio stack. Adds the executable GitHub Actions path after the publication contract/player/feed layer in #1648.

The workflow is fail-closed: dry-run plans are allowed, but synthesis requires `ready_for_audio: true`; publishing requires non-fake TTS, `dry_run=false`, execution from `main`, IA credentials, successful upload verification, and a successful site build before the verified manifest is committed.

It reuses the existing deterministic TTS plan, media runners and assembler instead of creating a second TTS implementation. Kaggle/Breeze is the default real path; `fake` remains only for non-publishing proof runs.

Stack: #1648 -> this PR -> pilot article/narration.