### PR TITLE
feat(audiobook): validate narration bodies as executable TTS payloads

### DIFF
--- a/changelog/changes/audiobook-narration-body-contract.md
+++ b/changelog/changes/audiobook-narration-body-contract.md
@@ -1,0 +1,13 @@
+---
+type: Change Card
+title: Audiobook narration body becomes a validated TTS payload
+summary: Record the executable narration envelope contract in specs, validation, and a dedicated agent skill.
+tags: [audiobook, narration, tts, okf, validation, skills]
+timestamp: 2026-09-01T21:05:00Z
+---
+
+Narration shards can now declare `tts_body_contract: body-is-payload-v1`. For those shards the frontmatter contains execution/editorial metadata and the Markdown body is the exact synthesis payload.
+
+The OKF validator rejects headings, fenced blocks, comments, empty bodies, invalid local notes, and unknown body-contract values. It also reports legacy narration shards so migration debt is explicit without instantly invalidating the existing in-progress corpus.
+
+Chapter readiness now requires every narration shard to use the contract before `ready_for_audio`, and the `audiobook-editorial-segment` skill teaches agents the same invariant while preserving the external-model boundary.

--- a/docs/okf/audiobook/chapter-readiness.md
+++ b/docs/okf/audiobook/chapter-readiness.md
@@ -57,7 +57,12 @@ A narração:
 - identifica speaker lógico;
 - aplica pronúncia, pontuação oral, expansão de símbolos e divisão de requests quando necessário;
 - mantém intenção sem substituir a tradução canônica;
-- usa somente instruções provider-neutral.
+- usa somente instruções provider-neutral;
+- declara `tts_body_contract: body-is-payload-v1` em todos os shards destinados à síntese;
+- mantém notas de realização e instruções no frontmatter, não no body;
+- possui body não vazio contendo exatamente o texto a enviar ao TTS, sem headings, notas, comentários ou blocos auxiliares.
+
+Shards legados sem `tts_body_contract` podem permanecer parseáveis durante a migração, mas impedem `narration_ready` e, portanto, `ready_for_audio`.
 
 ### G4 — consistency ready
 
@@ -87,7 +92,7 @@ Antes de síntese:
 
 - backend/modelo podem ser selecionados sem alterar o corpus;
 - todas as vozes lógicas resolvem para uma configuração do backend escolhido ou para fallback explícito;
-- o planner consegue emitir requests TTS determinísticos;
+- o planner consegue emitir requests TTS determinísticos usando o body sem limpeza heurística;
 - cache keys podem ser calculadas;
 - output esperado e estratégia de montagem são conhecidos.
 
@@ -121,6 +126,7 @@ O schema concreto pode usar YAML/JSON derivado, mas os conceitos acima são obri
 - alteração na tradução invalida narração/revisões afetadas.
 - alteração apenas em backend TTS não invalida tradução/narração, mas invalida plano/cache de áudio quando relevante.
 - um capítulo publicado pode voltar a ter áudio regenerado sem mudar seu `chapter_id`/GUID.
+- nenhuma etapa de produção pode depender de remover notas ou seções do body antes da síntese.
 
 ## 5. Gate de CI
 
@@ -131,6 +137,8 @@ audiobook validate --work <work_id> --chapter <id> --require-ready-for-audio
 ```
 
 Falha nesse comando deve impedir qualquer despacho para API, Colab ou Kaggle.
+
+Durante a migração, `scripts/audiobook/validate-okf.py` reporta `legacy_narration_segments`; o gate de audio readiness deve exigir zero no capítulo.
 
 ## 6. Retomada pelo agente recorrente
 

--- a/docs/okf/audiobook/guides/narration.md
+++ b/docs/okf/audiobook/guides/narration.md
@@ -36,15 +36,18 @@ Ela pode mudar a forma superficial do texto quando isso melhora pronúncia, pros
 
 ## 4. Direção provider-neutral
 
-A direção deve usar conceitos estáveis, por exemplo:
+A direção deve usar conceitos estáveis no frontmatter, por exemplo:
 
 ```yaml
+tts_body_contract: body-is-payload-v1
 speaker: narrator
 emotion: contemplative
 pace: slow
 intensity: low
 pause_before_ms: 0
 pause_after_ms: 600
+editorial_notes:
+  - "Leitura contida; não acrescentar emoção ausente do texto."
 ```
 
 Adapters podem traduzir isso para prompting, tokens especiais, parâmetros ou SSML específicos do backend.
@@ -55,41 +58,43 @@ A narração referencia nomes lógicos declarados em `voices.yaml`.
 
 Nunca gravar diretamente no capítulo um voice ID efêmero de fornecedor.
 
-Exemplos:
-
-- `narrator`
-- `harry`
-- `mcgonagall`
-- `krishna`
-- `arjuna`
-
-A mesma identidade lógica pode mapear para configurações diferentes conforme o backend do benchmark/produção.
-
 ## 6. Pronúncia
 
 Pronúncias recorrentes pertencem a `pronunciation.yaml` da obra, não a correções copiadas em dezenas de capítulos.
 
 Uma exceção local pode existir quando a mesma grafia deve soar de forma diferente naquele contexto.
 
-## 7. Granularidade TTS
+## 7. Contrato executável do body
 
-O segmento editorial e o request TTS podem coincidir, mas não precisam.
+Um `Audiobook Narration Segment` que declara `tts_body_contract: body-is-payload-v1` é um envelope diretamente executável pelo adapter TTS:
 
-Quando um segmento precisa ser dividido em vários requests, a relação deve ser derivada e determinística. Não destruir o `segment_id` editorial apenas por limitação do modelo.
+```text
+frontmatter = identidade + lineage + voz + prosódia + parâmetros + notas editoriais
+body        = exatamente o texto a sintetizar
+```
 
-## 8. Revisão oral
+O consumidor deve poder fazer conceitualmente `tts(body, frontmatter)` sem remover nada do body.
 
-Antes de `narration_ready`, ler mentalmente/em voz alta procurando:
+Portanto:
 
-- frases que exigem visão da pontuação para serem entendidas;
-- números/siglas ambíguos;
-- nomes estrangeiros suscetíveis a erro;
-- transições de speaker incorretas;
-- direção emocional excessiva ou arbitrária;
-- pausas que quebram a sintaxe;
-- requests longos demais para geração estável.
+- o body deve ser não vazio e conter somente material que deve ser pronunciado;
+- notas de realização, justificativas, instruções ao agente e observações editoriais ficam no frontmatter, em especial `editorial_notes`;
+- headings Markdown, fenced code blocks, comentários HTML e separadores editoriais são proibidos no body;
+- `## Nota de realização oral` e equivalentes são inválidos no body;
+- quebras de parágrafo do body fazem parte do payload;
+- o worker não deve possuir heurística para limpar notas do body: corpus inválido deve falhar antes do TTS.
 
-## 9. Feedback pós-TTS
+Shards legados ainda sem `tts_body_contract` podem existir durante a migração, mas um capítulo não pode atingir `ready_for_audio` enquanto houver shard de narração legado.
+
+## 8. Granularidade TTS
+
+O segmento editorial e o request TTS podem coincidir, mas não precisam. Se um adapter precisar dividir um segmento, a divisão deve ser derivada e determinística, sem alterar o `segment_id`; a fonte textual continua sendo exclusivamente o body canônico.
+
+## 9. Revisão oral
+
+Antes de `narration_ready`, verificar também se existe qualquer texto no body que não deva ser pronunciado.
+
+## 10. Feedback pós-TTS
 
 Erro observado no áudio deve ser corrigido na camada mais alta adequada:
 

--- a/scripts/audiobook/validate-okf.py
+++ b/scripts/audiobook/validate-okf.py
@@ -37,6 +37,8 @@ PROJECT_GUIDES = (
     "docs/okf/audiobook/multi-work-architecture.md",
 )
 WORK_PREREQUISITES = ("work.md", "editorial.md", "rights.md", "voices.yaml", "pronunciation.yaml")
+TTS_BODY_CONTRACT = "body-is-payload-v1"
+FORBIDDEN_NARRATION_BODY_PREFIXES = ("#", "```", "<!--", "---")
 
 
 def _args() -> argparse.Namespace:
@@ -56,11 +58,54 @@ def _load_yaml(path: Path) -> dict:
     return data if isinstance(data, dict) else {}
 
 
+def _markdown_body(path: Path) -> str:
+    text = path.read_text(encoding="utf-8")
+    lines = text.splitlines(keepends=True)
+    if not lines or lines[0].strip() != "---":
+        return ""
+    for index, line in enumerate(lines[1:], start=1):
+        if line.strip() == "---":
+            return "".join(lines[index + 1 :]).strip()
+    return ""
+
+
+def _validate_tts_body(root: Path, path: str, data: dict, errors: list[str]) -> bool:
+    contract = data.get("tts_body_contract")
+    if contract is None:
+        return False
+    if contract != TTS_BODY_CONTRACT:
+        errors.append(f"{path}: tts_body_contract must be {TTS_BODY_CONTRACT!r}")
+        return True
+
+    body = _markdown_body(root / path)
+    if not body:
+        errors.append(f"{path}: narration body must be a non-empty direct TTS payload")
+        return True
+
+    notes = data.get("editorial_notes")
+    if notes is not None and (
+        not isinstance(notes, list)
+        or not all(isinstance(note, str) and note.strip() for note in notes)
+    ):
+        errors.append(f"{path}: editorial_notes must be a list of non-empty strings when present")
+
+    for number, line in enumerate(body.splitlines(), start=1):
+        stripped = line.lstrip()
+        if stripped.startswith(FORBIDDEN_NARRATION_BODY_PREFIXES):
+            errors.append(
+                f"{path}: narration body line {number} contains Markdown/editorial markup; "
+                "move notes/instructions to frontmatter because body is the direct TTS payload"
+            )
+    return True
+
+
 def main() -> int:
     args = _args()
     root = Path(__file__).resolve().parents[2]
     work_dir = root / "data" / "audiobooks" / args.work
     errors: list[str] = []
+    tts_body_contract_segments = 0
+    legacy_narration_segments = 0
 
     for rel in PROJECT_GUIDES:
         if not (root / rel).is_file():
@@ -126,6 +171,10 @@ def main() -> int:
                     errors.append(f"{path}: mixed narration requires voice_partition")
             elif isinstance(speaker, str) and speaker not in voice_ids:
                 errors.append(f"{path}: speaker {speaker!r} has no entry in voices.yaml")
+            if _validate_tts_body(root, path, data, errors):
+                tts_body_contract_segments += 1
+            else:
+                legacy_narration_segments += 1
         key = (chapter_id, segment_id)
         if layer in segments[key]:
             errors.append(f"{chapter_id}/{segment_id}: duplicate canonical {layer} shard")
@@ -155,13 +204,20 @@ def main() -> int:
         "okf_conformant": report.is_conformant,
         "project_prerequisites_checked": len(PROJECT_GUIDES),
         "canonical_segments_checked": len(segments),
+        "tts_body_contract_segments": tts_body_contract_segments,
+        "legacy_narration_segments": legacy_narration_segments,
         "valid": not errors,
         "errors": errors,
     }
     if args.json:
         print(json.dumps(result, ensure_ascii=False, indent=2))
     else:
-        print(f"Audiobook OKF validation: work={args.work} segments={len(segments)} valid={not errors}")
+        print(
+            "Audiobook OKF validation: "
+            f"work={args.work} segments={len(segments)} "
+            f"tts_body_contract={tts_body_contract_segments} "
+            f"legacy_narration={legacy_narration_segments} valid={not errors}"
+        )
         for error in errors:
             print(f"- {error}", file=sys.stderr)
     return 0 if not errors else 1

--- a/scripts/hronir/skills/audiobook-editorial-segment/SKILL.md
+++ b/scripts/hronir/skills/audiobook-editorial-segment/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: audiobook-editorial-segment
+description: |
+  Canonical skill for advancing exactly one audiobook editorial segment through
+  source/original OKF -> translation OKF -> narration OKF. Use it whenever an
+  agent creates, edits, reviews, or validates audiobook segment shards. A
+  narration shard declaring tts_body_contract: body-is-payload-v1 is an
+  executable TTS envelope: frontmatter carries identity, lineage, voice/prosody,
+  pronunciation references, and editorial notes; the body is exactly the text
+  sent to synthesis and must contain no notes or cleanup-only markup.
+---
+
+# audiobook-editorial-segment
+
+Use this skill whenever you advance or repair audiobook editorial units in this repository.
+
+## Canonical pipeline
+
+Advance one stable unit through:
+
+```text
+source/original OKF -> translation OKF -> narration OKF -> validation/readiness
+```
+
+Keep `work_id`, `chapter_id`, and `segment_id` identical across the three layers. `derived_from` must resolve exactly translation -> original and narration -> translation.
+
+Do not create the following segment while finishing the current one unless the task is explicitly a structural migration.
+
+## Original
+
+The original body contains only the source text for that editorial unit. Provenance, source URL, digest and anchor belong in frontmatter.
+
+## Translation
+
+Use ChatGPT's own reasoning. Do not call external LLM APIs. The translation body contains only translated content, not commentary. Persist recurring editorial decisions in work/project guides rather than appending note sections to the body.
+
+Do not contaminate translation with provider-specific TTS workarounds.
+
+## Narration is an executable envelope
+
+For new or migrated narration shards, declare:
+
+```yaml
+tts_body_contract: body-is-payload-v1
+```
+
+Then obey this invariant:
+
+```text
+frontmatter = identity + lineage + speaker + prosody + pauses + editorial direction
+body        = exact text to synthesize
+```
+
+Put local production observations in `editorial_notes` in frontmatter. Put recurring pronunciation in the work's `pronunciation.yaml`; put logical voice identities in `voices.yaml`.
+
+Never append `## Nota de realização oral`, headings, fenced code blocks, HTML comments, metadata sections, or any other non-spoken material to the narration body. Do not expect the worker to strip them. If `tts(text=body, parameters=frontmatter)` would speak a note, the shard is invalid.
+
+Do not invent vocal events, sound effects, emotions, or stage business absent from the text unless an explicit editorial rule authorizes them.
+
+## Project prerequisites
+
+Before a chapter can be audio-ready, verify the relevant global/work controls exist and apply: translation guidance, narration/TTS guidance, work editorial guide, provenance/rights metadata, `voices.yaml`, `pronunciation.yaml`, validation/readiness rules, and multi-work identity architecture.
+
+A legacy narration shard without `tts_body_contract: body-is-payload-v1` may remain parseable during migration, but it blocks `narration_ready` and `ready_for_audio`.
+
+## Validation
+
+Run the canonical audiobook validation. `scripts/audiobook/validate-okf.py` is the fail-closed segment gate for identity, lineage, prerequisites, voices, pronunciation configuration, and direct-body TTS purity for migrated/new shards.
+
+The validator reports `legacy_narration_segments`; chapter audio readiness requires that count to be zero for the chapter.
+
+## External-model boundary
+
+Editorial generation remains in ChatGPT. External model APIs are prohibited for translation, rewriting, narration preparation, and editorial decisions. Only after a chapter is explicitly `ready_for_audio` may configured TTS execution use external models or free GPU runners.
+
+## State
+
+Persist deterministic progress through canonical shards and PR history. Derive the next cursor from the shard set; do not create an ad-hoc `state.yaml`.


### PR DESCRIPTION
Closed as duplicate after discovering #1654 already implements the same structural work more comprehensively (spec + validator + two dedicated skills + rollout metadata). I reviewed #1654 instead so we keep one canonical implementation.