### PR TITLE
ux: fix brand wrap at 920-1000px, verify header breakpoint

### DIFF
--- a/.routines/2026-09-03T05-01-14-ux-ui-run.md
+++ b/.routines/2026-09-03T05-01-14-ux-ui-run.md
@@ -29,3 +29,19 @@ está para decisão humana.
 
 CI local: astro check ✅ (0 erros, 0 warnings) · prettier ✅ · build ✅
 (3961 páginas, pagefind ok)
+
+## Code review (`/code-review --fix`)
+
+Achou uma regressão real que meu próprio "Test plan" (só 899-1280px) não
+cobria: `white-space: nowrap` no `.brand` sem escopo também desativava o
+wrap no layout do menu hambúrguer (<899px), causando overflow horizontal
+em larguras reais de celular (medido: overflow em ≤412px). Corrigido
+restaurando `white-space: normal` no `.brand` dentro do
+`@media (max-width: 899px)` já existente — mantém a correção original
+(920-1000px) intacta.
+
+Reverifiquei com Playwright em 320-1280px (en e pt): sem overflow em
+nenhuma largura ≥360px após a correção; o overflow em ≤340px é
+pré-existente no `main` (confirmado num worktree do commit-base,
+`e76a6253`, antes de qualquer mudança minha), fora do escopo desta issue.
+`astro check`/`prettier`/`build` revalidados verdes após a correção.

--- a/.routines/2026-09-03T05-01-14-ux-ui-run.md
+++ b/.routines/2026-09-03T05-01-14-ux-ui-run.md
@@ -1,0 +1,31 @@
+---
+date: "2026-09-03T05:01:14Z"
+branch: ux-ui/run-2026-09-03T05-01-14
+status: open
+---
+
+# Sessão 2026-09-03T05-01-14 — UX/UI
+
+Issues fechadas: #1536
+
+O que foi feito: medi `.nav-inline` do header com Playwright em 899-1280px
+(14 larguras) em `/pt/` e no home em, confirmando que o breakpoint de 899px
+não causa wrap/overflow do nav em nenhuma das duas línguas — o comentário
+`Unverified` em `src/components/Header.astro` estava correto em não ter sido
+revalidado, mas o breakpoint em si se mostrou correto. No mesmo range,
+achei um defeito real e independente da issue original: a marca "Franklin
+Baldo." quebrava em duas linhas entre ~920-1000px, em pt e en, por falta de
+`white-space: nowrap` (já presente nos links do `.nav-inline`, ausente em
+`.brand`). Corrigido com uma linha de CSS; reconfirmei as mesmas 14 larguras
+sem wrap/overflow.
+
+Nota (fora do escopo desta sessão): dois PRs antigos da rotina (#1564,
+#1566) ficaram irrecuperáveis — a branch `main` remota teve um force-push
+que reescreveu o histórico (`origin/main` e a `main` local anterior
+retornam "refusing to merge unrelated histories"), então esses PRs não têm
+mais um ancestral comum com `main` e não podem ser mesclados sem reabrir o
+trabalho do zero. Não tentei reescrever histórico de ninguém; deixo como
+está para decisão humana.
+
+CI local: astro check ✅ (0 erros, 0 warnings) · prettier ✅ · build ✅
+(3961 páginas, pagefind ok)

--- a/changelog/changes/header-brand-wrap-899-1280.md
+++ b/changelog/changes/header-brand-wrap-899-1280.md
@@ -1,0 +1,22 @@
+---
+type: changelog
+date: 2026-09-03
+description: Fix the site name wrapping onto two lines around 920-1000px width.
+tags: [a11y, header, i18n]
+---
+
+# Header brand stays on one line at laptop widths
+
+- `src/components/Header.astro`: the "Franklin Baldo." brand link lacked
+  `white-space: nowrap`, unlike every `.nav-inline` item, so it wrapped
+  onto two lines around 920-1000px viewport width — in both English and
+  Portuguese — even though there was plenty of room for it to stay on one
+  line. Fixed on `.brand`.
+- The fix is scoped to the ≥899px `.nav-inline` layout only: under the
+  899px burger breakpoint, `.brand` falls back to `white-space: normal`
+  again, since narrow phone widths (≤412px) need the wrap as a safety
+  valve against horizontal overflow.
+- Re-verified with Playwright, in both languages, that `.nav-inline`
+  itself never wraps or overflows between 899-1280px — the breakpoint's
+  own `Unverified` code comment is now replaced with the measured
+  justification.

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -419,6 +419,16 @@ const secondaryCurrent = secondaryLinks.some((link) => isCurrent(link.href));
     .nav-burger {
       display: flex;
     }
+    /* Below the burger breakpoint, .brand's white-space:nowrap (added
+       above for the 920-1000px wrap bug, which only exists in the
+       nav-inline layout) has no fallback: it forces "Franklin Baldo." to
+       stay on one line even when the burger-side controls leave no room,
+       overflowing the header horizontally on real phone widths (measured:
+       overflow at <=412px, e.g. most phones in portrait). Only nav-inline
+       widths needed nowrap; restore wrapping as the safety valve here. */
+    .brand {
+      white-space: normal;
+    }
   }
   .burger-menu > summary {
     padding-inline: 0.5rem;

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -358,6 +358,7 @@ const secondaryCurrent = secondaryLinks.some((link) => isCurrent(link.href));
     letter-spacing: -0.01em;
     text-decoration: none;
     overflow-wrap: normal;
+    white-space: nowrap;
   }
   .brand:hover {
     color: var(--pico-primary);
@@ -404,14 +405,13 @@ const secondaryCurrent = secondaryLinks.some((link) => isCurrent(link.href));
   .nav-burger {
     display: none;
   }
-  /* Unverified: this replaced a previous 1279px cutoff that had a specific
-     measured justification (Pico's own .container breakpoint, plus a
-     measured ~960px width need for the old 8-link flat nav — see git
-     history). This value has not been re-measured against the current
-     content (4 primaryLinks + the "More" summary + music button + language
-     switcher + theme toggle, longest in pt: "Ensaios"/"Projetos"/"Sobre"/
-     "Buscar"/"Mais"). Check in a real browser between ~899px and ~1280px
-     before trusting this, especially in pt. */
+  /* Measured with Playwright at 899-1280px (14 widths) on both /pt/ and en
+     home pages: .nav-inline never wraps or overflows in that range, in
+     either language, so the 899px cutoff stands. The one real defect found
+     at those widths was unrelated to nav-inline — the brand link ("Franklin
+     Baldo.") wrapped onto two lines around 920-1000px, in both languages,
+     because it lacked white-space: nowrap while nav-inline's items already
+     had it; fixed on .brand above. */
   @media (max-width: 899px) {
     .nav-inline {
       display: none;


### PR DESCRIPTION
## Summary

- `src/components/Header.astro:404-411` had an `Unverified` comment flagging that the 899px header breakpoint had not been re-measured against current content (4 `primaryLinks` + "More" summary + music button + language switcher + theme toggle, longest labels in pt: "Arquivo"/"Projetos"/"Sobre"/"Buscar"/"Mais").
- Measured `.nav-inline` with Playwright at 14 widths between 899-1280px, on both `/pt/` and the English home page: it never wraps or overflows in that range in either language, so the 899px cutoff itself is correct and stands.
- Found a real, independent defect in the same width range: the brand link ("Franklin Baldo.") wrapped onto two lines around 920-1000px, in both pt and en, because it lacked `white-space: nowrap` while every `.nav-inline` item already had it. Fixed with one line on `.brand`.
- Replaced the stale `Unverified` comment with the measured justification.

Closes #1536

## Note (out of scope for this PR)

Two older routine PRs (#1564, #1566) turned out to be unmergeable: `origin/main` had a force-push that rewrote history, so those branches no longer share a common ancestor with `main` (`git merge` on them returns "refusing to merge unrelated histories"). I did not attempt to rewrite anyone's history to work around this — flagging it here for a human decision (the underlying UX fixes in both would need to be redone against current `main` if still wanted).

## Test plan

- [x] `npx astro check` — 0 errors, 0 warnings
- [x] `npx prettier --check .` — passed
- [x] `npm run build` — full build (3961 pages, pagefind ok)
- [x] Playwright screenshots at 899/920/950/960/980/1000/1024/1050/1080/1100/1150/1200/1240/1260/1279/1280px on `/pt/` and `/`: no wrap or overlap in `.nav-inline` at any width; brand link no longer wraps after the fix
- [x] `document.documentElement.scrollWidth <= clientWidth` (no horizontal overflow) checked across the same range
- [x] Confirmed in the built CSS (`dist/_astro/PageLayout.*.css`, referenced by both `dist/index.html` and `dist/pt/index.html`) that `.brand` now has `white-space:nowrap`

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011zmu5i3kFj2wVpo4NfHCmK

---
_Generated by [Claude Code](https://claude.ai/code/session_011zmu5i3kFj2wVpo4NfHCmK)_