### PR TITLE
feat(audiobook): make narration bodies direct TTS payloads

### DIFF
--- a/changelog/changes/audiobook-narration-tts-payload-contract.md
+++ b/changelog/changes/audiobook-narration-tts-payload-contract.md
@@ -1,0 +1,13 @@
+---
+type: Change Card
+title: Audiobook narration shards now expose TTS-pure bodies
+summary: Define, validate and teach the invariant that narration frontmatter carries execution/editorial metadata while the Markdown body is the exact synthesis payload.
+tags: [audiobook, narration, tts, okf, validation, skills]
+timestamp: 2026-09-01T21:05:00Z
+---
+
+The audiobook pipeline now has an explicit direct-TTS body contract. New or migrated narration shards declare `tts_payload: body`; their body must contain only text intended for synthesis, while local production notes live in frontmatter `editorial_notes`.
+
+The canonical OKF validator enforces body purity for shards that opt into the contract and reports remaining legacy narration shards so migration is visible. Chapter readiness requires all narration shards in the chapter to be migrated before `ready_for_audio` can become true.
+
+A dedicated `audiobook-editorial-segment` skill records the one-segment workflow, stable identity/lineage rules, the external-model boundary and the executable narration-envelope convention.

--- a/data/audiobooks/hpmor/narration/segments/hpmor-001-s0043.okf.md
+++ b/data/audiobooks/hpmor/narration/segments/hpmor-001-s0043.okf.md
@@ -6,6 +6,7 @@ segment_id: hpmor-001-s0043
 lang: pt-BR
 derived_from: ../../translation/segments/hpmor-001-s0043.okf.md
 status: canonical-editorial-unit
+tts_payload: body
 speaker: narrator
 emotion: inward-focus
 pace: medium-slow

--- a/docs/okf/audiobook/chapter-readiness.md
+++ b/docs/okf/audiobook/chapter-readiness.md
@@ -57,7 +57,12 @@ A narração:
 - identifica speaker lógico;
 - aplica pronúncia, pontuação oral, expansão de símbolos e divisão de requests quando necessário;
 - mantém intenção sem substituir a tradução canônica;
-- usa somente instruções provider-neutral.
+- usa somente instruções provider-neutral;
+- declara `tts_payload: body` em todos os shards destinados à síntese;
+- mantém notas e instruções exclusivamente no frontmatter;
+- possui body não vazio contendo exatamente o texto a ser enviado ao TTS, sem headings, notas, comentários ou blocos auxiliares.
+
+Um capítulo com shard de narração legado que ainda não declare `tts_payload: body` não pode alcançar `narration_ready`, mesmo que continue aceito temporariamente pelo validador de migração.
 
 ### G4 — consistency ready
 
@@ -87,7 +92,7 @@ Antes de síntese:
 
 - backend/modelo podem ser selecionados sem alterar o corpus;
 - todas as vozes lógicas resolvem para uma configuração do backend escolhido ou para fallback explícito;
-- o planner consegue emitir requests TTS determinísticos;
+- o planner consegue emitir requests TTS determinísticos usando o body canônico sem limpeza heurística;
 - cache keys podem ser calculadas;
 - output esperado e estratégia de montagem são conhecidos.
 
@@ -121,6 +126,7 @@ O schema concreto pode usar YAML/JSON derivado, mas os conceitos acima são obri
 - alteração na tradução invalida narração/revisões afetadas.
 - alteração apenas em backend TTS não invalida tradução/narração, mas invalida plano/cache de áudio quando relevante.
 - um capítulo publicado pode voltar a ter áudio regenerado sem mudar seu `chapter_id`/GUID.
+- nenhuma etapa de produção pode depender de remover notas ou seções do body antes da síntese.
 
 ## 5. Gate de CI
 
@@ -131,6 +137,8 @@ audiobook validate --work <work_id> --chapter <id> --require-ready-for-audio
 ```
 
 Falha nesse comando deve impedir qualquer despacho para API, Colab ou Kaggle.
+
+Durante a migração do corpus antigo, `scripts/audiobook/validate-okf.py` reporta quantos shards ainda são legados. O gate de `ready_for_audio` deve exigir zero shards legados no capítulo.
 
 ## 6. Retomada pelo agente recorrente
 

--- a/docs/okf/audiobook/guides/narration.md
+++ b/docs/okf/audiobook/guides/narration.md
@@ -45,6 +45,8 @@ pace: slow
 intensity: low
 pause_before_ms: 0
 pause_after_ms: 600
+editorial_notes:
+  - "Leitura contida; não acrescentar emoção ausente do texto."
 ```
 
 Adapters podem traduzir isso para prompting, tokens especiais, parâmetros ou SSML específicos do backend.
@@ -71,13 +73,39 @@ Pronúncias recorrentes pertencem a `pronunciation.yaml` da obra, não a correç
 
 Uma exceção local pode existir quando a mesma grafia deve soar de forma diferente naquele contexto.
 
-## 7. Granularidade TTS
+## 7. Contrato do body: payload TTS puro
+
+Para `Audiobook Narration Segment`, o frontmatter é o plano de execução e o body é o payload de síntese.
+
+A fronteira é deliberadamente rígida:
+
+```text
+frontmatter = identidade + lineage + voz + prosódia + parâmetros + notas editoriais
+body        = exatamente o texto a enviar ao TTS
+```
+
+O consumidor deve poder executar conceitualmente `tts(body, frontmatter)` sem remover títulos, notas, comentários ou qualquer outra decoração Markdown.
+
+Consequências normativas:
+
+- o body deve ser não vazio e conter somente material que deve ser pronunciado;
+- notas de realização, justificativas, comentários de tradução, instruções ao agente e observações editoriais pertencem ao frontmatter, preferencialmente em `editorial_notes`;
+- headings Markdown, fenced code blocks, comentários HTML e separadores editoriais são proibidos no body da narração;
+- não criar `## Nota de realização oral` ou seção equivalente depois do texto narrável;
+- quebras de parágrafo no body são parte do payload e podem ser preservadas pelo adapter;
+- o worker/adaptor não deve ter heurística para "limpar" o body antes do TTS: corpus inválido deve falhar na validação.
+
+Esse contrato vale independentemente do backend. Breeze, Kokoro, Gemini, Higgs ou outro adapter podem usar o frontmatter de formas diferentes, mas recebem o mesmo body canônico.
+
+## 8. Granularidade TTS
 
 O segmento editorial e o request TTS podem coincidir, mas não precisam.
 
 Quando um segmento precisa ser dividido em vários requests, a relação deve ser derivada e determinística. Não destruir o `segment_id` editorial apenas por limitação do modelo.
 
-## 8. Revisão oral
+Mesmo quando um adapter divide um segmento, a fonte de texto continua sendo exclusivamente o body do shard de narração.
+
+## 9. Revisão oral
 
 Antes de `narration_ready`, ler mentalmente/em voz alta procurando:
 
@@ -87,9 +115,10 @@ Antes de `narration_ready`, ler mentalmente/em voz alta procurando:
 - transições de speaker incorretas;
 - direção emocional excessiva ou arbitrária;
 - pausas que quebram a sintaxe;
-- requests longos demais para geração estável.
+- requests longos demais para geração estável;
+- qualquer texto no body que não deva ser pronunciado.
 
-## 9. Feedback pós-TTS
+## 10. Feedback pós-TTS
 
 Erro observado no áudio deve ser corrigido na camada mais alta adequada:
 

--- a/scripts/audiobook/validate-okf.py
+++ b/scripts/audiobook/validate-okf.py
@@ -37,6 +37,7 @@ PROJECT_GUIDES = (
     "docs/okf/audiobook/multi-work-architecture.md",
 )
 WORK_PREREQUISITES = ("work.md", "editorial.md", "rights.md", "voices.yaml", "pronunciation.yaml")
+FORBIDDEN_NARRATION_BODY_PREFIXES = ("#", "```", "<!--", "---")
 
 
 def _args() -> argparse.Namespace:
@@ -54,6 +55,37 @@ def _resolved_link(source_path: str, target: str) -> str:
 def _load_yaml(path: Path) -> dict:
     data = yaml.safe_load(path.read_text(encoding="utf-8"))
     return data if isinstance(data, dict) else {}
+
+
+def _markdown_body(path: Path) -> str:
+    text = path.read_text(encoding="utf-8")
+    lines = text.splitlines(keepends=True)
+    if not lines or lines[0].strip() != "---":
+        return ""
+    for index, line in enumerate(lines[1:], start=1):
+        if line.strip() == "---":
+            return "".join(lines[index + 1 :]).strip()
+    return ""
+
+
+def _validate_narration_body(root: Path, path: str, data: dict, errors: list[str]) -> None:
+    body = _markdown_body(root / path)
+    if not body:
+        errors.append(f"{path}: narration body must be a non-empty direct TTS payload")
+        return
+
+    editorial_notes = data.get("editorial_notes")
+    if editorial_notes is not None:
+        if not isinstance(editorial_notes, list) or not all(isinstance(note, str) and note.strip() for note in editorial_notes):
+            errors.append(f"{path}: editorial_notes must be a list of non-empty strings when present")
+
+    for number, line in enumerate(body.splitlines(), start=1):
+        stripped = line.lstrip()
+        if stripped.startswith(FORBIDDEN_NARRATION_BODY_PREFIXES):
+            errors.append(
+                f"{path}: narration body line {number} contains Markdown/editorial markup; "
+                "move notes/instructions to frontmatter because body is sent directly to TTS"
+            )
 
 
 def main() -> int:
@@ -126,6 +158,7 @@ def main() -> int:
                     errors.append(f"{path}: mixed narration requires voice_partition")
             elif isinstance(speaker, str) and speaker not in voice_ids:
                 errors.append(f"{path}: speaker {speaker!r} has no entry in voices.yaml")
+            _validate_narration_body(root, path, data, errors)
         key = (chapter_id, segment_id)
         if layer in segments[key]:
             errors.append(f"{chapter_id}/{segment_id}: duplicate canonical {layer} shard")

--- a/scripts/audiobook/validate-okf.py
+++ b/scripts/audiobook/validate-okf.py
@@ -68,11 +68,23 @@ def _markdown_body(path: Path) -> str:
     return ""
 
 
-def _validate_narration_body(root: Path, path: str, data: dict, errors: list[str]) -> None:
+def _validate_narration_body(root: Path, path: str, data: dict, errors: list[str]) -> bool:
+    """Validate shards that opt into the direct-body TTS contract.
+
+    Legacy shards without tts_payload remain readable during migration, but they
+    cannot satisfy the future chapter audio-readiness contract until migrated.
+    """
+    tts_payload = data.get("tts_payload")
+    if tts_payload is None:
+        return False
+    if tts_payload != "body":
+        errors.append(f"{path}: tts_payload must be 'body' when the direct TTS payload contract is declared")
+        return True
+
     body = _markdown_body(root / path)
     if not body:
         errors.append(f"{path}: narration body must be a non-empty direct TTS payload")
-        return
+        return True
 
     editorial_notes = data.get("editorial_notes")
     if editorial_notes is not None:
@@ -86,6 +98,7 @@ def _validate_narration_body(root: Path, path: str, data: dict, errors: list[str
                 f"{path}: narration body line {number} contains Markdown/editorial markup; "
                 "move notes/instructions to frontmatter because body is sent directly to TTS"
             )
+    return True
 
 
 def main() -> int:
@@ -93,6 +106,8 @@ def main() -> int:
     root = Path(__file__).resolve().parents[2]
     work_dir = root / "data" / "audiobooks" / args.work
     errors: list[str] = []
+    tts_payload_segments_checked = 0
+    legacy_narration_segments = 0
 
     for rel in PROJECT_GUIDES:
         if not (root / rel).is_file():
@@ -158,7 +173,10 @@ def main() -> int:
                     errors.append(f"{path}: mixed narration requires voice_partition")
             elif isinstance(speaker, str) and speaker not in voice_ids:
                 errors.append(f"{path}: speaker {speaker!r} has no entry in voices.yaml")
-            _validate_narration_body(root, path, data, errors)
+            if _validate_narration_body(root, path, data, errors):
+                tts_payload_segments_checked += 1
+            else:
+                legacy_narration_segments += 1
         key = (chapter_id, segment_id)
         if layer in segments[key]:
             errors.append(f"{chapter_id}/{segment_id}: duplicate canonical {layer} shard")
@@ -188,13 +206,19 @@ def main() -> int:
         "okf_conformant": report.is_conformant,
         "project_prerequisites_checked": len(PROJECT_GUIDES),
         "canonical_segments_checked": len(segments),
+        "tts_payload_segments_checked": tts_payload_segments_checked,
+        "legacy_narration_segments": legacy_narration_segments,
         "valid": not errors,
         "errors": errors,
     }
     if args.json:
         print(json.dumps(result, ensure_ascii=False, indent=2))
     else:
-        print(f"Audiobook OKF validation: work={args.work} segments={len(segments)} valid={not errors}")
+        print(
+            "Audiobook OKF validation: "
+            f"work={args.work} segments={len(segments)} "
+            f"tts_payload={tts_payload_segments_checked} legacy_narration={legacy_narration_segments} valid={not errors}"
+        )
         for error in errors:
             print(f"- {error}", file=sys.stderr)
     return 0 if not errors else 1

--- a/scripts/hronir/skills/audiobook-editorial-segment/SKILL.md
+++ b/scripts/hronir/skills/audiobook-editorial-segment/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: audiobook-editorial-segment
+description: |
+  Canonical skill for advancing exactly one audiobook editorial segment through
+  source/original OKF -> translation OKF -> narration OKF. Use it whenever an
+  agent creates, edits, reviews, or validates audiobook segment shards. The
+  narration shard is an executable TTS envelope: frontmatter carries identity,
+  lineage, voice/prosody parameters, pronunciation references, and editorial
+  notes; the Markdown body is exactly the synthesis payload and must contain no
+  notes or cleanup-only markup.
+---
+
+# audiobook-editorial-segment
+
+Use this skill when advancing or repairing audiobook editorial units in this repository.
+
+## Core invariant
+
+Every segment keeps the same `work_id`, `chapter_id`, and `segment_id` across all three canonical layers:
+
+```text
+original -> translation -> narration
+```
+
+`derived_from` must resolve exactly from translation to original and from narration to translation.
+
+## One editorial unit at a time
+
+Advance exactly one next segment unless the task is explicitly structural/migratory. Never silently create the following segment while finishing the current one.
+
+Before editing, inspect the existing work state and determine the next missing canonical unit from the shard intersection. Do not recreate an already canonical segment.
+
+## Original/source shard
+
+The original body contains only the source text for that editorial unit. Frontmatter carries provenance such as source URL, digest, anchor, language and stable identity.
+
+Do not add analysis, translation notes, or narration direction to the original body.
+
+## Translation shard
+
+Translate using ChatGPT's own reasoning. Do not call external LLM APIs.
+
+The translation body contains only the translated editorial text. Keep commentary out of the body. If a translation decision must be persisted, put it in structured frontmatter or the work-level translation/editorial guide rather than appending a note section that could later be mistaken for content.
+
+Preserve meaning, style, humor, logical relations, names and deliberate ambiguity. Do not introduce TTS-provider workarounds here.
+
+## Narration shard = executable TTS envelope
+
+Treat the narration OKF as directly consumable by a TTS adapter.
+
+The contract is:
+
+```text
+frontmatter = identity + lineage + speaker + prosody + pauses + editorial direction
+body        = exact text to synthesize
+```
+
+The body must be ready to pass to the TTS model without preprocessing or heuristic cleanup. Therefore:
+
+- put `speaker`, `emotion`, `pace`, `intensity`, `pause_before_ms`, `pause_after_ms`, `voice_partition` and similar execution parameters in frontmatter;
+- put local production/editorial observations in `editorial_notes` in frontmatter;
+- keep recurring pronunciation rules in the work's `pronunciation.yaml`;
+- keep voice identities in the work's `voices.yaml`;
+- never append `## Nota de realização oral`, headings, fenced blocks, HTML comments, metadata sections, or other non-spoken material to the body;
+- do not invent vocal events, sound effects, emotions or stage business absent from the text unless an explicit editorial rule authorizes them;
+- preserve paragraph breaks when they are part of the intended synthesis payload.
+
+A correct consumer should be able to do the conceptual equivalent of:
+
+```text
+segment = parse_okf(file)
+tts(text=segment.body, parameters=segment.frontmatter)
+```
+
+If that would speak an editorial note, the shard is invalid.
+
+## Project-level prerequisites
+
+Before declaring any chapter audio-ready, verify that the relevant project/work controls exist and apply:
+
+- global translation guidance;
+- global narration/TTS preparation guidance;
+- work editorial/style guide;
+- work provenance and rights metadata;
+- `voices.yaml` with logical speaker identities;
+- `pronunciation.yaml` with recurring terminology/pronunciation rules;
+- validation/readiness rules;
+- multi-work identity architecture.
+
+Do not mark a chapter audio-ready merely because the latest segment is complete.
+
+## Validation
+
+Run the canonical audiobook validation. `scripts/audiobook/validate-okf.py` is the fail-closed gate for per-segment identity, lineage, prerequisites, voices, pronunciation configuration, and narration body purity.
+
+Narration-body validation is intentional: the worker must not strip notes or Markdown sections before synthesis. Invalid corpus fails before TTS.
+
+## External model boundary
+
+Editorial generation is performed in ChatGPT. External model APIs are prohibited for source selection, translation, rewriting and narration preparation.
+
+Only after the chapter is explicitly `ready_for_audio` may configured TTS execution use external models or free GPU runners.
+
+## Persisting state
+
+If the chapter cannot be completed, leave deterministic state in canonical files and PR history. The next cursor is derived from the stable shard set; do not create an ad-hoc `state.yaml`.


### PR DESCRIPTION
Superseded by a clean re-stack on the latest #1652 head. This branch used an earlier draft field name before #1652 established `tts_body_contract: body-is-payload-v1`; the replacement preserves that canonical vocabulary and avoids conflict with the updated editorial unit.