### PR TITLE
chore(ci): abrir PR em vez de empurrar direto na main

### DIFF
--- a/.github/workflows/audiobook-media.yml
+++ b/.github/workflows/audiobook-media.yml
@@ -55,6 +55,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 concurrency:
   group: audiobook-media-${{ inputs.work_id }}-${{ inputs.chapter_id }}
@@ -295,21 +296,26 @@ jobs:
         env:
           WORK_ID: ${{ inputs.work_id }}
           CHAPTER_ID: ${{ inputs.chapter_id }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add "data/audiobooks/$WORK_ID/state.yaml" "data/audiobooks/$WORK_ID/work.md"
           git commit -m "feat(audiobook): publish $WORK_ID $CHAPTER_ID"
-          for attempt in 1 2 3; do
-            if git push origin HEAD:main; then
-              exit 0
-            fi
-            echo "Push rejected (attempt $attempt/3), rebasing onto latest main..."
-            git fetch origin main
-            git rebase origin/main
-          done
-          echo "Push failed after 3 attempts; media is uploaded but publication state was not persisted." >&2
-          exit 1
+          # A main exige head atualizado antes do merge, e a regra tambem vale
+          # para push: o estado publicado vai por PR em auto-merge. O retry com
+          # rebase existia para lidar com a main andando; a branch e recriada a
+          # cada execucao, entao ele sai.
+          BRANCH=automation/audiobook-$WORK_ID
+          git checkout -B "$BRANCH"
+          git push -f origin "$BRANCH"
+          NUM=$(gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number // empty')
+          if [ -z "$NUM" ]; then
+            CORPO="Estado publicado do audiolivro, gerado pelo workflow audiobook-media."
+            URL=$(gh pr create --base main --head "$BRANCH" --title "feat(audiobook): publish episode state" --body "$CORPO")
+            NUM="${URL##*/}"
+          fi
+          gh pr merge "$NUM" --auto --squash
 
       - name: Upload plan
         if: ${{ always() && (inputs.dry_run == false || steps.readiness.outputs.narration_ready == 'true') }}

--- a/.github/workflows/suno-daily-sync.yml
+++ b/.github/workflows/suno-daily-sync.yml
@@ -21,6 +21,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 concurrency:
   group: suno-daily-sync
@@ -70,20 +71,26 @@ jobs:
       # direct push to main can easily land behind origin by the time this
       # job finishes its multi-minute catalog fetch. Rebase-and-retry
       # rather than fail the whole run over an ordinary race.
-      - name: Commit and push
+      # A main exige head atualizado antes do merge, e a regra tambem vale para
+      # push: o catalogo sincronizado vai por PR em auto-merge. O retry com
+      # rebase existia para lidar com a main andando; a branch e recriada a cada
+      # execucao, entao ele sai.
+      - name: Commit and open PR
         if: steps.changes.outputs.has_changes == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add data/suno-catalog.jsonl src/generated/blog-redirects.json
           git commit -m "feat(music): daily Suno sync — $(date -u +%Y-%m-%d)"
-          for attempt in 1 2 3; do
-            if git push origin HEAD:main; then
-              exit 0
-            fi
-            echo "Push rejected (attempt $attempt/3), rebasing onto latest main..."
-            git fetch origin main
-            git rebase origin/main
-          done
-          echo "Push failed after 3 attempts." >&2
-          exit 1
+          BRANCH=automation/suno-sync
+          git checkout -B "$BRANCH"
+          git push -f origin "$BRANCH"
+          NUM=$(gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number // empty')
+          if [ -z "$NUM" ]; then
+            CORPO="Sincronizacao diaria do catalogo Suno, gerada pelo workflow suno-daily-sync."
+            URL=$(gh pr create --base main --head "$BRANCH" --title "feat(music): daily Suno sync" --body "$CORPO")
+            NUM="${URL##*/}"
+          fi
+          gh pr merge "$NUM" --auto --squash

--- a/changelog/changes/automacao-abre-pr-em-vez-de-push.md
+++ b/changelog/changes/automacao-abre-pr-em-vez-de-push.md
@@ -1,0 +1,12 @@
+---
+type: changelog
+date: 2026-09-02
+description: Automated workflows now open a pull request instead of pushing straight to main.
+tags: [ci, automation, main]
+---
+
+# Automação abre PR em vez de empurrar na main
+
+- A branch `main` passou a exigir que o head esteja atualizado antes do merge, e essa regra também vale para push: o `git push origin HEAD:main` dos workflows agendados seria recusado.
+- `suno-daily-sync.yml` e `audiobook-media.yml` passam a commitar numa branch `automation/*`, abrir PR e deixar em auto-merge; o PR cai sozinho quando o check passa.
+- O retry com rebase sai dos dois. Ele existia para lidar com a main andando durante o push, e a branch de automação é recriada a cada execução — nunca fica atrás.


### PR DESCRIPTION
A branch default passa a exigir head atualizado antes do merge, e a regra vale também para push — o `git push origin HEAD:main` de `suno-daily-sync.yml` e `audiobook-media.yml` seria recusado.

Os dois passam a usar branch `automation/*` + PR em auto-merge. O retry com rebase sai: a branch é recriada a cada execução e nunca fica atrás.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y9yy5GokMcFU9SNssSnmTG