### PR TITLE
fix(ui): preserve readable 404 recovery flow on mobile

### DIFF
--- a/changelog/changes/404-mobile-recovery-flow.md
+++ b/changelog/changes/404-mobile-recovery-flow.md
@@ -1,0 +1,11 @@
+---
+type: changelog
+date: 2026-09-02
+description: Keep recently published recovery links readable on narrow 404 pages.
+tags: [ui, responsive, accessibility]
+---
+
+# 404 recovery links stay readable on mobile
+
+- The English and Portuguese 404 pages now let the recent-content recovery block reflow vertically on narrow viewports instead of compressing long article titles into tiny horizontal columns.
+- Search, alternate navigation and the existing desktop composition remain unchanged.

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -22,7 +22,7 @@ const recent = (await getCollection("blog"))
     </search>
   </section>
 
-  <nav aria-label="Recently published">
+  <nav class="recovery-recent" aria-label="Recently published">
     <h2>Recently published</h2>
     <ul>
       {recent.map((post) => (
@@ -49,3 +49,22 @@ const recent = (await getCollection("blog"))
   <link rel="stylesheet" href="/pagefind/pagefind-component-ui.css" />
   <script is:inline type="module" src="/pagefind/pagefind-component-ui.js"></script>
 </PageLayout>
+
+<style>
+  @media (max-width: 40rem) {
+    .recovery-recent {
+      display: block;
+    }
+
+    .recovery-recent ul {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr);
+      gap: 0.5rem;
+      padding-inline-start: 0;
+    }
+
+    .recovery-recent li {
+      min-width: 0;
+    }
+  }
+</style>

--- a/src/pages/pt/404.astro
+++ b/src/pages/pt/404.astro
@@ -27,7 +27,7 @@ const recent = (await getCollection("blog"))
     </search>
   </section>
 
-  <nav aria-label="Publicados recentemente">
+  <nav class="recovery-recent" aria-label="Publicados recentemente">
     <h2>Publicados recentemente</h2>
     <ul>
       {recent.map((post) => (
@@ -54,3 +54,22 @@ const recent = (await getCollection("blog"))
   <link rel="stylesheet" href="/pagefind/pagefind-component-ui.css" />
   <script is:inline type="module" src="/pagefind/pagefind-component-ui.js"></script>
 </PageLayout>
+
+<style>
+  @media (max-width: 40rem) {
+    .recovery-recent {
+      display: block;
+    }
+
+    .recovery-recent ul {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr);
+      gap: 0.5rem;
+      padding-inline-start: 0;
+    }
+
+    .recovery-recent li {
+      min-width: 0;
+    }
+  }
+</style>


### PR DESCRIPTION
## Problema observado

Na evidência visual canônica do `main` `17995efe13904d56e58d63686d3cca49dea23093` (Visual evidence run `33636267817`, artifact `9849063746`), a 404 em viewport estreito comprime o heading `Recently published` e os cinco títulos/data em colunas muito estreitas. O DOM continua correto, mas a recuperação deixa de ser legível.

Dimensões afetadas no baseline Cobogó: **UI 2/4** e **UX 3/4**. O restante das capturas mobile/desktop do mesmo artifact é forte; esta PR não redesenha o blog.

## Posição Cobogó

Aplica a recomendação em formulação `recovery-options-preserve-readable-flow`: conteúdo alternativo em estado de erro deve preservar ordem de leitura, legibilidade e acionabilidade no viewport estreito. A regra não exige uma aparência específica.

## Mudança

- marca apenas o bloco de recentes das 404 EN/PT como `recovery-recent`;
- em `<= 40rem`, retira esse bloco do comportamento horizontal herdado de `nav` e organiza os itens em uma única coluna legível;
- desktop permanece sob o comportamento atual.

## Critério congelado antes da implementação

1. em mobile (~390px), o heading fica legível como unidade normal;
2. cinco títulos e datas ficam legíveis em ordem de leitura, sem clipping, scroll horizontal implícito ou compressão em colunas de poucas letras;
3. Search e demais caminhos continuam perceptíveis/acionáveis;
4. desktop preservado;
5. checks aplicáveis verdes no head exato antes do merge;
6. após squash, deploy + Visual evidence de `main` no landing exato antes de considerar fechado.

A solução local pode ser substituída por qualquer composição equivalente/superior que satisfaça esses invariantes.