### PR TITLE
feat(audiobook): make narration shards directly executable by TTS

### DIFF
--- a/changelog/changes/audiobook-tts-ready-narration-contract.md
+++ b/changelog/changes/audiobook-tts-ready-narration-contract.md
@@ -1,0 +1,9 @@
+---
+type: Change Card
+title: Narration shards gain an executable TTS body contract
+description: Specifies and validates that narration frontmatter carries non-spoken controls while the Markdown body is the exact TTS payload, and adds agent skills for the audiobook editorial workflow.
+tags: [audiobook, narration, tts, okf, validation, skills]
+timestamp: 2026-09-01T21:12:00Z
+---
+
+Formaliza `tts_body_contract: tts-input-v1` para narration shards. O body de um shard marcado passa a ser validado como payload TTS puro, sem headings, notas editoriais, fenced code, comentários ou outras estruturas de documentação. A especificação estabelece que notas e direção não faladas pertencem ao frontmatter. Também adiciona skills para avanço de unidade editorial e preparação/revisão de narration shards. Shards legados permanecem em migração até receberem o marcador; nenhum TTS é disparado por esta mudança.

--- a/data/audiobooks/hpmor/narration/segments/hpmor-001-s0043.okf.md
+++ b/data/audiobooks/hpmor/narration/segments/hpmor-001-s0043.okf.md
@@ -12,6 +12,7 @@ pace: medium-slow
 intensity: low
 pause_before_ms: 160
 pause_after_ms: 180
+tts_body_contract: tts-input-v1
 editorial_notes:
   - "Narração única e contida."
   - "A frase funciona como transição entre a discussão familiar e a análise interna de Harry; marcar levemente o isolamento sugerido por fechar a porta e terminar com atenção recolhida em tentou pensar."

--- a/docs/okf/audiobook/guides/narration.md
+++ b/docs/okf/audiobook/guides/narration.md
@@ -99,3 +99,13 @@ Erro observado no áudio deve ser corrigido na camada mais alta adequada:
 - problema de um backend específico -> adapter/configuração do backend.
 
 Não contaminar o corpus global com workaround específico de modelo quando o adapter consegue resolver.
+
+## 10. Contrato executável do narration shard
+
+Novos `Audiobook Narration Segment` usam `tts_body_contract: tts-input-v1`.
+
+Nesse contrato, o frontmatter contém identidade, lineage, direção de voz, prosódia, pausas e qualquer nota não falada. Notas de realização pertencem a `editorial_notes` ou a outro campo estruturado de frontmatter.
+
+O body contém exclusivamente o texto a ser enviado ao TTS. Não colocar depois do texto seções como `## Nota de realização oral`, observações editoriais, instruções ao modelo ou documentação. O consumidor deve poder executar `tts(body.strip(), frontmatter)` sem limpeza heurística.
+
+A especificação normativa detalhada está em `docs/okf/audiobook/narration-segment-contract.md`.

--- a/docs/okf/audiobook/narration-segment-contract.md
+++ b/docs/okf/audiobook/narration-segment-contract.md
@@ -1,0 +1,94 @@
+---
+type: Specification
+title: Audiobook Narration Segment — contrato TTS-ready
+description: Contrato executável entre a camada editorial de narração e qualquer backend TTS.
+tags: [audiobook, narration, tts, okf, specification]
+timestamp: 2026-09-01T21:08:00Z
+---
+
+# Audiobook Narration Segment — contrato TTS-ready
+
+## Objetivo
+
+Um `Audiobook Narration Segment` canônico é uma unidade diretamente consumível pela etapa TTS. O consumidor não deve precisar remover notas, interpretar headings editoriais ou adivinhar qual parte do Markdown deve ser falada.
+
+O contrato é deliberadamente simples:
+
+```text
+frontmatter -> metadados, identidade, lineage, voz, prosódia, parâmetros e notas
+body        -> exatamente o texto enviado ao TTS
+```
+
+## Invariante principal
+
+O body de um narration shard marcado com `tts_body_contract: tts-input-v1` MUST conter somente material destinado à síntese de voz. Depois de remover o frontmatter e o whitespace externo, o resultado pode ser entregue diretamente ao adapter TTS.
+
+Nenhuma etapa posterior pode depender de limpeza heurística como "cortar tudo depois de ## Nota".
+
+## O que pertence ao frontmatter
+
+Pertencem ao frontmatter:
+
+- `work_id`, `chapter_id`, `segment_id`, `lang`, `derived_from` e `status`;
+- `speaker`, `voice_partition` quando aplicável;
+- `emotion`, `pace`, `intensity`, `pause_before_ms`, `pause_after_ms`;
+- `tts_body_contract`;
+- notas editoriais ou de realização em `editorial_notes`;
+- exceções locais de pronúncia ou intenção quando previstas pelo schema;
+- qualquer informação de controle que não deve ser pronunciada.
+
+## O que pertence ao body
+
+Somente a realização oral final da unidade. O body pode conter parágrafos e pontuação necessária à fala, mas não documentação sobre como narrar o próprio texto.
+
+## Conteúdo proibido no body
+
+O body TTS-ready MUST NOT conter:
+
+- headings Markdown;
+- listas editoriais;
+- fenced code blocks;
+- comentários HTML;
+- links ou imagens em sintaxe Markdown destinados apenas ao leitor visual;
+- seções como `Nota de realização oral`, `Nota editorial`, `Observação` ou equivalentes;
+- instruções ao modelo, ao narrador ou ao operador;
+- metadata duplicada do frontmatter.
+
+Se algo precisa orientar o TTS sem ser falado, ele pertence ao frontmatter ou ao adapter do backend.
+
+## Exemplo
+
+```yaml
+---
+type: Audiobook Narration Segment
+work_id: hpmor
+chapter_id: hpmor-001
+segment_id: hpmor-001-s0043
+lang: pt-BR
+derived_from: ../../translation/segments/hpmor-001-s0043.okf.md
+status: canonical-editorial-unit
+speaker: narrator
+emotion: inward-focus
+pace: medium-slow
+intensity: low
+pause_before_ms: 160
+pause_after_ms: 180
+tts_body_contract: tts-input-v1
+editorial_notes:
+  - "Narração única e contida."
+---
+
+Ele fechou a porta atrás de si e tentou pensar.
+```
+
+O adapter pode fazer literalmente `tts(body, frontmatter)` depois da validação.
+
+## Migração
+
+Narration shards legados podem não declarar `tts_body_contract`. Eles permanecem legíveis durante a migração, mas não devem ser tratados como TTS-ready sob este contrato até receberem o marcador e passarem a validação de pureza do body.
+
+Novos narration shards MUST usar `tts_body_contract: tts-input-v1`. A migração dos shards antigos é estrutural e não altera `work_id`, `chapter_id`, `segment_id` nem o texto a ser falado.
+
+## Readiness
+
+Um capítulo não pode ser considerado `ready_for_audio` enquanto qualquer narration shard canônico necessário ao capítulo estiver sem contrato TTS-ready validado.

--- a/scripts/audiobook/skills/editorial-unit/SKILL.md
+++ b/scripts/audiobook/skills/editorial-unit/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: audiobook-editorial-unit
+description: |
+  Advance exactly one audiobook editorial unit through source/original OKF,
+  translation OKF, narration OKF and validation/readiness without using an
+  external LLM for editorial generation. Preserve stable work/chapter/segment
+  identity and keep the narration shard directly consumable by TTS.
+---
+
+# audiobook-editorial-unit
+
+Use this skill whenever advancing one audiobook unit in the canonical factory.
+
+## Before editing
+
+Read the project-level audiobook specs and guides, especially:
+
+- `docs/okf/audiobook/editorial-control-plane.md`
+- `docs/okf/audiobook/guides/translation.md`
+- `docs/okf/audiobook/guides/narration.md`
+- `docs/okf/audiobook/narration-segment-contract.md`
+- `docs/okf/audiobook/chapter-readiness.md`
+- `docs/okf/audiobook/multi-work-architecture.md`
+
+Then read the work-level `work.md`, `editorial.md`, `rights.md`, `voices.yaml` and `pronunciation.yaml`.
+
+## One-unit rule
+
+Advance exactly one next editorial unit. Do not prepare the following unit in the same run.
+
+Preserve the same `work_id`, `chapter_id` and `segment_id` in original, translation and narration shards. Preserve deterministic lineage with `derived_from`.
+
+## Pipeline
+
+1. Create/verify the source shard from the canonical source, with provenance and digest.
+2. Produce the translation in ChatGPT itself; do not call an external LLM API.
+3. Produce the narration shard in ChatGPT itself; do not call an external LLM API.
+4. Apply voice, pronunciation and work-specific editorial guidance.
+5. Validate the OKF bundle and readiness constraints.
+6. Never dispatch TTS unless the chapter is explicitly audio-ready.
+
+## Narration handoff
+
+For every new narration shard, set:
+
+```yaml
+tts_body_contract: tts-input-v1
+```
+
+The narration Markdown body is not documentation. It is the exact payload to be synthesized. Put non-spoken direction and notes in frontmatter, usually under `editorial_notes`.
+
+Before finishing, mentally execute:
+
+```text
+frontmatter = parse_frontmatter(file)
+body = markdown_body(file).strip()
+tts(body, frontmatter)
+```
+
+If that would speak a note, heading, instruction, metadata or Markdown artifact, the shard is wrong.
+
+## Completion
+
+Run the repository audiobook validator. Persist a deterministic next cursor through the canonical shard set; do not create an ad-hoc `state.yaml`.

--- a/scripts/audiobook/skills/narration-shard/SKILL.md
+++ b/scripts/audiobook/skills/narration-shard/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: audiobook-narration-shard
+description: |
+  Prepare and review an Audiobook Narration Segment as an executable TTS
+  envelope: all non-spoken controls and notes in frontmatter, and only the
+  exact text to synthesize in the Markdown body.
+---
+
+# audiobook-narration-shard
+
+Use this skill whenever creating, reviewing or migrating an `Audiobook Narration Segment`.
+
+## Contract
+
+A canonical narration shard is an executable handoff:
+
+```text
+frontmatter = TTS/editorial control plane
+body        = exact TTS input
+```
+
+Set `tts_body_contract: tts-input-v1` on new shards.
+
+## Frontmatter
+
+Keep identity, lineage, language, speaker, voice partition, emotion, pace, intensity, pauses and every non-spoken instruction in frontmatter. Put prose notes under `editorial_notes` rather than after the body.
+
+Provider-specific IDs, secret values and backend hacks do not belong in the canonical shard.
+
+## Body purity
+
+The body must survive this operation unchanged:
+
+```text
+tts(markdown_body.strip(), frontmatter)
+```
+
+Do not put headings, editorial notes, model instructions, comments, fenced code, Markdown-only links/images, metadata or explanations in the body.
+
+Do not rely on a later consumer to remove `## Nota de realização oral` or any other suffix. There is no cleanup heuristic in the contract.
+
+## Review questions
+
+Before accepting the shard, answer yes to all of these:
+
+- Is every character in the body intended to participate in the spoken payload?
+- Are all non-spoken directions represented in frontmatter or work-level config?
+- Does `speaker` resolve through `voices.yaml`?
+- Are recurring pronunciations handled by `pronunciation.yaml` rather than copied as hacks?
+- Does the body preserve the approved translation's meaning?
+- Can a backend-independent adapter consume the shard without editorial inference?
+
+## Validation
+
+Run `scripts/audiobook/validate-okf.py`. A shard declaring `tts-input-v1` must fail validation if its body contains obvious Markdown/documentation structures or is empty.
+
+A chapter cannot become `ready_for_audio` until all of its required narration shards satisfy the current TTS body contract.

--- a/scripts/audiobook/validate-okf.py
+++ b/scripts/audiobook/validate-okf.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import argparse
 import json
 import posixpath
+import re
 import sys
 from collections import defaultdict
 from pathlib import Path, PurePosixPath
@@ -19,6 +20,7 @@ import yaml
 from okf_parser import load_bundle, validate_path
 
 CANONICAL_STATUSES = {"canonical", "canonical-editorial-unit"}
+TTS_BODY_CONTRACT = "tts-input-v1"
 LAYER_TYPES = {
     "Audiobook Source Segment": "original",
     "Audiobook Translation Segment": "translation",
@@ -33,6 +35,7 @@ PROJECT_GUIDES = (
     "docs/okf/audiobook/editorial-control-plane.md",
     "docs/okf/audiobook/guides/translation.md",
     "docs/okf/audiobook/guides/narration.md",
+    "docs/okf/audiobook/narration-segment-contract.md",
     "docs/okf/audiobook/chapter-readiness.md",
     "docs/okf/audiobook/multi-work-architecture.md",
 )
@@ -54,6 +57,47 @@ def _resolved_link(source_path: str, target: str) -> str:
 def _load_yaml(path: Path) -> dict:
     data = yaml.safe_load(path.read_text(encoding="utf-8"))
     return data if isinstance(data, dict) else {}
+
+
+def _markdown_body(path: Path) -> str:
+    text = path.read_text(encoding="utf-8")
+    if not text.startswith("---\n"):
+        return ""
+    marker = text.find("\n---\n", 4)
+    if marker < 0:
+        return ""
+    return text[marker + 5 :].strip()
+
+
+def _validate_tts_body(path: str, body: str, errors: list[str]) -> None:
+    if not body:
+        errors.append(f"{path}: {TTS_BODY_CONTRACT} narration body must not be empty")
+        return
+
+    forbidden_line_prefixes = ("#", "- ", "* ", "> ", "```", "~~~")
+    for line in body.splitlines():
+        stripped = line.lstrip()
+        if stripped.startswith(forbidden_line_prefixes):
+            errors.append(f"{path}: {TTS_BODY_CONTRACT} body contains Markdown/documentation line {line!r}")
+            break
+
+    forbidden_fragments = (
+        "<!--",
+        "-->",
+        "## Nota",
+        "## Observa",
+        "## Editorial",
+        "![",
+        "](",
+        "**",
+        "__",
+    )
+    for fragment in forbidden_fragments:
+        if fragment in body:
+            errors.append(f"{path}: {TTS_BODY_CONTRACT} body contains non-spoken Markdown/documentation fragment {fragment!r}")
+
+    if re.search(r"<\/?[A-Za-z][^>]*>", body):
+        errors.append(f"{path}: {TTS_BODY_CONTRACT} body contains HTML markup")
 
 
 def main() -> int:
@@ -126,6 +170,13 @@ def main() -> int:
                     errors.append(f"{path}: mixed narration requires voice_partition")
             elif isinstance(speaker, str) and speaker not in voice_ids:
                 errors.append(f"{path}: speaker {speaker!r} has no entry in voices.yaml")
+
+            body_contract = data.get("tts_body_contract")
+            if body_contract is not None and body_contract != TTS_BODY_CONTRACT:
+                errors.append(f"{path}: unknown tts_body_contract {body_contract!r}")
+            if body_contract == TTS_BODY_CONTRACT:
+                _validate_tts_body(path, _markdown_body(root / path), errors)
+
         key = (chapter_id, segment_id)
         if layer in segments[key]:
             errors.append(f"{chapter_id}/{segment_id}: duplicate canonical {layer} shard")


### PR DESCRIPTION
Superseded by #1654, which keeps the same direct-TTS body invariant but adds an explicit per-work migration boundary (`narration_payload_contract_from`) and separates the reusable skills into editorial-segment and TTS-payload concerns. Closing this duplicate to avoid two competing contract names.