### PR TITLE
feat(audio): add first audio-ready blog article pilot

### DIFF
--- a/changelog/changes/audio-blog-first-pilot.md
+++ b/changelog/changes/audio-blog-first-pilot.md
@@ -1,0 +1,7 @@
+---
+type: Changelog Entry
+version: unreleased
+date: 2026-09-01
+description: Add the first audio-ready blog article with canonical narrator, pronunciation policy, editorial guidance and prepared narration for the blog-audio workflow.
+tags: [audio, blog, tts, podcast]
+---

--- a/changelog/changes/audio-blog-first-pilot.md
+++ b/changelog/changes/audio-blog-first-pilot.md
@@ -1,6 +1,5 @@
 ---
-type: Changelog Entry
-version: unreleased
+type: changelog
 date: 2026-09-01
 description: Add the first audio-ready blog article with canonical narrator, pronunciation policy, editorial guidance and prepared narration for the blog-audio workflow.
 tags: [audio, blog, tts, podcast]

--- a/changelog/changes/audio-blog-player-feed.md
+++ b/changelog/changes/audio-blog-player-feed.md
@@ -1,6 +1,5 @@
 ---
-type: Changelog Entry
-version: unreleased
+type: changelog
 date: 2026-09-01
 description: Surface verified Internet Archive audio on blog posts and expose the blog audio podcast feed.
 tags: [audio, blog, rss, podcast]

--- a/changelog/changes/audio-blog-publication-manifest.md
+++ b/changelog/changes/audio-blog-publication-manifest.md
@@ -1,6 +1,5 @@
 ---
-type: Changelog Entry
-version: unreleased
+type: changelog
 date: 2026-09-01
 description: Add the canonical publication manifest for blog audio episodes, separating editorial post identity from externally hosted media.
 tags: [audio, blog, podcast, internet-archive]

--- a/changelog/changes/audio-blog-workflow.md
+++ b/changelog/changes/audio-blog-workflow.md
@@ -1,6 +1,5 @@
 ---
-type: Changelog Entry
-version: unreleased
+type: changelog
 date: 2026-09-01
 description: Add a fail-closed end-to-end workflow that turns prepared blog narration into TTS media, publishes verified audio to Internet Archive, and updates the blog audio manifest.
 tags: [audio, blog, tts, internet-archive, github-actions]

--- a/data/audio/blog/editorial.md
+++ b/data/audio/blog/editorial.md
@@ -1,0 +1,16 @@
+---
+type: Audio Editorial Guide
+audience: blog
+lang: pt-BR
+status: canonical
+---
+
+# Guia editorial de áudio do blog
+
+A matéria publicada é a fonte canônica. A versão de narração pode apenas adaptar a realização oral: expandir siglas, resolver pronúncias, inserir pausas, dividir frases excessivamente longas e omitir elementos puramente visuais que não carreguem conteúdo proposicional. Não pode acrescentar fatos, argumentos, exemplos ou conclusões.
+
+A voz padrão é `narrator`, definida em `voices.yaml`. A direção deve privilegiar fala brasileira natural, sem voz de locutor, dramatização artificial ou eventos vocais inventados. Termos cobertos por `pronunciation.yaml` devem seguir aquela leitura.
+
+`ready_for_audio: true` significa que a derivação foi revista contra a matéria canônica, identidade e lineage estão estáveis, voz e pronúncia foram resolvidas e nenhum gate editorial permanece aberto. Só depois disso TTS externo pode ser acionado.
+
+O binário final nunca entra no Git. Ele é publicado no Internet Archive, verificado por HEAD, byte range e tamanho, e somente então entra em `data/blog-audio.json`, que alimenta player, índice e feed.

--- a/data/audio/blog/o-blog-agora-tem-audio/narration.md
+++ b/data/audio/blog/o-blog-agora-tem-audio/narration.md
@@ -1,0 +1,34 @@
+---
+type: Audiobook Narration Chapter
+work_id: blog
+chapter_id: o-blog-agora-tem-audio
+post_id: o-blog-agora-tem-audio
+lang: pt-BR
+derived_from: ../../../../src/content/blog/o-blog-agora-tem-audio.mdx
+editorial_guide: ../editorial.md
+voices: ../voices.yaml
+pronunciation_guide: ../pronunciation.yaml
+ready_for_audio: true
+status: canonical-editorial-unit
+---
+
+<!-- tts: {"id":"o-blog-agora-tem-audio-s0001","speaker":"narrator","emotion":"reflective","pace":"medium","intensity":"low"} -->
+Eu comecei querendo uma fábrica de audiolivros. No caminho, ficou claro que a parte mais útil da infraestrutura não tinha nada de exclusiva a livros: era uma pipeline que transforma texto editorialmente controlado em áudio publicável.
+
+<!-- tts: {"id":"o-blog-agora-tem-audio-s0002","speaker":"narrator","emotion":"clear-explanatory","pace":"medium","intensity":"low"} -->
+A partir de agora, qualquer matéria do blog pode ganhar uma versão para ouvir. O Markdown publicado continua sendo a fonte canônica. A narração é preparada como uma camada derivada, com decisões explícitas de voz, ritmo e pronúncia. Só depois de essa camada ficar pronta o T T S pode rodar.
+
+<!-- tts: {"id":"o-blog-agora-tem-audio-s0003","speaker":"narrator","emotion":"matter-of-fact","pace":"medium","intensity":"low"} -->
+A síntese pode usar runners de GPU gratuitos, como Kaggle, e o backend de voz fica separado do trabalho editorial. Isso importa porque tradução, reescrita e preparação da narração continuam sendo trabalho editorial; o modelo externo entra apenas para transformar a versão já aprovada em som.
+
+<!-- tts: {"id":"o-blog-agora-tem-audio-s0004","speaker":"narrator","emotion":"precise-explanatory","pace":"medium","intensity":"low"} -->
+Os arquivos de áudio finais não ficam no Git. Eles são enviados para o Internet Archive. Antes de o site publicar qualquer player, a pipeline verifica se o arquivo está realmente público, se responde a uma requisição parcial e se o tamanho remoto corresponde ao arquivo produzido.
+
+<!-- tts: {"id":"o-blog-agora-tem-audio-s0005","speaker":"narrator","emotion":"upbeat-explanatory","pace":"medium","intensity":"low"} -->
+Depois da verificação, um único manifesto de publicação alimenta três superfícies: o player dentro da própria matéria, uma página com todos os áudios do blog e um feed R S S de áudio. Na prática, o blog também passa a funcionar como um podcast.
+
+<!-- tts: {"id":"o-blog-agora-tem-audio-s0006","speaker":"narrator","emotion":"expansive","pace":"medium","intensity":"low"} -->
+A mesma camada continua servindo aos audiolivros. H P M O R é uma obra; uma matéria é outra unidade editorial; amanhã a Bhagavad Gita pode usar a mesma infraestrutura. O que muda é a fonte e o contrato editorial. A mídia, a verificação e a publicação não precisam ser reinventadas.
+
+<!-- tts: {"id":"o-blog-agora-tem-audio-s0007","speaker":"narrator","emotion":"inviting-conclusion","pace":"medium-slow","intensity":"low"} -->
+Este texto é o primeiro piloto dessa nova trilha. Se você estiver lendo depois de a geração de mídia ter sido concluída, deve haver um player no topo da matéria — e o mesmo episódio deve aparecer no feed de áudio do blog.

--- a/data/audio/blog/pronunciation.yaml
+++ b/data/audio/blog/pronunciation.yaml
@@ -1,0 +1,15 @@
+version: 1
+locale: pt-BR
+entries:
+  - term: OKF
+    say_as: "ó-ká-éfe"
+  - term: GitHub
+    say_as: "guít-râb"
+  - term: Internet Archive
+    say_as: "ínternet árkaiv"
+  - term: TTS
+    say_as: "tê-tê-ésse"
+  - term: Breeze
+    say_as: "bríz"
+  - term: Kaggle
+    say_as: "káguel"

--- a/data/audio/blog/voices.yaml
+++ b/data/audio/blog/voices.yaml
@@ -1,0 +1,5 @@
+default_locale: pt-BR
+voices:
+  narrator:
+    description: "A warm, thoughtful Brazilian Portuguese narrator with a clear voice and calm, reflective delivery. Natural conversational pacing, precise diction, no announcer affectation."
+    seed: 41021

--- a/src/content/blog/o-blog-agora-tem-audio.mdx
+++ b/src/content/blog/o-blog-agora-tem-audio.mdx
@@ -1,0 +1,23 @@
+---
+type: Blog Post
+title: O blog agora também é para ouvir
+description: Como transformei a infraestrutura de audiolivros em uma pipeline geral de áudio para matérias, com TTS em GPU gratuita, mídia no Internet Archive e feed próprio.
+date: 2026-09-01
+lang: pt
+tags: [audio, podcast, tts, internet-archive, okf]
+docType: technical
+---
+
+Eu comecei querendo uma fábrica de audiolivros. No caminho, ficou claro que a parte mais útil da infraestrutura não tinha nada de exclusiva a livros: era uma pipeline que transforma texto editorialmente controlado em áudio publicável.
+
+A partir de agora, qualquer matéria do blog pode ganhar uma versão para ouvir. O Markdown publicado continua sendo a fonte canônica. A narração é preparada como uma camada derivada, com decisões explícitas de voz, ritmo e pronúncia. Só depois de essa camada ficar pronta o TTS pode rodar.
+
+A síntese pode usar runners de GPU gratuitos, como Kaggle, e o backend de voz fica separado do trabalho editorial. Isso importa porque tradução, reescrita e preparação da narração continuam sendo trabalho editorial; o modelo externo entra apenas para transformar a versão já aprovada em som.
+
+Os arquivos de áudio finais não ficam no Git. Eles são enviados para o Internet Archive. Antes de o site publicar qualquer player, a pipeline verifica se o arquivo está realmente público, se responde a uma requisição parcial e se o tamanho remoto corresponde ao arquivo produzido.
+
+Depois da verificação, um único manifesto de publicação alimenta três superfícies: o player dentro da própria matéria, uma página com todos os áudios do blog e um feed RSS de áudio. Na prática, o blog também passa a funcionar como um podcast.
+
+A mesma camada continua servindo aos audiolivros. HPMOR é uma obra; uma matéria é outra unidade editorial; amanhã a Bhagavad Gita pode usar a mesma infraestrutura. O que muda é a fonte e o contrato editorial. A mídia, a verificação e a publicação não precisam ser reinventadas.
+
+Este texto é o primeiro piloto dessa nova trilha. Se você estiver lendo depois de a geração de mídia ter sido concluída, deve haver um player no topo da matéria — e o mesmo episódio deve aparecer no feed de áudio do blog.


### PR DESCRIPTION
Third PR in the blog-audio stack. Adds the first real editorial unit prepared for the new pipeline.

Includes:
- canonical blog narrator voice;
- pronunciation policy for OKF/GitHub/Internet Archive/TTS/Breeze/Kaggle;
- blog-audio editorial/readiness guide;
- new post `o-blog-agora-tem-audio`;
- prepared narration with stable ids, lineage and `ready_for_audio: true`;
- changelog entry.

No external model was used to write or adapt the article/narration. After this stack lands on `main`, the `Blog Audio` workflow can synthesize this pilot with Kaggle/Breeze, publish the verified MP3 to Internet Archive, commit the publication manifest, and the same manifest will surface it in the article player, `/audio/`, and `/audio.xml`.

Stack: #1648 -> #1649 -> this PR.